### PR TITLE
feat: Repository 삭제 기능 추가

### DIFF
--- a/src/api/repos.py
+++ b/src/api/repos.py
@@ -6,6 +6,8 @@ from src.api.deps import get_repo_or_404
 from src.database import SessionLocal
 from src.models.repository import Repository
 from src.models.analysis import Analysis
+from src.models.repo_config import RepoConfig
+from src.models.gate_decision import GateDecision
 from src.config_manager.manager import upsert_repo_config, RepoConfigData
 
 router = APIRouter(prefix="/api", dependencies=[require_api_key])
@@ -89,3 +91,32 @@ def update_repo_config(repo_name: str, body: RepoConfigUpdate):
             "auto_merge": record.auto_merge,
             "merge_threshold": record.merge_threshold,
         }
+
+
+@router.delete("/repos/{repo_name:path}")
+def delete_repo_api(repo_name: str):
+    """리포지토리와 모든 연관 데이터(Analysis, GateDecision, RepoConfig)를 삭제한다.
+
+    API 모드는 사용자 OAuth 토큰이 없으므로 GitHub Webhook은 자동 삭제하지 않는다.
+    응답에 `webhook_id`를 포함해 호출자가 직접 정리할 수 있게 한다.
+    """
+    with SessionLocal() as db:
+        repo = get_repo_or_404(repo_name, db)
+        webhook_id = repo.webhook_id
+        full_name = repo.full_name
+
+        analysis_ids = [
+            row.id for row in db.query(Analysis.id).filter(Analysis.repo_id == repo.id).all()
+        ]
+        if analysis_ids:
+            db.query(GateDecision).filter(
+                GateDecision.analysis_id.in_(analysis_ids)
+            ).delete(synchronize_session=False)
+        db.query(Analysis).filter(Analysis.repo_id == repo.id).delete(synchronize_session=False)
+        db.query(RepoConfig).filter(
+            RepoConfig.repo_full_name == full_name
+        ).delete(synchronize_session=False)
+        db.delete(repo)
+        db.commit()
+
+    return {"deleted": True, "repo_full_name": full_name, "webhook_id": webhook_id}

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -382,6 +382,29 @@
     </div>
 
   </form>
+
+  <!-- 위험 구역 (메인 form 외부) -->
+  <div class="s-card" style="border:1px solid var(--danger);margin-top:1.5rem;">
+    <div class="s-card-hdr" style="background:rgba(220,53,69,.08);color:var(--danger);">
+      <span class="hdr-icon">⚠️</span>
+      <span class="hdr-title">위험 구역</span>
+    </div>
+    <div class="s-card-body">
+      <div class="toggle-row">
+        <div class="toggle-info">
+          <div class="t-title">리포지토리 삭제</div>
+          <div class="t-desc">SCAManager에서 이 리포지토리를 제거합니다.<br>
+            GitHub Webhook과 모든 분석 이력이 영구 삭제됩니다.</div>
+        </div>
+        <form method="post" action="/repos/{{ repo_name }}/delete"
+              onsubmit="return confirm('정말 「{{ repo_name }}」 리포지토리를 삭제하시겠습니까?\n\n모든 분석 이력과 GitHub Webhook이 영구 삭제됩니다.');">
+          <button type="submit" style="background:var(--danger);color:#fff;border:none;border-radius:8px;padding:.6rem 1.1rem;font-weight:600;cursor:pointer;">
+            🗑️ 삭제
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
 </div>
 
 <script>

--- a/src/ui/router.py
+++ b/src/ui/router.py
@@ -9,6 +9,7 @@ from src.database import SessionLocal
 from src.models.repository import Repository
 from src.models.analysis import Analysis
 from src.models.repo_config import RepoConfig
+from src.models.gate_decision import GateDecision
 from src.models.user import User
 from src.auth.session import require_login
 from src.config_manager.manager import get_repo_config, upsert_repo_config, RepoConfigData
@@ -33,6 +34,40 @@ def _get_accessible_repo(db, repo_name: str, current_user: User) -> Repository:
     if repo.user_id is not None and repo.user_id != current_user.id:
         raise HTTPException(status_code=404)
     return repo
