### PR TITLE
fix: Telegram 알림 누락 수정 — DB 마이그레이션 추가 + pipeline 안전망

### DIFF
--- a/alembic/versions/0007_add_notification_channels.py
+++ b/alembic/versions/0007_add_notification_channels.py
@@ -1,0 +1,27 @@
+"""add notification channel columns to repo_configs
+
+Revision ID: 0007notifychannels
+Revises: 0006phase8bgithub
+Create Date: 2026-04-08
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0007notifychannels'
+down_revision = '0006phase8bgithub'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('repo_configs', sa.Column('discord_webhook_url', sa.String(), nullable=True))
+    op.add_column('repo_configs', sa.Column('slack_webhook_url', sa.String(), nullable=True))
+    op.add_column('repo_configs', sa.Column('custom_webhook_url', sa.String(), nullable=True))
+    op.add_column('repo_configs', sa.Column('email_recipients', sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('repo_configs', 'email_recipients')
+    op.drop_column('repo_configs', 'custom_webhook_url')
+    op.drop_column('repo_configs', 'slack_webhook_url')
+    op.drop_column('repo_configs', 'discord_webhook_url')

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -46,7 +46,7 @@ def _build_notify_tasks(
     names = []
 
     # Telegram (리포 설정 우선, 없으면 global fallback)
-    tg_chat_id = repo_config.notify_chat_id or settings.telegram_chat_id
+    tg_chat_id = (repo_config.notify_chat_id if repo_config else None) or settings.telegram_chat_id
     tasks.append(send_analysis_result(
         bot_token=settings.telegram_bot_token,
         chat_id=tg_chat_id,
@@ -72,7 +72,7 @@ def _build_notify_tasks(
         names.append("github_comment")
 
     # Discord
-    if repo_config.discord_webhook_url:
+    if repo_config and repo_config.discord_webhook_url:
         tasks.append(send_discord_notification(
             webhook_url=repo_config.discord_webhook_url,
             repo_name=repo_name,
@@ -85,7 +85,7 @@ def _build_notify_tasks(
         names.append("discord")
 
     # Slack
-    if repo_config.slack_webhook_url:
+    if repo_config and repo_config.slack_webhook_url:
         tasks.append(send_slack_notification(
             webhook_url=repo_config.slack_webhook_url,
             repo_name=repo_name,
@@ -98,7 +98,7 @@ def _build_notify_tasks(
         names.append("slack")
 
     # Generic Webhook
-    if repo_config.custom_webhook_url:
+    if repo_config and repo_config.custom_webhook_url:
         tasks.append(send_webhook_notification(
             webhook_url=repo_config.custom_webhook_url,
             repo_name=repo_name,
@@ -111,7 +111,7 @@ def _build_notify_tasks(
         names.append("webhook")
 
     # Email
-    if repo_config.email_recipients and settings.smtp_host:
+    if repo_config and repo_config.email_recipients and settings.smtp_host:
         tasks.append(send_email_notification(
             recipients=repo_config.email_recipients,
             repo_name=repo_name,
@@ -128,7 +128,7 @@ def _build_notify_tasks(
         names.append("email")
 
     # n8n
-    if repo_config.n8n_webhook_url:
+    if repo_config and repo_config.n8n_webhook_url:
         tasks.append(notify_n8n(
             webhook_url=repo_config.n8n_webhook_url,
             repo_full_name=repo_name,
@@ -184,7 +184,7 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:
 
         score_result = calculate_score(analysis_results, ai_review=ai_review)
 
-        n8n_url: str | None = None
+        repo_config = None
         db = SessionLocal()
         try:
             repo = db.query(Repository).filter_by(full_name=repo_name).first()
@@ -228,7 +228,11 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:
             db.commit()
             db.refresh(analysis)
 
-            repo_config = get_repo_config(db, repo_name)
+            try:
+                repo_config = get_repo_config(db, repo_name)
+            except Exception:
+                logger.warning("Failed to load repo config for %s, using defaults", repo_name)
+                repo_config = None
 
             # Gate Engine (PR 이벤트만)
             if pr_number is not None:


### PR DESCRIPTION
## Summary\n- **Alembic 마이그레이션 0007 추가**: `discord_webhook_url`, `slack_webhook_url`, `custom_webhook_url`, `email_recipients` 컬럼을 `repo_configs` 테이블에 추가\n- **Pipeline 안전망**: `get_repo_config()` 실패 시 `repo_config=None` fallback → Telegram은 global `settings.telegram_chat_id`로 항상 발송\n- **근본 원인**: ORM 모델에 컬럼을 추가했으나 마이그레이션을 누락하여 프로덕션 DB 쿼리 실패 → 전체 파이프라인 중단\n\n## Test plan\n- [x] 223개 단위 테스트 전체 통과\n- [ ] Railway 배포 후 Telegram 알림 수신 확인\n\nhttps://claude.ai/code/session_01NydP62noEvJjVqtcHZ2rCP