### PR TITLE
fix: Telegram 알림 Markdown→HTML 전환으로 전송 실패 해결

### DIFF
--- a/src/notifier/telegram.py
+++ b/src/notifier/telegram.py
@@ -1,4 +1,4 @@
-import re
+from html import escape
 
 import httpx
 from src.scorer.calculator import ScoreResult
@@ -6,13 +6,6 @@ from src.analyzer.static import StaticAnalysisResult
 from src.analyzer.ai_review import AiReviewResult
 
 GRADE_EMOJI = {"A": "🟢", "B": "🔵", "C": "🟡", "D": "🟠", "F": "🔴"}
-
-_MD_SPECIAL = re.compile(r"[*_`\[\]]")
-
-
-def _escape_md(text: str) -> str:
-    """Telegram Markdown 특수문자를 제거하여 파싱 오류를 방지한다."""
-    return _MD_SPECIAL.sub("", text)
 
 
 def _build_message(
@@ -26,7 +19,7 @@ def _build_message(
     ref = f"PR #{pr_number}" if pr_number else f"커밋 {commit_sha[:7]}"
     total_issues = sum(len(r.issues) for r in analysis_results)
     top_issues = [
-        f"- [{i.tool}] {i.message[:80]}"
+        f"- [{escape(i.tool)}] {escape(i.message[:80])}"
         for r in analysis_results
         for i in r.issues
     ][:5]
@@ -36,12 +29,12 @@ def _build_message(
     bd = score_result.breakdown
 
     lines = [
-        f"{grade_emoji} *SCA 분석 결과*",
-        f"📁 `{repo_name}` — {ref}",
+        f"{grade_emoji} <b>SCA 분석 결과</b>",
+        f"📁 <code>{escape(repo_name)}</code> — {escape(ref)}",
         "",
-        f"*총점:* {score_result.total}/100  (등급 {score_result.grade})",
+        f"<b>총점:</b> {score_result.total}/100  (등급 {score_result.grade})",
         "",
-        "*점수 상세:*",
+        "<b>점수 상세:</b>",
         f"  커밋 메시지: {bd.get('commit_message', '-')}/20",
         f"  코드 품질: {bd.get('code_quality', '-')}/30",
         f"  보안: {bd.get('security', '-')}/20",
@@ -50,17 +43,17 @@ def _build_message(
     ]
 
     if ai_review and ai_review.summary:
-        lines += ["", f"*AI 요약:* {_escape_md(ai_review.summary)}"]
+        lines += ["", f"<b>AI 요약:</b> {escape(ai_review.summary)}"]
 
     if ai_review and ai_review.suggestions:
-        lines += ["", "*개선 제안:*"]
+        lines += ["", "<b>개선 제안:</b>"]
         for s in ai_review.suggestions:
-            lines.append(f"- {_escape_md(s)}")
+            lines.append(f"- {escape(s)}")
 
     if top_issues:
         lines += [
             "",
-            f"*정적 분석 이슈:* {total_issues}건",
+            f"<b>정적 분석 이슈:</b> {total_issues}건",
             issues_text,
         ]
 
@@ -83,6 +76,6 @@ async def send_analysis_result(
         r = await client.post(url, json={
             "chat_id": chat_id,
             "text": text,
-            "parse_mode": "Markdown",
+            "parse_mode": "HTML",
         })
         r.raise_for_status()

--- a/tests/test_notifier_telegram.py
+++ b/tests/test_notifier_telegram.py
@@ -24,18 +24,22 @@ def test_build_message_contains_repo_name():
     msg = _build_message("owner/repo", "abc1234", _make_score(), _make_analysis(), None)
     assert "owner/repo" in msg
 
+
 def test_build_message_contains_score():
     msg = _build_message("owner/repo", "abc1234", _make_score(80, "B"), _make_analysis(), None)
     assert "80" in msg
     assert "B" in msg
 
+
 def test_build_message_shows_pr_number():
     msg = _build_message("owner/repo", "abc1234", _make_score(), _make_analysis(), 42)
     assert "PR #42" in msg
 
+
 def test_build_message_shows_commit_when_no_pr():
     msg = _build_message("owner/repo", "abc1234567", _make_score(), _make_analysis(), None)
     assert "abc1234" in msg
+
 
 def test_build_message_lists_issues():
     issues = [AnalysisIssue(tool="pylint", severity="error", message="undefined variable x", line=5)]
@@ -55,22 +59,31 @@ def test_build_message_includes_ai_summary():
     assert "함수를 분리하세요" in msg
 
 
-def test_build_message_escapes_markdown_special_chars():
-    """AI 생성 텍스트에 Markdown 특수문자가 있어도 메시지가 깨지지 않아야 한다."""
+def test_build_message_escapes_html_special_chars():
+    """HTML 특수문자가 이스케이프되어 Telegram 파싱 오류를 방지해야 한다."""
     ai = AiReviewResult(
         commit_score=17, ai_score=15, has_tests=True,
-        summary="변수 `user_name`을 *snake_case*로 변경하세요. [참고](link)",
-        suggestions=["_private 메서드를 `__init__`에서 호출하세요"],
+        summary="변수 <user_name>을 사용하세요 & 'config'를 확인",
+        suggestions=["func<T>() 제네릭을 추가하세요"],
     )
     msg = _build_message("owner/repo", "abc1234", _make_score(), _make_analysis(), None, ai_review=ai)
-    # Markdown 특수문자(`, *, [, ])가 제거되어야 함
-    assert "`user_name`" not in msg
-    assert "*snake_case*" not in msg
-    assert "[참고]" not in msg
-    # 특수문자 제거 후 텍스트 내용은 유지되어야 함
-    assert "username" in msg
-    assert "snakecase" in msg
-    assert "init" in msg
+    assert "&lt;user_name&gt;" in msg
+    assert "&amp;" in msg
+    assert "<user_name>" not in msg
+
+
+def test_build_message_escapes_issue_text():
+    """정적 분석 이슈 메시지의 특수문자도 이스케이프되어야 한다."""
+    issues = [AnalysisIssue(tool="pylint", severity="error", message="Unable to import 'src.config'", line=1)]
+    msg = _build_message("owner/repo", "abc1234", _make_score(), _make_analysis(issues), None)
+    assert "Unable to import &#x27;src.config&#x27;" in msg or "Unable to import 'src.config'" in msg
+    assert "[pylint]" in msg
+
+
+def test_build_message_uses_html_formatting():
+    msg = _build_message("owner/repo", "abc1234", _make_score(), _make_analysis(), None)
+    assert "<b>" in msg
+    assert "<code>" in msg
 
 
 def test_build_message_includes_score_breakdown():
@@ -79,8 +92,9 @@ def test_build_message_includes_score_breakdown():
     assert "보안" in msg
     assert "커밋" in msg
 
+
 @pytest.mark.asyncio
-async def test_send_analysis_result_calls_telegram_api():
+async def test_send_analysis_result_uses_html_parse_mode():
     with patch("src.notifier.telegram.httpx.AsyncClient") as MockClient:
         mock_response = MagicMock()
         mock_response.raise_for_status = MagicMock()
@@ -102,3 +116,4 @@ async def test_send_analysis_result_calls_telegram_api():
     call_kwargs = mock_post.call_args[1]
     assert "sendMessage" in mock_post.call_args[0][0]
     assert call_kwargs["json"]["chat_id"] == "-100123"
+    assert call_kwargs["json"]["parse_mode"] == "HTML"


### PR DESCRIPTION
## Summary
- `parse_mode: "Markdown"` → `"HTML"` 전환
- 정적 분석 이슈(`[pylint]`, 따옴표 등)와 AI 텍스트의 특수문자가 Telegram Markdown 파싱을 깨뜨려 메시지 전송 실패
- HTML은 `<`, `>`, `&`만 이스케이프하면 되어 안정적 (stdlib `html.escape` 사용)
- 모든 동적 콘텐츠(이슈 메시지, AI 요약, 제안)에 `html.escape()` 적용

## Test plan
- [x] 143개 테스트 통과
- [x] `test_build_message_escapes_html_special_chars` — HTML 이스케이프 검증
- [x] `test_build_message_escapes_issue_text` — 정적 분석 이슈 이스케이프 검증
- [x] `test_send_analysis_result_uses_html_parse_mode` — HTML parse_mode 확인

https://claude.ai/code/session_01CxJwMGcUKWfMQmSiropiFM