+
+
+async def _delete_repo_cascade(db, repo: Repository, github_token: str) -> None:
+    """리포 + 연관 데이터(Webhook, GateDecision, Analysis, RepoConfig)를 모두 삭제한다.
+
+    Webhook 삭제는 best-effort — GitHub API 실패 시에도 DB 정리는 계속 진행된다.
+    """
+    # 1. GitHub Webhook 삭제 (best-effort — httpx·네트워크·권한 등 모든 예외 무시)
+    if repo.webhook_id:
+        try:
+            await delete_webhook(github_token, repo.full_name, repo.webhook_id)
+        except Exception:  # nosec B110  # pylint: disable=broad-except
+            pass
+
+    # 2. GateDecision 삭제 (Analysis.id FK 참조)
+    analysis_ids = [
+        row.id for row in db.query(Analysis.id).filter(Analysis.repo_id == repo.id).all()
+    ]
+    if analysis_ids:
+        db.query(GateDecision).filter(
+            GateDecision.analysis_id.in_(analysis_ids)
+        ).delete(synchronize_session=False)
+
+    # 3. Analysis 삭제
+    db.query(Analysis).filter(Analysis.repo_id == repo.id).delete(synchronize_session=False)
+
+    # 4. RepoConfig 삭제 (FK 아님 — full_name 기반)
+    db.query(RepoConfig).filter(
+        RepoConfig.repo_full_name == repo.full_name
+    ).delete(synchronize_session=False)
+
+    # 5. Repository 삭제
+    db.delete(repo)
+    db.commit()
 
 
 @router.get("/repos/add", response_class=HTMLResponse)
@@ -281,6 +316,18 @@ async def reinstall_webhook(
         url=f"/repos/{repo_name}/settings?hook_ok=1",
         status_code=303,
     )
+
+
+@router.post("/repos/{repo_name:path}/delete")
+async def delete_repo(
+    repo_name: str,
+    current_user: User = Depends(require_login),
+):
+    """리포지토리 + 연관 데이터(Webhook, Analysis, GateDecision, RepoConfig)를 삭제한다."""
+    with SessionLocal() as db:
+        repo = _get_accessible_repo(db, repo_name, current_user)
+        await _delete_repo_cascade(db, repo, current_user.plaintext_token or "")
+    return RedirectResponse(url="/?deleted=1", status_code=303)
 
 
 @router.get("/repos/{repo_name:path}/analyses/{analysis_id}", response_class=HTMLResponse)

--- a/tests/test_api_repos.py
+++ b/tests/test_api_repos.py
@@ -339,3 +339,34 @@ def test_config_update_approve_threshold_passed_to_upsert():
     called_data = mock_upsert.call_args[0][1]
     assert called_data.approve_threshold == 90
     assert called_data.reject_threshold == 60
+
+
+# ── DELETE /api/repos/{repo} 테스트 ──────────────────────────
+
+def test_delete_repo_api_success():
+    """API로 리포 삭제 시 연관 데이터 정리 후 200 JSON 반환."""
+    mock_repo = MagicMock(id=1, full_name="owner/repo", webhook_id=999)
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_repo
+    mock_db.query.return_value.filter.return_value.all.return_value = []
+
+    with patch("src.api.repos.SessionLocal", return_value=_make_session_mock(mock_db)):
+        r = client.delete("/api/repos/owner%2Frepo")
+
+    assert r.status_code == 200
+    body = r.json()
+    assert body["deleted"] is True
+    assert body["repo_full_name"] == "owner/repo"
+    assert body["webhook_id"] == 999
+    mock_db.delete.assert_called_once_with(mock_repo)
+    mock_db.commit.assert_called()
+
+
+def test_delete_repo_api_404():
+    """존재하지 않는 리포 삭제 → 404."""
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+    with patch("src.api.repos.SessionLocal", return_value=_make_session_mock(mock_db)):
+        r = client.delete("/api/repos/nope%2Frepo")
+    assert r.status_code == 404
+    mock_db.delete.assert_not_called()

--- a/tests/test_ui_router.py
+++ b/tests/test_ui_router.py
@@ -514,6 +514,90 @@ def test_reinstall_webhook_no_existing_webhook():
     assert r.status_code == 303
 
 
