### PR TITLE
fix: webhook 목록 미노출 수정 및 AI 피드백 리포트 강화

### DIFF
--- a/src/analyzer/ai_review.py
+++ b/src/analyzer/ai_review.py
@@ -17,6 +17,12 @@ class AiReviewResult:
     has_tests: bool
     summary: str
     suggestions: list[str] = field(default_factory=list)
+    commit_message_feedback: str = ""    # 커밋 메시지 평가 상세
+    code_quality_feedback: str = ""      # 코드 품질 평가 상세
+    security_feedback: str = ""          # 보안 평가 상세
+    direction_feedback: str = ""         # 구현 방향성 평가 상세
+    test_feedback: str = ""              # 테스트 평가 상세
+    file_feedbacks: list[dict] = field(default_factory=list)  # 파일별 피드백
 
 
 _PROMPT_TEMPLATE = """\
@@ -33,8 +39,16 @@ _PROMPT_TEMPLATE = """\
   "commit_message_score": <0~20 정수, 컨벤션 준수/명확성/변경범위 일치성>,
   "direction_score": <0~20 정수, 구현 방향성/패턴/설계 적합성>,
   "has_tests": <true/false, 테스트 코드 변경 포함 여부>,
-  "summary": "<변경사항 한 줄 요약>",
-  "suggestions": ["<개선 제안1>", "<개선 제안2>"]
+  "summary": "<변경사항 2~3문장 요약: 무엇을 왜 변경했는지>",
+  "suggestions": ["<구체적 개선 제안 (파일명:라인 포함)>"],
+  "commit_message_feedback": "<커밋 메시지 평가: 컨벤션 준수 여부, 명확성, 변경범위 일치성에 대한 구체적 피드백>",
+  "code_quality_feedback": "<코드 품질 평가: 가독성, 네이밍, 중복, 복잡도 등 구체적 피드백>",
+  "security_feedback": "<보안 평가: 잠재적 보안 취약점, 입력 검증, 인증 등에 대한 피드백. 이슈 없으면 '보안 이슈 없음'>",
+  "direction_feedback": "<구현 방향성 평가: 설계 패턴, 아키텍처 적합성, 확장성에 대한 피드백>",
+  "test_feedback": "<테스트 평가: 테스트 존재 여부, 커버리지 충분성, 엣지케이스 포함 여부>",
+  "file_feedbacks": [
+    {{"file": "<파일명>", "issues": ["<라인 N: 구체적 문제 설명과 수정 방법>"]}}
+  ]
 }}"""
 
 
@@ -55,7 +69,7 @@ async def review_code(
         client = anthropic.AsyncAnthropic(api_key=api_key)
         response = await client.messages.create(
             model="claude-haiku-4-5",
-            max_tokens=512,
+            max_tokens=1500,
             messages=[{
                 "role": "user",
                 "content": _PROMPT_TEMPLATE.format(
@@ -84,6 +98,12 @@ def _parse_response(text: str) -> AiReviewResult:
             has_tests=bool(data.get("has_tests", False)),
             summary=str(data.get("summary", "")),
             suggestions=[str(s) for s in data.get("suggestions", [])],
+            commit_message_feedback=str(data.get("commit_message_feedback", "")),
+            code_quality_feedback=str(data.get("code_quality_feedback", "")),
+            security_feedback=str(data.get("security_feedback", "")),
+            direction_feedback=str(data.get("direction_feedback", "")),
+            test_feedback=str(data.get("test_feedback", "")),
+            file_feedbacks=list(data.get("file_feedbacks", [])),
         )
     except (json.JSONDecodeError, ValueError, KeyError):
         logger.warning("Failed to parse AI review response: %s", text[:200])

--- a/src/notifier/github_comment.py
+++ b/src/notifier/github_comment.py
@@ -32,6 +32,30 @@ def _build_comment_body(
     if ai_review and ai_review.summary:
         lines += ["", "### AI 요약", ai_review.summary]
 
+    # 카테고리별 상세 피드백
+    if ai_review:
+        feedback_items = [
+            ("커밋 메시지", ai_review.commit_message_feedback),
+            ("코드 품질", ai_review.code_quality_feedback),
+            ("보안", ai_review.security_feedback),
+            ("구현 방향성", ai_review.direction_feedback),
+            ("테스트", ai_review.test_feedback),
+        ]
+        has_feedback = any(fb for _, fb in feedback_items)
+        if has_feedback:
+            lines += ["", "### 카테고리별 피드백"]
+            for label, fb in feedback_items:
+                if fb:
+                    lines.append(f"- **{label}**: {fb}")
+
+    # 파일별 피드백
+    if ai_review and ai_review.file_feedbacks:
+        lines += ["", "### 파일별 피드백"]
+        for ff in ai_review.file_feedbacks:
+            lines.append(f"#### `{ff.get('file', '?')}`")
+            for issue in ff.get("issues", []):
+                lines.append(f"- {issue}")
+
     if ai_review and ai_review.suggestions:
         lines += ["", "### 개선 제안"]
         for s in ai_review.suggestions:
@@ -39,7 +63,7 @@ def _build_comment_body(
 
     all_issues = [i for r in analysis_results for i in r.issues]
     if all_issues:
-        lines += ["", "### 주요 이슈 (상위 10건)"]
+        lines += ["", "### 정적 분석 이슈 (상위 10건)"]
         for issue in all_issues[:10]:
             lines.append(f"- **[{issue.tool}]** {issue.message} (line {issue.line})")
 

--- a/src/notifier/telegram.py
+++ b/src/notifier/telegram.py
@@ -1,6 +1,7 @@
 import httpx
 from src.scorer.calculator import ScoreResult
 from src.analyzer.static import StaticAnalysisResult
+from src.analyzer.ai_review import AiReviewResult
 
 GRADE_EMOJI = {"A": "🟢", "B": "🔵", "C": "🟡", "D": "🟠", "F": "🔴"}
 
@@ -11,6 +12,7 @@ def _build_message(
     score_result: ScoreResult,
     analysis_results: list[StaticAnalysisResult],
     pr_number: int | None,
+    ai_review: AiReviewResult | None = None,
 ) -> str:
     ref = f"PR #{pr_number}" if pr_number else f"커밋 {commit_sha[:7]}"
     total_issues = sum(len(r.issues) for r in analysis_results)
@@ -22,14 +24,38 @@ def _build_message(
 
     grade_emoji = GRADE_EMOJI.get(score_result.grade, "⚪")
     issues_text = "\n".join(top_issues) if top_issues else "이슈 없음"
+    bd = score_result.breakdown
 
-    return (
-        f"{grade_emoji} *SCA 분석 결과*\n"
-        f"📁 `{repo_name}` — {ref}\n\n"
-        f"*점수:* {score_result.total}/100  (등급 {score_result.grade})\n"
-        f"*이슈 수:* {total_issues}건\n\n"
-        f"*주요 이슈:*\n{issues_text}"
-    )
+    lines = [
+        f"{grade_emoji} *SCA 분석 결과*",
+        f"📁 `{repo_name}` — {ref}",
+        "",
+        f"*총점:* {score_result.total}/100  (등급 {score_result.grade})",
+        "",
+        "*점수 상세:*",
+        f"  커밋 메시지: {bd.get('commit_message', '-')}/20",
+        f"  코드 품질: {bd.get('code_quality', '-')}/30",
+        f"  보안: {bd.get('security', '-')}/20",
+        f"  구현 방향성: {bd.get('ai_review', '-')}/20",
+        f"  테스트: {bd.get('test_coverage', '-')}/10",
+    ]
+
+    if ai_review and ai_review.summary:
+        lines += ["", f"*AI 요약:* {ai_review.summary}"]
+
+    if ai_review and ai_review.suggestions:
+        lines += ["", "*개선 제안:*"]
+        for s in ai_review.suggestions:
+            lines.append(f"- {s}")
+
+    if top_issues:
+        lines += [
+            "",
+            f"*정적 분석 이슈:* {total_issues}건",
+            issues_text,
+        ]
+
+    return "\n".join(lines)
 
 
 async def send_analysis_result(
@@ -40,8 +66,9 @@ async def send_analysis_result(
     score_result: ScoreResult,
     analysis_results: list[StaticAnalysisResult],
     pr_number: int | None = None,
+    ai_review: AiReviewResult | None = None,
 ) -> None:
-    text = _build_message(repo_name, commit_sha, score_result, analysis_results, pr_number)
+    text = _build_message(repo_name, commit_sha, score_result, analysis_results, pr_number, ai_review=ai_review)
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
     async with httpx.AsyncClient() as client:
         r = await client.post(url, json={

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -45,6 +45,19 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:
             commit_sha = data["after"]
             files = get_push_files(settings.github_token, repo_name, commit_sha)
 
+        db: Session = SessionLocal()
+        try:
+            repo = db.query(Repository).filter_by(full_name=repo_name).first()
+            if not repo:
+                repo = Repository(
+                    full_name=repo_name,
+                    telegram_chat_id=settings.telegram_chat_id,
+                )
+                db.add(repo)
+                db.commit()
+        finally:
+            db.close()
+
         if not files:
             logger.info("No Python files changed in %s @ %s", repo_name, commit_sha)
             return
@@ -58,16 +71,9 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:
         score_result = calculate_score(analysis_results, ai_review=ai_review)
 
         n8n_url: str | None = None
-        db: Session = SessionLocal()
+        db = SessionLocal()
         try:
             repo = db.query(Repository).filter_by(full_name=repo_name).first()
-            if not repo:
-                repo = Repository(
-                    full_name=repo_name,
-                    telegram_chat_id=settings.telegram_chat_id,
-                )
-                db.add(repo)
-                db.flush()
 
             existing = db.query(Analysis).filter_by(
                 commit_sha=commit_sha, repo_id=repo.id

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -92,6 +92,12 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:
                     "breakdown": score_result.breakdown,
                     "ai_summary": ai_review.summary,
                     "ai_suggestions": ai_review.suggestions,
+                    "commit_message_feedback": ai_review.commit_message_feedback,
+                    "code_quality_feedback": ai_review.code_quality_feedback,
+                    "security_feedback": ai_review.security_feedback,
+                    "direction_feedback": ai_review.direction_feedback,
+                    "test_feedback": ai_review.test_feedback,
+                    "file_feedbacks": ai_review.file_feedbacks,
                     "issues": [
                         {
                             "tool": i.tool,
@@ -136,6 +142,7 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:
                 score_result=score_result,
                 analysis_results=analysis_results,
                 pr_number=pr_number,
+                ai_review=ai_review,
             )
         ]
         if pr_number is not None:

--- a/tests/test_ai_review.py
+++ b/tests/test_ai_review.py
@@ -20,13 +20,20 @@ async def test_empty_patches_returns_default():
 
 
 def test_parse_response_valid_json():
-    text = '{"commit_message_score": 18, "direction_score": 16, "has_tests": true, "summary": "Good refactoring", "suggestions": ["Add type hints"]}'
+    text = '{"commit_message_score": 18, "direction_score": 16, "has_tests": true, "summary": "Good refactoring", "suggestions": ["Add type hints"], "commit_message_feedback": "커밋 메시지가 명확합니다", "code_quality_feedback": "코드 품질이 우수합니다", "security_feedback": "보안 이슈 없음", "direction_feedback": "설계 방향이 적절합니다", "test_feedback": "테스트 코드가 포함되어 있습니다", "file_feedbacks": [{"file": "app.py", "issues": ["라인 10: 변수명 개선 필요"]}]}'
     result = _parse_response(text)
     assert result.commit_score == 18
     assert result.ai_score == 16
     assert result.has_tests is True
     assert result.summary == "Good refactoring"
     assert "Add type hints" in result.suggestions
+    assert result.commit_message_feedback == "커밋 메시지가 명확합니다"
+    assert result.code_quality_feedback == "코드 품질이 우수합니다"
+    assert result.security_feedback == "보안 이슈 없음"
+    assert result.direction_feedback == "설계 방향이 적절합니다"
+    assert result.test_feedback == "테스트 코드가 포함되어 있습니다"
+    assert len(result.file_feedbacks) == 1
+    assert result.file_feedbacks[0]["file"] == "app.py"
 
 
 def test_parse_response_clamps_above_max():
@@ -62,6 +69,21 @@ def test_default_result_values():
     assert result.ai_score == 15
     assert result.has_tests is False
     assert isinstance(result.suggestions, list)
+    assert result.commit_message_feedback == ""
+    assert result.code_quality_feedback == ""
+    assert result.security_feedback == ""
+    assert result.direction_feedback == ""
+    assert result.test_feedback == ""
+    assert result.file_feedbacks == []
+
+
+def test_parse_response_without_new_fields_uses_defaults():
+    """기존 형식(새 필드 없음)의 응답도 정상 파싱되어야 함."""
+    text = '{"commit_message_score": 18, "direction_score": 16, "has_tests": true, "summary": "ok", "suggestions": []}'
+    result = _parse_response(text)
+    assert result.commit_score == 18
+    assert result.commit_message_feedback == ""
+    assert result.file_feedbacks == []
 
 
 async def test_review_code_calls_anthropic_and_parses():

--- a/tests/test_github_comment.py
+++ b/tests/test_github_comment.py
@@ -100,6 +100,28 @@ async def test_post_pr_comment_calls_github_api():
     assert "42" in url
 
 
+def test_comment_body_includes_category_feedback():
+    ai = AiReviewResult(
+        commit_score=17, ai_score=15, has_tests=True,
+        summary="좋은 리팩토링입니다.",
+        suggestions=["타입 힌트 추가 권장"],
+        commit_message_feedback="커밋 메시지가 변경 범위를 잘 설명합니다.",
+        code_quality_feedback="전반적으로 깔끔한 코드입니다.",
+        security_feedback="보안 이슈가 발견되지 않았습니다.",
+        direction_feedback="설계 방향이 적절합니다.",
+        test_feedback="테스트 코드가 포함되어 있습니다.",
+        file_feedbacks=[{"file": "app.py", "issues": ["라인 10: 변수명 개선 필요"]}],
+    )
+    body = _build_comment_body(_make_score(), [], ai)
+    assert "커밋 메시지가 변경 범위를 잘 설명합니다." in body
+    assert "전반적으로 깔끔한 코드입니다." in body
+    assert "보안 이슈가 발견되지 않았습니다." in body
+    assert "설계 방향이 적절합니다." in body
+    assert "테스트 코드가 포함되어 있습니다." in body
+    assert "app.py" in body
+    assert "변수명 개선 필요" in body
+
+
 async def test_post_pr_comment_sets_auth_header():
     with patch("src.notifier.github_comment.httpx.AsyncClient") as mock_cls:
         mock_client = AsyncMock()

--- a/tests/test_notifier_telegram.py
+++ b/tests/test_notifier_telegram.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 from src.notifier.telegram import send_analysis_result, _build_message
 from src.scorer.calculator import ScoreResult
 from src.analyzer.static import StaticAnalysisResult, AnalysisIssue
+from src.analyzer.ai_review import AiReviewResult
 
 
 def _make_score(total=80, grade="B") -> ScoreResult:
@@ -40,6 +41,25 @@ def test_build_message_lists_issues():
     issues = [AnalysisIssue(tool="pylint", severity="error", message="undefined variable x", line=5)]
     msg = _build_message("owner/repo", "abc1234", _make_score(), _make_analysis(issues), None)
     assert "undefined variable x" in msg
+
+
+def test_build_message_includes_ai_summary():
+    ai = AiReviewResult(
+        commit_score=17, ai_score=15, has_tests=True,
+        summary="전체적으로 좋은 리팩토링입니다.",
+        suggestions=["타입 힌트를 추가하세요", "함수를 분리하세요"],
+    )
+    msg = _build_message("owner/repo", "abc1234", _make_score(), _make_analysis(), None, ai_review=ai)
+    assert "전체적으로 좋은 리팩토링입니다." in msg
+    assert "타입 힌트를 추가하세요" in msg
+    assert "함수를 분리하세요" in msg
+
+
+def test_build_message_includes_score_breakdown():
+    msg = _build_message("owner/repo", "abc1234", _make_score(), _make_analysis(), None)
+    assert "코드 품질" in msg
+    assert "보안" in msg
+    assert "커밋" in msg
 
 @pytest.mark.asyncio
 async def test_send_analysis_result_calls_telegram_api():

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -53,7 +53,12 @@ def mock_deps():
         )
 
         mock_db = MagicMock()
-        mock_db.query.return_value.filter_by.return_value.first.return_value = None
+        mock_repo = MagicMock(id=1)
+        # Call sequence: 1) repo creation (None→create), 2) repo lookup (found),
+        # 3) dup check (None), 4) get_repo_config (None→defaults)
+        mock_db.query.return_value.filter_by.return_value.first.side_effect = [
+            None, mock_repo, None, None,
+        ]
         mock_db.flush = MagicMock()
         mock_db.commit = MagicMock()
         mock_session_cls.return_value = mock_db
@@ -74,7 +79,7 @@ async def test_push_event_calls_full_pipeline(mock_deps):
     mock_deps["ai"].assert_called_once()
     mock_deps["score"].assert_called_once()
     mock_deps["telegram"].assert_called_once()
-    mock_deps["db"].commit.assert_called_once()
+    assert mock_deps["db"].commit.call_count == 2  # repo creation + analysis save
 
 
 async def test_pr_event_calls_full_pipeline(mock_deps):
@@ -110,6 +115,21 @@ async def test_no_python_files_skips_pipeline(mock_deps):
 
     mock_deps["ai"].assert_not_called()
     mock_deps["telegram"].assert_not_called()
+
+
+async def test_no_python_files_still_creates_repository(mock_deps):
+    """Even when no Python files changed, the Repository should be created in DB."""
+    mock_deps["push"].return_value = []
+    from src.worker.pipeline import run_analysis_pipeline
+    await run_analysis_pipeline("push", PUSH_DATA)
+
+    # Repository should have been added and committed even though pipeline was skipped
+    from src.models.repository import Repository
+    add_calls = mock_deps["db"].add.call_args_list
+    added_repos = [c[0][0] for c in add_calls if isinstance(c[0][0], Repository)]
+    assert len(added_repos) == 1
+    assert added_repos[0].full_name == "owner/repo"
+    mock_deps["db"].commit.assert_called()
 
 
 async def test_duplicate_commit_is_skipped(mock_deps):
@@ -171,7 +191,7 @@ async def test_pipeline_calls_gate_for_pr(mock_deps):
 
     mock_db = mock_deps["db"]
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [
-        MagicMock(id=1), None, None
+        MagicMock(id=1), MagicMock(id=1), None,
     ]
     mock_db.refresh = MagicMock()
 
@@ -195,7 +215,7 @@ async def test_pipeline_calls_n8n_when_url_set(mock_deps):
 
     mock_db = mock_deps["db"]
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [
-        MagicMock(id=1), None, None
+        MagicMock(id=1), MagicMock(id=1), None,
     ]
     mock_db.refresh = MagicMock()
 
@@ -223,7 +243,7 @@ async def test_pipeline_skips_gate_for_push(mock_deps):
 
     mock_db = mock_deps["db"]
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [
-        MagicMock(id=1), None, None
+        MagicMock(id=1), MagicMock(id=1), None,
     ]
     mock_db.refresh = MagicMock()
 


### PR DESCRIPTION
## Summary
- **웹훅 목록 미노출 버그 수정**: Python 파일이 없는 push/PR 이벤트 시 Repository가 DB에 등록되지 않아 메인페이지에 리포가 안 보이던 문제 해결
- **AI 피드백 리포트 강화**: 카테고리별 상세 피드백(커밋/코드품질/보안/방향성/테스트), 파일별 라인 단위 피드백, Telegram 점수 상세 추가

## Test plan
- [x] 전체 136개 테스트 통과 (기존 131 + 신규 5)
- [x] `test_no_python_files_still_creates_repository` — 파일 없어도 repo 생성 확인
- [x] `test_parse_response_valid_json` — 새 피드백 필드 파싱 확인
- [x] `test_build_message_includes_ai_summary` — Telegram에 AI 요약 포함 확인
- [x] `test_comment_body_includes_category_feedback` — PR Comment에 카테고리별 피드백 포함 확인

https://claude.ai/code/session_01CxJwMGcUKWfMQmSiropiFM