### PR TITLE
feat: 3-테마 UI 리디자인 + Playwright E2E 테스트 26개

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,9 @@ make run
 | `make run` | 개발 서버 실행 (port 8000) |
 | `make migrate` | DB 마이그레이션 실행 |
 | `make revision m="설명"` | 새 마이그레이션 파일 생성 |
+| `make install-playwright` | Playwright + Chromium 설치 |
+| `make test-e2e` | E2E 테스트 실행 (headless) |
+| `make test-e2e-headed` | E2E 테스트 실행 (브라우저 표시) |
 
 ## GitHub Codespaces (모바일/원격 개발)
 
@@ -86,7 +89,7 @@ make run         # 개발 서버 (포트 8000 자동 포워딩)
 src/
 ├── main.py                     # FastAPI 앱, lifespan(DB 마이그레이션), 전체 라우터 등록
 ├── config.py                   # pydantic-settings 환경변수 관리, postgres:// URL 자동 변환
-├── database.py                 # SQLAlchemy engine, Base, SessionLocal
+├── database.py                 # SQLAlchemy engine, Base, SessionLocal (SQLite는 hostaddr 제외)
 ├── models/
 │   ├── repository.py           # Repository ORM
 │   ├── analysis.py             # Analysis ORM
@@ -126,7 +129,14 @@ src/
 └── worker/
     └── pipeline.py             # run_analysis_pipeline — 전체 파이프라인
 
-tests/                          # 146개 테스트 (Phase 1~6 + 버그 수정 + 점수 개선)
+e2e/                            # Playwright E2E 테스트 26개 (브라우저 기반 JS 동작 검증)
+├── conftest.py                 # uvicorn 스레드 서버 + Playwright browser/page fixture
+├── pytest.ini                  # asyncio_mode 없는 별도 설정 (tests/ 와 격리)
+├── test_theme.py               # 3-테마 전환 E2E (localStorage, data-theme, dropdown)
+├── test_settings.py            # 설정 페이지 E2E (Gate 모드 토글, 슬라이더, 폼 제출)
+└── test_navigation.py          # 네비게이션 E2E (로고, 뒤로가기, 설정 버튼)
+
+tests/                          # 146개 단위 테스트 (Phase 1~6 + 버그 수정 + 점수 개선)
 ├── conftest.py
 ├── test_config.py, test_models.py, test_repo_config_model.py
 ├── test_github_diff.py, test_webhook_router.py, test_webhook_validator.py
@@ -214,6 +224,9 @@ Telegram 반자동 콜백:
 - **Telegram HTML 파싱**: `parse_mode: "HTML"` 사용 — 모든 동적 콘텐츠(AI 요약, 이슈 메시지)에 `html.escape()` 적용 필수
 - **비-Python 파일 AI 리뷰**: `.md`, `.cfg`, `.yml` 등도 AI 리뷰 대상 — 정적 분석은 `.py`만 실행, 비-코드 파일만 변경 시 테스트 점수 면제(10/10)
 - **PR action 필터링**: `pull_request` 이벤트 중 `opened`/`synchronize`/`reopened`만 처리, `closed`/`labeled` 등은 무시
+- **E2E 테스트 격리**: `e2e/`를 최상위 별도 디렉토리로 분리 (`tests/` 아래 금지) — `tests/e2e/`가 있으면 `asyncio_mode=auto`와 `sys.modules` 삭제가 충돌해 단위 테스트 98개 실패
+- **SQLite hostaddr 제외**: `src/database.py`의 `_ipv4_connect_args`는 hostname이 None(SQLite URL)이면 빈 dict 반환 — 그렇지 않으면 `sqlite3.connect(hostaddr=...)` TypeError 발생
+- **E2E 서버 asyncio**: `uvicorn.Server.serve()`를 `asyncio.new_event_loop()` + `loop.run_until_complete()`로 실행 — `server.run()` 대신 사용 (`server.run()`은 asyncio_mode=auto 환경에서 이벤트 루프 충돌)
 
 ## Railway 배포
 
@@ -307,3 +320,4 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 | Phase 4 | Dashboard API + Web UI (Jinja2 + Chart.js) | ✅ 완료 (~15 테스트) |
 | Phase 5 | n8n 연동 + 외부 REST API + 통계 고도화 | ✅ 완료 (~4 테스트, 총 112 테스트) |
 | Phase 6 | PR 자동 Merge (auto_merge 설정 + squash merge) | ✅ 완료 (19 테스트, 총 146 테스트) |
+| Phase 7 | 3-테마 UI 리디자인 + Playwright E2E 테스트 | ✅ 완료 (단위 146개 + E2E 26개) |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test test-v test-cov lint run migrate
+.PHONY: install test test-v test-cov lint run migrate install-playwright test-e2e test-e2e-headed
 
 # 의존성 설치
 install:
@@ -37,3 +37,16 @@ run:
 # 새 마이그레이션 생성 (예: make revision m="add column")
 revision:
 	alembic revision --autogenerate -m "$(m)"
+
+# Playwright 브라우저 설치
+install-playwright:
+	pip install playwright pytest-playwright
+	playwright install chromium
+
+# E2E 테스트 (headless)
+test-e2e:
+	python -m pytest e2e/ -v -p no:asyncio
+
+# E2E 테스트 (브라우저 표시)
+test-e2e-headed:
+	python -m pytest e2e/ -v -p no:asyncio --headed

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -1,0 +1,168 @@
+"""E2E 테스트용 fixture — uvicorn(스레드) + Playwright.
+
+tests/ conftest.py와 분리되어 asyncio_mode=auto 없이 실행됨.
+"""
+import asyncio
+import hashlib
+import hmac
+import json
+import os
+import sys
+import threading
+import time
+
+import pytest
+import requests
+
+E2E_PORT = 8001
+BASE_URL = f"http://localhost:{E2E_PORT}"
+
+
+# ── 서버 시작/종료 ──────────────────────────────────────────────────────
+
+
+def _start_uvicorn(db_path: str) -> tuple:
+    """uvicorn Server를 별도 스레드(새 event loop)로 실행하고 (server, thread)를 반환한다."""
+    import uvicorn
+
+    # E2E용 환경변수 세팅 (import 전에 설정 — setdefault 대신 강제 덮어쓰기)
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    os.environ["GITHUB_WEBHOOK_SECRET"] = "e2e-test-secret"
+    os.environ["GITHUB_TOKEN"] = "e2e-test-token"
+    os.environ["TELEGRAM_BOT_TOKEN"] = "1234567890:AAe2etest"
+    os.environ["TELEGRAM_CHAT_ID"] = "-100000000"
+    os.environ["API_KEY"] = "e2e-api-key"
+
+    # pydantic-settings 캐시 무효화
+    for mod_name in list(sys.modules.keys()):
+        if mod_name.startswith("src."):
+            del sys.modules[mod_name]
+
+    from src.main import app  # noqa: PLC0415
+
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=E2E_PORT,
+        log_level="error",
+    )
+    server = uvicorn.Server(config)
+
+    def run_in_new_loop():
+        """스레드 내에서 새 event loop를 생성해 uvicorn을 실행한다."""
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(server.serve())
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=run_in_new_loop, daemon=True)
+    thread.start()
+    return server, thread
+
+
+@pytest.fixture(scope="session")
+def live_server(tmp_path_factory):
+    """SQLite + 더미 시크릿으로 uvicorn 서버를 세션 동안 실행한다."""
+    db_file = tmp_path_factory.mktemp("e2e_db") / "test_e2e.db"
+    db_path = str(db_file)
+
+    server, thread = _start_uvicorn(db_path)
+
+    # 서버가 200을 반환할 때까지 대기 (최대 30초)
+    ready = False
+    for _ in range(60):
+        try:
+            r = requests.get(f"{BASE_URL}/health", timeout=1)
+            if r.status_code == 200:
+                ready = True
+                break
+        except Exception:
+            pass
+        time.sleep(0.5)
+
+    if not ready:
+        server.should_exit = True
+        thread.join(timeout=5)
+        pytest.skip("E2E 서버 시작 실패 — 테스트 건너뜁니다")
+
+    yield BASE_URL
+
+    server.should_exit = True
+    thread.join(timeout=10)
+
+
+@pytest.fixture(scope="session")
+def base_url(live_server):
+    return live_server
+
+
+# ── Playwright browser/page fixture ───────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def browser_instance():
+    """세션 동안 Chromium 브라우저 인스턴스를 공유한다."""
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=True)
+        yield browser
+        browser.close()
+
+
+@pytest.fixture
+def page(browser_instance, base_url):  # noqa: F811
+    """테스트마다 새로운 브라우저 컨텍스트(격리된 localStorage)를 제공한다."""
+    context = browser_instance.new_context(base_url=base_url)
+    pg = context.new_page()
+    yield pg
+    context.close()
+
+
+# ── 테스트 데이터 시드 ────────────────────────────────────────────────
+
+
+def _build_sig(payload: str, secret: str) -> str:
+    return "sha256=" + hmac.new(  # type: ignore[attr-defined]
+        secret.encode(), payload.encode(), hashlib.sha256
+    ).hexdigest()
+
+
+def _seed_repo(base_url: str) -> None:
+    """Push Webhook을 시뮬레이션해 Repository를 DB에 등록한다."""
+    payload = json.dumps({
+        "ref": "refs/heads/main",
+        "repository": {"full_name": "owner/testrepo"},
+        "head_commit": {
+            "id": "abc1234567890abc1234567890abc1234567890ab",
+            "message": "feat: e2e test seed commit",
+        },
+        "commits": [],
+    })
+    sig = _build_sig(payload, "e2e-test-secret")
+    try:
+        requests.post(
+            f"{base_url}/webhooks/github",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "X-GitHub-Event": "push",
+                "X-Hub-Signature-256": sig,
+            },
+            timeout=5,
+        )
+    except Exception:
+        pass
+    time.sleep(0.3)
+
+
+@pytest.fixture
+def seeded_page(browser_instance, live_server):
+    """테스트 레포(owner/testrepo)가 DB에 등록된 상태의 page fixture."""
+    _seed_repo(live_server)
+    context = browser_instance.new_context(base_url=live_server)
+    pg = context.new_page()
+    yield pg
+    context.close()

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = ..

