### PR TITLE
feat: overview 평균 점수 표시 + 전체 페이지 모바일 반응형 CSS

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -363,6 +363,35 @@
       color: var(--text-muted);
       margin: 0 0 1rem;
     }
+
+    /* ── 테이블 스크롤 래퍼 ────────────────────── */
+    .table-wrap {
+      overflow-x: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+
+    /* ── 모바일 반응형 (태블릿) ────────────────── */
+    @media (max-width: 768px) {
+      nav { padding: 0 1rem; gap: 1rem; }
+      .container { padding: 1.25rem 0.75rem; }
+      .card { padding: 1rem; border-radius: 8px; }
+      th { padding: .5rem .625rem; font-size: 11px; }
+      td { padding: .625rem; font-size: 13px; }
+      .page-header { flex-wrap: wrap; gap: .75rem; }
+      .page-header h2 { font-size: 1.2rem; }
+      .back-btn { padding: 3px 8px; font-size: 12px; }
+      .btn { padding: .4rem 1rem; font-size: 13px; }
+    }
+
+    /* ── 모바일 반응형 (소형) ─────────────────── */
+    @media (max-width: 480px) {
+      nav { gap: 0.5rem; padding: 0 0.75rem; }
+      .nav-logo strong { display: none; }
+      .theme-btn { padding: 5px 8px; font-size: 12px; }
+      .container { padding: 1rem 0.5rem; }
+      th { padding: .4rem .5rem; }
+      td { padding: .5rem; font-size: 12px; }
+    }
   </style>
 </head>
 <body data-theme="dark">

--- a/src/templates/overview.html
+++ b/src/templates/overview.html
@@ -88,6 +88,13 @@
   .empty-state code {
     font-size: 12px;
   }
+  @media (max-width: 768px) {
+    .overview-header {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.75rem;
+    }
+  }
 </style>
 
 <div class="overview-header">
@@ -102,12 +109,14 @@
 
 {% if repos %}
 <div class="card" style="padding:0;overflow:hidden;">
+  <div class="table-wrap">
   <table>
     <thead>
       <tr>
         <th>리포지토리</th>
         <th>분석 수</th>
         <th>최근 점수</th>
+        <th>평균 점수</th>
         <th>등급</th>
         <th></th>
       </tr>
@@ -131,6 +140,15 @@
         {% endif %}
       </td>
       <td>
+        {% if item.avg_score %}
+        <span class="score-cell {% if item.avg_score >= 75 %}score-high{% elif item.avg_score >= 50 %}score-mid{% else %}score-low{% endif %}">
+          {{ item.avg_score }}
+        </span>
+        {% else %}
+        <span style="color:var(--text-muted)">—</span>
+        {% endif %}
+      </td>
+      <td>
         {% if item.latest_grade %}
         <span class="grade grade-{{ item.latest_grade }}">{{ item.latest_grade }}</span>
         {% endif %}
@@ -142,6 +160,7 @@
     {% endfor %}
     </tbody>
   </table>
+  </div>
 </div>
 {% else %}
 <div class="card">

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -85,6 +85,11 @@
     border-color: var(--accent);
     text-decoration: none;
   }
+  @media (max-width: 768px) {
+    .detail-header { flex-wrap: wrap; gap: 0.75rem; }
+    .settings-btn { margin-left: 0; }
+    .chart-card { padding: 1rem; }
+  }
 </style>
 
 <!-- 헤더 -->
@@ -108,6 +113,7 @@
     <h3>분석 이력</h3>
     <span class="history-count">최근 {{ analyses | length }}건</span>
   </div>
+  <div class="table-wrap">
   <table>
     <thead>
       <tr>
@@ -140,6 +146,7 @@
     {% endfor %}
     </tbody>
   </table>
+  </div>
 </div>
 {% endblock %}
 

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -310,6 +310,12 @@
     box-shadow: 0 6px 20px rgba(99,102,241,0.5);
   }
   .btn-save:active { transform: translateY(0); }
+  @media (max-width: 480px) {
+    .gate-mode-group { grid-template-columns: 1fr; }
+    .settings-header { flex-direction: column; gap: 0.5rem; }
+    .settings-card-body { padding: 1rem; }
+    .settings-card-header { padding: 0.875rem 1rem; }
+  }
 </style>
 
 <div class="settings-layout">

--- a/src/ui/router.py
+++ b/src/ui/router.py
@@ -94,6 +94,14 @@ def overview(request: Request, current_user: User = Depends(require_login)):
                 .all()
             )
 
+            # 평균 점수 배치 조회
+            avg_map = dict(
+                db.query(Analysis.repo_id, func.avg(Analysis.score))
+                .filter(Analysis.repo_id.in_(repo_ids))
+                .group_by(Analysis.repo_id)
+                .all()
+            )
+
             # 리포별 최신 분석 배치 조회
             latest_id_subq = (
                 db.query(func.max(Analysis.id))
@@ -111,6 +119,7 @@ def overview(request: Request, current_user: User = Depends(require_login)):
                 repo_data.append({
                     "full_name": r.full_name,
                     "analysis_count": count_map.get(r.id, 0),
+                    "avg_score": round(avg_map.get(r.id) or 0),
                     "latest_score": latest.score if latest else None,
                     "latest_grade": latest.grade if latest else None,
                 })

--- a/tests/test_ui_router.py
+++ b/tests/test_ui_router.py
@@ -55,6 +55,20 @@ def test_overview_returns_html():
     assert "text/html" in r.headers["content-type"]
 
 
+def test_overview_with_repos_shows_avg_score():
+    """리포 목록에 평균 점수(avg_score) 컬럼이 표시되어야 한다."""
+    mock_db = MagicMock()
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1, created_at="2026-01-01")
+    mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [mock_repo]
+    # count_map, avg_map → dict([]) = {}, latest_map → {}
+    mock_db.query.return_value.filter.return_value.group_by.return_value.all.return_value = []
+    mock_db.query.return_value.filter.return_value.all.return_value = []
+    with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+        r = client.get("/")
+    assert r.status_code == 200
+    assert "평균 점수" in r.text
+
+
 def test_repo_detail_returns_html():
     """로그인 후 본인 리포 상세 페이지는 200 HTML을 반환한다."""
     mock_db = MagicMock()


### PR DESCRIPTION
## Summary\n- overview 페이지에 리포별 **평균 점수** 컬럼 추가 (N+1 방지 배치 쿼리)\n- 전체 페이지 **모바일 반응형 CSS** 추가 (768px/480px 미디어 쿼리)\n- 테이블 수평 스크롤 래퍼 적용 (overview, repo_detail)\n- settings 페이지 gate mode 버튼 소형 모바일 1열 전환\n\n## Test plan\n- [x] 180개 단위 테스트 전체 통과 (신규 avg_score 테스트 포함)\n- [x] pylint + flake8 + bandit lint 통과\n- [ ] 브라우저 DevTools 모바일 에뮬레이션 (375px, 768px) 레이아웃 확인\n\nhttps://claude.ai/code/session_01NydP62noEvJjVqtcHZ2rCP