### PR TITLE
fix: pylint E0401 import-error 비활성화 (임시파일 분석 시 오탐)

### DIFF
--- a/src/analyzer/static.py
+++ b/src/analyzer/static.py
@@ -45,6 +45,7 @@ def _run_pylint(path: str) -> list[AnalysisIssue]:
         r = subprocess.run(  # nosec B603 B607
             ["pylint", path, "--output-format=json",
              "--disable=C0114,C0115,C0116,C0301,C0411,"
+             "E0401,"
              "R0801,R0902,R0903,R0912,R0913,R0914,R0915,R0917,"
              "W0511,W0613,W0621,W0718"],
             capture_output=True, text=True, timeout=30, check=False,


### PR DESCRIPTION
## Summary
- 분석기가 파일을 임시 경로에 복사 후 pylint 실행 → `from src.xxx import ...`가 항상 E0401 발생
- E0401은 error 타입이라 건당 **-5점**, 4건 = **-20점**으로 코드 품질 점수 대폭 하락의 주 원인
- pylint disable 목록에 `E0401` 추가

## Test plan
- [x] 140개 테스트 통과
- [x] flake8 0건, bandit 0건

https://claude.ai/code/session_01CxJwMGcUKWfMQmSiropiFM