### PR TITLE
feat: 네비게이션 바에 사용자 정보 + 로그아웃 버튼 추가

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -190,6 +190,40 @@
     nav a.nav-link:hover { color: var(--text-nav); }
     .nav-spacer { flex: 1; }
 
+    /* ── 사용자 정보 & 로그아웃 ──────────────────────── */
+    .nav-user {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-shrink: 0;
+    }
+    .nav-user-name {
+      font-size: 13px;
+      color: var(--text-nav);
+      white-space: nowrap;
+      max-width: 140px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .nav-logout-btn {
+      display: flex;
+      align-items: center;
+      background: rgba(255,255,255,0.08);
+      border: 1px solid rgba(255,255,255,0.12);
+      color: var(--text-nav);
+      padding: 6px 12px;
+      border-radius: 20px;
+      cursor: pointer;
+      font-size: 13px;
+      transition: background var(--transition), border-color var(--transition), color var(--transition);
+      white-space: nowrap;
+    }
+    .nav-logout-btn:hover {
+      background: rgba(239, 68, 68, 0.18);
+      border-color: rgba(239, 68, 68, 0.45);
+      color: #fca5a5;
+    }
+
     /* ── 테마 스위처 ──────────────────────────── */
     .theme-switcher {
       position: relative;
@@ -429,13 +463,17 @@
       .page-header h2 { font-size: 1.2rem; }
       .back-btn { padding: 3px 8px; font-size: 12px; }
       .btn { padding: .4rem 1rem; font-size: 13px; }
+      .nav-user-name { max-width: 90px; }
+      .nav-logout-btn { padding: 4px 9px; font-size: 12px; }
     }
 
     /* ── 모바일 반응형 (소형) ─────────────────── */
     @media (max-width: 480px) {
       nav { gap: 0.5rem; padding: 0 0.75rem; }
       .nav-logo strong { display: none; }
+      .nav-user-name { display: none; }
       .theme-btn { padding: 5px 8px; font-size: 12px; }
+      .nav-logout-btn { padding: 4px 8px; font-size: 11px; }
       .container { padding: 1rem 0.5rem; }
       th { padding: .4rem .5rem; }
       td { padding: .5rem; font-size: 12px; }
@@ -450,6 +488,14 @@
     </a>
     <a class="nav-link" href="/">Overview</a>
     <div class="nav-spacer"></div>
+    {% if current_user %}
+    <div class="nav-user">
+      <span class="nav-user-name">{{ current_user.display_name or current_user.github_login }}</span>
+      <form method="post" action="/auth/logout" style="display:inline;margin:0">
+        <button type="submit" class="nav-logout-btn">로그아웃</button>
+      </form>
+    </div>
+    {% endif %}
     <div class="theme-switcher" id="themeSwitcher">
       <button class="theme-btn" id="themeToggle" aria-label="테마 변경">
         <span id="themeIcon">🌙</span>

--- a/tests/test_ui_router.py
+++ b/tests/test_ui_router.py
@@ -512,3 +512,44 @@ def test_reinstall_webhook_no_existing_webhook():
                 r = client.post("/repos/owner%2Frepo/reinstall-webhook", follow_redirects=False)
     mock_del.assert_not_called()  # webhook_id None → 삭제 스킵
     assert r.status_code == 303
+
+
+# ── 네비게이션 사용자 UI 테스트 ──────────────────────────
+
+def test_overview_shows_display_name_in_nav():
+    """로그인 후 nav에 display_name이 표시된다."""
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+    with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+        r = client.get("/")
+    assert r.status_code == 200
+    assert "Test User" in r.text
+
+
+def test_overview_shows_logout_button_in_nav():
+    """로그인 후 nav에 로그아웃 버튼과 action URL이 표시된다."""
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+    with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+        r = client.get("/")
+    assert r.status_code == 200
+    assert "로그아웃" in r.text
+    assert "/auth/logout" in r.text
+
+
+def test_nav_user_fallback_to_github_login():
+    """display_name이 빈 문자열이면 github_login이 nav에 표시된다."""
+    no_name_user = UserModel(
+        id=2, github_id="99999", github_login="fallback_user",
+        github_access_token="gho_x", email="fb@example.com", display_name=""
+    )
+    app.dependency_overrides[require_login] = lambda: no_name_user
+    try:
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+        with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+            r = client.get("/")
+        assert r.status_code == 200
+        assert "fallback_user" in r.text
+    finally:
+        app.dependency_overrides[require_login] = lambda: _test_user


### PR DESCRIPTION
## Summary

- `base.html` nav에 로그인 사용자 이름(`display_name`, 없으면 `github_login`) 표시
- 로그아웃 버튼 추가 — HTML form `POST /auth/logout` (JS 불필요, CSP 안전)
- 3테마(dark/light/glass) `var(--text-nav)` CSS 변수 활용, hover 시 붉은 계열 강조
- 모바일 반응형: 768px 이하 이름 축소(`max-width: 90px`), 480px 이하 이름 숨김(버튼만 유지)
- `{% if current_user %}` 조건부 렌더링 — `analysis_detail` 등 `current_user` 미전달 라우트 안전 처리
- 테스트 3개 추가: display_name 표시 / 로그아웃 버튼 표시 / github_login fallback (284 → 287 passed)

## Test plan

- [x] `make test` — 287 passed 확인
- [ ] 로그인 후 nav에 이름 + 로그아웃 버튼 표시 확인
- [ ] 로그아웃 버튼 클릭 → `/login` 리다이렉트 확인
- [ ] 모바일(480px) 에서 이름 숨김, 버튼만 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)