--- a/e2e/test_navigation.py
+++ b/e2e/test_navigation.py
@@ -1,0 +1,71 @@
+"""E2E — 네비게이션 테스트."""
+import pytest
+
+
+def test_overview_page_loads(page, base_url):
+    """Overview 페이지가 정상적으로 로드되어야 한다."""
+    page.goto(base_url)
+    assert "Overview" in page.title()
+
+
+def test_overview_empty_state(page, base_url):
+    """레포가 없을 때 빈 상태 메시지가 표시되어야 한다."""
+    page.goto(base_url)
+    # 레포가 없는 경우 empty-state 표시 (seeded_page 미사용)
+    # 또는 테이블이 있는 경우 테이블이 표시
+    content = page.content()
+    assert "SCAManager" in content
+
+
+def test_nav_logo_is_visible(page, base_url):
+    """네이비바 로고가 표시되어야 한다."""
+    page.goto(base_url)
+    assert page.is_visible(".nav-logo")
+
+
+def test_nav_logo_navigates_to_overview(seeded_page, base_url):
+    """로고 클릭 시 Overview 페이지로 이동해야 한다."""
+    seeded_page.goto(f"{base_url}/repos/owner%2Ftestrepo")
+    seeded_page.click(".nav-logo")
+    seeded_page.wait_for_url(f"{base_url}/", timeout=5000)
+    assert seeded_page.url.rstrip("/") == base_url.rstrip("/")
+
+
+def test_overview_link_in_nav(page, base_url):
+    """네이비바 Overview 링크가 작동해야 한다."""
+    page.goto(base_url)
+    page.click("nav a.nav-link")
+    assert page.url.rstrip("/") == base_url.rstrip("/")
+
+
+def test_repo_detail_back_button(seeded_page, base_url):
+    """레포 상세 페이지의 ← 목록 버튼이 Overview로 이동해야 한다."""
+    seeded_page.goto(f"{base_url}/repos/owner%2Ftestrepo")
+    seeded_page.click(".back-btn")
+    seeded_page.wait_for_url(f"{base_url}/", timeout=5000)
+    assert seeded_page.url.rstrip("/") == base_url.rstrip("/")
+
+
+def test_settings_back_button(seeded_page, base_url):
+    """설정 페이지의 ← 상세 버튼이 레포 상세 페이지로 이동해야 한다."""
+    seeded_page.goto(f"{base_url}/repos/owner%2Ftestrepo/settings")
+    seeded_page.click(".back-btn")
+    seeded_page.wait_for_url("**/repos/**", timeout=5000)
+    assert "/settings" not in seeded_page.url
+    assert "owner" in seeded_page.url
+
+
+def test_detail_settings_button(seeded_page, base_url):
+    """레포 상세 페이지의 ⚙️ 설정 버튼이 설정 페이지로 이동해야 한다."""
+    seeded_page.goto(f"{base_url}/repos/owner%2Ftestrepo")
+    seeded_page.click(".settings-btn")
+    seeded_page.wait_for_url("**/settings", timeout=5000)
+    assert "/settings" in seeded_page.url
+
+
+def test_settings_cancel_button(seeded_page, base_url):
+    """설정 페이지의 취소 버튼이 레포 상세로 이동해야 한다."""
+    seeded_page.goto(f"{base_url}/repos/owner%2Ftestrepo/settings")
+    seeded_page.click("a.btn-ghost")
+    seeded_page.wait_for_url("**/repos/**", timeout=5000)
+    assert "/settings" not in seeded_page.url

