### PR TITLE
chore: PR 워크플로 + 작업 시작 전 체크리스트 CLAUDE.md 규칙화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,8 +294,29 @@ requirements-dev.txt  ← 로컬 개발 환경 — pytest, playwright 포함 (-r
 - **TDD 우선**: 구현 코드 작성 전 반드시 `test-writer` 에이전트로 테스트를 먼저 작성한다.
 - **Hook 신뢰**: `src/` 파일 편집 후 PostToolUse Hook이 자동 실행하는 pytest 결과를 확인한다. 실패 시 다음 단계로 진행하지 않는다.
 - **Phase 완료 조건**: 테스트 전체 통과 + `/lint` 통과 + (파이프라인 변경 시 `pipeline-reviewer` 승인) 세 조건이 모두 충족될 때만 Phase 완료를 선언한다.
-- **완료 시 필수 3-step**: 작업이 완료되면 반드시 ① 커밋 → ② `git push` → ③ `docs/STATE.md` 수치 갱신을 순서대로 수행한다. 예외 없음.
+- **완료 시 필수 4-step**: 작업이 완료되면 반드시 ① 커밋 → ② PR 생성(`gh pr create`) → ③ `git push` → ④ `docs/STATE.md` 수치 갱신을 순서대로 수행한다. 예외 없음.
 - **README.md 배지 동기화**: 테스트 수·pylint·커버리지 수치가 바뀌면 `README.md` 14~18줄 배지도 함께 갱신한다. 수치 출처는 항상 `docs/STATE.md`.
+
+### 작업 시작 전 필수 체크리스트 (매 작업마다)
+
+모든 작업 착수 전 아래 세 가지를 순서대로 확인한다. 30초면 충분하다.
+
+```bash
+gh run list --limit 3        # CI 현재 상태 — 기존 실패와 신규 실패 구분
+git status                   # 미커밋 변경 없는지 확인
+git checkout -b <브랜치명>   # 브랜치 생성 (main 직접 커밋 금지)
+```
+
+**브랜치 명명 규칙**
+
+| 접두사 | 사용 시점 |
+|--------|----------|
+| `feat/` | 새 기능 구현 |
+| `fix/` | 버그 수정 |
+| `chore/` | 설정·문서·툴링 변경 |
+| `docs/` | 문서 전용 변경 |
+
+**예외 없음** — `.claude/` 내부 파일(Hook·에이전트·스킬), `CLAUDE.md`, `docs/` 변경도 모두 브랜치 + PR 방식으로 진행한다.
 
 ### 모바일 환경 보호 — 수정 금지 파일
 


### PR DESCRIPTION
## Summary

- **완료 시 3-step → 4-step**: 커밋 → **PR 생성** → push → STATE.md 갱신으로 변경
- **작업 시작 전 필수 체크리스트** 신설: CI 상태 확인 → git status → 브랜치 생성
- **브랜치 명명 규칙** 표 추가 (feat / fix / chore / docs)
- **main 직접 커밋 금지** 명문화 — `.claude/` 내부 파일 포함 예외 없음

## Background

2026-04-26 문서 심의 시스템 작업이 main에 직접 커밋된 것을 사용자가 확인하고 PR 방식 전환을 요청함. 회고 후 즉시 CLAUDE.md에 반영.

## Test plan

- [x] 전체 테스트 1332개 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)