### PR TITLE
fix: 알림 실패 로깅 강화 (태스크명 + traceback)

### DIFF
--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -169,9 +169,15 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:
                 )
             )
         results = await asyncio.gather(*notify_tasks, return_exceptions=True)
-        for exc in results:
+        for idx, exc in enumerate(results):
             if isinstance(exc, Exception):
-                logger.error("Notification task failed: %s", exc)
+                task_names = ["telegram"]
+                if pr_number is not None:
+                    task_names.append("github_comment")
+                if n8n_url:
+                    task_names.append("n8n")
+                name = task_names[idx] if idx < len(task_names) else "unknown"
+                logger.error("Notification [%s] failed: %s", name, exc, exc_info=exc)
 
     except Exception:
         logger.exception("Analysis pipeline failed for event=%s", event)


### PR DESCRIPTION
## Summary
- 알림 실패 시 어떤 알림(telegram/github_comment/n8n)이 실패했는지 + 전체 traceback 로깅
- 이전에는 예외 메시지만 남겨 디버깅이 어려웠음

https://claude.ai/code/session_01CxJwMGcUKWfMQmSiropiFM