--- a/e2e/test_settings.py
+++ b/e2e/test_settings.py
@@ -1,0 +1,99 @@
+"""E2E — 설정 페이지 테스트."""
+import pytest
+
+SETTINGS_URL = "/repos/owner%2Ftestrepo/settings"
+
+
+def test_settings_page_loads(seeded_page, base_url):
+    """설정 페이지가 정상적으로 로드되어야 한다."""
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    assert seeded_page.title() == "설정 — owner/testrepo"
+
+
+def test_gate_mode_disabled_is_default(seeded_page, base_url):
+    """초기 Gate 모드는 비활성 상태여야 한다."""
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    cls = seeded_page.get_attribute('[data-mode="disabled"]', "class") or ""
+    assert "active" in cls
+
+
+def test_gate_mode_auto_button_click(seeded_page, base_url):
+    """자동 모드 버튼 클릭 시 active 클래스와 hidden input 값이 변경되어야 한다."""
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    seeded_page.click('[data-mode="auto"]')
+    # hidden input 값 확인
+    assert seeded_page.input_value("#gateModeValue") == "auto"
+    # active 클래스 확인
+    cls = seeded_page.get_attribute('[data-mode="auto"]', "class") or ""
+    assert "active" in cls
+    # 다른 버튼에는 active 없어야 함
+    cls_disabled = seeded_page.get_attribute('[data-mode="disabled"]', "class") or ""
+    assert "active" not in cls_disabled
+
+
+def test_gate_mode_semi_auto_button_click(seeded_page, base_url):
+    """반자동 모드 버튼 클릭이 동작해야 한다."""
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    seeded_page.click('[data-mode="semi-auto"]')
+    assert seeded_page.input_value("#gateModeValue") == "semi-auto"
+    cls = seeded_page.get_attribute('[data-mode="semi-auto"]', "class") or ""
+    assert "active" in cls
+
+
+def test_approve_slider_updates_badge(seeded_page, base_url):
+    """승인 임계값 슬라이더 조작 시 배지 숫자가 업데이트되어야 한다."""
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    slider = seeded_page.locator('input[name="auto_approve_threshold"]')
+    # JavaScript로 값 변경 + input 이벤트 발생
+    seeded_page.evaluate(
+        """() => {
+            const el = document.querySelector('input[name="auto_approve_threshold"]');
+            el.value = '85';
+            el.dispatchEvent(new Event('input'));
+        }"""
+    )
+    assert seeded_page.text_content("#approveVal") == "85"
+
+
+def test_reject_slider_updates_badge(seeded_page, base_url):
+    """반려 임계값 슬라이더 조작 시 배지 숫자가 업데이트되어야 한다."""
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    seeded_page.evaluate(
+        """() => {
+            const el = document.querySelector('input[name="auto_reject_threshold"]');
+            el.value = '30';
+            el.dispatchEvent(new Event('input'));
+        }"""
+    )
+    assert seeded_page.text_content("#rejectVal") == "30"
+
+
+def test_auto_merge_toggle_switches_checkbox(seeded_page, base_url):
+    """auto_merge 토글 클릭 시 체크박스 상태가 반전되어야 한다."""
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    checkbox = seeded_page.locator('input[name="auto_merge"]')
+    initial = checkbox.is_checked()
+    seeded_page.click(".toggle-track")
+    assert checkbox.is_checked() != initial
+
+
+def test_settings_form_submit_redirects(seeded_page, base_url):
+    """설정 저장 후 같은 설정 페이지로 리다이렉트되어야 한다."""
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    seeded_page.click('[data-mode="auto"]')
+    seeded_page.click('button[type="submit"]')
+    # redirect URL은 디코딩된 경로(/repos/owner/testrepo/settings)
+    seeded_page.wait_for_url("**/settings", timeout=5000)
+    assert "/settings" in seeded_page.url
+
+
+def test_gate_mode_persists_after_save(seeded_page, base_url):
+    """저장한 Gate 모드가 리로드 후에도 유지되어야 한다."""
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    seeded_page.click('[data-mode="auto"]')
+    seeded_page.click('button[type="submit"]')
+    # redirect URL은 디코딩된 경로(/repos/owner/testrepo/settings)
+    seeded_page.wait_for_url("**/settings", timeout=5000)
+    # 저장 후 active 버튼 확인
+    cls = seeded_page.get_attribute('[data-mode="auto"]', "class") or ""
+    assert "active" in cls

--- a/e2e/test_theme.py
+++ b/e2e/test_theme.py
@@ -1,0 +1,71 @@
+"""E2E — 테마 전환 테스트."""
+import pytest
+
+
+def test_default_theme_is_dark(page, base_url):
+    """초기 접속 시 다크 테마가 기본값이어야 한다."""
+    page.goto(base_url)
+    assert page.get_attribute("body", "data-theme") == "dark"
+
+
+def test_theme_switcher_dropdown_opens(page, base_url):
+    """테마 버튼 클릭 시 드롭다운이 열려야 한다."""
+    page.goto(base_url)
+    page.click("#themeToggle")
+    page.wait_for_selector(".theme-switcher.open", timeout=2000)
+    assert page.is_visible('[data-theme="light"]')
+
+
+def test_switch_to_light_theme(page, base_url):
+    """클린(라이트) 테마로 전환되어야 한다."""
+    page.goto(base_url)
+    page.click("#themeToggle")
+    page.click('[data-theme="light"]')
+    assert page.get_attribute("body", "data-theme") == "light"
+
+
+def test_switch_to_glass_theme(page, base_url):
+    """글래스모피즘 테마로 전환되어야 한다."""
+    page.goto(base_url)
+    page.click("#themeToggle")
+    page.click('[data-theme="glass"]')
+    assert page.get_attribute("body", "data-theme") == "glass"
+
+
+def test_theme_persists_after_reload(page, base_url):
+    """테마 선택 후 새로고침해도 테마가 유지되어야 한다."""
+    page.goto(base_url)
+    page.click("#themeToggle")
+    page.click('[data-theme="light"]')
+    page.reload()
+    assert page.get_attribute("body", "data-theme") == "light"
+
+
+def test_theme_saved_to_localstorage(page, base_url):
+    """선택한 테마가 localStorage에 저장되어야 한다."""
+    page.goto(base_url)
+    page.click("#themeToggle")
+    page.click('[data-theme="glass"]')
+    value = page.evaluate("localStorage.getItem('sca-theme')")
+    assert value == "glass"
+
+
+def test_active_class_on_selected_theme(page, base_url):
+    """선택된 테마 옵션에 active 클래스가 붙어야 한다."""
+    page.goto(base_url)
+    page.click("#themeToggle")
+    page.click('.theme-option[data-theme="light"]')
+    # 드롭다운 다시 열기
+    page.click("#themeToggle")
+    cls = page.get_attribute('.theme-option[data-theme="light"]', "class") or ""
+    assert "active" in cls
+
+
+def test_dropdown_closes_on_outside_click(page, base_url):
+    """드롭다운 외부 클릭 시 닫혀야 한다."""
+    page.goto(base_url)
+    page.click("#themeToggle")
+    page.wait_for_selector(".theme-switcher.open", timeout=2000)
+    # 외부 영역 클릭
+    page.click("h2, .overview-header h2, body", position={"x": 10, "y": 10})
+    assert not page.is_visible(".theme-switcher.open")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,7 @@ flake8==7.1.1
 bandit==1.8.0
 pytest==8.3.3
 pytest-asyncio==0.24.0
+playwright>=1.44.0
+pytest-playwright>=0.5.0
 jinja2==3.1.6
 python-multipart==0.0.22

