### PR TITLE
fix: 분석 상세 페이지 정보 표시 개선

### DIFF
--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -187,25 +187,27 @@
 
 <!-- 메타 정보 -->
 <div class="ad-meta">
-  <span>📅 {{ analysis.created_at[:10] if analysis.created_at else "—" }}</span>
-  <span>🔗 <code style="font-size:12px">{{ analysis.commit_sha[:7] }}</code></span>
+  <span>📅 {{ analysis.created_at[:16].replace('T', ' ') if analysis.created_at else "—" }}</span>
+  <span>🔗 <code style="font-size:12px" title="{{ analysis.commit_sha }}">{{ analysis.commit_sha[:7] }}</code></span>
   {% if analysis.pr_number %}
   <span>🔀 PR #{{ analysis.pr_number }}</span>
   {% endif %}
+  <span>
+    {% if analysis.source == 'cli' %}🖥️ CLI
+    {% elif analysis.source == 'pr' %}🔀 PR
+    {% else %}📤 Push
+    {% endif %}
+  </span>
 </div>
 
 <!-- 커밋 메시지 -->
-{% if analysis.commit_message %}
 <div class="card ad-section">
   <div class="ad-section-title">📝 커밋 메시지</div>
-  <div class="commit-msg-text">{{ analysis.commit_message }}</div>
+  <div class="commit-msg-text">{{ analysis.commit_message or "(커밋 메시지 없음)" }}</div>
 </div>
-{% endif %}
-
-{% set r = analysis.result %}
-{% if r %}
 
 <!-- 점수 배너 -->
+{% if analysis.score is not none %}
 <div class="card ad-score-banner">
   <div>
     <span class="ad-score-big {% if analysis.score >= 75 %}high{% elif analysis.score >= 50 %}mid{% else %}low{% endif %}">
@@ -218,9 +220,12 @@
     <div class="ad-score-label">종합 점수</div>
   </div>
 </div>
+{% endif %}
+
+{% set r = analysis.result %}
 
 <!-- 점수 상세 -->
-{% set bd = r.get('breakdown', {}) %}
+{% set bd = r.get('breakdown', {}) if r else {} %}
 {% if bd %}
 <div class="card ad-breakdown">
   <div class="ad-section-title">📊 점수 상세</div>
@@ -244,6 +249,7 @@
 </div>
 {% endif %}
 
+{% if r %}
 <!-- AI 요약 -->
 {% if r.get('ai_summary') %}
 <div class="card ad-section">
@@ -319,8 +325,8 @@
 </div>
 {% endif %}
 
-{% else %}
-<!-- result가 없는 구버전 분석 -->
+{% elif analysis.score is none %}
+<!-- result도 없고 score도 없는 구버전 분석 -->
 <div class="card">
   <div class="ad-empty">
     <div style="font-size:2rem;margin-bottom:.75rem;opacity:0.5">📭</div>

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -85,10 +85,22 @@
     border-color: var(--accent);
     text-decoration: none;
   }
+  .commit-msg-preview {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-top: 2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
+  }
   @media (max-width: 768px) {
     .detail-header { flex-wrap: wrap; gap: 0.75rem; }
     .settings-btn { margin-left: 0; }
     .chart-card { padding: 1rem; }
+  }
+  @media (max-width: 480px) {
+    .commit-msg-preview { display: none; }
   }
 </style>
 
@@ -140,7 +152,12 @@
     <tbody>
     {% for a in analyses %}
     <tr style="cursor:pointer" onclick="location.href='/repos/{{ repo_name }}/analyses/{{ a.id }}'">
-      <td class="date-cell">{{ a.created_at[:10] if a.created_at else "—" }}</td>
+      <td class="date-cell">
+        {{ a.created_at[:10] if a.created_at else "—" }}
+        {% if a.commit_message %}
+        <div class="commit-msg-preview">{{ a.commit_message.split('\n')[0][:50] }}{% if a.commit_message|length > 50 %}…{% endif %}</div>
+        {% endif %}
+      </td>
       <td><span class="commit-sha">{{ a.commit_sha[:7] }}</span></td>
       <td>
         {% if a.pr_number %}

--- a/src/ui/router.py
+++ b/src/ui/router.py
@@ -300,6 +300,8 @@ def analysis_detail(
         ).first()
         if not analysis:
             raise HTTPException(status_code=404, detail="Analysis not found")