+# ── 리포 삭제 엔드포인트 테스트 ──────────────────────────
+
+def test_delete_repo_success():
+    """소유자 삭제 시 webhook 삭제 + DB cascade 후 303 /?deleted=1."""
+    from unittest.mock import AsyncMock, patch
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1, webhook_id=999)
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_repo
+    # Analysis.id 조회 시 빈 결과
+    mock_db.query.return_value.filter.return_value.all.return_value = []
+
+    with patch("src.ui.router.delete_webhook", new_callable=AsyncMock, return_value=True) as mock_del:
+        with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+            r = client.post("/repos/owner%2Frepo/delete", follow_redirects=False)
+
+    assert r.status_code == 303
+    assert r.headers["location"] == "/?deleted=1"
+    mock_del.assert_called_once()
+    mock_db.delete.assert_called_once_with(mock_repo)
+    mock_db.commit.assert_called()
+
+
+def test_delete_repo_404_for_other_user():
+    """타인 소유 리포 삭제 → 404, db.delete 호출되지 않음."""
+    from unittest.mock import AsyncMock, patch
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = MagicMock(
+        id=2, full_name="owner/repo", user_id=99, webhook_id=None
+    )
+    with patch("src.ui.router.delete_webhook", new_callable=AsyncMock) as mock_del:
+        with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+            r = client.post("/repos/owner%2Frepo/delete", follow_redirects=False)
+
+    assert r.status_code == 404
+    mock_del.assert_not_called()
+    mock_db.delete.assert_not_called()
+
+
+def test_delete_repo_404_not_found():
+    """존재하지 않는 리포 삭제 → 404."""
+    from unittest.mock import AsyncMock, patch
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+    with patch("src.ui.router.delete_webhook", new_callable=AsyncMock):
+        with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+            r = client.post("/repos/nope%2Frepo/delete", follow_redirects=False)
+    assert r.status_code == 404
+
+
+def test_delete_repo_webhook_failure_still_deletes_db():
+    """delete_webhook이 예외를 던져도 DB 정리는 계속 진행되어야 한다."""
+    from unittest.mock import AsyncMock, patch
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=None, webhook_id=999)
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_repo
+    mock_db.query.return_value.filter.return_value.all.return_value = []
+
+    with patch("src.ui.router.delete_webhook", new_callable=AsyncMock,
+               side_effect=RuntimeError("github api down")):
+        with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+            r = client.post("/repos/owner%2Frepo/delete", follow_redirects=False)
+
+    assert r.status_code == 303
+    mock_db.delete.assert_called_once_with(mock_repo)
+    mock_db.commit.assert_called()
+
+
+def test_delete_repo_skips_webhook_when_none():
+    """webhook_id가 None이면 delete_webhook 호출하지 않고 DB만 정리."""
+    from unittest.mock import AsyncMock, patch
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1, webhook_id=None)
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_repo
+    mock_db.query.return_value.filter.return_value.all.return_value = []
+
+    with patch("src.ui.router.delete_webhook", new_callable=AsyncMock) as mock_del:
+        with patch("src.ui.router.SessionLocal", return_value=_ctx(mock_db)):
+            r = client.post("/repos/owner%2Frepo/delete", follow_redirects=False)
+
+    assert r.status_code == 303
+    mock_del.assert_not_called()
+    mock_db.delete.assert_called_once_with(mock_repo)
+
+
 # ── 네비게이션 사용자 UI 테스트 ──────────────────────────
 
 def test_overview_shows_display_name_in_nav():


### PR DESCRIPTION
- POST /repos/{repo}/delete: UI 삭제 라우트 (소유권 체크 + cascade)
- DELETE /api/repos/{repo}: REST API 삭제 엔드포인트 (X-API-Key)
- settings 페이지 하단에 위험 구역(Danger Zone) 카드 + confirm 모달
- GateDecision → Analysis → RepoConfig → Repository 순 cascade 삭제
- GitHub Webhook 삭제는 best-effort (실패해도 DB 정리 진행)
- 테스트 7건 추가 (UI 5건 + API 2건)

https://claude.ai/code/session_0133Tv3XNZAPTn6iCpRuBZGn