--- a/src/database.py
+++ b/src/database.py
@@ -9,10 +9,13 @@ from src.config import settings
 def _ipv4_connect_args(url: str) -> dict:
     """Railway 컨테이너에서 IPv6 아웃바운드 차단 문제 해결.
     Python socket으로 IPv4 주소를 조회한 뒤 psycopg2 hostaddr에 전달.
-    libpq는 hostaddr로 직접 TCP 연결하고, SSL 인증서는 host(hostname)로 검증."""
+    libpq는 hostaddr로 직접 TCP 연결하고, SSL 인증서는 host(hostname)로 검증.
+    SQLite는 hostaddr를 지원하지 않으므로 건너뜀."""
     try:
         parsed = urlparse(url)
         hostname = parsed.hostname
+        if not hostname:  # SQLite (hostname이 None인 경우)
+            return {}
         port = parsed.port or 5432
         infos = socket.getaddrinfo(hostname, port, socket.AF_INET)
         if infos:

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -5,31 +5,421 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>{% block title %}SCAManager{% endblock %}</title>
   <style>
-    body { font-family: system-ui, sans-serif; margin: 0; background: #f5f5f5; }
-    nav { background: #1a1a2e; color: white; padding: 1rem 2rem; display: flex; align-items: center; gap: 2rem; }
-    nav a { color: #eee; text-decoration: none; }
-    nav a:hover { color: white; }
-    .container { max-width: 1200px; margin: 2rem auto; padding: 0 1rem; }
-    .card { background: white; border-radius: 8px; padding: 1.5rem; margin-bottom: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,.1); }
-    .grade { display: inline-block; padding: 2px 8px; border-radius: 4px; font-weight: bold; }
-    .grade-A { background: #d4edda; color: #155724; }
-    .grade-B { background: #cce5ff; color: #004085; }
-    .grade-C { background: #fff3cd; color: #856404; }
-    .grade-D { background: #ffd0b3; color: #7a3000; }
-    .grade-F { background: #f8d7da; color: #721c24; }
+    /* ── 공통 변수 ─────────────────────────────── */
+    :root {
+      --radius-card: 12px;
+      --radius-btn:  8px;
+      --transition:  0.25s ease;
+    }
+
+    /* ── 다크 대시보드 (기본) ─────────────────── */
+    [data-theme="dark"], body:not([data-theme]) {
+      --bg-page:      #0f1117;
+      --bg-card:      #1e2130;
+      --bg-nav:       #1a1a2e;
+      --bg-input:     #2d3748;
+      --bg-input-focus: #374151;
+      --border:       #2d3748;
+      --border-focus: #6366f1;
+      --text-primary: #e2e8f0;
+      --text-muted:   #64748b;
+      --text-nav:     #cbd5e1;
+      --accent:       #6366f1;
+      --accent-hover: #818cf8;
+      --accent-grad:  linear-gradient(135deg, #6366f1, #818cf8);
+      --success:      #10b981;
+      --danger:       #ef4444;
+      --shadow:       0 4px 24px rgba(0,0,0,0.4);
+      --shadow-card:  0 2px 12px rgba(0,0,0,0.3);
+      --table-head:   #252840;
+      --table-row-hover: #252840;
+      --code-bg:      #0f1117;
+    }
+
+    /* ── 클린 카드 (라이트) ───────────────────── */
+    [data-theme="light"] {
+      --bg-page:      #f1f5f9;
+      --bg-card:      #ffffff;
+      --bg-nav:       #1e293b;
+      --bg-input:     #f8fafc;
+      --bg-input-focus: #ffffff;
+      --border:       #e2e8f0;
+      --border-focus: #6366f1;
+      --text-primary: #1e293b;
+      --text-muted:   #94a3b8;
+      --text-nav:     #cbd5e1;
+      --accent:       #6366f1;
+      --accent-hover: #4f46e5;
+      --accent-grad:  linear-gradient(135deg, #667eea, #764ba2);
+      --success:      #10b981;
+      --danger:       #ef4444;
+      --shadow:       0 4px 16px rgba(0,0,0,0.08);
+      --shadow-card:  0 2px 8px rgba(0,0,0,0.06);
+      --table-head:   #f8fafc;
+      --table-row-hover: #f8fafc;
+      --code-bg:      #f1f5f9;
+    }
+
+    /* ── 글래스모피즘 ─────────────────────────── */
+    [data-theme="glass"] {
+      --bg-page:      #0f3460;
+      --bg-card:      rgba(255,255,255,0.07);
+      --bg-nav:       rgba(15,20,60,0.85);
+      --bg-input:     rgba(255,255,255,0.08);
+      --bg-input-focus: rgba(255,255,255,0.14);
+      --border:       rgba(255,255,255,0.14);
+      --border-focus: #818cf8;
+      --text-primary: #e2e8f0;
+      --text-muted:   rgba(255,255,255,0.45);
+      --text-nav:     #cbd5e1;
+      --accent:       #818cf8;
+      --accent-hover: #a5b4fc;
+      --accent-grad:  linear-gradient(135deg, #6366f1, #ec4899);
+      --success:      #10b981;
+      --danger:       #ef4444;
+      --shadow:       0 8px 32px rgba(0,0,0,0.4);
+      --shadow-card:  0 4px 20px rgba(0,0,0,0.35);
+      --table-head:   rgba(255,255,255,0.05);
+      --table-row-hover: rgba(255,255,255,0.05);
+      --code-bg:      rgba(0,0,0,0.25);
+    }
+
+    /* ── 리셋 & 기본 ──────────────────────────── */
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      margin: 0;
+      background-color: var(--bg-page);
+      color: var(--text-primary);
+      transition: background-color var(--transition), color var(--transition);
+      min-height: 100vh;
+    }
+    body[data-theme="glass"] {
+      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+      background-attachment: fixed;
+    }
+
+    /* ── 네비게이션 ───────────────────────────── */
+    nav {
+      background: var(--bg-nav);
+      color: var(--text-nav);
+      padding: 0 2rem;
+      display: flex;
+      align-items: center;
+      gap: 2rem;
+      height: 56px;
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      box-shadow: 0 1px 0 rgba(255,255,255,0.06), var(--shadow);
+      backdrop-filter: blur(12px);
+    }
+    .nav-logo {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      text-decoration: none;
+      color: #fff;
+    }
+    .nav-logo-icon {
+      width: 28px;
+      height: 28px;
+      background: var(--accent-grad);
+      border-radius: 7px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      flex-shrink: 0;
+    }
+    .nav-logo strong { font-size: 15px; letter-spacing: -.2px; }
+    nav a.nav-link {
+      color: var(--text-muted);
+      text-decoration: none;
+      font-size: 14px;
+      transition: color var(--transition);
+    }
+    nav a.nav-link:hover { color: var(--text-nav); }
+    .nav-spacer { flex: 1; }
+
+    /* ── 테마 스위처 ──────────────────────────── */
+    .theme-switcher {
+      position: relative;
+    }
+    .theme-btn {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      background: rgba(255,255,255,0.08);
+      border: 1px solid rgba(255,255,255,0.12);
+      color: var(--text-nav);
+      padding: 6px 12px;
+      border-radius: 20px;
+      cursor: pointer;
+      font-size: 13px;
+      transition: background var(--transition), border-color var(--transition);
+      white-space: nowrap;
+    }
+    .theme-btn:hover {
+      background: rgba(255,255,255,0.14);
+      border-color: rgba(255,255,255,0.2);
+    }
+    .theme-btn .chevron {
+      font-size: 10px;
+      opacity: 0.6;
+      transition: transform var(--transition);
+    }
+    .theme-switcher.open .chevron { transform: rotate(180deg); }
+    .theme-dropdown {
+      display: none;
+      position: absolute;
+      right: 0;
+      top: calc(100% + 8px);
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-card);
+      box-shadow: var(--shadow);
+      min-width: 180px;
+      overflow: hidden;
+      z-index: 200;
+    }
+    .theme-switcher.open .theme-dropdown { display: block; }
+    body[data-theme="glass"] .theme-dropdown {
+      backdrop-filter: blur(20px);
+    }
+    .theme-option {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 14px;
+      cursor: pointer;
+      font-size: 13px;
+      color: var(--text-primary);
+      transition: background var(--transition);
+    }
+    .theme-option:hover { background: rgba(99,102,241,0.12); }
+    .theme-option.active {
+      color: var(--accent);
+      background: rgba(99,102,241,0.1);
+      font-weight: 600;
+    }
+    .theme-option.active::after {
+      content: '✓';
+      margin-left: auto;
+      font-size: 12px;
+    }
+
+    /* ── 레이아웃 ──────────────────────────────── */
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+
+    /* ── 카드 ──────────────────────────────────── */
+    .card {
+      background: var(--bg-card);
+      border-radius: var(--radius-card);
+      padding: 1.5rem;
+      margin-bottom: 1.25rem;
+      box-shadow: var(--shadow-card);
+      border: 1px solid var(--border);
+      transition: background var(--transition), border-color var(--transition);
+    }
+    body[data-theme="glass"] .card {
+      backdrop-filter: blur(16px);
+    }
+
+    /* ── 등급 배지 ─────────────────────────────── */
+    .grade {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      border-radius: 6px;
+      font-weight: 700;
+      font-size: 13px;
+    }
+    .grade-A { background: rgba(16,185,129,0.15); color: #10b981; }
+    .grade-B { background: rgba(59,130,246,0.15); color: #3b82f6; }
+    .grade-C { background: rgba(245,158,11,0.15); color: #f59e0b; }
+    .grade-D { background: rgba(249,115,22,0.15); color: #f97316; }
+    .grade-F { background: rgba(239,68,68,0.15);  color: #ef4444; }
+
+    /* ── 테이블 ────────────────────────────────── */
     table { width: 100%; border-collapse: collapse; }
-    th, td { padding: .75rem; text-align: left; border-bottom: 1px solid #eee; }
-    th { background: #f8f9fa; font-weight: 600; }
-    .btn { padding: .4rem 1rem; border-radius: 4px; border: none; cursor: pointer; }
-    .btn-primary { background: #0066cc; color: white; }
+    th {
+      padding: .75rem 1rem;
+      text-align: left;
+      background: var(--table-head);
+      color: var(--text-muted);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: .05em;
+      border-bottom: 1px solid var(--border);
+    }
+    td {
+      padding: .875rem 1rem;
+      border-bottom: 1px solid var(--border);
+      font-size: 14px;
+      color: var(--text-primary);
+    }
+    tbody tr:last-child td { border-bottom: none; }
+    tbody tr:hover td { background: var(--table-row-hover); }
+    tbody tr { transition: background var(--transition); }
+
+    /* ── 링크 ──────────────────────────────────── */
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { color: var(--accent-hover); text-decoration: underline; }
+
+    /* ── 버튼 ──────────────────────────────────── */
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: .5rem 1.25rem;
+      border-radius: var(--radius-btn);
+      border: none;
+      cursor: pointer;
+      font-size: 14px;
+      font-weight: 600;
+      transition: all var(--transition);
+    }
+    .btn-primary {
+      background: var(--accent-grad);
+      color: #fff;
+      box-shadow: 0 2px 8px rgba(99,102,241,0.35);
+    }
+    .btn-primary:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 16px rgba(99,102,241,0.5);
+    }
+    .btn-ghost {
+      background: transparent;
+      color: var(--text-muted);
+      border: 1px solid var(--border);
+    }
+    .btn-ghost:hover {
+      border-color: var(--accent);
+      color: var(--accent);
+    }
+
+    /* ── 페이지 헤더 ───────────────────────────── */
+    .page-header {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1.75rem;
+    }
+    .page-header h2 {
+      margin: 0;
+      font-size: 1.4rem;
+      font-weight: 700;
+      color: var(--text-primary);
+    }
+    .page-header .subtitle {
+      font-size: 13px;
+      color: var(--text-muted);
+      margin-top: 2px;
+    }
+    .back-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--text-muted);
+      font-size: 13px;
+      text-decoration: none;
+      padding: 4px 10px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      transition: all var(--transition);
+      flex-shrink: 0;
+    }
+    .back-btn:hover {
+      color: var(--text-primary);
+      border-color: var(--accent);
+      text-decoration: none;
+    }
+
+    /* ── 코드 ──────────────────────────────────── */
+    code {
+      background: var(--code-bg);
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-family: 'Menlo', 'Consolas', monospace;
+      color: var(--accent-hover);
+      border: 1px solid var(--border);
+    }
+
+    /* ── 섹션 제목 ─────────────────────────────── */
+    .section-title {
+      font-size: 11px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--text-muted);
+      margin: 0 0 1rem;
+    }
   </style>
 </head>
-<body>
+<body data-theme="dark">
   <nav>
-    <strong>SCAManager</strong>
-    <a href="/">Overview</a>
+    <a class="nav-logo" href="/">
+      <div class="nav-logo-icon">⚡</div>
+      <strong>SCAManager</strong>
+    </a>
+    <a class="nav-link" href="/">Overview</a>
+    <div class="nav-spacer"></div>
+    <div class="theme-switcher" id="themeSwitcher">
+      <button class="theme-btn" id="themeToggle" aria-label="테마 변경">
+        <span id="themeIcon">🌙</span>
+        <span id="themeName">다크</span>
+        <span class="chevron">▾</span>
+      </button>
+      <div class="theme-dropdown" id="themeDropdown">
+        <div class="theme-option" data-theme="dark">🌙 다크 대시보드</div>
+        <div class="theme-option" data-theme="light">☀️ 클린 카드</div>
+        <div class="theme-option" data-theme="glass">✨ 글래스모피즘</div>
+      </div>
+    </div>
   </nav>
   <div class="container">{% block content %}{% endblock %}</div>
   {% block scripts %}{% endblock %}
+  <script>
+    const THEMES = {
+      dark:  { icon: '🌙', name: '다크' },
+      light: { icon: '☀️', name: '클린' },
+      glass: { icon: '✨', name: '글래스' }
+    };
+    function applyTheme(theme) {
+      if (!THEMES[theme]) theme = 'dark';
+      document.body.dataset.theme = theme;
+      localStorage.setItem('sca-theme', theme);
+      document.getElementById('themeIcon').textContent = THEMES[theme].icon;
+      document.getElementById('themeName').textContent = THEMES[theme].name;
+      document.querySelectorAll('.theme-option').forEach(el => {
+        el.classList.toggle('active', el.dataset.theme === theme);
+      });
+      document.dispatchEvent(new CustomEvent('themechange', { detail: theme }));
+    }
+    // 초기화
+    applyTheme(localStorage.getItem('sca-theme') || 'dark');
+    // 드롭다운 토글
+    const switcher = document.getElementById('themeSwitcher');
+    document.getElementById('themeToggle').addEventListener('click', e => {
+      e.stopPropagation();
+      switcher.classList.toggle('open');
+    });
+    document.querySelectorAll('.theme-option').forEach(el => {
+      el.addEventListener('click', () => {
+        applyTheme(el.dataset.theme);
+        switcher.classList.remove('open');
+      });
+    });
+    document.addEventListener('click', () => switcher.classList.remove('open'));
+  </script>
 </body>
 </html>

--- a/src/templates/overview.html
+++ b/src/templates/overview.html
@@ -1,25 +1,152 @@
 {% extends "base.html" %}
 {% block title %}Overview — SCAManager{% endblock %}
 {% block content %}
-<h2>리포지토리 현황</h2>
+<style>
+  .overview-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1.75rem;
+  }
+  .overview-header h2 {
+    margin: 0;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+  .repo-count {
+    font-size: 13px;
+    color: var(--text-muted);
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    padding: 4px 12px;
+    border-radius: 20px;
+  }
+  .repo-link {
+    font-weight: 600;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-primary);
+    text-decoration: none;
+  }
+  .repo-link:hover { color: var(--accent); text-decoration: none; }
+  .repo-link::before {
+    content: '';
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--success);
+    flex-shrink: 0;
+  }
+  .score-cell {
+    font-weight: 700;
+    font-size: 15px;
+    color: var(--text-primary);
+  }
+  .score-cell.score-high { color: var(--success); }
+  .score-cell.score-mid  { color: #f59e0b; }
+  .score-cell.score-low  { color: var(--danger); }
+  .analysis-count {
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .settings-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 4px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    transition: all var(--transition);
+  }
+  .settings-link:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    text-decoration: none;
+  }
+  .empty-state {
+    text-align: center;
+    padding: 4rem 2rem;
+  }
+  .empty-state .empty-icon {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+    opacity: 0.5;
+  }
+  .empty-state p {
+    color: var(--text-muted);
+    margin: 0;
+    font-size: 14px;
+    line-height: 1.6;
+  }
+  .empty-state code {
+    font-size: 12px;
+  }
+</style>
+
+<div class="overview-header">
+  <h2>리포지토리 현황</h2>
+  {% if repos %}
+  <span class="repo-count">{{ repos | length }}개 리포</span>
+  {% endif %}
+</div>
+
 {% if repos %}
-<div class="card">
+<div class="card" style="padding:0;overflow:hidden;">
   <table>
-    <thead><tr><th>리포지토리</th><th>분석 수</th><th>최근 점수</th><th>등급</th><th></th></tr></thead>
+    <thead>
+      <tr>
+        <th>리포지토리</th>
+        <th>분석 수</th>
+        <th>최근 점수</th>
+        <th>등급</th>
+        <th></th>
+      </tr>
+    </thead>
     <tbody>
     {% for item in repos %}
     <tr>
-      <td><a href="/repos/{{ item.full_name }}">{{ item.full_name }}</a></td>
-      <td>{{ item.analysis_count }}</td>
-      <td>{{ item.latest_score if item.latest_score is not none else "—" }}</td>
-      <td>{% if item.latest_grade %}<span class="grade grade-{{ item.latest_grade }}">{{ item.latest_grade }}</span>{% endif %}</td>
-      <td><a href="/repos/{{ item.full_name }}/settings">설정</a></td>
+      <td>
+        <a class="repo-link" href="/repos/{{ item.full_name }}">{{ item.full_name }}</a>
+      </td>
+      <td>
+        <span class="analysis-count">{{ item.analysis_count }}회</span>
+      </td>
+      <td>
+        {% if item.latest_score is not none %}
+        <span class="score-cell {% if item.latest_score >= 75 %}score-high{% elif item.latest_score >= 50 %}score-mid{% else %}score-low{% endif %}">
+          {{ item.latest_score }}
+        </span>
+        {% else %}
+        <span style="color:var(--text-muted)">—</span>
+        {% endif %}
+      </td>
+      <td>
+        {% if item.latest_grade %}
+        <span class="grade grade-{{ item.latest_grade }}">{{ item.latest_grade }}</span>
+        {% endif %}
+      </td>
+      <td>
+        <a class="settings-link" href="/repos/{{ item.full_name }}/settings">⚙️ 설정</a>
+      </td>
     </tr>
     {% endfor %}
     </tbody>
   </table>
 </div>
 {% else %}
-<div class="card"><p>등록된 리포지토리가 없습니다. GitHub Webhook을 설정하면 자동으로 등록됩니다.</p></div>
+<div class="card">
+  <div class="empty-state">
+    <div class="empty-icon">🔗</div>
+    <p>등록된 리포지토리가 없습니다.<br>
+      GitHub Webhook을 설정하면 자동으로 등록됩니다.</p>
+  </div>
+</div>
 {% endif %}
 {% endblock %}

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -1,19 +1,140 @@
 {% extends "base.html" %}
 {% block title %}{{ repo_name }} — SCAManager{% endblock %}
 {% block content %}
-<h2>{{ repo_name }}</h2>
-<div class="card"><canvas id="scoreChart" height="80"></canvas></div>
-<div class="card">
-  <h3>분석 이력</h3>
+<style>
+  .detail-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.75rem;
+  }
+  .detail-header-text h2 {
+    margin: 0 0 4px;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--text-primary);
+    font-family: 'Menlo', 'Consolas', monospace;
+  }
+  .chart-card {
+    padding: 1.25rem 1.5rem;
+  }
+  .chart-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+    color: var(--text-muted);
+    margin-bottom: .75rem;
+  }
+  .history-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+  .history-header h3 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+  .history-count {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .commit-sha {
+    font-family: 'Menlo', 'Consolas', monospace;
+    font-size: 12px;
+    color: var(--text-muted);
+    background: var(--code-bg);
+    padding: 2px 6px;
+    border-radius: 4px;
+    border: 1px solid var(--border);
+  }
+  .pr-badge {
+    font-size: 12px;
+    color: var(--accent);
+    font-weight: 600;
+  }
+  .score-val {
+    font-weight: 700;
+    font-size: 15px;
+  }
+  .score-val.high { color: var(--success); }
+  .score-val.mid  { color: #f59e0b; }
+  .score-val.low  { color: var(--danger); }
+  .date-cell {
+    font-size: 13px;
+    color: var(--text-muted);
+  }
+  .settings-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--text-muted);
+    text-decoration: none;
+    padding: 5px 12px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    transition: all var(--transition);
+    margin-left: auto;
+  }
+  .settings-btn:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    text-decoration: none;
+  }
+</style>
+
+<!-- 헤더 -->
+<div class="detail-header">
+  <a class="back-btn" href="/">← 목록</a>
+  <div class="detail-header-text">
+    <h2>{{ repo_name }}</h2>
+  </div>
+  <a class="settings-btn" href="/repos/{{ repo_name }}/settings">⚙️ 설정</a>
+</div>
+
+<!-- 점수 차트 -->
+<div class="card chart-card">
+  <div class="chart-label">점수 추이</div>
+  <canvas id="scoreChart" height="80"></canvas>
+</div>
+
+<!-- 분석 이력 -->
+<div class="card" style="padding:1.25rem 1.5rem;">
+  <div class="history-header">
+    <h3>분석 이력</h3>
+    <span class="history-count">최근 {{ analyses | length }}건</span>
+  </div>
   <table>
-    <thead><tr><th>날짜</th><th>커밋</th><th>PR</th><th>점수</th><th>등급</th></tr></thead>
+    <thead>
+      <tr>
+        <th>날짜</th>
+        <th>커밋</th>
+        <th>PR</th>
+        <th>점수</th>
+        <th>등급</th>
+      </tr>
+    </thead>
     <tbody>
     {% for a in analyses %}
     <tr>
-      <td>{{ a.created_at[:10] if a.created_at else "—" }}</td>
-      <td><code>{{ a.commit_sha[:7] }}</code></td>
-      <td>{% if a.pr_number %}#{{ a.pr_number }}{% else %}—{% endif %}</td>
-      <td>{{ a.score }}</td>
+      <td class="date-cell">{{ a.created_at[:10] if a.created_at else "—" }}</td>
+      <td><span class="commit-sha">{{ a.commit_sha[:7] }}</span></td>
+      <td>
+        {% if a.pr_number %}
+        <span class="pr-badge">#{{ a.pr_number }}</span>
+        {% else %}
+        <span style="color:var(--text-muted)">—</span>
+        {% endif %}
+      </td>
+      <td>
+        <span class="score-val {% if a.score >= 75 %}high{% elif a.score >= 50 %}mid{% else %}low{% endif %}">
+          {{ a.score }}
+        </span>
+      </td>
       <td><span class="grade grade-{{ a.grade }}">{{ a.grade }}</span></td>
     </tr>
     {% endfor %}
@@ -21,18 +142,72 @@
   </table>
 </div>
 {% endblock %}
+
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 <script>
-new Chart(document.getElementById('scoreChart'), {
-  type: 'line',
-  data: {
-    labels: {{ chart_labels | tojson }},
-    datasets: [{ label: '점수', data: {{ chart_scores | tojson }},
-      borderColor: '#0066cc', backgroundColor: 'rgba(0,102,204,0.1)',
-      tension: 0.3, fill: true }]
-  },
-  options: { scales: { y: { min: 0, max: 100 } }, plugins: { legend: { display: false } } }
-});
+  function getThemeColors() {
+    const s = getComputedStyle(document.body);
+    const accent  = s.getPropertyValue('--accent').trim()  || '#6366f1';
+    const muted   = s.getPropertyValue('--text-muted').trim() || '#64748b';
+    const border  = s.getPropertyValue('--border').trim()  || '#2d3748';
+    return { accent, muted, border };
+  }
+
+  let chart;
+  function buildChart() {
+    const { accent, muted, border } = getThemeColors();
+    const ctx = document.getElementById('scoreChart');
+    if (chart) chart.destroy();
+    chart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: {{ chart_labels | tojson }},
+        datasets: [{
+          label: '점수',
+          data: {{ chart_scores | tojson }},
+          borderColor: accent,
+          backgroundColor: accent + '22',
+          borderWidth: 2,
+          pointBackgroundColor: accent,
+          pointBorderColor: '#fff',
+          pointBorderWidth: 2,
+          pointRadius: 4,
+          pointHoverRadius: 6,
+          tension: 0.35,
+          fill: true
+        }]
+      },
+      options: {
+        scales: {
+          y: {
+            min: 0, max: 100,
+            grid: { color: border + '66' },
+            ticks: { color: muted, font: { size: 11 } }
+          },
+          x: {
+            grid: { display: false },
+            ticks: { color: muted, font: { size: 11 }, maxTicksLimit: 8 }
+          }
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: {
+            backgroundColor: 'rgba(0,0,0,0.75)',
+            titleColor: '#fff',
+            bodyColor: '#e2e8f0',
+            padding: 10,
+            cornerRadius: 8
+          }
+        },
+        responsive: true,
+        maintainAspectRatio: true
+      }
+    });
+  }
+
+  buildChart();
+  // 테마 변경 시 차트 색상 재빌드
+  document.addEventListener('themechange', buildChart);
 </script>
 {% endblock %}

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -1,42 +1,467 @@
 {% extends "base.html" %}
 {% block title %}설정 — {{ repo_name }}{% endblock %}
 {% block content %}
-<h2>{{ repo_name }} 설정</h2>
-<div class="card">
+<style>
+  /* ── 설정 페이지 전용 ─────────────────────── */
+  .settings-layout {
+    max-width: 680px;
+  }
+
+  /* 페이지 헤더 */
+  .settings-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+    margin-bottom: 2rem;
+  }
+  .settings-header-text h2 {
+    margin: 0 0 4px;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--text-primary);
+  }
+  .settings-header-text .repo-path {
+    font-size: 13px;
+    color: var(--text-muted);
+    font-family: 'Menlo', 'Consolas', monospace;
+  }
+
+  /* 설정 카드 공통 */
+  .settings-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-card);
+    margin-bottom: 1.25rem;
+    overflow: hidden;
+    box-shadow: var(--shadow-card);
+    transition: background var(--transition), border-color var(--transition);
+  }
+  body[data-theme="glass"] .settings-card {
+    backdrop-filter: blur(16px);
+  }
+  .settings-card-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 1.125rem 1.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+  .settings-card-icon {
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    background: rgba(99,102,241,0.15);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 15px;
+    flex-shrink: 0;
+  }
+  .settings-card-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text-primary);
+    margin: 0;
+  }
+  .settings-card-desc {
+    font-size: 12px;
+    color: var(--text-muted);
+    margin: 2px 0 0;
+  }
+  .settings-card-body {
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+  }
+
+  /* Gate 모드 버튼 그룹 */
+  .gate-mode-group {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+  }
+  .gate-mode-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 6px;
+    padding: 12px 8px;
+    border-radius: 10px;
+    border: 1.5px solid var(--border);
+    background: var(--bg-input);
+    cursor: pointer;
+    transition: all var(--transition);
+    color: var(--text-muted);
+    font-size: 12px;
+    font-weight: 600;
+    text-align: center;
+    line-height: 1.3;
+  }
+  .gate-mode-btn .gm-icon {
+    font-size: 20px;
+    line-height: 1;
+  }
+  .gate-mode-btn:hover {
+    border-color: var(--accent);
+    color: var(--text-primary);
+    background: rgba(99,102,241,0.08);
+  }
+  .gate-mode-btn.active {
+    border-color: var(--accent);
+    background: rgba(99,102,241,0.14);
+    color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(99,102,241,0.15);
+  }
+  body[data-theme="glass"] .gate-mode-btn.active {
+    box-shadow: 0 0 0 3px rgba(129,140,248,0.2);
+  }
+
+  /* 슬라이더 행 */
+  .slider-row {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .slider-label-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .slider-label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+  .slider-badge {
+    font-size: 14px;
+    font-weight: 700;
+    min-width: 36px;
+    text-align: right;
+  }
+  .slider-badge.approve { color: var(--success); }
+  .slider-badge.reject  { color: var(--danger); }
+  input[type="range"] {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--border);
+    outline: none;
+    transition: background var(--transition);
+  }
+  input[type="range"]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--accent-grad);
+    cursor: pointer;
+    box-shadow: 0 2px 6px rgba(99,102,241,0.4);
+    transition: transform var(--transition), box-shadow var(--transition);
+  }
+  input[type="range"]::-webkit-slider-thumb:hover {
+    transform: scale(1.2);
+    box-shadow: 0 3px 10px rgba(99,102,241,0.5);
+  }
+  input[type="range"].approve-slider::-webkit-slider-thumb { background: linear-gradient(135deg, #10b981, #34d399); box-shadow: 0 2px 6px rgba(16,185,129,0.4); }
+  input[type="range"].reject-slider::-webkit-slider-thumb  { background: linear-gradient(135deg, #ef4444, #f87171); box-shadow: 0 2px 6px rgba(239,68,68,0.4); }
+  .slider-range-hint {
+    display: flex;
+    justify-content: space-between;
+    font-size: 10px;
+    color: var(--text-muted);
+    margin-top: -4px;
+  }
+
+  /* 토글 스위치 */
+  .toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+  .toggle-label-group { flex: 1; }
+  .toggle-label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    display: block;
+    margin-bottom: 2px;
+  }
+  .toggle-hint {
+    font-size: 12px;
+    color: var(--text-muted);
+    line-height: 1.4;
+  }
+  .toggle-switch {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+  .toggle-switch input[type="checkbox"] {
+    width: 0;
+    height: 0;
+    opacity: 0;
+    position: absolute;
+  }
+  .toggle-track {
+    width: 44px;
+    height: 24px;
+    background: var(--border);
+    border-radius: 12px;
+    cursor: pointer;
+    transition: background var(--transition);
+    position: relative;
+    display: block;
+  }
+  .toggle-track::after {
+    content: '';
+    position: absolute;
+    top: 3px;
+    left: 3px;
+    width: 18px;
+    height: 18px;
+    background: #fff;
+    border-radius: 50%;
+    transition: transform var(--transition);
+    box-shadow: 0 1px 4px rgba(0,0,0,0.3);
+  }
+  .toggle-switch input:checked + .toggle-track {
+    background: var(--success);
+  }
+  .toggle-switch input:checked + .toggle-track::after {
+    transform: translateX(20px);
+  }
+
+  /* 입력 필드 */
+  .field-row {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .field-label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .field-tag {
+    font-size: 10px;
+    font-weight: 600;
+    padding: 2px 6px;
+    border-radius: 4px;
+    background: rgba(99,102,241,0.12);
+    color: var(--accent);
+    letter-spacing: .04em;
+  }
+  .field-hint {
+    font-size: 12px;
+    color: var(--text-muted);
+  }
+  .field-input {
+    width: 100%;
+    padding: .625rem .875rem;
+    border-radius: 8px;
+    border: 1.5px solid var(--border);
+    background: var(--bg-input);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: 'Menlo', 'Consolas', monospace;
+    transition: border-color var(--transition), background var(--transition), box-shadow var(--transition);
+    outline: none;
+  }
+  .field-input:focus {
+    border-color: var(--border-focus);
+    background: var(--bg-input-focus);
+    box-shadow: 0 0 0 3px rgba(99,102,241,0.15);
+  }
+  .field-input::placeholder { color: var(--text-muted); opacity: 0.7; }
+
+  /* 저장 버튼 영역 */
+  .settings-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+    margin-top: .5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border);
+  }
+  .btn-save {
+    padding: .65rem 2rem;
+    font-size: 14px;
+    font-weight: 700;
+    background: var(--accent-grad);
+    color: #fff;
+    border: none;
+    border-radius: var(--radius-btn);
+    cursor: pointer;
+    box-shadow: 0 2px 12px rgba(99,102,241,0.4);
+    transition: all var(--transition);
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .btn-save:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(99,102,241,0.5);
+  }
+  .btn-save:active { transform: translateY(0); }
+</style>
+
+<div class="settings-layout">
+  <!-- 헤더 -->
+  <div class="settings-header">
+    <a class="back-btn" href="/repos/{{ repo_name }}">← 상세</a>
+    <div class="settings-header-text">
+      <h2>⚙️ 설정</h2>
+      <div class="repo-path">{{ repo_name }}</div>
+    </div>
+  </div>
+
   <form method="post" action="/repos/{{ repo_name }}/settings">
-    <div style="margin-bottom:1rem">
-      <label><strong>Gate 모드</strong></label><br>
-      <select name="gate_mode" style="padding:.4rem;margin-top:.3rem">
-        <option value="disabled" {% if config.gate_mode == "disabled" %}selected{% endif %}>비활성화</option>
-        <option value="auto" {% if config.gate_mode == "auto" %}selected{% endif %}>자동</option>
-        <option value="semi-auto" {% if config.gate_mode == "semi-auto" %}selected{% endif %}>반자동 (Telegram)</option>
-      </select>
+    <!-- Hidden: gate_mode (JS로 관리) -->
+    <input type="hidden" name="gate_mode" id="gateModeValue" value="{{ config.gate_mode }}">
+
+    <!-- ① Gate 엔진 카드 -->
+    <div class="settings-card">
+      <div class="settings-card-header">
+        <div class="settings-card-icon">⚡</div>
+        <div>
+          <div class="settings-card-title">Gate 엔진</div>
+          <div class="settings-card-desc">PR 승인/반려 자동화 설정</div>
+        </div>
+      </div>
+      <div class="settings-card-body">
+
+        <!-- Gate 모드 선택 -->
+        <div>
+          <div class="section-title" style="margin-bottom:.75rem;">Gate 모드</div>
+          <div class="gate-mode-group">
+            <div class="gate-mode-btn {% if config.gate_mode == 'disabled' %}active{% endif %}"
+                 data-mode="disabled" onclick="setGateMode('disabled')">
+              <span class="gm-icon">🚫</span>
+              비활성
+            </div>
+            <div class="gate-mode-btn {% if config.gate_mode == 'auto' %}active{% endif %}"
+                 data-mode="auto" onclick="setGateMode('auto')">
+              <span class="gm-icon">⚡</span>
+              자동
+            </div>
+            <div class="gate-mode-btn {% if config.gate_mode == 'semi-auto' %}active{% endif %}"
+                 data-mode="semi-auto" onclick="setGateMode('semi-auto')">
+              <span class="gm-icon">📱</span>
+              반자동
+            </div>
+          </div>
+        </div>
+
+        <!-- 승인 임계값 슬라이더 -->
+        <div class="slider-row">
+          <div class="slider-label-row">
+            <span class="slider-label">자동 승인 임계값</span>
+            <span class="slider-badge approve" id="approveVal">{{ config.auto_approve_threshold }}</span>
+          </div>
+          <input type="range" class="approve-slider" name="auto_approve_threshold"
+                 min="0" max="100" value="{{ config.auto_approve_threshold }}"
+                 oninput="document.getElementById('approveVal').textContent=this.value">
+          <div class="slider-range-hint"><span>0</span><span>100</span></div>
+        </div>
+
+        <!-- 반려 임계값 슬라이더 -->
+        <div class="slider-row">
+          <div class="slider-label-row">
+            <span class="slider-label">자동 반려 임계값</span>
+            <span class="slider-badge reject" id="rejectVal">{{ config.auto_reject_threshold }}</span>
+          </div>
+          <input type="range" class="reject-slider" name="auto_reject_threshold"
+                 min="0" max="100" value="{{ config.auto_reject_threshold }}"
+                 oninput="document.getElementById('rejectVal').textContent=this.value">
+          <div class="slider-range-hint"><span>0</span><span>100</span></div>
+        </div>
+
+      </div>
     </div>
-    <div style="margin-bottom:1rem">
-      <label><strong>자동 승인 임계값</strong></label><br>
-      <input type="number" name="auto_approve_threshold" value="{{ config.auto_approve_threshold }}" min="0" max="100" style="padding:.4rem;margin-top:.3rem">
+
+    <!-- ② 자동 Merge 카드 -->
+    <div class="settings-card">
+      <div class="settings-card-header">
+        <div class="settings-card-icon">🔀</div>
+        <div>
+          <div class="settings-card-title">자동 Merge</div>
+          <div class="settings-card-desc">승인 후 PR을 자동으로 병합합니다</div>
+        </div>
+      </div>
+      <div class="settings-card-body">
+        <div class="toggle-row">
+          <div class="toggle-label-group">
+            <span class="toggle-label">PR 자동 Merge</span>
+            <span class="toggle-hint">Gate 승인 시 squash merge를 자동 실행합니다.<br>
+              <code style="font-size:11px;">pull_requests: write</code> 권한 필요</span>
+          </div>
+          <label class="toggle-switch">
+            <input type="checkbox" name="auto_merge" value="on"
+                   {% if config.auto_merge %}checked{% endif %}>
+            <span class="toggle-track"></span>
+          </label>
+        </div>
+      </div>
     </div>
-    <div style="margin-bottom:1rem">
-      <label><strong>자동 반려 임계값</strong></label><br>
-      <input type="number" name="auto_reject_threshold" value="{{ config.auto_reject_threshold }}" min="0" max="100" style="padding:.4rem;margin-top:.3rem">
+
+    <!-- ③ 알림 설정 카드 -->
+    <div class="settings-card">
+      <div class="settings-card-header">
+        <div class="settings-card-icon">🔔</div>
+        <div>
+          <div class="settings-card-title">알림 설정</div>
+          <div class="settings-card-desc">Telegram 반자동 게이트 및 n8n 웹훅</div>
+        </div>
+      </div>
+      <div class="settings-card-body">
+
+        <div class="field-row">
+          <label class="field-label">
+            Telegram Chat ID
+            <span class="field-tag">반자동 모드</span>
+          </label>
+          <span class="field-hint">반자동 Gate에서 승인 요청을 보낼 채팅 ID</span>
+          <input class="field-input" type="text" name="notify_chat_id"
+                 value="{{ config.notify_chat_id or '' }}"
+                 placeholder="-100xxxxxxxxx">
+        </div>
+
+        <div class="field-row">
+          <label class="field-label">
+            n8n Webhook URL
+            <span class="field-tag">선택</span>
+          </label>
+          <span class="field-hint">분석 완료 시 n8n 워크플로우로 결과를 전달합니다</span>
+          <input class="field-input" type="url" name="n8n_webhook_url"
+                 value="{{ config.n8n_webhook_url or '' }}"
+                 placeholder="https://n8n.example.com/webhook/...">
+        </div>
+
+      </div>
     </div>
-    <div style="margin-bottom:1rem">
-      <label><strong>Telegram Chat ID (반자동 모드)</strong></label><br>
-      <input type="text" name="notify_chat_id" value="{{ config.notify_chat_id or '' }}" placeholder="-100xxxxxxxxx" style="padding:.4rem;margin-top:.3rem;width:300px">
+
+    <!-- 저장 버튼 -->
+    <div class="settings-actions">
+      <a class="btn btn-ghost" href="/repos/{{ repo_name }}">취소</a>
+      <button type="submit" class="btn-save">💾 설정 저장</button>
     </div>
-    <div style="margin-bottom:1rem">
-      <label><strong>n8n Webhook URL</strong></label><br>
-      <input type="url" name="n8n_webhook_url" value="{{ config.n8n_webhook_url or '' }}" placeholder="https://n8n.example.com/webhook/..." style="padding:.4rem;margin-top:.3rem;width:400px">
-    </div>
-    <div style="margin-bottom:1rem">
-      <label><strong>PR 자동 Merge</strong></label><br>
-      <label style="margin-top:.3rem;display:inline-flex;align-items:center;gap:.4rem">
-        <input type="checkbox" name="auto_merge" value="on"
-               {% if config.auto_merge %}checked{% endif %}>
-        승인 시 자동으로 PR을 Merge합니다 (squash merge)
-      </label>
-    </div>
-    <button type="submit" class="btn btn-primary">저장</button>
+
   </form>
 </div>
+
+<script>
+  function setGateMode(mode) {
+    document.getElementById('gateModeValue').value = mode;
+    document.querySelectorAll('.gate-mode-btn').forEach(btn => {
+      btn.classList.toggle('active', btn.dataset.mode === mode);
+    });
+  }
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- **3-테마 CSS 변수 시스템**: 다크 대시보드 / 클린 카드(라이트) / 글래스모피즘을 navbar 드롭다운으로 전환, localStorage에 저장
- **설정 페이지 리디자인**: Gate 모드 버튼 토글, 임계값 슬라이더 + 실시간 배지, auto_merge CSS 슬라이드 스위치
- **E2E 테스트 26개**: Playwright + uvicorn 스레드 서버로 JS 동작 검증 (테마 전환, 설정 폼, 네비게이션)
- **버그 수정**: `src/database.py` SQLite URL에 `hostaddr` 전달하던 오류 해결 (E2E 서버 500 오류 원인)

## Test plan

- [x] `make test` — 기존 단위 테스트 146개 통과
- [x] `make test-e2e` — Playwright E2E 테스트 26개 전체 통과
- [x] `src/database.py` SQLite 경로 수정 후 단위 테스트 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)