+        result = analysis.result or {}
+        source = result.get("source") or ("pr" if analysis.pr_number else "push")
         data = {
             "id": analysis.id,
             "commit_sha": analysis.commit_sha,
@@ -307,7 +309,8 @@ def analysis_detail(
             "pr_number": analysis.pr_number,
             "score": analysis.score,
             "grade": analysis.grade,
-            "result": analysis.result or {},
+            "result": result,
+            "source": source,
             "created_at": analysis.created_at.isoformat() if analysis.created_at else None,
         }
     return templates.TemplateResponse(request, "analysis_detail.html", {
@@ -332,6 +335,7 @@ def repo_detail(
                     .order_by(Analysis.created_at.desc()).limit(30).all())
         analyses_data = [
             {"id": a.id, "commit_sha": a.commit_sha, "pr_number": a.pr_number,
+             "commit_message": a.commit_message,
              "score": a.score, "grade": a.grade,
              "created_at": a.created_at.isoformat() if a.created_at else None}
             for a in analyses

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -213,6 +213,7 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:
                 score=score_result.total,
                 grade=score_result.grade,
                 result={
+                    "source": "pr" if pr_number else "push",
                     "breakdown": score_result.breakdown,
                     "ai_summary": ai_review.summary,
                     "ai_suggestions": ai_review.suggestions,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -211,6 +211,24 @@ async def test_db_stores_commit_message(mock_deps):
     assert analysis_added.commit_message == "feat: add awesome feature"
 
 
+async def test_db_result_stores_source_push(mock_deps):
+    """Push 이벤트 시 result에 source='push'가 저장된다."""
+    from src.worker.pipeline import run_analysis_pipeline
+    await run_analysis_pipeline("push", PUSH_DATA)
+
+    analysis_added = mock_deps["db"].add.call_args_list[-1][0][0]
+    assert analysis_added.result["source"] == "push"
+
+
+async def test_db_result_stores_source_pr(mock_deps):
+    """PR 이벤트 시 result에 source='pr'이 저장된다."""
+    from src.worker.pipeline import run_analysis_pipeline
+    await run_analysis_pipeline("pull_request", PR_DATA)
+
+    analysis_added = mock_deps["db"].add.call_args_list[-1][0][0]
+    assert analysis_added.result["source"] == "pr"
+
+
 async def test_pipeline_calls_gate_for_pr(mock_deps):
     from src.worker.pipeline import run_analysis_pipeline
     from src.analyzer.ai_review import AiReviewResult

--- a/tests/test_ui_router.py
+++ b/tests/test_ui_router.py
@@ -357,6 +357,120 @@ def test_analysis_detail_404_for_other_users_repo():
     assert r.status_code == 404
 
 
+def test_analysis_detail_shows_commit_message():
+    """분석 상세 페이지에 커밋 메시지가 표시된다."""
+    mock_db = MagicMock()
+    mock_analysis = MagicMock(
+        id=42, commit_sha="abc1234567890", commit_message="feat: add login page",
+        pr_number=10, score=82, grade="B",
+        result={"breakdown": {"code_quality": 20}, "ai_summary": "good code"},
+        created_at=MagicMock(isoformat=MagicMock(return_value="2026-04-08T14:30:00")),
+    )
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        MagicMock(id=1, full_name="owner/repo", user_id=None),
+        mock_analysis,
+    ]
+    with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+        r = client.get("/repos/owner%2Frepo/analyses/42")
+    assert r.status_code == 200
+    assert "feat: add login page" in r.text
+
+
+def test_analysis_detail_shows_fallback_when_no_commit_message():
+    """커밋 메시지가 없어도 fallback 텍스트가 표시된다."""
+    mock_db = MagicMock()
+    mock_analysis = MagicMock(
+        id=42, commit_sha="abc1234567890", commit_message=None,
+        pr_number=None, score=70, grade="C",
+        result={"breakdown": {}},
+        created_at=MagicMock(isoformat=MagicMock(return_value="2026-04-08T10:00:00")),
+    )
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        MagicMock(id=1, full_name="owner/repo", user_id=None),
+        mock_analysis,
+    ]
+    with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+        r = client.get("/repos/owner%2Frepo/analyses/42")
+    assert r.status_code == 200
+    assert "커밋 메시지 없음" in r.text
+
+
+def test_analysis_detail_shows_score_when_result_empty():
+    """result가 빈 dict일 때도 점수 배너가 표시된다."""
+    mock_db = MagicMock()
+    mock_analysis = MagicMock(
+        id=42, commit_sha="abc1234567890", commit_message="fix: bug",
+        pr_number=None, score=65, grade="C",
+        result={},
+        created_at=MagicMock(isoformat=MagicMock(return_value="2026-04-08T10:00:00")),
+    )
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        MagicMock(id=1, full_name="owner/repo", user_id=None),
+        mock_analysis,
+    ]
+    with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+        r = client.get("/repos/owner%2Frepo/analyses/42")
+    assert r.status_code == 200
+    assert "65" in r.text
+    assert "/100" in r.text
+
+
+def test_analysis_detail_shows_source_indicator():
+    """분석 소스(CLI/PR/Push)가 표시된다."""
+    mock_db = MagicMock()
+    mock_analysis = MagicMock(
+        id=42, commit_sha="abc1234567890", commit_message="test",
+        pr_number=None, score=80, grade="B",
+        result={"source": "cli", "breakdown": {}},
+        created_at=MagicMock(isoformat=MagicMock(return_value="2026-04-08T10:00:00")),
+    )
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        MagicMock(id=1, full_name="owner/repo", user_id=None),
+        mock_analysis,
+    ]
+    with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+        r = client.get("/repos/owner%2Frepo/analyses/42")
+    assert r.status_code == 200
+    assert "CLI" in r.text
+
+
+def test_analysis_detail_shows_full_datetime():
+    """분석 상세에 날짜와 시간이 모두 표시된다."""
+    mock_db = MagicMock()
+    mock_analysis = MagicMock(
+        id=42, commit_sha="abc1234567890", commit_message="test",
+        pr_number=None, score=80, grade="B",
+        result={"breakdown": {}},
+        created_at=MagicMock(isoformat=MagicMock(return_value="2026-04-08T14:30:00")),
+    )
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        MagicMock(id=1, full_name="owner/repo", user_id=None),
+        mock_analysis,
+    ]
+    with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+        r = client.get("/repos/owner%2Frepo/analyses/42")
+    assert r.status_code == 200
+    assert "2026-04-08 14:30" in r.text
+
+
+def test_repo_detail_shows_commit_message():
+    """리포 상세 이력 테이블에 커밋 메시지 미리보기가 표시된다."""
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = MagicMock(
+        id=1, full_name="owner/repo", user_id=None
+    )
+    mock_analysis = MagicMock(
+        id=1, commit_sha="abc1234", commit_message="feat: new feature for users",
+        pr_number=None, score=90, grade="A",
+        created_at=MagicMock(isoformat=MagicMock(return_value="2026-04-08T10:00:00")),
+    )
+    mock_db.query.return_value.filter.return_value.order_by.return_value.limit.return_value.all.return_value = [mock_analysis]
+    with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+        r = client.get("/repos/owner%2Frepo")
+    assert r.status_code == 200
+    assert "feat: new feature" in r.text
+
+
 # ── reinstall-webhook 엔드포인트 테스트 ──────────────────────────
 
 def test_reinstall_webhook_deletes_and_recreates():


### PR DESCRIPTION
## Summary
- 분석 상세 페이지에서 커밋 메시지, 점수 배너 등 상세 정보가 표시되지 않던 문제 수정
- `result`가 빈 dict일 때 Jinja2 falsy 판정으로 모든 섹션이 숨겨지던 버그 해결
- 분석 이력 테이블에 커밋 메시지 미리보기 추가, 소스(CLI/PR/Push) 표시 추가

## Test plan
- [x] 전체 테스트 284개 통과 (기존 276 + 신규 8)
- [x] commit_message NULL일 때 fallback 텍스트 표시 검증
- [x] result `{}`일 때도 점수 배너 표시 검증
- [x] 소스 표시(CLI/PR/Push) 검증
- [x] 날짜+시간 표시 검증
- [x] 이력 테이블 커밋 메시지 미리보기 검증

https://claude.ai/code/session_015S26VDuuiZBtdQSo5CFhZn