### PR TITLE
fix: #51 README 오타 수정: SCAMange → SCAManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# 🛡️ SCAManage
+# 🛡️ SCAManager
 
 **GitHub Push / PR 이벤트 기반 자동 코드 품질 분석 · AI 리뷰 · Gate 서비스**
 


### PR DESCRIPTION
Closes #51

자동 생성 PR — n8n + Claude CLI.

## Claude 요약
README.md 3번째 줄의 오타(`SCAManage` → `SCAManager`)를 수정했습니다. 커밋 명령에 사용자 승인이 필요합니다.

**변경 내역:**
- `README.md:3` — `# 🛡️ SCAManage` → `# 🛡️ SCAManager`

**참고:** 이슈 본문의 'SCAMange'는 이슈 작성자의 표기 오류이며, 실제 파일 내 오타는 `SCAManage`(끝 'r' 누락)였습니다. 의도된 수정값 `SCAManager`로 변경했습니다. 문서(README) 단독 오타 수정이므로 대응 테스트는 추가하지 않았습니다.

승인 후 아래 커밋이 진행될 예정입니다:
```
fix: #51 - README 제목 오타 SCAManage → SCAManager 수정
```