### PR TITLE
feat(phase-10): Telegram 확장 — 주간 리포트·트렌드 알림·/connect OTP 흐름

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,6 +384,7 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 - **require_login 우회**: `tests/test_ui_router.py`는 `app.dependency_overrides[require_login] = lambda: _test_user`로 의존성 override. 신규 UI 라우트 테스트 작성 시 동일 패턴 사용.
 - **Mock side_effect 재귀**: `mock.add.side_effect = fn` 설정 후 fn 내에서 `original_add(obj)` 호출 시 재귀 발생. side_effect 함수에서는 원본 mock을 호출하지 말 것 — 캡처만 하고 return None.
 - **모듈 레벨 캐시 격리**: `src/webhook/router.py`의 `_webhook_secret_cache`는 모듈 레벨 dict. `tests/conftest.py`의 `_clear_webhook_secret_cache` autouse fixture가 테스트마다 자동 클리어. 신규 모듈 레벨 캐시 추가 시 동일한 autouse fixture 패턴 적용 필수 — 미적용 시 테스트 순서 의존성 버그 발생.
+- **`services/analytics_service.py` 테스트 패턴**: `db: Session` 인자 + `now: datetime | None = None` 의존성 주입(freezegun 미사용). 각 테스트 파일은 자체 in-memory SQLite engine fixture (`tests/unit/repositories/test_analysis_feedback_repo.py:20-58` 참조). `func.count/avg/min/max` 호출 시 `# pylint: disable=not-callable` 인라인 주석 필수 (E1102 false positive).
 
 ### DB / 마이그레이션
 
@@ -437,6 +438,9 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 - **MergeAttempt 관측 (Phase F.1+F.2)**: `src/gate/engine.py::_run_auto_merge`(자동) 및 `src/webhook/providers/telegram.py::handle_gate_callback`(반자동) 양쪽에서 `merge_pr` 직후 `log_merge_attempt()`(`src/shared/merge_metrics.py`)로 모든 시도(성공·실패)를 DB에 기록. `failure_reason`은 `src/gate/merge_reasons.py`의 정규 태그(`branch_protection_blocked`, `unstable_ci`, `permission_denied` 등). 관측 실패는 notify 경로를 막지 않도록 nested try/except로 격리 — DB 오류 시 rollback 후 WARNING + None. **Phase F.3**: `engine.py::_run_auto_merge` 실패 시 `get_advice(reason)` + 조건부 `create_merge_failure_issue()` 호출 — `auto_merge_issue_on_failure` 필드(5-way sync 적용)로 Issue 생성 제어.
 - **notifier 공통 헬퍼**: `src/notifier/_common.py`의 `format_ref()`, `get_all_issues()`, `get_issue_samples()`, `truncate_message()`, `truncate_issue_msg()`를 사용. 각 notifier 모듈에 이슈 수집 루프나 메시지 절단 로직 직접 작성 금지.
 - **webhook secret TTL 캐시**: `_get_webhook_secret(full_name)` 함수가 `_webhook_secret_cache` dict에 5분(WEBHOOK_SECRET_CACHE_TTL=300초) TTL로 per-repo 시크릿을 캐시. 리포 시크릿 변경 후 최대 5분간 구 시크릿으로 검증 — 인지하고 있을 것.
+- **Telegram 콜백 도메인 분리**: `_make_callback_token(bot_token, scope, payload_id)`이 `scope ∈ {"gate","cmd"}`별 다른 HMAC 생성. 신규 명령 추가 시 `cmd:<verb>:<id>:<token>` 준수, 64-byte 한도 검증 (numeric id). `_gate_callback_token()`은 `_make_callback_token(..., "gate", analysis_id)` thin wrapper. `test_callback_data_within_64_bytes_all_commands` 단위 테스트 강제.
+- **Cron 엔드포인트 인증**: `POST /api/internal/cron/*`는 `INTERNAL_CRON_API_KEY` 전용 (admin key와 분리). Railway `[[deploy.cronJobs]]` 트리거. `hmac.compare_digest` 타이밍 안전 비교. `INTERNAL_CRON_API_KEY` 미설정 시 503 반환.
+- **Telegram chat_id 라우팅 우선순위**: cron 알림의 chat_id 결정은 `analytics_service.resolve_chat_id(repo, config)` 단일 헬퍼 — `RepoConfig.notify_chat_id` → `Repository.telegram_chat_id` → `settings.telegram_chat_id` → None(skip + WARNING).
 
 ### 보안
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
-[![Tests](https://img.shields.io/badge/Tests-1344_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-1417_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
 [![E2E](https://img.shields.io/badge/E2E-49_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)

--- a/alembic/versions/0017_add_user_telegram_id.py
+++ b/alembic/versions/0017_add_user_telegram_id.py
@@ -1,0 +1,57 @@
+"""add telegram_user_id, telegram_otp, telegram_otp_expires_at to users
+
+Revision ID: 0017addusertelegramid
+Revises: 0016uniqueanalysissha
+Create Date: 2026-04-26
+"""
+# Telegram 연동을 위한 users 테이블 컬럼 3개 추가 마이그레이션
+# Migration that adds three columns to the users table for Telegram integration.
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0017addusertelegramid"
+down_revision = "0016uniqueanalysissha"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # telegram_user_id — Telegram 사용자 고유 ID (NULL 허용, UNIQUE)
+    # telegram_user_id — Telegram user unique ID (nullable, unique).
+    op.add_column(
+        "users",
+        sa.Column("telegram_user_id", sa.String(), nullable=True),
+    )
+    op.create_unique_constraint(
+        "uq_users_telegram_user_id",
+        "users",
+        ["telegram_user_id"],
+    )
+
+    # telegram_otp — 연동 인증용 일회용 패스코드 (NULL 허용)
+    # telegram_otp — one-time passcode for Telegram linking (nullable).
+    op.add_column(
+        "users",
+        sa.Column("telegram_otp", sa.String(), nullable=True),
+    )
+
+    # telegram_otp_expires_at — OTP 만료 시각 (타임존 포함, NULL 허용)
+    # telegram_otp_expires_at — OTP expiry timestamp with timezone (nullable).
+    op.add_column(
+        "users",
+        sa.Column(
+            "telegram_otp_expires_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    # 역순으로 제거: constraint 먼저, 컬럼 나중
+    # Remove in reverse order: constraint first, then columns.
+    op.drop_constraint("uq_users_telegram_user_id", "users", type_="unique")
+    op.drop_column("users", "telegram_otp_expires_at")
+    op.drop_column("users", "telegram_otp")
+    op.drop_column("users", "telegram_user_id")

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,11 +2,11 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-04-26 기준 — Phase F Quick Win + F.1 관측 완료 · Phase F.3 실패 어드바이저 완료 · G.2 수치 동기화 · Phase G 완료 · P2 이슈 수정 완료 · Phase H 착수 (F.2 관측 완료) · 이중언어 주석 마이그레이션 완료 · 보안 강화 그룹 39 완료 · lint 회귀 수정 · 문서 다중 에이전트 심의 시스템 완료 · **Phase 9 자기 분석 루프 방지 완료**)
+## 현재 수치 (2026-04-26 기준 — Phase F Quick Win + F.1 관측 완료 · Phase F.3 실패 어드바이저 완료 · G.2 수치 동기화 · Phase G 완료 · P2 이슈 수정 완료 · Phase H 착수 (F.2 관측 완료) · 이중언어 주석 마이그레이션 완료 · 보안 강화 그룹 39 완료 · lint 회귀 수정 · 문서 다중 에이전트 심의 시스템 완료 · Phase 9 자기 분석 루프 방지 완료 · **Phase 10 Telegram 확장 완료**)
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 단위 테스트 | **1344개** | pytest 9.0.3 (0 failed) — 2026-04-26 로컬 실측 (Phase 9 self-analysis loop_guard 12개 추가) |
+| 단위 테스트 | **1417개** | pytest 9.0.3 (0 failed) — 2026-04-26 로컬 실측 (Phase 10: +73 테스트) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
 | SonarCloud Reliability Rating | **A** | Bugs 0 |

--- a/railway.toml
+++ b/railway.toml
@@ -8,3 +8,20 @@ healthcheckPath = "/health"
 healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
+
+# 주간 리포트: 매주 월요일 KST 09:00 = UTC 00:00 (0 0 * * 1)
+# Weekly report: every Monday at KST 09:00 = UTC 00:00
+[[deploy.cronJobs]]
+schedule = "0 0 * * 1"
+command = "curl -s -X POST -H 'X-API-Key: $INTERNAL_CRON_API_KEY' http://localhost:$PORT/api/internal/cron/weekly"
+
+# 트렌드 체크: 매일 KST 12:00 = UTC 03:00 (0 3 * * *)
+# Trend check: every day at KST 12:00 = UTC 03:00
+[[deploy.cronJobs]]
+schedule = "0 3 * * *"
+command = "curl -s -X POST -H 'X-API-Key: $INTERNAL_CRON_API_KEY' http://localhost:$PORT/api/internal/cron/trend"
+
+# Fallback B (Railway native cron 제한 시): cron-job.org 외부 → curl
+# Fallback B (if Railway native cron is unavailable): use cron-job.org with:
+#   POST https://<APP_BASE_URL>/api/internal/cron/weekly   (Header: X-API-Key: $INTERNAL_CRON_API_KEY)
+#   POST https://<APP_BASE_URL>/api/internal/cron/trend    (Header: X-API-Key: $INTERNAL_CRON_API_KEY)

--- a/src/api/internal_cron.py
+++ b/src/api/internal_cron.py
@@ -1,0 +1,93 @@
+"""내부 Cron 엔드포인트 — Railway native cron 트리거용.
+Internal cron endpoints — triggered by Railway native cron jobs.
+
+인증: INTERNAL_CRON_API_KEY 헤더 (admin api_key와 분리).
+Auth: INTERNAL_CRON_API_KEY header (separate from admin api_key).
+"""
+from __future__ import annotations
+
+import hmac as _hmac
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Security
+from fastapi.security import APIKeyHeader
+
+from src.config import settings
+from src.database import SessionLocal
+from src.services.cron_service import run_trend_check, run_weekly_reports
+
+logger = logging.getLogger(__name__)
+
+# cron 전용 API 키 헤더 스키마 — admin X-API-Key와 동일 헤더명이지만 별도 검증 로직
+# Cron-specific API key header — same header name as admin but validated separately
+_cron_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+async def _require_cron_key(
+    api_key: str | None = Security(_cron_key_header),
+) -> None:
+    """INTERNAL_CRON_API_KEY 검증.
+    Validate the INTERNAL_CRON_API_KEY.
+
+    - 키 미설정 시 503 반환 (운영 환경에서 미설정 차단)
+    - 키 불일치 시 401 반환 (타이밍 안전 비교)
+    - Returns 503 if key is not configured (blocks accidental open access)
+    - Returns 401 on mismatch (timing-safe comparison)
+    """
+    expected = settings.internal_cron_api_key
+    # 키 미설정 시 503 — 실수로 빈 설정에서 노출 방지
+    # Return 503 if unconfigured — prevents accidental open access
+    if not expected:
+        raise HTTPException(
+            status_code=503,
+            detail="Cron API key not configured",
+        )
+    # 타이밍 공격 방지를 위해 hmac.compare_digest 사용
+    # Use hmac.compare_digest to prevent timing attacks
+    if api_key is None or not _hmac.compare_digest(expected, api_key):
+        raise HTTPException(
+            status_code=401,
+            detail="Invalid cron API key",
+        )
+
+
+router = APIRouter(
+    prefix="/api/internal/cron",
+    # 라우터 레벨 인증 — 모든 cron 엔드포인트에 일괄 적용
+    # Router-level auth dependency — applied to all cron endpoints uniformly
+    dependencies=[Depends(_require_cron_key)],
+)
+
+
+@router.post("/weekly", status_code=200)
+async def trigger_weekly_reports() -> dict:
+    """주간 리포트 cron 트리거.
+    Trigger weekly report sending for all repositories.
+
+    Returns:
+        {"status": "ok", "sent": <int>} — 발송된 리포트 수
+        {"status": "ok", "sent": <int>} — number of reports sent
+    """
+    # SessionLocal() context manager로 DB 세션 획득 — 함수 종료 시 자동 반환
+    # Acquire DB session via SessionLocal() context manager — auto-released on exit
+    with SessionLocal() as db:
+        sent = await run_weekly_reports(db)
+    logger.info("weekly_reports: sent=%d", sent)
+    return {"status": "ok", "sent": sent}
+
+
+@router.post("/trend", status_code=200)
+async def trigger_trend_check() -> dict:
+    """트렌드 체크 cron 트리거.
+    Trigger trend-check alerts for all repositories.
+
+    Returns:
+        {"status": "ok", "alerted": <int>} — 경고 발송된 리포 수
+        {"status": "ok", "alerted": <int>} — number of repos that received an alert
+    """
+    # SessionLocal() context manager로 DB 세션 획득 — 함수 종료 시 자동 반환
+    # Acquire DB session via SessionLocal() context manager — auto-released on exit
+    with SessionLocal() as db:
+        alerted = await run_trend_check(db)
+    logger.info("trend_check: alerted=%d", alerted)
+    return {"status": "ok", "alerted": alerted}

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -1,0 +1,58 @@
+"""사용자 계정 API — Telegram 연동 OTP 발급 등.
+User account API — Telegram link OTP issuance, etc.
+"""
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import update
+
+from src.auth.session import CurrentUser, require_login
+from src.database import SessionLocal
+from src.models.user import User
+
+logger = logging.getLogger(__name__)
+
+# OTP 자릿수 — One-time passcode digit count.
+_OTP_LENGTH = 6
+# OTP 유효 시간(분) — OTP validity window in minutes.
+_OTP_TTL_MINUTES = 5
+
+router = APIRouter(prefix="/api/users", tags=["users"])
+
+
+@router.post("/me/telegram-otp", status_code=200)
+async def issue_telegram_otp(
+    current_user: Annotated[CurrentUser, Depends(require_login)],
+) -> dict:
+    """Telegram 연동용 6자리 OTP를 발급한다.
+    Issue a 6-digit OTP for Telegram account linking.
+
+    기존 OTP가 있으면 덮어쓴다 — 마지막 OTP만 유효.
+    Overwrites any existing OTP — only the last issued OTP is valid.
+    """
+    # secrets.choice 사용 — random 모듈 사용 금지 (보안)
+    # Use secrets.choice — never use the random module (security requirement).
+    otp = "".join(secrets.choice("0123456789") for _ in range(_OTP_LENGTH))
+    expires_at = datetime.now(timezone.utc) + timedelta(minutes=_OTP_TTL_MINUTES)
+
+    # DB에 OTP 저장 — 기존 값을 덮어씀으로써 마지막 발급 OTP만 유효하게 유지
+    # Save OTP to DB — overwrite any existing value so only the latest OTP is valid.
+    with SessionLocal() as db:
+        db.execute(
+            update(User)
+            .where(User.id == current_user.id)
+            .values(telegram_otp=otp, telegram_otp_expires_at=expires_at)
+        )
+        db.commit()
+
+    logger.info("telegram_otp issued for user_id=%d", current_user.id)
+    return {
+        "otp": otp,
+        "expires_at": expires_at.isoformat(),
+        "ttl_minutes": _OTP_TTL_MINUTES,
+    }

--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -1,5 +1,5 @@
 """Session helpers — get_current_user() and require_login Depends."""
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from fastapi import Request, HTTPException
 from src.database import SessionLocal
 from src.repositories import user_repo
@@ -8,18 +8,25 @@ from src.repositories import user_repo
 @dataclass
 class CurrentUser:
     """세션 사용자 정보 — ORM 세션과 독립된 순수 데이터 컨테이너.
+    Session user data — pure data container independent of the ORM session.
 
     DetachedInstanceError 위험 없이 세션 밖에서 안전하게 사용 가능.
+    Safe to use outside the ORM session — no DetachedInstanceError risk.
     """
     id: int
     github_login: str | None
     email: str
     display_name: str
     plaintext_token: str
+    # Telegram 연동 여부 — True이면 Telegram 계정이 연결된 상태
+    # Whether a Telegram account is linked — True when linked.
+    is_telegram_connected: bool = field(default=False)
 
 
 def get_current_user(request: Request) -> CurrentUser | None:
-    """세션에서 현재 사용자를 반환. 없으면 None."""
+    """세션에서 현재 사용자를 반환. 없으면 None.
+    Return the current user from the session, or None if not logged in.
+    """
     user_id = request.session.get("user_id")
     if not user_id:
         return None
@@ -33,6 +40,9 @@ def get_current_user(request: Request) -> CurrentUser | None:
             email=user.email,
             display_name=user.display_name,
             plaintext_token=user.plaintext_token or "",
+            # telegram_user_id가 있으면 연동 완료 상태
+            # is_telegram_connected is True when telegram_user_id is set.
+            is_telegram_connected=user.is_telegram_connected,
         )
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""  # 빈 문자열이면 AI 리뷰 건너뜀
     claude_review_model: str = "claude-sonnet-4-6"  # AI 코드리뷰 모델 (환경변수 CLAUDE_REVIEW_MODEL로 오버라이드)
     api_key: str = ""  # 빈 문자열이면 인증 건너뜀
+    internal_cron_api_key: str = ""  # 내부 cron 엔드포인트 전용 키 (admin api_key와 분리)
+    # Internal cron endpoint key — separate from admin api_key
     github_client_id: str = ""
     github_client_secret: str = ""
     session_secret: str = "dev-secret-change-in-production"

--- a/src/gate/telegram_gate.py
+++ b/src/gate/telegram_gate.py
@@ -6,19 +6,39 @@ from src.notifier.telegram import telegram_post_message
 from src.scorer.calculator import ScoreResult
 
 
-def _gate_callback_token(bot_token: str, analysis_id: int) -> str:
-    """콜백 데이터 위변조 방지용 HMAC-SHA256 토큰 — 32자 hex (128-bit 절단).
-    HMAC-SHA256 callback integrity token truncated to 32 hex chars (128-bit).
+def _make_callback_token(bot_token: str, scope: str, payload_id: int) -> str:
+    """scope + payload_id 기반 HMAC 토큰을 생성한다.
+    Generate an HMAC token for the given scope and payload_id.
+
+    scope ∈ {"gate", "cmd"} — 도메인별로 다른 HMAC을 생성하여 교차 재생 공격을 방지한다.
+    scope ∈ {"gate", "cmd"} — Different HMACs per domain prevent cross-replay attacks.
 
     Telegram callback_data 한도 64바이트 준수:
     "gate:approve:<id>:<32-char-token>" 최대 ~51바이트 (id≤99999 기준).
     Telegram callback_data 64-byte limit compliance:
     "gate:approve:<id>:<32-char-token>" is at most ~51 bytes (id≤99999).
     128-bit HMAC 절단은 NIST SP 800-107 기준 충분한 보안 강도 제공.
-    128-bit HMAC truncation provides sufficient security per NIST SP 800-107."""
+    128-bit HMAC truncation provides sufficient security per NIST SP 800-107.
+    """
+    # scope:payload_id 를 HMAC 메시지로 사용해 도메인 격리 보장
+    # Use scope:payload_id as HMAC message to guarantee domain isolation
+    msg = f"{scope}:{payload_id}"
     return hmac.new(
-        bot_token.encode(), str(analysis_id).encode(), digestmod=hashlib.sha256
+        bot_token.encode(), msg.encode(), digestmod=hashlib.sha256
     ).hexdigest()[:32]  # 32자(128-bit) — Telegram 64-byte 한도 준수 필수
+    # 32 chars (128-bit) — required to stay within Telegram's 64-byte limit
+
+
+def _gate_callback_token(bot_token: str, analysis_id: int) -> str:
+    """gate 도메인 콜백 토큰 생성 — _make_callback_token 의 thin wrapper.
+    Generate a gate-domain callback token — thin wrapper over _make_callback_token.
+
+    기존 호출자(webhook/providers/telegram.py 등)와의 하위 호환성 유지.
+    Maintains backwards compatibility with existing callers (webhook/providers/telegram.py etc.).
+    """
+    # 시그니처 변경 없이 _make_callback_token 에 위임 — 기존 mock 패치 영향 없음
+    # Delegates to _make_callback_token without signature change — existing mocks unaffected
+    return _make_callback_token(bot_token, "gate", analysis_id)
 
 
 async def send_gate_request(

--- a/src/main.py
+++ b/src/main.py
@@ -17,6 +17,7 @@ from src.api.repos import router as api_repos_router
 from src.api.stats import router as api_stats_router
 from src.api.hook import router as api_hook_router
 from src.api.users import router as api_users_router
+from src.api.internal_cron import router as api_internal_cron_router
 from src.ui.router import router as ui_router
 from src.auth.github import router as auth_router
 
@@ -111,6 +112,7 @@ app.include_router(api_repos_router)
 app.include_router(api_stats_router)
 app.include_router(api_hook_router)
 app.include_router(api_users_router)
+app.include_router(api_internal_cron_router)
 app.include_router(ui_router)
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ from src.webhook.router import router as webhook_router
 from src.api.repos import router as api_repos_router
 from src.api.stats import router as api_stats_router
 from src.api.hook import router as api_hook_router
+from src.api.users import router as api_users_router
 from src.ui.router import router as ui_router
 from src.auth.github import router as auth_router
 
@@ -109,6 +110,7 @@ app.include_router(webhook_router)
 app.include_router(api_repos_router)
 app.include_router(api_stats_router)
 app.include_router(api_hook_router)
+app.include_router(api_users_router)
 app.include_router(ui_router)
 
 

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -54,3 +54,9 @@ class User(Base):
         Returns True when this user has a linked Telegram account.
         """
         return self.telegram_user_id is not None
+
+    def __repr__(self) -> str:
+        """OTP 및 토큰 필드를 제외한 User 표현.
+        User representation excluding OTP and token fields.
+        """
+        return f"<User id={self.id!r} github_login={self.github_login!r}>"

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -1,4 +1,6 @@
-"""User ORM 모델 — GitHub OAuth 인증 사용자 정보."""
+"""User ORM 모델 — GitHub OAuth 인증 사용자 정보.
+User ORM model — GitHub OAuth authenticated user information.
+"""
 from datetime import datetime, timezone
 from sqlalchemy import Column, Integer, String, DateTime
 from sqlalchemy.orm import relationship
@@ -7,25 +9,48 @@ from src.database import Base
 
 # pylint: disable=too-few-public-methods
 class User(Base):
-    """GitHub OAuth 로그인 사용자 테이블."""
+    """GitHub OAuth 로그인 사용자 테이블.
+    Table for GitHub OAuth logged-in users.
+    """
 
     __tablename__ = "users"
 
     id                  = Column(Integer, primary_key=True, index=True)
     github_id           = Column(String, unique=True, nullable=False, index=True)
     github_login        = Column(String, nullable=True)
-    github_access_token = Column(String, nullable=True)  # Fernet 암호화 저장
+    # Fernet 암호화 저장 — Stored with Fernet encryption.
+    github_access_token = Column(String, nullable=True)
     email               = Column(String, unique=True, nullable=False)
     display_name        = Column(String, nullable=False)
     created_at          = Column(DateTime, default=lambda: datetime.now(timezone.utc))
+
+    # Telegram 연동 컬럼 — Telegram integration columns.
+    # telegram_user_id: Telegram 사용자 고유 ID (연동 완료 시 설정)
+    # telegram_user_id: Telegram user unique ID (set upon successful linking).
+    telegram_user_id      = Column(String, nullable=True, unique=True)
+    # telegram_otp: 연동 인증용 일회용 패스코드
+    # telegram_otp: One-time passcode for Telegram account linking.
+    telegram_otp          = Column(String, nullable=True)
+    # telegram_otp_expires_at: OTP 만료 시각 (타임존 포함)
+    # telegram_otp_expires_at: OTP expiry timestamp with timezone.
+    telegram_otp_expires_at = Column(DateTime(timezone=True), nullable=True)
 
     repositories = relationship("Repository", back_populates="owner")
 
     @property
     def plaintext_token(self) -> str:
         """DB에 암호화 저장된 GitHub 액세스 토큰을 복호화하여 반환.
+        Decrypts and returns the GitHub access token stored encrypted in DB.
 
         TOKEN_ENCRYPTION_KEY 미설정 시 평문 그대로 반환(하위 호환).
+        Falls back to plaintext when TOKEN_ENCRYPTION_KEY is not set (backward-compat).
         """
         from src.crypto import decrypt_token  # pylint: disable=import-outside-toplevel
         return decrypt_token(self.github_access_token or "")
+
+    @property
+    def is_telegram_connected(self) -> bool:
+        """Telegram 연동 여부를 반환한다.
+        Returns True when this user has a linked Telegram account.
+        """
+        return self.telegram_user_id is not None

--- a/src/notifier/telegram_commands.py
+++ b/src/notifier/telegram_commands.py
@@ -1,0 +1,253 @@
+"""Telegram 봇 텍스트 명령 및 cmd: 콜백 핸들러.
+Telegram bot text-command and cmd: callback handlers.
+
+계층 의존성 규칙: repositories/*, models/*, services/analytics_service, config.py 만 import.
+Layer dependency rule: only import from repositories/*, models/*, services/analytics_service, config.py.
+api/, ui/, webhook/ import 금지.
+Do NOT import from api/, ui/, webhook/.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.repository import Repository
+from src.repositories import repository_repo, user_repo
+from src.services.analytics_service import moving_average, weekly_summary
+
+logger = logging.getLogger(__name__)
+
+# 미연결 사용자 공통 안내 메시지
+# Common prompt message for disconnected users
+_NOT_CONNECTED_MSG = (
+    "먼저 /connect <코드>로 계정을 연결하세요.\n"
+    "Connect your account first: /connect <code>"
+)
+
+
+@dataclass(frozen=True)
+class CmdCallback:
+    """파싱된 cmd: 콜백 데이터.
+    Parsed cmd: callback data.
+    """
+
+    # 동작 동사 (예: "stats", "connect")
+    # Action verb (e.g. "stats", "connect")
+    verb: str
+    # 대상 리소스 PK (없을 수 있음)
+    # Target resource PK (may be absent)
+    payload_id: int | None
+    # HMAC 토큰 — 위변조 방지
+    # HMAC token — tamper prevention
+    token: str
+
+
+def parse_cmd_callback(data: str) -> CmdCallback | None:
+    """cmd: 접두사 콜백 데이터를 파싱한다.
+    Parse cmd: prefix callback data.
+
+    Returns None for gate: callbacks or malformed data.
+
+    형식 1: cmd:<verb>:<token>           (3-part, id 없음)
+    Format 1: cmd:<verb>:<token>          (3-part, no id)
+    형식 2: cmd:<verb>:<id>:<token>       (4-part, id 포함)
+    Format 2: cmd:<verb>:<id>:<token>     (4-part, with id)
+    """
+    # cmd: 접두사가 아니면 처리 대상 아님
+    # Not a cmd: callback — skip
+    if not data.startswith("cmd:"):
+        return None
+
+    parts = data.split(":")
+
+    if len(parts) == 3:
+        # cmd:connect:<token> 패턴 — id 없음
+        # cmd:connect:<token> pattern — no id
+        _, verb, token = parts
+        return CmdCallback(verb=verb, payload_id=None, token=token)
+
+    if len(parts) == 4:
+        # cmd:<verb>:<id>:<token> 패턴
+        # cmd:<verb>:<id>:<token> pattern
+        _, verb, raw_id, token = parts
+        try:
+            return CmdCallback(verb=verb, payload_id=int(raw_id), token=token)
+        except ValueError:
+            # id가 정수로 변환 불가 → 잘못된 데이터
+            # id cannot be converted to int → malformed data
+            return None
+
+    # 파트 수가 맞지 않는 잘못된 형식
+    # Wrong number of parts — malformed
+    return None
+
+
+def handle_message_command(db: Session, telegram_user_id: str, text: str) -> str:
+    """Telegram 텍스트 명령을 처리하고 응답 텍스트를 반환한다.
+    Handle a Telegram text command and return the reply text.
+
+    Args:
+        db: SQLAlchemy 세션 / SQLAlchemy session
+        telegram_user_id: 발신 Telegram 사용자 ID / Sender Telegram user ID
+        text: 수신된 명령 텍스트 / Received command text
+
+    Returns:
+        Telegram 응답 텍스트 / Telegram reply text
+    """
+    text = (text or "").strip()
+
+    # /connect 는 미연결 사용자도 사용 가능 — 먼저 처리
+    # /connect is allowed for unlinked users — handle first
+    if text.startswith("/connect"):
+        parts = text.split(maxsplit=1)
+        otp = parts[1].strip() if len(parts) > 1 else ""
+        return _handle_connect(db, telegram_user_id, otp)
+
+    # 그 외 명령은 연결된 사용자만 허용
+    # All other commands require a linked user
+    user = user_repo.find_by_telegram_user_id(db, telegram_user_id)
+    if user is None:
+        return _NOT_CONNECTED_MSG
+
+    if text.startswith("/stats"):
+        parts = text.split(maxsplit=1)
+        repo_name = parts[1].strip() if len(parts) > 1 else ""
+        return _handle_stats(db, user, repo_name)
+
+    if text.startswith("/settings"):
+        return _handle_settings(db, user)
+
+    # 알 수 없는 명령 — 도움말 반환
+    # Unknown command — return help
+    return (
+        "지원하지 않는 명령입니다. 사용 가능: /stats <repo>, /settings, /connect <코드>\n"
+        "Unknown command. Available: /stats <repo>, /settings, /connect <code>"
+    )
+
+
+def _handle_connect(db: Session, telegram_user_id: str, otp: str) -> str:
+    """OTP를 검증해 계정을 연결한다.
+    Validate OTP and link the Telegram account.
+
+    Args:
+        db: SQLAlchemy 세션 / SQLAlchemy session
+        telegram_user_id: 연결할 Telegram 사용자 ID / Telegram user ID to link
+        otp: 사용자 입력 OTP / User-supplied OTP
+
+    Returns:
+        성공 또는 실패 메시지 / Success or failure message
+    """
+    # OTP 인수 미입력 시 사용법 안내
+    # Show usage if OTP argument is missing
+    if not otp:
+        return "사용법: /connect <6자리 코드>\nUsage: /connect <6-digit code>"
+
+    # 만료되지 않은 OTP로 사용자 조회
+    # Look up user by unexpired OTP
+    found = user_repo.find_by_otp(db, otp)
+    if found is None:
+        return "OTP가 잘못되었거나 만료되었습니다.\nInvalid or expired OTP."
+
+    try:
+        # telegram_user_id 매핑 + OTP 무효화
+        # Map telegram_user_id and nullify OTP
+        user_repo.set_telegram_user_id(db, found.id, telegram_user_id)
+    except ValueError:
+        # 이미 다른 사용자에게 연결된 Telegram ID
+        # Telegram ID already linked to another user
+        return (
+            "이 Telegram 계정은 이미 다른 사용자에게 연결되어 있습니다.\n"
+            "This Telegram account is already linked to another user."
+        )
+
+    name = found.display_name or found.github_login or "사용자"
+    return f"✅ {name} 님의 계정이 연결되었습니다!\n✅ Account linked for {name}!"
+
+
+def _handle_stats(db: Session, user: Any, repo_name: str) -> str:
+    """리포지토리 주간 통계를 반환한다.
+    Return weekly stats for a repository.
+
+    Args:
+        db: SQLAlchemy 세션 / SQLAlchemy session
+        user: 인증된 User ORM 인스턴스 / Authenticated User ORM instance
+        repo_name: 조회할 리포 전체 이름 (owner/repo) / Target repo full name
+    """
+    # 리포 인수 미입력 시 사용법 안내
+    # Show usage if repo argument is missing
+    if not repo_name:
+        return (
+            "사용법: /stats <리포지토리 전체 이름 (owner/repo)>\n"
+            "Usage: /stats <owner/repo>"
+        )
+
+    # 리포 존재 여부 및 소유권 확인
+    # Verify repo existence and ownership
+    repo = repository_repo.find_by_full_name(db, repo_name)
+    if repo is None or repo.user_id != user.id:
+        return (
+            f"리포지토리를 찾을 수 없습니다: {repo_name}\n"
+            f"Repository not found: {repo_name}"
+        )
+
+    # 주간 집계 — 현재 시각 기준 7일 전부터
+    # Weekly summary — from 7 days before current time
+    now = datetime.now(timezone.utc)
+    week_start = now - timedelta(days=7)
+    summary = weekly_summary(db, repo.id, week_start, now=now)
+
+    if summary is None:
+        return (
+            f"📊 {repo_name}\n"
+            f"최근 7일간 분석 데이터가 없습니다.\n"
+            f"No analysis data in the past 7 days."
+        )
+
+    avg = summary["avg_score"]
+    count = summary["count"]
+
+    # 이동 평균과 비교한 추세 계산 (샘플 부족 시 생략)
+    # Compute trend vs moving average (omit when samples are insufficient)
+    avg_ma = moving_average(db, repo.id, now=now)
+    trend = ""
+    if avg_ma is not None:
+        diff = round(avg - avg_ma, 1)
+        trend = f" (7일 이동평균 대비 {diff:+.1f}점 / vs 7d avg {diff:+.1f})"
+
+    return (
+        f"📊 {repo_name}\n"
+        f"최근 7일 분석: {count}건\n"
+        f"평균 점수: {avg:.1f}점{trend}\n"
+        f"최저: {summary['min_score']} / 최고: {summary['max_score']}\n"
+        f"Analyses (7d): {count} | Avg: {avg:.1f}{trend}"
+    )
+
+
+def _handle_settings(db: Session, user: Any) -> str:
+    """사용자의 등록 리포지토리 목록을 반환한다.
+    Return the user's registered repository list.
+
+    Args:
+        db: SQLAlchemy 세션 / SQLAlchemy session
+        user: 인증된 User ORM 인스턴스 / Authenticated User ORM instance
+    """
+    # 사용자 소유 리포를 이름순 정렬로 조회
+    # Fetch user-owned repos sorted alphabetically
+    repos = db.scalars(
+        select(Repository)
+        .where(Repository.user_id == user.id)
+        .order_by(Repository.full_name)
+    ).all()
+
+    if not repos:
+        return "등록된 리포지토리가 없습니다.\nNo repositories registered."
+
+    lines = ["📋 등록된 리포지토리 / Registered repositories:"]
+    for repo in repos:
+        lines.append(f"  • {repo.full_name}")
+    return "\n".join(lines)

--- a/src/repositories/repository_repo.py
+++ b/src/repositories/repository_repo.py
@@ -8,6 +8,13 @@ from sqlalchemy.orm import Session
 from src.models.repository import Repository
 
 
+def find_all(db: Session) -> list[Repository]:
+    """모든 Repository 레코드를 반환한다.
+    Return all Repository records.
+    """
+    return db.query(Repository).all()
+
+
 def find_by_full_name(db: Session, full_name: str) -> Repository | None:
     """리포 전체 이름(owner/repo)으로 조회.
 

--- a/src/repositories/user_repo.py
+++ b/src/repositories/user_repo.py
@@ -77,6 +77,15 @@ def set_telegram_user_id(
         raise ValueError(f"telegram_user_id already mapped: {telegram_user_id}") from exc
 
 
+def find_by_telegram_user_id(db: Session, telegram_user_id: str) -> "User | None":
+    """Telegram user_id로 사용자를 조회한다.
+    Find a user by Telegram user_id.
+    """
+    # telegram_user_id unique 인덱스 컬럼으로 단건 조회
+    # Single-row lookup via the unique-indexed telegram_user_id column
+    return db.scalar(select(User).where(User.telegram_user_id == telegram_user_id))
+
+
 def clear_otp(db: Session, user_id: int) -> None:
     """OTP를 무효화한다.
     Nullify the OTP fields (e.g. on timeout or explicit cancellation).

--- a/src/repositories/user_repo.py
+++ b/src/repositories/user_repo.py
@@ -1,18 +1,75 @@
 """UserRepo — User ORM 쿼리 단일 출처.
+UserRepo — Single source of truth for User ORM queries.
 
 Note: filter() 기반 — 기존 mock 패턴 (`db.query(...).filter(...).first()`)
 호환 유지.
+Note: filter()-based — keeps backward-compat with existing mock pattern.
 """
+from datetime import datetime, timezone
+
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from src.models.user import User
 
 
 def find_by_id(db: Session, user_id: int) -> User | None:
-    """PK 로 조회."""
+    """PK 로 조회.
+    Find a user by primary key.
+    """
     return db.query(User).filter(User.id == user_id).first()
 
 
 def find_by_github_id(db: Session, github_id: str) -> User | None:
-    """GitHub 계정 ID(문자열) 로 조회 (OAuth 로그인 경로)."""
+    """GitHub 계정 ID(문자열) 로 조회 (OAuth 로그인 경로).
+    Find a user by GitHub account ID string (OAuth login path).
+    """
     return db.query(User).filter(User.github_id == github_id).first()
+
+
+def find_by_otp(db: Session, otp: str) -> User | None:
+    """만료되지 않은 OTP로 사용자를 조회한다.
+    Find a user whose OTP is still valid (not yet expired).
+    """
+    # 현재 UTC 시각을 기준으로 만료 여부 판정
+    # Use current UTC time to determine whether the OTP has expired.
+    now = datetime.now(timezone.utc)
+    return db.scalar(
+        select(User)
+        .where(User.telegram_otp == otp)
+        .where(User.telegram_otp_expires_at > now)
+    )
+
+
+def set_telegram_user_id(
+    db: Session,
+    user_id: int,
+    telegram_user_id: str,
+) -> None:
+    """Telegram user_id를 매핑하고 OTP를 무효화한다.
+    Map telegram_user_id to the user and nullify the OTP fields.
+    """
+    # OTP는 연동 완료 즉시 무효화하여 재사용을 방지한다
+    # Nullify OTP immediately after linking to prevent replay attacks.
+    db.execute(
+        update(User)
+        .where(User.id == user_id)
+        .values(
+            telegram_user_id=telegram_user_id,
+            telegram_otp=None,
+            telegram_otp_expires_at=None,
+        )
+    )
+    db.commit()
+
+
+def clear_otp(db: Session, user_id: int) -> None:
+    """OTP를 무효화한다.
+    Nullify the OTP fields (e.g. on timeout or explicit cancellation).
+    """
+    db.execute(
+        update(User)
+        .where(User.id == user_id)
+        .values(telegram_otp=None, telegram_otp_expires_at=None)
+    )
+    db.commit()

--- a/src/repositories/user_repo.py
+++ b/src/repositories/user_repo.py
@@ -8,6 +8,7 @@ Note: filter()-based — keeps backward-compat with existing mock pattern.
 from datetime import datetime, timezone
 
 from sqlalchemy import select, update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.models.user import User
@@ -29,7 +30,12 @@ def find_by_github_id(db: Session, github_id: str) -> User | None:
 
 def find_by_otp(db: Session, otp: str) -> User | None:
     """만료되지 않은 OTP로 사용자를 조회한다.
-    Find a user whose OTP is still valid (not yet expired).
+    Find a user by unexpired OTP.
+
+    Note: 호출자는 OTP 비교 타이밍 공격(enumeration attack)을 방지하기 위해
+    응답 속도를 일정하게 유지하거나 hmac.compare_digest를 활용해야 한다.
+    Callers should ensure constant-time OTP comparison or add response latency
+    padding to mitigate timing-based enumeration attacks.
     """
     # 현재 UTC 시각을 기준으로 만료 여부 판정
     # Use current UTC time to determine whether the OTP has expired.
@@ -47,20 +53,28 @@ def set_telegram_user_id(
     telegram_user_id: str,
 ) -> None:
     """Telegram user_id를 매핑하고 OTP를 무효화한다.
-    Map telegram_user_id to the user and nullify the OTP fields.
+    Map telegram_user_id and nullify the OTP.
+
+    Raises:
+        ValueError: telegram_user_id가 이미 다른 사용자에게 매핑된 경우.
+                    Raised if telegram_user_id is already mapped to another user.
     """
     # OTP는 연동 완료 즉시 무효화하여 재사용을 방지한다
     # Nullify OTP immediately after linking to prevent replay attacks.
-    db.execute(
-        update(User)
-        .where(User.id == user_id)
-        .values(
-            telegram_user_id=telegram_user_id,
-            telegram_otp=None,
-            telegram_otp_expires_at=None,
+    try:
+        db.execute(
+            update(User)
+            .where(User.id == user_id)
+            .values(
+                telegram_user_id=telegram_user_id,
+                telegram_otp=None,
+                telegram_otp_expires_at=None,
+            )
         )
-    )
-    db.commit()
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise ValueError(f"telegram_user_id already mapped: {telegram_user_id}") from exc
 
 
 def clear_otp(db: Session, user_id: int) -> None:

--- a/src/services/analytics_service.py
+++ b/src/services/analytics_service.py
@@ -1,0 +1,213 @@
+"""주간 집계, 이동 평균, 주요 이슈, chat_id 라우팅 등 분석 집계 서비스.
+Analytics aggregation service — weekly summary, moving average, top issues, chat_id routing.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from src.config import settings
+from src.models.analysis import Analysis
+from src.models.repo_config import RepoConfig
+from src.models.repository import Repository
+
+logger = logging.getLogger(__name__)
+
+
+def weekly_summary(
+    db: Session,
+    repo_id: int,
+    week_start: datetime,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """지정된 주간 시작 시각부터 7일간의 분석 요약을 반환한다.
+    Return a 7-day analysis summary starting from week_start.
+
+    Returns None if no analyses exist in the window.
+
+    Args:
+        db: SQLAlchemy 세션 / SQLAlchemy session
+        repo_id: 대상 리포지토리 PK / Target repository PK
+        week_start: 집계 시작 시각 (UTC 권장) / Aggregation start time (UTC recommended)
+        now: 현재 시각 주입용 (테스트 고정 지원) / Injected current time (for test pinning)
+
+    Returns:
+        집계 결과 dict 또는 분석이 없으면 None
+        Aggregation result dict or None if no analyses exist.
+    """
+    # now 기본값 설정 — 테스트에서 고정 시각 주입 가능
+    # Default now — allows injecting a fixed time in tests
+    _now = now or datetime.now(timezone.utc)
+    week_end = week_start + timedelta(days=7)
+
+    # week_end가 now를 초과하면 now로 clamp
+    # Clamp week_end to now if it exceeds the current time
+    week_end = min(week_end, _now)
+
+    row = db.execute(
+        select(
+            func.count(Analysis.id).label("count"),  # pylint: disable=not-callable
+            func.avg(Analysis.score).label("avg_score"),  # pylint: disable=not-callable
+            func.min(Analysis.score).label("min_score"),  # pylint: disable=not-callable
+            func.max(Analysis.score).label("max_score"),  # pylint: disable=not-callable
+        )
+        .where(Analysis.repo_id == repo_id)
+        .where(Analysis.score.isnot(None))
+        .where(Analysis.created_at >= week_start)
+        .where(Analysis.created_at < week_end)
+    ).one()
+
+    # 분석 건수가 0이면 집계 없음 → None 반환
+    # No analyses in the window → return None
+    if not row.count:
+        return None
+
+    return {
+        "count": row.count,
+        "avg_score": round(float(row.avg_score), 1),
+        "min_score": row.min_score,
+        "max_score": row.max_score,
+        "week_start": week_start.isoformat(),
+    }
+
+
+def moving_average(
+    db: Session,
+    repo_id: int,
+    window_days: int = 7,
+    *,
+    min_samples: int = 5,
+    now: datetime | None = None,
+) -> float | None:
+    """최근 window_days일 이동 평균 점수를 반환한다.
+    Return the moving average score over the last window_days days.
+
+    Returns None if fewer than min_samples analyses exist.
+
+    Args:
+        db: SQLAlchemy 세션 / SQLAlchemy session
+        repo_id: 대상 리포지토리 PK / Target repository PK
+        window_days: 이동 평균 윈도우 크기(일) / Window size in days
+        min_samples: 최소 샘플 수 미만이면 None 반환 / Return None if below this threshold
+        now: 현재 시각 주입용 (테스트 고정 지원) / Injected current time (for test pinning)
+
+    Returns:
+        이동 평균 점수(소수점 1자리) 또는 샘플 부족 시 None
+        Moving average score (1 decimal place) or None when samples are insufficient.
+    """
+    # now 기본값 설정 — 테스트에서 고정 시각 주입 가능
+    # Default now — allows injecting a fixed time in tests
+    _now = now or datetime.now(timezone.utc)
+    since = _now - timedelta(days=window_days)
+
+    rows = db.scalars(
+        select(Analysis.score)
+        .where(Analysis.repo_id == repo_id)
+        .where(Analysis.score.isnot(None))
+        .where(Analysis.created_at >= since)
+        .order_by(Analysis.created_at.desc())
+    ).all()
+
+    # 최소 샘플 수 미만이면 신뢰할 수 없는 평균 → None 반환
+    # Fewer than min_samples → unreliable average → return None
+    if len(rows) < min_samples:
+        return None
+
+    return round(sum(rows) / len(rows), 1)
+
+
+def top_issues(
+    db: Session,
+    repo_id: int,
+    days: int = 30,
+    n: int = 5,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """최근 N일간 가장 자주 발생한 이슈 상위 n개를 반환한다.
+    Return the top-n most frequent issues from the last `days` days.
+
+    Parses the Analysis.result JSON on the Python side for SQLite/PG compatibility.
+
+    Args:
+        db: SQLAlchemy 세션 / SQLAlchemy session
+        repo_id: 대상 리포지토리 PK / Target repository PK
+        days: 집계 기간(일) / Aggregation period in days
+        n: 반환할 최대 이슈 수 / Maximum number of issues to return
+        now: 현재 시각 주입용 (테스트 고정 지원) / Injected current time (for test pinning)
+
+    Returns:
+        {"message": str, "count": int} dict 리스트 (빈도 내림차순)
+        List of {"message": str, "count": int} dicts sorted by frequency descending.
+    """
+    # now 기본값 설정 — 테스트에서 고정 시각 주입 가능
+    # Default now — allows injecting a fixed time in tests
+    _now = now or datetime.now(timezone.utc)
+    since = _now - timedelta(days=days)
+
+    analyses = db.scalars(
+        select(Analysis)
+        .where(Analysis.repo_id == repo_id)
+        .where(Analysis.created_at >= since)
+        .where(Analysis.result.isnot(None))
+    ).all()
+
+    # result JSON에서 이슈를 Python-side 파싱 (SQLite/PG 호환)
+    # Parse issues from result JSON on the Python side for SQLite/PG compatibility
+    counter: dict[str, int] = {}
+    for analysis in analyses:
+        result = analysis.result or {}
+        issues = result.get("issues", [])
+        for issue in issues:
+            if isinstance(issue, dict):
+                # "message" 키 우선, 없으면 "code" 키 사용
+                # Prefer "message" key, fall back to "code" key
+                key = issue.get("message", "") or issue.get("code", "")
+                if key:
+                    counter[key] = counter.get(key, 0) + 1
+
+    # 빈도 내림차순 정렬 후 상위 n개 반환
+    # Sort by frequency descending and return top-n items
+    sorted_issues = sorted(counter.items(), key=lambda x: x[1], reverse=True)
+    return [{"message": msg, "count": cnt} for msg, cnt in sorted_issues[:n]]
+
+
+def resolve_chat_id(repo: Repository, config: RepoConfig | None) -> str | None:
+    """chat_id 우선순위에 따라 Telegram 채팅 ID를 반환한다.
+    Resolve the Telegram chat_id with priority:
+    1. RepoConfig.notify_chat_id
+    2. Repository.telegram_chat_id
+    3. settings.telegram_chat_id (global fallback)
+    4. None → caller must skip with WARNING log
+
+    Args:
+        repo: Repository ORM 인스턴스 / Repository ORM instance
+        config: RepoConfig ORM 인스턴스 (없으면 None) / RepoConfig ORM instance (None if absent)
+
+    Returns:
+        Telegram chat_id 문자열 또는 None (전송 불가 상태)
+        Telegram chat_id string or None (no valid destination).
+    """
+    # 1순위: RepoConfig.notify_chat_id (리포 전용 채팅 ID)
+    # Priority 1: RepoConfig.notify_chat_id (repo-specific chat ID)
+    if config and config.notify_chat_id:
+        return config.notify_chat_id
+
+    # 2순위: Repository.telegram_chat_id (리포 레거시 채팅 ID)
+    # Priority 2: Repository.telegram_chat_id (repo-level legacy chat ID)
+    if repo.telegram_chat_id:
+        return repo.telegram_chat_id
+
+    # 3순위: 전역 settings fallback
+    # Priority 3: global settings fallback
+    if settings.telegram_chat_id:
+        return settings.telegram_chat_id
+
+    # 모든 소스가 없음 → 호출자가 WARNING 로그 후 전송 건너뜀
+    # All sources absent → caller must log WARNING and skip sending
+    return None

--- a/src/services/cron_service.py
+++ b/src/services/cron_service.py
@@ -1,0 +1,193 @@
+"""주간 리포트 + 트렌드 체크 cron 서비스.
+Weekly report and trend-check cron service.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+import httpx
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
+
+from src.config import settings
+from src.notifier.telegram import telegram_post_message
+from src.repositories import repo_config_repo, repository_repo
+from src.services.analytics_service import moving_average, resolve_chat_id, weekly_summary
+
+logger = logging.getLogger(__name__)
+
+# 7일 이동평균 하락 기준점 (점수) — 이 값 이상 하락 시 경고 발송
+# Score drop threshold to trigger a trend alert
+_TREND_DROP_THRESHOLD = 10.0
+
+
+async def run_weekly_reports(db: Session, *, now: datetime | None = None) -> int:
+    """모든 활성 리포에 대해 주간 요약을 Telegram으로 발송한다.
+    Send weekly summary Telegram messages for all active repositories.
+
+    Returns the number of successfully sent reports.
+    """
+    # now 기본값 설정 — 테스트에서 고정 시각 주입 가능
+    # Default now — allows injecting a fixed time in tests
+    _now = now or datetime.now(timezone.utc)
+    week_start = _now - timedelta(days=7)
+    sent = 0
+
+    # 전체 리포 목록 조회
+    # Fetch all repository records
+    repos = repository_repo.find_all(db)
+
+    for repo in repos:
+        try:
+            # 리포별 설정 조회 (없으면 None)
+            # Fetch per-repo config (None if absent)
+            config = repo_config_repo.find_by_full_name(db, repo.full_name)
+
+            # chat_id 우선순위 라우팅 — None 이면 skip
+            # Resolve chat_id with priority routing — skip if None
+            chat_id = resolve_chat_id(repo, config)
+            if not chat_id:
+                logger.warning(
+                    "weekly_report: no chat_id resolved for repo=%s", repo.full_name
+                )
+                continue
+
+            # 주간 요약 집계 — 분석 없으면 None 반환
+            # Aggregate weekly summary — returns None if no analyses exist
+            summary = weekly_summary(db, repo.id, week_start, now=_now)
+            if summary is None:
+                continue
+
+            # 메시지 포맷팅 후 Telegram 발송
+            # Format message and send via Telegram
+            text = _format_weekly_message(repo.full_name, summary)
+            await telegram_post_message(
+                settings.telegram_bot_token,
+                chat_id,
+                {"text": text, "parse_mode": "HTML"},
+            )
+            sent += 1
+
+        except (httpx.HTTPError, SQLAlchemyError, KeyError, ValueError) as exc:
+            # 리포별 예외 격리 — 한 리포 실패가 다른 리포 알림을 막지 않는다
+            # Per-repo exception isolation — one failure does not block others
+            logger.warning(
+                "weekly_report: failed for repo=%s: %s", repo.full_name, exc
+            )
+
+    return sent
+
+
+def _format_weekly_message(repo_full_name: str, summary: dict) -> str:
+    """주간 요약 Telegram 메시지를 포맷팅한다.
+    Format a weekly summary Telegram message.
+
+    Args:
+        repo_full_name: 리포 전체 이름 (owner/repo) / Repository full name
+        summary: weekly_summary() 반환 dict / Return value of weekly_summary()
+
+    Returns:
+        HTML 포맷 메시지 문자열 / HTML-formatted message string
+    """
+    avg = summary["avg_score"]
+    count = summary["count"]
+    return (
+        f"<b>\U0001f4ca 주간 리포트 / Weekly Report</b>\n"
+        f"<code>{repo_full_name}</code>\n"
+        f"분석 건수 / Analyses: {count}\n"
+        f"평균 점수 / Avg score: {avg:.1f}"
+    )
+
+
+async def run_trend_check(db: Session, *, now: datetime | None = None) -> int:
+    """7일 이동 평균이 10점 이상 하락한 리포에 트렌드 경고를 발송한다.
+    Send trend alerts for repos whose 7-day moving average drops by 10+ points.
+
+    Returns the number of alerts sent.
+    """
+    # now 기본값 설정 — 테스트에서 고정 시각 주입 가능
+    # Default now — allows injecting a fixed time in tests
+    _now = now or datetime.now(timezone.utc)
+    alerted = 0
+
+    # 전체 리포 목록 조회
+    # Fetch all repository records
+    repos = repository_repo.find_all(db)
+
+    for repo in repos:
+        try:
+            # 리포별 설정 조회 (없으면 None)
+            # Fetch per-repo config (None if absent)
+            config = repo_config_repo.find_by_full_name(db, repo.full_name)
+
+            # chat_id 우선순위 라우팅 — None 이면 skip
+            # Resolve chat_id with priority routing — skip if None
+            chat_id = resolve_chat_id(repo, config)
+            if not chat_id:
+                continue
+
+            # 현재 7일 이동 평균
+            # Current 7-day moving average
+            current_avg = moving_average(db, repo.id, now=_now)
+            if current_avg is None:
+                # min_samples 미충족 — skip
+                # Below min_samples — skip
+                continue
+
+            # 이전 주(7일 전 기준) 이동 평균 — 비교 기준
+            # Previous week's moving average (baseline 7 days ago)
+            prev_now = _now - timedelta(days=7)
+            prev_avg = moving_average(db, repo.id, now=prev_now)
+            if prev_avg is None:
+                # 이전 기간 샘플 부족 — 비교 불가, skip
+                # Insufficient samples for previous window — cannot compare, skip
+                continue
+
+            # 하락폭 계산 — 10점 이상이면 경고 발송
+            # Calculate drop — send alert if >= threshold
+            drop = prev_avg - current_avg
+            if drop >= _TREND_DROP_THRESHOLD:
+                text = _format_trend_alert(repo.full_name, current_avg, prev_avg, drop)
+                await telegram_post_message(
+                    settings.telegram_bot_token,
+                    chat_id,
+                    {"text": text, "parse_mode": "HTML"},
+                )
+                alerted += 1
+
+        except (httpx.HTTPError, SQLAlchemyError, KeyError, ValueError) as exc:
+            # 리포별 예외 격리 — 한 리포 실패가 다른 리포 알림을 막지 않는다
+            # Per-repo exception isolation — one failure does not block others
+            logger.warning(
+                "trend_check: failed for repo=%s: %s", repo.full_name, exc
+            )
+
+    return alerted
+
+
+def _format_trend_alert(
+    repo_full_name: str,
+    current: float,
+    prev: float,
+    drop: float,
+) -> str:
+    """트렌드 경고 메시지를 포맷팅한다.
+    Format a trend alert message.
+
+    Args:
+        repo_full_name: 리포 전체 이름 (owner/repo) / Repository full name
+        current: 현재 7일 이동 평균 / Current 7-day moving average
+        prev: 이전 7일 이동 평균 / Previous 7-day moving average
+        drop: 하락폭 (prev - current) / Score drop (prev - current)
+
+    Returns:
+        HTML 포맷 경고 메시지 / HTML-formatted alert message
+    """
+    return (
+        f"<b>⚠️ 점수 하락 경고 / Score Drop Alert</b>\n"
+        f"<code>{repo_full_name}</code>\n"
+        f"이전 7일 평균 / Prev avg: {prev:.1f}\n"
+        f"현재 7일 평균 / Current avg: {current:.1f}\n"
+        f"하락 / Drop: -{drop:.1f}점"
+    )

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -830,6 +830,75 @@
       <span class="field-hint">설정 저장 후 Railway Webhook URL 이 자동 생성됩니다.</span>
       {% endif %}
 
+      <div class="s-divider"></div>
+
+      <!-- Telegram 연결 서브섹션 / Telegram Connection subsection -->
+      <div class="s-section-label">Telegram 연결 / Telegram Connection</div>
+      <div class="mb-4" id="telegram-connect-section">
+        {% if current_user.is_telegram_connected %}
+        <p class="text-success mb-2" style="font-size:13px;">✅ Telegram 계정이 연결되어 있습니다.</p>
+        {% else %}
+        <p style="font-size:13px;color:var(--text-muted);margin-bottom:.6rem;">
+          Telegram 봇에서 /connect 명령으로 계정을 연결하세요.
+        </p>
+        <button type="button" class="hook-btn" id="issueTelegramOtp">
+          🔗 연결 코드 발급 / Issue Code
+        </button>
+        <div id="telegramOtpDisplay" style="display:none;margin-top:.65rem;">
+          <code id="telegramOtpCode" style="font-size:1.4rem;font-weight:700;letter-spacing:.12em;"></code>
+          <span style="font-size:12px;color:var(--text-muted);margin-left:.5rem;">
+            (<span id="telegramOtpCountdown">5:00</span> 후 만료)
+          </span>
+          <p style="font-size:11px;color:var(--text-muted);margin-top:.35rem;margin-bottom:0;">
+            이전 코드는 무효화됩니다. / Previous codes are invalidated.
+          </p>
+        </div>
+
+        <script>
+          // Telegram OTP 발급 버튼 클릭 핸들러 — 미연결 상태에서만 렌더링
+          // Click handler for Telegram OTP issuance — rendered only when not connected.
+          (function () {
+            var btn = document.getElementById('issueTelegramOtp');
+            if (!btn) { return; }
+            btn.addEventListener('click', async function () {
+              btn.disabled = true;
+              try {
+                var resp = await fetch('/api/users/me/telegram-otp', { method: 'POST' });
+                if (!resp.ok) { btn.disabled = false; return; }
+                var data = await resp.json();
+                // OTP 코드 표시
+                // Display the issued OTP code.
+                document.getElementById('telegramOtpCode').textContent = data.otp;
+                document.getElementById('telegramOtpDisplay').style.display = '';
+
+                // 카운트다운 타이머 (5분) — Countdown timer (5 minutes).
+                var remaining = data.ttl_minutes * 60;
+                var cd = document.getElementById('telegramOtpCountdown');
+                var timer = setInterval(function () {
+                  remaining -= 1;
+                  var m = Math.floor(remaining / 60);
+                  var s = remaining % 60;
+                  cd.textContent = m + ':' + (s < 10 ? '0' : '') + s;
+                  if (remaining <= 0) {
+                    clearInterval(timer);
+                    // 만료 시 OTP 표시 영역 숨김 및 버튼 재활성화
+                    // Hide OTP display and re-enable button upon expiry.
+                    document.getElementById('telegramOtpDisplay').style.display = 'none';
+                    btn.disabled = false;
+                  }
+                }, 1000);
+              } catch (e) {
+                // 네트워크 오류 등 예외 발생 시 버튼을 재활성화하여 재시도 허용
+                // Re-enable button on network or other errors so the user can retry.
+                console.error('Telegram OTP issuance failed:', e);
+                btn.disabled = false;
+              }
+            });
+          }());
+        </script>
+        {% endif %}
+      </div>
+
     </div>
   </div>
 

--- a/src/webhook/providers/telegram.py
+++ b/src/webhook/providers/telegram.py
@@ -2,6 +2,8 @@
 
 반자동 Gate 모드에서 Telegram 인라인 키보드 버튼 클릭 콜백을 수신.
 HMAC 으로 서명된 callback token 을 검증하고 GitHub Review 를 실행한다.
+Semi-auto gate mode: receives Telegram inline-keyboard button callbacks,
+validates HMAC-signed callback token, and executes GitHub Review.
 """
 from __future__ import annotations
 
@@ -19,6 +21,8 @@ from src.config_manager.manager import get_repo_config
 from src.database import SessionLocal
 from src.gate.engine import save_gate_decision
 from src.gate.github_review import merge_pr, post_github_review
+from src.notifier.telegram import telegram_post_message
+from src.notifier.telegram_commands import handle_message_command, parse_cmd_callback
 from src.repositories import analysis_repo, repository_repo
 from src.shared.merge_metrics import log_merge_attempt
 
@@ -119,15 +123,63 @@ async def handle_gate_callback(
             logger.error("Gate callback failed: %s", exc)
 
 
+def _handle_message(
+    data: dict,
+    background_tasks: BackgroundTasks,
+    bot_token: str,
+) -> dict:
+    """Telegram message 이벤트를 처리한다.
+    Handle a Telegram message event (text commands).
+
+    텍스트 명령(/start, /connect, /stats, /settings)을 수신해
+    handle_message_command로 위임하고 응답을 background에서 전송한다.
+    Receives text commands and delegates to handle_message_command,
+    sending the reply in background.
+    """
+    message = data.get("message") or {}
+    text = message.get("text") or ""
+    # 텍스트 없으면 처리 불필요
+    # No text — nothing to process
+    if not text:
+        return {"status": "ok"}
+
+    sender = message.get("from") or {}
+    sender_id = str(sender.get("id", ""))
+    chat = message.get("chat") or {}
+    chat_id = str(chat.get("id", ""))
+
+    # 발신자 또는 채팅 ID 없으면 처리 불필요
+    # Missing sender or chat ID — skip
+    if not sender_id or not chat_id:
+        return {"status": "ok"}
+
+    with SessionLocal() as db:
+        # 텍스트 명령 처리 후 응답 텍스트 반환
+        # Process text command and obtain reply text
+        reply = handle_message_command(db=db, telegram_user_id=sender_id, text=text)
+
+    # 응답 메시지 비동기 전송 (background)
+    # Send reply message asynchronously in background
+    background_tasks.add_task(
+        telegram_post_message,
+        bot_token,
+        chat_id,
+        {"text": reply, "parse_mode": "HTML"},
+    )
+    return {"status": "ok"}
+
+
 @router.post("/api/webhook/telegram", responses={401: {"description": "Invalid secret token"}})
 async def telegram_webhook(
     request: Request,
     background_tasks: BackgroundTasks,
     x_telegram_bot_api_secret_token: Annotated[str | None, Header()] = None,
 ):
-    """Telegram 게이트 콜백 수신 엔드포인트.
+    """Telegram 게이트 콜백 + 텍스트 명령 수신 엔드포인트.
+    Telegram gate callback and text command receiver endpoint.
 
     TELEGRAM_WEBHOOK_SECRET 설정 시 X-Telegram-Bot-Api-Secret-Token 헤더를 검증한다.
+    Validates X-Telegram-Bot-Api-Secret-Token header when TELEGRAM_WEBHOOK_SECRET is set.
     """
     if settings.telegram_webhook_secret:
         provided = x_telegram_bot_api_secret_token or ""
@@ -136,10 +188,32 @@ async def telegram_webhook(
             raise HTTPException(status_code=401, detail="Invalid secret token")
 
     payload = await request.json()
+
+    # message.text 분기: 텍스트 명령 처리
+    # message.text branch: handle text commands
+    if payload.get("message"):
+        return _handle_message(payload, background_tasks, settings.telegram_bot_token)
+
     callback_query = payload.get("callback_query")
     if not callback_query:
+        # message도 callback_query도 없는 알 수 없는 페이로드 — 무시
+        # Unknown payload with neither key — ignore gracefully
         return {"status": "ok"}
+
     callback_data = callback_query.get("data", "")
+
+    # cmd: 접두사 콜백 위임
+    # cmd: prefix callback dispatch
+    if callback_data.startswith("cmd:"):
+        cmd = parse_cmd_callback(callback_data)
+        if cmd is not None:
+            # 향후 cmd 동작 처리 자리 (현재: 기능 준비 중)
+            # Placeholder for future cmd action handling (currently: feature in progress)
+            logger.debug("cmd: callback received — verb=%s, payload_id=%s", cmd.verb, cmd.payload_id)
+        return {"status": "ok"}
+
+    # gate: 접두사 콜백 처리 (기존 로직 완전 보존)
+    # gate: prefix callback handling (existing logic fully preserved)
     parsed = _parse_gate_callback(callback_data)
     if parsed is None:
         return {"status": "ok"}

--- a/tests/unit/api/test_internal_cron.py
+++ b/tests/unit/api/test_internal_cron.py
@@ -15,7 +15,6 @@ os.environ.setdefault("API_KEY", "")
 
 from unittest.mock import AsyncMock, patch  # noqa: E402
 
-import pytest  # noqa: E402
 from fastapi import FastAPI  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 

--- a/tests/unit/api/test_internal_cron.py
+++ b/tests/unit/api/test_internal_cron.py
@@ -1,0 +1,194 @@
+"""내부 Cron 엔드포인트 단위 테스트.
+Unit tests for the internal cron API endpoints.
+"""
+import os
+
+# src 임포트 전 환경변수 주입 필수
+# Environment variables must be injected before any src.* imports
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "")
+os.environ.setdefault("API_KEY", "")
+
+from unittest.mock import AsyncMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from src.api.internal_cron import router  # noqa: E402
+
+# 라우터만 붙인 독립 테스트 앱 — main.py 등록 전(T10 이전) 단위 테스트용
+# Standalone test app with only the cron router — for unit testing before main.py wires it (T10)
+_app = FastAPI()
+_app.include_router(router)
+
+client = TestClient(_app, raise_server_exceptions=True)
+
+_VALID_KEY = "test-cron-key-for-unit-tests"
+_WRONG_KEY = "wrong-key"
+
+
+# ---------------------------------------------------------------------------
+# 인증 실패 케이스
+# Authentication failure cases
+# ---------------------------------------------------------------------------
+
+
+def test_weekly_endpoint_requires_api_key(monkeypatch):
+    """X-API-Key 헤더 없이 /weekly 요청 시 401을 반환한다.
+    Returns 401 when X-API-Key header is absent on /weekly.
+    """
+    monkeypatch.setattr("src.config.settings.internal_cron_api_key", _VALID_KEY)
+    resp = client.post("/api/internal/cron/weekly")
+    assert resp.status_code == 401
+
+
+def test_weekly_endpoint_with_wrong_key_returns_401(monkeypatch):
+    """잘못된 X-API-Key로 /weekly 요청 시 401을 반환한다.
+    Returns 401 when X-API-Key header contains an incorrect key on /weekly.
+    """
+    monkeypatch.setattr("src.config.settings.internal_cron_api_key", _VALID_KEY)
+    resp = client.post(
+        "/api/internal/cron/weekly",
+        headers={"X-API-Key": _WRONG_KEY},
+    )
+    assert resp.status_code == 401
+
+
+def test_trend_endpoint_requires_api_key(monkeypatch):
+    """X-API-Key 헤더 없이 /trend 요청 시 401을 반환한다.
+    Returns 401 when X-API-Key header is absent on /trend.
+    """
+    monkeypatch.setattr("src.config.settings.internal_cron_api_key", _VALID_KEY)
+    resp = client.post("/api/internal/cron/trend")
+    assert resp.status_code == 401
+
+
+def test_trend_endpoint_with_wrong_key_returns_401(monkeypatch):
+    """잘못된 X-API-Key로 /trend 요청 시 401을 반환한다.
+    Returns 401 when X-API-Key header contains an incorrect key on /trend.
+    """
+    monkeypatch.setattr("src.config.settings.internal_cron_api_key", _VALID_KEY)
+    resp = client.post(
+        "/api/internal/cron/trend",
+        headers={"X-API-Key": _WRONG_KEY},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# 키 미설정 케이스 (503)
+# Key not configured case (503)
+# ---------------------------------------------------------------------------
+
+
+def test_weekly_endpoint_returns_503_when_key_not_configured(monkeypatch):
+    """`internal_cron_api_key` 미설정 시 503을 반환한다.
+    Returns 503 when internal_cron_api_key is not configured.
+    """
+    monkeypatch.setattr("src.config.settings.internal_cron_api_key", "")
+    resp = client.post(
+        "/api/internal/cron/weekly",
+        headers={"X-API-Key": _VALID_KEY},
+    )
+    assert resp.status_code == 503
+
+
+def test_trend_endpoint_returns_503_when_key_not_configured(monkeypatch):
+    """`internal_cron_api_key` 미설정 시 503을 반환한다.
+    Returns 503 when internal_cron_api_key is not configured on /trend.
+    """
+    monkeypatch.setattr("src.config.settings.internal_cron_api_key", "")
+    resp = client.post(
+        "/api/internal/cron/trend",
+        headers={"X-API-Key": _VALID_KEY},
+    )
+    assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# 정상 동작 케이스
+# Success cases
+# ---------------------------------------------------------------------------
+
+
+def test_weekly_endpoint_invokes_run_weekly_reports(monkeypatch):
+    """올바른 키로 /weekly 요청 시 200과 {"status":"ok","sent":N} 응답을 반환한다.
+    Returns 200 with {"status":"ok","sent":N} when the correct key is provided on /weekly.
+    """
+    monkeypatch.setattr("src.config.settings.internal_cron_api_key", _VALID_KEY)
+    with patch(
+        "src.api.internal_cron.run_weekly_reports",
+        new_callable=AsyncMock,
+        return_value=3,
+    ) as mock_fn:
+        resp = client.post(
+            "/api/internal/cron/weekly",
+            headers={"X-API-Key": _VALID_KEY},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "sent": 3}
+    # run_weekly_reports가 정확히 한 번 호출되었는지 확인
+    # Verify run_weekly_reports was awaited exactly once
+    mock_fn.assert_awaited_once()
+
+
+def test_trend_endpoint_invokes_run_trend_check(monkeypatch):
+    """올바른 키로 /trend 요청 시 200과 {"status":"ok","alerted":N} 응답을 반환한다.
+    Returns 200 with {"status":"ok","alerted":N} when the correct key is provided on /trend.
+    """
+    monkeypatch.setattr("src.config.settings.internal_cron_api_key", _VALID_KEY)
+    with patch(
+        "src.api.internal_cron.run_trend_check",
+        new_callable=AsyncMock,
+        return_value=2,
+    ) as mock_fn:
+        resp = client.post(
+            "/api/internal/cron/trend",
+            headers={"X-API-Key": _VALID_KEY},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok", "alerted": 2}
+    # run_trend_check가 정확히 한 번 호출되었는지 확인
+    # Verify run_trend_check was awaited exactly once
+    mock_fn.assert_awaited_once()
+
+
+def test_weekly_endpoint_returns_zero_when_no_repos(monkeypatch):
+    """리포가 없어 sent=0인 경우에도 200을 반환한다.
+    Returns 200 with sent=0 when there are no repositories to report on.
+    """
+    monkeypatch.setattr("src.config.settings.internal_cron_api_key", _VALID_KEY)
+    with patch(
+        "src.api.internal_cron.run_weekly_reports",
+        new_callable=AsyncMock,
+        return_value=0,
+    ):
+        resp = client.post(
+            "/api/internal/cron/weekly",
+            headers={"X-API-Key": _VALID_KEY},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["sent"] == 0
+
+
+def test_trend_endpoint_returns_zero_when_no_alerts(monkeypatch):
+    """트렌드 하락 없어 alerted=0인 경우에도 200을 반환한다.
+    Returns 200 with alerted=0 when no trend alerts are needed.
+    """
+    monkeypatch.setattr("src.config.settings.internal_cron_api_key", _VALID_KEY)
+    with patch(
+        "src.api.internal_cron.run_trend_check",
+        new_callable=AsyncMock,
+        return_value=0,
+    ):
+        resp = client.post(
+            "/api/internal/cron/trend",
+            headers={"X-API-Key": _VALID_KEY},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["alerted"] == 0

--- a/tests/unit/api/test_users_api.py
+++ b/tests/unit/api/test_users_api.py
@@ -126,8 +126,9 @@ def test_post_telegram_otp_requires_login():
     """비인증 상태에서 호출 시 302 리다이렉트 또는 401을 반환한다.
     Returns 302 redirect or 401 when called without authentication.
     """
-    # 의존성 오버라이드를 일시적으로 제거하여 비인증 상태 시뮬레이션
-    # Temporarily remove the override to simulate unauthenticated state.
+    # 현재 오버라이드를 저장하여 다른 테스트 모듈의 전역 상태를 보존한다
+    # Save the current override to preserve global state across test modules.
+    _saved = app.dependency_overrides.get(require_login)
     del app.dependency_overrides[require_login]
     try:
         r = client.post("/api/users/me/telegram-otp", follow_redirects=False)
@@ -135,9 +136,10 @@ def test_post_telegram_otp_requires_login():
         # require_login raises 302 (Location: /login) or 401.
         assert r.status_code in (302, 401)
     finally:
-        # 다른 테스트에 영향을 주지 않도록 오버라이드 복원
-        # Restore the override so other tests are not affected.
-        app.dependency_overrides[require_login] = lambda: _FAKE_USER
+        # 저장된 오버라이드로 복원 — 이 파일 외부의 모듈이 설정한 오버라이드도 보존
+        # Restore the saved override — preserves overrides set by other test modules.
+        if _saved is not None:
+            app.dependency_overrides[require_login] = _saved
 
 
 def test_post_telegram_otp_uses_secrets_for_randomness():

--- a/tests/unit/api/test_users_api.py
+++ b/tests/unit/api/test_users_api.py
@@ -1,0 +1,162 @@
+"""tests/unit/api/test_users_api.py — Telegram OTP API 엔드포인트 단위 테스트.
+tests/unit/api/test_users_api.py — Unit tests for Telegram OTP API endpoint.
+
+환경변수는 src 임포트 전 반드시 주입해야 한다.
+Environment variables must be injected before any src.* imports.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "")
+os.environ.setdefault("API_KEY", "")
+os.environ.setdefault("GITHUB_CLIENT_ID", "test-github-client-id")
+os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-github-client-secret")
+os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from src.main import app  # noqa: E402
+from src.auth.session import CurrentUser, require_login  # noqa: E402
+
+# ── 테스트용 인증된 사용자 픽스처 ──
+# ── Authenticated user fixture for tests ──
+_FAKE_USER = CurrentUser(
+    id=42,
+    github_login="testuser",
+    email="test@example.com",
+    display_name="Test User",
+    plaintext_token="gho_test",
+)
+
+# require_login 의존성 우회 — 인증된 상태로 테스트
+# Override require_login dependency — test in authenticated state.
+app.dependency_overrides[require_login] = lambda: _FAKE_USER
+
+client = TestClient(app)
+
+
+def _make_db_session_mock(db_mock: MagicMock) -> MagicMock:
+    """context manager 패턴 DB 세션 mock을 생성한다.
+    Create a DB session mock that supports the context manager protocol.
+    """
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=db_mock)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+# ── T9-A: POST /api/users/me/telegram-otp ──
+
+
+def test_post_telegram_otp_returns_six_digit_code():
+    """인증된 사용자 호출 시 200과 6자리 숫자 OTP, expires_at을 반환한다.
+    Returns 200 with a 6-digit numeric OTP and expires_at for an authenticated user.
+    """
+    mock_db = MagicMock()
+    # execute/commit은 부작용만 — 반환값 불필요
+    # execute/commit are side-effects only — return value not needed.
+    mock_db.execute.return_value = None
+    mock_db.commit.return_value = None
+
+    with patch("src.api.users.SessionLocal", return_value=_make_db_session_mock(mock_db)):
+        r = client.post("/api/users/me/telegram-otp")
+
+    assert r.status_code == 200
+    body = r.json()
+    # OTP는 6자리 숫자 문자열이어야 한다
+    # OTP must be a 6-digit numeric string.
+    assert "otp" in body
+    assert len(body["otp"]) == 6
+    assert body["otp"].isdigit()
+    # 만료 시각과 TTL 필드가 있어야 한다
+    # expires_at and ttl_minutes must be present.
+    assert "expires_at" in body
+    assert "ttl_minutes" in body
+    assert body["ttl_minutes"] == 5
+
+
+def test_post_telegram_otp_overwrites_previous_otp():
+    """2회 연속 호출 시 두 번째 OTP가 발급되어 첫 번째 OTP가 무효화된다.
+    Two consecutive calls produce different OTPs — the second overwrites the first.
+    """
+    mock_db = MagicMock()
+    mock_db.execute.return_value = None
+    mock_db.commit.return_value = None
+
+    collected_otps = []
+
+    def _capture_execute(stmt, *args, **kwargs):
+        # update() statement의 values에서 OTP 값을 캡처한다
+        # Capture the OTP value from the update() statement values.
+        return None
+
+    mock_db.execute.side_effect = _capture_execute
+
+    with patch("src.api.users.SessionLocal", return_value=_make_db_session_mock(mock_db)):
+        r1 = client.post("/api/users/me/telegram-otp")
+        r2 = client.post("/api/users/me/telegram-otp")
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+
+    otp1 = r1.json()["otp"]
+    otp2 = r2.json()["otp"]
+
+    # 두 OTP 모두 6자리 숫자 형식
+    # Both OTPs must be 6-digit numeric strings.
+    assert len(otp1) == 6 and otp1.isdigit()
+    assert len(otp2) == 6 and otp2.isdigit()
+
+    # DB execute가 각 요청마다 호출되어야 한다 (덮어쓰기 보장)
+    # DB execute must be called once per request (overwrite guarantee).
+    assert mock_db.execute.call_count == 2
+    assert mock_db.commit.call_count == 2
+
+    # 연속으로 발급된 OTP가 동일할 확률은 1/1,000,000 — 실용적으로 다름을 기대
+    # Probability of collision is 1/1,000,000 — expect different values in practice.
+    collected_otps.extend([otp1, otp2])
+    assert len(collected_otps) == 2
+
+
+def test_post_telegram_otp_requires_login():
+    """비인증 상태에서 호출 시 302 리다이렉트 또는 401을 반환한다.
+    Returns 302 redirect or 401 when called without authentication.
+    """
+    # 의존성 오버라이드를 일시적으로 제거하여 비인증 상태 시뮬레이션
+    # Temporarily remove the override to simulate unauthenticated state.
+    del app.dependency_overrides[require_login]
+    try:
+        r = client.post("/api/users/me/telegram-otp", follow_redirects=False)
+        # require_login은 302(Location: /login) 또는 401을 발생시킨다
+        # require_login raises 302 (Location: /login) or 401.
+        assert r.status_code in (302, 401)
+    finally:
+        # 다른 테스트에 영향을 주지 않도록 오버라이드 복원
+        # Restore the override so other tests are not affected.
+        app.dependency_overrides[require_login] = lambda: _FAKE_USER
+
+
+def test_post_telegram_otp_uses_secrets_for_randomness():
+    """OTP 생성에 secrets 모듈을 사용하는지 검증한다 (random 사용 금지).
+    Verifies OTP generation uses secrets module (not random).
+
+    실제 구현이 secrets.choice를 사용하면 응답값은 항상 숫자만 포함한다.
+    If the implementation uses secrets.choice correctly, the OTP contains only digits.
+    """
+    mock_db = MagicMock()
+    mock_db.execute.return_value = None
+    mock_db.commit.return_value = None
+
+    with patch("src.api.users.SessionLocal", return_value=_make_db_session_mock(mock_db)):
+        r = client.post("/api/users/me/telegram-otp")
+
+    body = r.json()
+    otp = body["otp"]
+    # 숫자 문자만 포함 — secrets.choice("0123456789") 보장
+    # Only digit chars — guaranteed by secrets.choice("0123456789").
+    assert all(c in "0123456789" for c in otp)
+    assert len(otp) == 6

--- a/tests/unit/gate/test_telegram_gate.py
+++ b/tests/unit/gate/test_telegram_gate.py
@@ -7,7 +7,11 @@ os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
 os.environ.setdefault("ANTHROPIC_API_KEY", "")
 
 from unittest.mock import AsyncMock, patch, MagicMock
-from src.gate.telegram_gate import send_gate_request
+from src.gate.telegram_gate import (
+    send_gate_request,
+    _gate_callback_token,
+    _make_callback_token,
+)
 from src.scorer.calculator import ScoreResult
 
 
@@ -54,3 +58,48 @@ async def test_send_gate_request_includes_analysis_id_in_callback():
         call_args = mock_client.post.call_args
         payload = call_args.kwargs.get("json") or call_args.args[1]
         assert "99" in str(payload.get("reply_markup", ""))
+
+
+def test_make_callback_token_scope_isolation():
+    """다른 scope는 다른 HMAC을 생성한다 (도메인 격리).
+    Different scopes produce different HMACs (domain isolation).
+    """
+    # "gate" 와 "cmd" scope 가 동일 payload_id 에서 서로 다른 토큰을 만들어야 함
+    # "gate" and "cmd" scopes must produce different tokens for the same payload_id
+    token_gate = _make_callback_token("bot_secret", "gate", 123)
+    token_cmd = _make_callback_token("bot_secret", "cmd", 123)
+    assert token_gate != token_cmd
+
+
+def test_legacy_gate_wrapper_backwards_compatible():
+    """_gate_callback_token 은 _make_callback_token("gate", id) 와 동일한 결과를 반환한다.
+    _gate_callback_token returns the same result as _make_callback_token("gate", id).
+    """
+    # 기존 호출 코드(webhook/providers/telegram.py 등)가 영향받지 않아야 함
+    # Existing callers (webhook/providers/telegram.py etc.) must not be affected
+    bot_token = "test_bot_token"
+    analysis_id = 456
+    assert _gate_callback_token(bot_token, analysis_id) == _make_callback_token(
+        bot_token, "gate", analysis_id
+    )
+
+
+def test_callback_data_within_64_bytes_all_commands():
+    """모든 cmd: callback_data 가 Telegram 64-byte 한계 내에 있다.
+    All cmd: callback_data strings stay within Telegram's 64-byte limit.
+    """
+    # Telegram callback_data 최대 64 바이트 — 이를 초과하면 sendMessage API 가 오류를 반환함
+    # Telegram callback_data max is 64 bytes — exceeding it causes sendMessage API error
+    bot_token = "any_token"
+    repo_id = 9999  # 최대 4자리 숫자 가정 / assume max 4-digit repo id
+    token = _make_callback_token(bot_token, "cmd", repo_id)
+    candidates = [
+        f"cmd:set:{repo_id}:{token}",
+        f"cmd:stats:{repo_id}:{token}",
+        f"cmd:settings:{repo_id}:{token}",
+        f"cmd:connect:{token}",
+    ]
+    for data in candidates:
+        assert len(data.encode()) <= 64, (
+            f"callback_data too long: {data!r} ({len(data.encode())} bytes)"
+        )

--- a/tests/unit/notifier/test_telegram_commands.py
+++ b/tests/unit/notifier/test_telegram_commands.py
@@ -1,0 +1,383 @@
+"""telegram_commands 단위 테스트 — TDD Red → Green.
+Unit tests for telegram_commands — TDD Red → Green.
+
+In-memory SQLite 자체 fixture 사용, now 의존성 주입으로 시간 고정.
+Uses self-contained in-memory SQLite fixture; injects fixed `now` for time control.
+"""
+# pylint: disable=redefined-outer-name
+import os
+
+# src 모듈 임포트 전 환경변수 주입 필수
+# Inject env vars before any src.* import that triggers Settings() loading
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.repository import Repository
+from src.models.user import User
+from src.notifier.telegram_commands import (
+    CmdCallback,
+    _NOT_CONNECTED_MSG,
+    handle_message_command,
+    parse_cmd_callback,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — in-memory SQLite DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션을 제공한다.
+    Provide an in-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _make_user(
+    db: Session,
+    *,
+    github_id: str = "gh-1",
+    github_login: str = "tester",
+    email: str = "t@example.com",
+    display_name: str = "Tester",
+    telegram_user_id: str | None = None,
+    telegram_otp: str | None = None,
+    telegram_otp_expires_at: datetime | None = None,
+) -> User:
+    """테스트용 User 레코드를 DB에 저장하고 반환한다.
+    Create and persist a test User record.
+    """
+    user = User(
+        github_id=github_id,
+        github_login=github_login,
+        email=email,
+        display_name=display_name,
+        telegram_user_id=telegram_user_id,
+        telegram_otp=telegram_otp,
+        telegram_otp_expires_at=telegram_otp_expires_at,
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _make_repo(db: Session, user_id: int, full_name: str = "owner/repo") -> Repository:
+    """테스트용 Repository 레코드를 DB에 저장하고 반환한다.
+    Create and persist a test Repository record.
+    """
+    repo = Repository(full_name=full_name, user_id=user_id)
+    db.add(repo)
+    db.commit()
+    db.refresh(repo)
+    return repo
+
+
+def _make_analysis(
+    db: Session,
+    repo_id: int,
+    score: int = 80,
+    offset_hours: int = 0,
+) -> Analysis:
+    """테스트용 Analysis 레코드를 생성하는 헬퍼.
+    Helper to create a test Analysis record.
+    """
+    created = datetime.now(timezone.utc) - timedelta(hours=offset_hours)
+    analysis = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{score}-{offset_hours}-{id(object())}",
+        score=score,
+        grade="B",
+        created_at=created,
+    )
+    db.add(analysis)
+    db.commit()
+    db.refresh(analysis)
+    return analysis
+
+
+# ---------------------------------------------------------------------------
+# Test: parse_cmd_callback
+# ---------------------------------------------------------------------------
+
+
+def test_parse_cmd_callback_returns_none_for_gate_prefix():
+    """gate: 접두사 데이터는 None을 반환해야 한다.
+    gate: prefix data must return None.
+    """
+    result = parse_cmd_callback("gate:approve:1:abc")
+    assert result is None
+
+
+def test_parse_cmd_callback_returns_none_for_unknown_prefix():
+    """알 수 없는 접두사는 None을 반환해야 한다.
+    Unknown prefix must return None.
+    """
+    result = parse_cmd_callback("unknown:verb:1:token")
+    assert result is None
+
+
+def test_parse_cmd_callback_parses_cmd_with_id():
+    """cmd:<verb>:<id>:<token> 형식을 올바르게 파싱해야 한다.
+    Must correctly parse cmd:<verb>:<id>:<token> format.
+    """
+    result = parse_cmd_callback("cmd:stats:42:abc")
+    assert result is not None
+    assert isinstance(result, CmdCallback)
+    assert result.verb == "stats"
+    assert result.payload_id == 42
+    assert result.token == "abc"
+
+
+def test_parse_cmd_callback_parses_connect_without_id():
+    """cmd:connect:<token> 형식(id 없음)을 올바르게 파싱해야 한다.
+    Must correctly parse cmd:connect:<token> format (no id).
+    """
+    result = parse_cmd_callback("cmd:connect:abc")
+    assert result is not None
+    assert result.verb == "connect"
+    assert result.payload_id is None
+    assert result.token == "abc"
+
+
+def test_parse_cmd_callback_returns_none_for_non_integer_id():
+    """id 필드가 정수로 변환되지 않으면 None을 반환해야 한다.
+    Must return None if the id field cannot be converted to int.
+    """
+    result = parse_cmd_callback("cmd:stats:notanint:token")
+    assert result is None
+
+
+def test_parse_cmd_callback_returns_none_for_malformed_data():
+    """파트 수가 맞지 않는 잘못된 형식은 None을 반환해야 한다.
+    Malformed data with wrong number of parts must return None.
+    """
+    result = parse_cmd_callback("cmd:only_two")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Test: handle_message_command — /connect
+# ---------------------------------------------------------------------------
+
+
+def test_handle_connect_accepts_valid_otp(db):
+    """유효한 OTP로 /connect 시 연결 성공 메시지를 반환해야 한다.
+    /connect with a valid OTP must return a success message.
+    """
+    future = datetime.now(timezone.utc) + timedelta(minutes=10)
+    user = _make_user(
+        db,
+        github_id="gh-otp",
+        email="otp@example.com",
+        display_name="OtpUser",
+        telegram_otp="123456",
+        telegram_otp_expires_at=future,
+    )
+
+    result = handle_message_command(db, "tg-999", "/connect 123456")
+
+    assert "OtpUser" in result
+    assert "연결" in result or "linked" in result.lower()
+
+
+def test_handle_connect_rejects_expired_otp(db):
+    """만료된 OTP는 오류 메시지를 반환해야 한다 (find_by_otp가 None).
+    Expired OTP must return an error message (find_by_otp returns None).
+    """
+    past = datetime.now(timezone.utc) - timedelta(minutes=1)
+    _make_user(
+        db,
+        github_id="gh-expired",
+        email="expired@example.com",
+        display_name="Expired",
+        telegram_otp="expired1",
+        telegram_otp_expires_at=past,
+    )
+
+    result = handle_message_command(db, "tg-expired", "/connect expired1")
+
+    assert "OTP" in result
+    assert "잘못" in result or "Invalid" in result or "expired" in result.lower()
+
+
+def test_handle_connect_rejects_double_mapping(db):
+    """이미 연결된 Telegram ID로 재연결 시도 시 에러 메시지를 반환해야 한다.
+    Re-linking with an already-mapped Telegram ID must return an error message.
+    """
+    future = datetime.now(timezone.utc) + timedelta(minutes=10)
+    # 먼저 tg-already를 다른 사용자에게 연결
+    # Link tg-already to another user first
+    _make_user(
+        db,
+        github_id="gh-existing",
+        email="existing@example.com",
+        display_name="Existing",
+        telegram_user_id="tg-already",
+    )
+    # OTP를 가진 새 사용자
+    # New user with OTP
+    _make_user(
+        db,
+        github_id="gh-new",
+        email="new@example.com",
+        display_name="NewUser",
+        telegram_otp="newcode1",
+        telegram_otp_expires_at=future,
+    )
+
+    # set_telegram_user_id가 IntegrityError → ValueError를 발생시키는 상황을 모사
+    # Simulate set_telegram_user_id raising ValueError due to IntegrityError
+    with patch(
+        "src.notifier.telegram_commands.user_repo.set_telegram_user_id",
+        side_effect=ValueError("already mapped"),
+    ):
+        result = handle_message_command(db, "tg-already", "/connect newcode1")
+
+    assert "이미" in result or "already" in result.lower()
+
+
+def test_handle_connect_requires_otp_argument(db):
+    """/connect 명령에 OTP 인수가 없으면 사용법 안내를 반환해야 한다.
+    /connect without OTP argument must return usage instructions.
+    """
+    result = handle_message_command(db, "tg-noarg", "/connect")
+    assert "사용법" in result or "Usage" in result
+
+
+# ---------------------------------------------------------------------------
+# Test: handle_message_command — /stats
+# ---------------------------------------------------------------------------
+
+
+def test_handle_message_not_connected_prompts_connect(db):
+    """미연결 사용자의 /stats 요청은 연결 안내 메시지를 반환해야 한다.
+    /stats from a disconnected user must return the connect prompt.
+    """
+    result = handle_message_command(db, "tg-unknown", "/stats owner/repo")
+    assert result == _NOT_CONNECTED_MSG
+
+
+def test_handle_stats_requires_repo_argument(db):
+    """/stats에 리포 인수가 없으면 사용법 안내를 반환해야 한다.
+    /stats without repo argument must return usage instructions.
+    """
+    user = _make_user(db, telegram_user_id="tg-norepo")
+    result = handle_message_command(db, "tg-norepo", "/stats")
+    assert "사용법" in result or "Usage" in result
+
+
+def test_handle_stats_returns_not_found_for_unknown_repo(db):
+    """등록되지 않은 리포 요청 시 에러 메시지를 반환해야 한다.
+    Unknown repo request must return an error message.
+    """
+    _make_user(db, telegram_user_id="tg-stat1")
+    result = handle_message_command(db, "tg-stat1", "/stats nonexistent/repo")
+    assert "없습니다" in result or "not found" in result.lower()
+
+
+def test_handle_stats_returns_no_data_when_no_analyses(db):
+    """분석 데이터가 없는 리포는 데이터 없음 메시지를 반환해야 한다.
+    Repo with no analyses must return a no-data message.
+    """
+    user = _make_user(db, telegram_user_id="tg-empty")
+    _make_repo(db, user.id, "owner/empty")
+
+    result = handle_message_command(db, "tg-empty", "/stats owner/empty")
+    assert "없습니다" in result or "No analysis" in result
+
+
+def test_handle_stats_returns_summary_for_valid_repo(db):
+    """분석 있는 리포 /stats 요청 시 통계 메시지를 반환해야 한다.
+    /stats for a repo with analyses must return a statistics message.
+    """
+    user = _make_user(db, telegram_user_id="tg-stat2")
+    repo = _make_repo(db, user.id, "owner/statrepo")
+
+    # 최근 7일 이내 분석 5건 생성 (moving_average는 min_samples=5 기본값)
+    # Create 5 analyses within the last 7 days (moving_average defaults min_samples=5)
+    for i in range(5):
+        _make_analysis(db, repo.id, score=80 + i, offset_hours=i * 10)
+
+    result = handle_message_command(db, "tg-stat2", "/stats owner/statrepo")
+
+    assert "owner/statrepo" in result
+    assert "5" in result  # 분석 건수 / analysis count
+
+
+# ---------------------------------------------------------------------------
+# Test: handle_message_command — /settings
+# ---------------------------------------------------------------------------
+
+
+def test_handle_settings_lists_repos(db):
+    """/settings 요청 시 등록된 리포지토리 목록을 반환해야 한다.
+    /settings must return the list of registered repositories.
+    """
+    user = _make_user(db, telegram_user_id="tg-settings1")
+    _make_repo(db, user.id, "owner/repo-alpha")
+    _make_repo(db, user.id, "owner/repo-beta")
+
+    result = handle_message_command(db, "tg-settings1", "/settings")
+
+    assert "owner/repo-alpha" in result
+    assert "owner/repo-beta" in result
+
+
+def test_handle_settings_returns_empty_message_when_no_repos(db):
+    """/settings 요청 시 등록된 리포가 없으면 안내 메시지를 반환해야 한다.
+    /settings with no repos must return a guidance message.
+    """
+    _make_user(db, telegram_user_id="tg-settings-empty")
+    result = handle_message_command(db, "tg-settings-empty", "/settings")
+    assert "없습니다" in result or "No repositories" in result
+
+
+def test_handle_settings_not_connected_prompts_connect(db):
+    """미연결 사용자의 /settings 요청은 연결 안내 메시지를 반환해야 한다.
+    /settings from disconnected user must return the connect prompt.
+    """
+    result = handle_message_command(db, "tg-nosettings", "/settings")
+    assert result == _NOT_CONNECTED_MSG
+
+
+# ---------------------------------------------------------------------------
+# Test: handle_message_command — unknown commands
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_command_returns_help(db):
+    """알 수 없는 명령은 도움말 메시지를 반환해야 한다.
+    Unknown command must return a help message.
+    """
+    user = _make_user(db, telegram_user_id="tg-unknown-cmd")
+    result = handle_message_command(db, "tg-unknown-cmd", "/unknown")
+    assert "/stats" in result
+    assert "/settings" in result
+    assert "/connect" in result
+
+
+def test_unknown_command_not_connected_prompts_connect(db):
+    """미연결 사용자의 알 수 없는 명령은 연결 안내 메시지를 반환해야 한다.
+    Unknown command from disconnected user must return the connect prompt.
+    """
+    result = handle_message_command(db, "tg-disconnected", "/unknown")
+    assert result == _NOT_CONNECTED_MSG

--- a/tests/unit/notifier/test_telegram_commands.py
+++ b/tests/unit/notifier/test_telegram_commands.py
@@ -280,7 +280,7 @@ def test_handle_stats_requires_repo_argument(db):
     """/stats에 리포 인수가 없으면 사용법 안내를 반환해야 한다.
     /stats without repo argument must return usage instructions.
     """
-    user = _make_user(db, telegram_user_id="tg-norepo")
+    _make_user(db, telegram_user_id="tg-norepo")
     result = handle_message_command(db, "tg-norepo", "/stats")
     assert "사용법" in result or "Usage" in result
 

--- a/tests/unit/notifier/test_telegram_commands.py
+++ b/tests/unit/notifier/test_telegram_commands.py
@@ -368,7 +368,7 @@ def test_unknown_command_returns_help(db):
     """알 수 없는 명령은 도움말 메시지를 반환해야 한다.
     Unknown command must return a help message.
     """
-    user = _make_user(db, telegram_user_id="tg-unknown-cmd")
+    _make_user(db, telegram_user_id="tg-unknown-cmd")
     result = handle_message_command(db, "tg-unknown-cmd", "/unknown")
     assert "/stats" in result
     assert "/settings" in result

--- a/tests/unit/notifier/test_telegram_commands.py
+++ b/tests/unit/notifier/test_telegram_commands.py
@@ -184,7 +184,7 @@ def test_handle_connect_accepts_valid_otp(db):
     /connect with a valid OTP must return a success message.
     """
     future = datetime.now(timezone.utc) + timedelta(minutes=10)
-    user = _make_user(
+    _make_user(
         db,
         github_id="gh-otp",
         email="otp@example.com",

--- a/tests/unit/repositories/test_user_repo.py
+++ b/tests/unit/repositories/test_user_repo.py
@@ -168,3 +168,80 @@ def test_is_telegram_connected_property(db_session):
     db_session.refresh(user)
 
     assert user.is_telegram_connected is True
+
+
+def test_clear_otp_nullifies_fields(db_session):
+    """clear_otp가 OTP 있는 사용자의 otp/expires_at을 None으로 만든다.
+    clear_otp nullifies telegram_otp and telegram_otp_expires_at.
+    """
+    # OTP가 설정된 사용자 생성
+    # Create a user with an active OTP.
+    future = datetime.now(timezone.utc) + timedelta(minutes=10)
+    user = User(
+        github_id="tg_clear1",
+        github_login="hank",
+        email="h@i.com",
+        display_name="H",
+        telegram_otp="CLEAR01",
+        telegram_otp_expires_at=future,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    # clear_otp 호출 후 두 필드가 None이어야 한다
+    # Both fields must be None after clear_otp.
+    user_repo.clear_otp(db_session, user.id)
+    db_session.refresh(user)
+
+    assert user.telegram_otp is None
+    assert user.telegram_otp_expires_at is None
+
+
+def test_clear_otp_on_user_without_otp_is_noop(db_session):
+    """clear_otp는 OTP가 없는 사용자에 대해 예외 없이 처리된다.
+    clear_otp is a no-op when the user has no OTP.
+    """
+    # OTP가 없는 사용자 생성
+    # Create a user with no OTP set.
+    user = User(
+        github_id="tg_clear2",
+        github_login="iris",
+        email="i@j.com",
+        display_name="I",
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    # 예외 없이 통과해야 한다
+    # Must complete without raising any exception.
+    user_repo.clear_otp(db_session, user.id)
+    db_session.refresh(user)
+
+    assert user.telegram_otp is None
+    assert user.telegram_otp_expires_at is None
+
+
+def test_find_by_otp_returns_none_for_wrong_code(db_session):
+    """만료되지 않았지만 OTP 코드가 틀리면 None을 반환한다.
+    Returns None when the OTP code is incorrect even if not expired.
+    """
+    # 유효한 OTP를 가진 사용자 생성
+    # Create a user with a valid, unexpired OTP.
+    future = datetime.now(timezone.utc) + timedelta(minutes=10)
+    user = User(
+        github_id="tg_wrong",
+        github_login="jake",
+        email="j@k.com",
+        display_name="J",
+        telegram_otp="CORRECT",
+        telegram_otp_expires_at=future,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    # 다른 코드로 조회하면 None을 반환해야 한다
+    # Querying with a different code must return None.
+    found = user_repo.find_by_otp(db_session, "WRONGCODE")
+    assert found is None

--- a/tests/unit/repositories/test_user_repo.py
+++ b/tests/unit/repositories/test_user_repo.py
@@ -1,4 +1,5 @@
 """user_repo 단위 테스트."""
+# pylint: disable=redefined-outer-name
 import os
 
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
@@ -6,6 +7,8 @@ os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
 os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
 os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import create_engine
@@ -18,7 +21,9 @@ from src.repositories import user_repo
 
 @pytest.fixture
 def db_session():
-    """In-memory SQLite session — 각 테스트 격리."""
+    """In-memory SQLite session — 각 테스트 격리.
+    In-memory SQLite session isolated per test.
+    """
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     session_cls = sessionmaker(bind=engine)
@@ -27,9 +32,16 @@ def db_session():
         yield session
     finally:
         session.close()
+        engine.dispose()
 
+
+# ---------------------------------------------------------------------------
+# 기존 조회 테스트 (Existing query tests)
+# ---------------------------------------------------------------------------
 
 def test_find_by_id_returns_user(db_session):
+    # PK로 사용자를 조회하면 올바른 레코드를 반환한다
+    # Finding a user by PK returns the correct record.
     user = User(github_id="12345", github_login="alice", email="a@b.com", display_name="A")
     db_session.add(user)
     db_session.commit()
@@ -39,10 +51,14 @@ def test_find_by_id_returns_user(db_session):
 
 
 def test_find_by_id_not_found(db_session):
+    # 존재하지 않는 ID 조회 시 None을 반환한다
+    # Returns None when ID does not exist.
     assert user_repo.find_by_id(db_session, 9999) is None
 
 
 def test_find_by_github_id_returns_user(db_session):
+    # GitHub ID 문자열로 사용자를 정확히 조회한다
+    # Finds user by GitHub account ID string accurately.
     user = User(github_id="54321", github_login="bob", email="b@c.com", display_name="B")
     db_session.add(user)
     db_session.commit()
@@ -52,4 +68,103 @@ def test_find_by_github_id_returns_user(db_session):
 
 
 def test_find_by_github_id_not_found(db_session):
+    # 없는 GitHub ID는 None을 반환한다
+    # Returns None for a non-existent GitHub ID.
     assert user_repo.find_by_github_id(db_session, "no-such-id") is None
+
+
+# ---------------------------------------------------------------------------
+# T2 신규 테스트 (New T2 tests for Telegram columns + helpers)
+# ---------------------------------------------------------------------------
+
+def test_user_telegram_columns_default_null(db_session):
+    # User 생성 시 Telegram 관련 컬럼 3개는 모두 None이어야 한다
+    # All three Telegram columns must be None on a freshly created User.
+    user = User(github_id="tg_null", github_login="cain", email="c@d.com", display_name="C")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    assert user.telegram_user_id is None
+    assert user.telegram_otp is None
+    assert user.telegram_otp_expires_at is None
+
+
+def test_find_by_otp_returns_unexpired(db_session):
+    # 유효 기간 내 OTP로 find_by_otp 호출 시 해당 User를 반환한다
+    # find_by_otp returns the User when OTP is still within expiry.
+    future = datetime.now(timezone.utc) + timedelta(minutes=10)
+    user = User(
+        github_id="tg_otp1",
+        github_login="dave",
+        email="d@e.com",
+        display_name="D",
+        telegram_otp="ABC123",
+        telegram_otp_expires_at=future,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    found = user_repo.find_by_otp(db_session, "ABC123")
+    assert found is not None
+    assert found.github_login == "dave"
+
+
+def test_find_by_otp_skips_expired(db_session):
+    # 만료된 OTP로 find_by_otp 호출 시 None을 반환한다
+    # find_by_otp returns None when the OTP has expired.
+    past = datetime.now(timezone.utc) - timedelta(minutes=1)
+    user = User(
+        github_id="tg_otp2",
+        github_login="eve",
+        email="e@f.com",
+        display_name="E",
+        telegram_otp="EXPIRED",
+        telegram_otp_expires_at=past,
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    found = user_repo.find_by_otp(db_session, "EXPIRED")
+    assert found is None
+
+
+def test_set_telegram_user_id_clears_otp(db_session):
+    # set_telegram_user_id 호출 후 telegram_user_id가 설정되고 OTP가 무효화된다
+    # After set_telegram_user_id, telegram_user_id is stored and OTP fields are nullified.
+    future = datetime.now(timezone.utc) + timedelta(minutes=10)
+    user = User(
+        github_id="tg_link",
+        github_login="frank",
+        email="f@g.com",
+        display_name="F",
+        telegram_otp="LINK99",
+        telegram_otp_expires_at=future,
+    )
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    user_repo.set_telegram_user_id(db_session, user.id, telegram_user_id="111222333")
+
+    db_session.refresh(user)
+    assert user.telegram_user_id == "111222333"
+    assert user.telegram_otp is None
+    assert user.telegram_otp_expires_at is None
+
+
+def test_is_telegram_connected_property(db_session):
+    # telegram_user_id가 None이면 False, 값이 있으면 True를 반환한다
+    # is_telegram_connected returns False when telegram_user_id is None, True otherwise.
+    user = User(github_id="tg_prop", github_login="grace", email="g@h.com", display_name="G")
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    assert user.is_telegram_connected is False
+
+    user.telegram_user_id = "987654321"
+    db_session.commit()
+    db_session.refresh(user)
+
+    assert user.is_telegram_connected is True

--- a/tests/unit/services/test_analytics_service.py
+++ b/tests/unit/services/test_analytics_service.py
@@ -1,0 +1,475 @@
+"""analytics_service 단위 테스트 — TDD Red 단계.
+Unit tests for analytics_service — TDD Red phase.
+
+In-memory SQLite + Base.metadata.create_all 자체 fixture 사용.
+Uses in-memory SQLite with Base.metadata.create_all — no conftest dependency.
+"""
+# pylint: disable=redefined-outer-name
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.repo_config import RepoConfig
+from src.models.repository import Repository
+from src.models.user import User
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — in-memory SQLite DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션을 제공한다.
+    Provide an in-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def repo(db):
+    """테스트용 Repository 레코드를 생성하고 반환한다.
+    Create and return a test Repository record.
+    """
+    user = User(github_id=1, github_login="tester", email="t@x.com", display_name="Tester")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    repository = Repository(full_name="owner/testrepo", user_id=user.id)
+    db.add(repository)
+    db.commit()
+    db.refresh(repository)
+    return repository
+
+
+def _make_analysis(db: Session, repo_id: int, score: int | None, offset_hours: int = 0) -> Analysis:
+    """테스트용 Analysis 레코드를 생성하는 헬퍼 함수.
+    Helper to create a test Analysis record.
+
+    offset_hours: 현재 시각으로부터 얼마나 과거 시점인지 (음수면 미래)
+    offset_hours: how many hours in the past from now (negative = future)
+    """
+    created = datetime.now(timezone.utc) - timedelta(hours=offset_hours)
+    analysis = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{score}-{offset_hours}-{id(object())}",
+        score=score,
+        grade="B",
+        created_at=created,
+    )
+    db.add(analysis)
+    db.commit()
+    db.refresh(analysis)
+    return analysis
+
+
+# ---------------------------------------------------------------------------
+# Test: weekly_summary
+# ---------------------------------------------------------------------------
+
+
+class TestWeeklySummary:
+    """weekly_summary — 7일 집계 함수 테스트."""
+
+    def test_weekly_summary_returns_aggregated_data(self, db, repo):
+        """7일 윈도우 내 분석 3개 → count/avg/min/max 올바르게 집계된다.
+        3 analyses within the 7-day window → count/avg/min/max are correctly aggregated.
+        """
+        from src.services.analytics_service import weekly_summary
+
+        # 고정된 now를 기준으로 week_start 설정
+        # Set week_start relative to a fixed now
+        now = datetime.now(timezone.utc)
+        week_start = now - timedelta(days=6)
+
+        _make_analysis(db, repo.id, score=80, offset_hours=10)
+        _make_analysis(db, repo.id, score=70, offset_hours=20)
+        _make_analysis(db, repo.id, score=90, offset_hours=30)
+
+        result = weekly_summary(db, repo.id, week_start, now=now)
+
+        assert result is not None
+        assert result["count"] == 3
+        assert result["min_score"] == 70
+        assert result["max_score"] == 90
+        assert result["avg_score"] == pytest.approx(80.0, abs=0.1)
+        assert "week_start" in result
+
+    def test_weekly_summary_returns_none_when_empty(self, db, repo):
+        """분석 레코드가 없으면 None을 반환한다.
+        Return None when no analyses exist in the window.
+        """
+        from src.services.analytics_service import weekly_summary
+
+        now = datetime.now(timezone.utc)
+        week_start = now - timedelta(days=6)
+
+        result = weekly_summary(db, repo.id, week_start, now=now)
+
+        assert result is None
+
+    def test_weekly_summary_excludes_null_scores(self, db, repo):
+        """score=None인 레코드는 집계에서 제외된다.
+        Records with score=None are excluded from the aggregation.
+        """
+        from src.services.analytics_service import weekly_summary
+
+        now = datetime.now(timezone.utc)
+        week_start = now - timedelta(days=6)
+
+        # score가 있는 분석 1개 + NULL 분석 2개
+        # 1 analysis with score, 2 with NULL score
+        _make_analysis(db, repo.id, score=85, offset_hours=5)
+        _make_analysis(db, repo.id, score=None, offset_hours=10)
+        _make_analysis(db, repo.id, score=None, offset_hours=15)
+
+        result = weekly_summary(db, repo.id, week_start, now=now)
+
+        assert result is not None
+        # NULL 제외 후 count는 1이어야 한다
+        # count should be 1 after excluding NULLs
+        assert result["count"] == 1
+        assert result["avg_score"] == pytest.approx(85.0, abs=0.1)
+
+    def test_weekly_summary_excludes_records_outside_window(self, db, repo):
+        """week_start 이전 레코드는 윈도우에서 제외된다.
+        Records before week_start are excluded from the window.
+        """
+        from src.services.analytics_service import weekly_summary
+
+        now = datetime.now(timezone.utc)
+        week_start = now - timedelta(days=3)
+
+        # 윈도우 내 분석 1개, 윈도우 밖(8일 전) 분석 1개
+        # 1 analysis inside window, 1 outside (8 days ago)
+        _make_analysis(db, repo.id, score=80, offset_hours=24)       # 1일 전 — 윈도우 내
+        _make_analysis(db, repo.id, score=50, offset_hours=8 * 24)   # 8일 전 — 윈도우 밖
+
+        result = weekly_summary(db, repo.id, week_start, now=now)
+
+        assert result is not None
+        assert result["count"] == 1
+        assert result["avg_score"] == pytest.approx(80.0, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Test: moving_average
+# ---------------------------------------------------------------------------
+
+
+class TestMovingAverage:
+    """moving_average — 이동 평균 계산 함수 테스트."""
+
+    def test_moving_average_returns_none_below_min_samples(self, db, repo):
+        """min_samples=5 미만(4개)이면 None을 반환한다.
+        Return None when sample count is below min_samples=5 (4 samples).
+        """
+        from src.services.analytics_service import moving_average
+
+        now = datetime.now(timezone.utc)
+
+        # 4개 분석 — min_samples=5 미만
+        # 4 analyses — below min_samples=5
+        for i in range(4):
+            _make_analysis(db, repo.id, score=75, offset_hours=i * 10)
+
+        result = moving_average(db, repo.id, window_days=7, min_samples=5, now=now)
+
+        assert result is None
+
+    def test_moving_average_returns_average_above_min_samples(self, db, repo):
+        """min_samples=5 이상(6개)이면 평균 float을 반환한다.
+        Return a float average when sample count meets min_samples=5 (6 samples).
+        """
+        from src.services.analytics_service import moving_average
+
+        now = datetime.now(timezone.utc)
+
+        # 6개 분석 — 점수 60, 70, 80, 90, 75, 85
+        # 6 analyses — scores 60, 70, 80, 90, 75, 85
+        scores = [60, 70, 80, 90, 75, 85]
+        for i, score in enumerate(scores):
+            _make_analysis(db, repo.id, score=score, offset_hours=i * 5)
+
+        result = moving_average(db, repo.id, window_days=7, min_samples=5, now=now)
+
+        assert result is not None
+        expected = round(sum(scores) / len(scores), 1)
+        assert result == expected
+
+    def test_moving_average_excludes_records_outside_window(self, db, repo):
+        """window_days 바깥 레코드는 이동 평균에서 제외된다.
+        Records outside the window_days range are excluded from the moving average.
+        """
+        from src.services.analytics_service import moving_average
+
+        now = datetime.now(timezone.utc)
+
+        # 윈도우(3일) 내 5개, 윈도우 밖(10일 전) 1개
+        # 5 inside window (3 days), 1 outside (10 days ago)
+        inside_scores = [80, 85, 75, 90, 70]
+        for i, score in enumerate(inside_scores):
+            _make_analysis(db, repo.id, score=score, offset_hours=i * 10)
+        _make_analysis(db, repo.id, score=10, offset_hours=10 * 24)  # 10일 전
+
+        result = moving_average(db, repo.id, window_days=3, min_samples=5, now=now)
+
+        assert result is not None
+        # 10점짜리가 포함되면 평균이 크게 낮아짐 — 포함되지 않아야 함
+        # If 10 is included, the average drops significantly — it must not be included
+        expected = round(sum(inside_scores) / len(inside_scores), 1)
+        assert result == expected
+
+
+# ---------------------------------------------------------------------------
+# Test: top_issues
+# ---------------------------------------------------------------------------
+
+
+class TestTopIssues:
+    """top_issues — 상위 이슈 집계 함수 테스트."""
+
+    def test_top_issues_returns_sorted_by_frequency(self, db, repo):
+        """이슈가 여러 분석에 분산되어 있어도 빈도 내림차순으로 정렬된다.
+        Issues spread across analyses are returned sorted by frequency (descending).
+        """
+        from src.services.analytics_service import top_issues
+
+        now = datetime.now(timezone.utc)
+
+        # "issue-A"는 3회, "issue-B"는 2회, "issue-C"는 1회 등장
+        # "issue-A" appears 3 times, "issue-B" 2 times, "issue-C" 1 time
+        analysis_data = [
+            {"issues": [{"message": "issue-A"}, {"message": "issue-B"}]},
+            {"issues": [{"message": "issue-A"}, {"message": "issue-C"}]},
+            {"issues": [{"message": "issue-A"}, {"message": "issue-B"}]},
+        ]
+
+        for i, result_data in enumerate(analysis_data):
+            a = Analysis(
+                repo_id=repo.id,
+                commit_sha=f"sha-top-{i}",
+                score=80,
+                grade="B",
+                result=result_data,
+                created_at=datetime.now(timezone.utc) - timedelta(hours=i * 5),
+            )
+            db.add(a)
+        db.commit()
+
+        result = top_issues(db, repo.id, days=30, n=5, now=now)
+
+        assert len(result) == 3
+        # 첫 번째는 "issue-A" (3회)여야 한다
+        # First item must be "issue-A" (3 occurrences)
+        assert result[0]["message"] == "issue-A"
+        assert result[0]["count"] == 3
+        # 두 번째는 "issue-B" (2회)
+        # Second must be "issue-B" (2 occurrences)
+        assert result[1]["message"] == "issue-B"
+        assert result[1]["count"] == 2
+        # 세 번째는 "issue-C" (1회)
+        # Third must be "issue-C" (1 occurrence)
+        assert result[2]["message"] == "issue-C"
+        assert result[2]["count"] == 1
+
+    def test_top_issues_returns_empty_when_no_analyses(self, db, repo):
+        """분석 레코드가 없으면 빈 리스트를 반환한다.
+        Return an empty list when no analyses exist.
+        """
+        from src.services.analytics_service import top_issues
+
+        result = top_issues(db, repo.id, days=30, n=5)
+
+        assert result == []
+
+    def test_top_issues_limits_to_n(self, db, repo):
+        """n=2이면 최대 2개만 반환한다.
+        Return at most n=2 items when more exist.
+        """
+        from src.services.analytics_service import top_issues
+
+        now = datetime.now(timezone.utc)
+
+        # 5가지 이슈를 각기 다른 빈도로 삽입
+        # Insert 5 distinct issues with different frequencies
+        result_data = {
+            "issues": [
+                {"message": "issue-1"},
+                {"message": "issue-2"},
+                {"message": "issue-3"},
+                {"message": "issue-4"},
+                {"message": "issue-5"},
+            ]
+        }
+        a = Analysis(
+            repo_id=repo.id,
+            commit_sha="sha-limit",
+            score=80,
+            grade="B",
+            result=result_data,
+            created_at=datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+        db.add(a)
+        db.commit()
+
+        result = top_issues(db, repo.id, days=30, n=2, now=now)
+
+        # n=2이므로 최대 2개
+        # At most 2 items since n=2
+        assert len(result) <= 2
+
+    def test_top_issues_excludes_records_outside_days_window(self, db, repo):
+        """days 바깥의 분석 레코드는 집계에서 제외된다.
+        Analyses outside the days window are excluded from the aggregation.
+        """
+        from src.services.analytics_service import top_issues
+
+        now = datetime.now(timezone.utc)
+
+        # 10일 이내 레코드 — 포함 대상
+        # Record within 10 days — should be included
+        a_inside = Analysis(
+            repo_id=repo.id,
+            commit_sha="sha-inside",
+            score=80,
+            grade="B",
+            result={"issues": [{"message": "recent-issue"}]},
+            created_at=now - timedelta(days=5),
+        )
+        # 40일 전 레코드 — 제외 대상
+        # Record 40 days ago — should be excluded
+        a_outside = Analysis(
+            repo_id=repo.id,
+            commit_sha="sha-outside",
+            score=80,
+            grade="B",
+            result={"issues": [{"message": "old-issue"}]},
+            created_at=now - timedelta(days=40),
+        )
+        db.add(a_inside)
+        db.add(a_outside)
+        db.commit()
+
+        result = top_issues(db, repo.id, days=30, n=5, now=now)
+
+        messages = [r["message"] for r in result]
+        assert "recent-issue" in messages
+        # old-issue는 30일 윈도우 밖이므로 포함되지 않아야 한다
+        # old-issue is outside the 30-day window — must not appear
+        assert "old-issue" not in messages
+
+
+# ---------------------------------------------------------------------------
+# Test: resolve_chat_id
+# ---------------------------------------------------------------------------
+
+
+class TestResolveChatId:
+    """resolve_chat_id — chat_id 우선순위 라우팅 테스트."""
+
+    def _make_repo(self, telegram_chat_id: str | None = None) -> object:
+        """테스트용 Repository duck-type 객체를 생성한다 (DB 불필요).
+        Create a duck-type Repository object without needing a DB session.
+
+        SQLAlchemy instrumented attribute는 _sa_instance_state 없이 __new__ 로 생성하면
+        직접 설정이 불가하므로 SimpleNamespace로 duck-typing 처리한다.
+        SQLAlchemy instrumented attributes cannot be set via __new__ without
+        _sa_instance_state, so we use SimpleNamespace for duck-typing.
+        """
+        from types import SimpleNamespace
+        return SimpleNamespace(telegram_chat_id=telegram_chat_id)
+
+    def _make_config(self, notify_chat_id: str | None = None) -> object:
+        """테스트용 RepoConfig duck-type 객체를 생성한다 (DB 불필요).
+        Create a duck-type RepoConfig object without needing a DB session.
+        """
+        from types import SimpleNamespace
+        return SimpleNamespace(notify_chat_id=notify_chat_id)
+
+    def test_resolve_chat_id_priority_notify_first(self, monkeypatch):
+        """RepoConfig.notify_chat_id가 있으면 최우선으로 반환한다.
+        Return RepoConfig.notify_chat_id first when it is set.
+        """
+        from src.services import analytics_service
+        monkeypatch.setattr(analytics_service.settings, "telegram_chat_id", "global_chat")
+
+        repo = self._make_repo(telegram_chat_id="repo_chat")
+        config = self._make_config(notify_chat_id="config_chat")
+
+        result = analytics_service.resolve_chat_id(repo, config)
+
+        # notify_chat_id가 최우선
+        # notify_chat_id has highest priority
+        assert result == "config_chat"
+
+    def test_resolve_chat_id_priority_repo_before_global(self, monkeypatch):
+        """notify_chat_id 없으면 Repository.telegram_chat_id를 반환한다.
+        Return Repository.telegram_chat_id when notify_chat_id is absent.
+        """
+        from src.services import analytics_service
+        monkeypatch.setattr(analytics_service.settings, "telegram_chat_id", "global_chat")
+
+        repo = self._make_repo(telegram_chat_id="repo_chat")
+        config = self._make_config(notify_chat_id=None)  # 없음 / absent
+
+        result = analytics_service.resolve_chat_id(repo, config)
+
+        # repo chat_id가 두 번째 우선순위
+        # repo chat_id is second priority
+        assert result == "repo_chat"
+
+    def test_resolve_chat_id_priority_global_fallback(self, monkeypatch):
+        """notify_chat_id, repo.telegram_chat_id 모두 없으면 전역 settings를 반환한다.
+        Return global settings.telegram_chat_id when both repo fields are absent.
+        """
+        from src.services import analytics_service
+        monkeypatch.setattr(analytics_service.settings, "telegram_chat_id", "global_chat")
+
+        repo = self._make_repo(telegram_chat_id=None)
+        config = self._make_config(notify_chat_id=None)
+
+        result = analytics_service.resolve_chat_id(repo, config)
+
+        assert result == "global_chat"
+
+    def test_resolve_chat_id_returns_none_when_all_empty(self, monkeypatch):
+        """모든 chat_id 소스가 비어있으면 None을 반환한다.
+        Return None when all chat_id sources are empty or None.
+        """
+        from src.services import analytics_service
+        monkeypatch.setattr(analytics_service.settings, "telegram_chat_id", "")
+
+        repo = self._make_repo(telegram_chat_id=None)
+        config = self._make_config(notify_chat_id=None)
+
+        result = analytics_service.resolve_chat_id(repo, config)
+
+        # 모든 소스가 없으면 None
+        # None when all sources are absent
+        assert result is None
+
+    def test_resolve_chat_id_with_none_config(self, monkeypatch):
+        """config=None이어도 repo 및 전역 fallback으로 정상 동작한다.
+        Work correctly with config=None, falling through to repo and global.
+        """
+        from src.services import analytics_service
+        monkeypatch.setattr(analytics_service.settings, "telegram_chat_id", "global_chat")
+
+        repo = self._make_repo(telegram_chat_id=None)
+
+        result = analytics_service.resolve_chat_id(repo, None)
+
+        # config=None → 전역 fallback 반환
+        # config=None → global fallback returned
+        assert result == "global_chat"

--- a/tests/unit/services/test_cron_service.py
+++ b/tests/unit/services/test_cron_service.py
@@ -284,9 +284,7 @@ class TestRunTrendCheck:
         # current_avg=None → triggers the min_samples insufficient branch
         mock_ma.return_value = None
 
-        from src.services.cron_service import run_trend_check
-
-        alerted = await run_trend_check(db, now=now)
+        alerted = await cs.run_trend_check(db, now=now)
 
         # min_samples 미충족 → Telegram 호출 없음
         # Below min_samples → no Telegram call
@@ -310,9 +308,7 @@ class TestRunTrendCheck:
         # moving_average return values: current=71, prev=80 → drop=9
         mock_ma.side_effect = [71.0, 80.0]
 
-        from src.services.cron_service import run_trend_check
-
-        alerted = await run_trend_check(db, now=now)
+        alerted = await cs.run_trend_check(db, now=now)
 
         # drop=9 < _TREND_DROP_THRESHOLD=10 → 알림 없음
         # drop=9 < _TREND_DROP_THRESHOLD=10 → no alert

--- a/tests/unit/services/test_cron_service.py
+++ b/tests/unit/services/test_cron_service.py
@@ -211,9 +211,7 @@ class TestRunWeeklyReports:
             None,
         ]
 
-        from src.services.cron_service import run_weekly_reports
-
-        sent = await run_weekly_reports(db, now=now)
+        sent = await cs.run_weekly_reports(db, now=now)
 
         # 두 번 호출 — 첫 번째 실패, 두 번째 성공 → sent=1
         # Called twice — first fails, second succeeds → sent=1

--- a/tests/unit/services/test_cron_service.py
+++ b/tests/unit/services/test_cron_service.py
@@ -252,9 +252,7 @@ class TestRunTrendCheck:
         # moving_average return values: first call=current(70), second=prev(80)
         mock_ma.side_effect = [70.0, 80.0]
 
-        from src.services.cron_service import run_trend_check
-
-        alerted = await run_trend_check(db, now=now)
+        alerted = await cs.run_trend_check(db, now=now)
 
         # drop=80-70=10 ≥ _TREND_DROP_THRESHOLD=10 → 알림 발송
         # drop=80-70=10 >= _TREND_DROP_THRESHOLD=10 → alert sent

--- a/tests/unit/services/test_cron_service.py
+++ b/tests/unit/services/test_cron_service.py
@@ -130,9 +130,7 @@ class TestRunWeeklyReports:
         for i in range(5):
             _make_analysis(db, repo.id, score=75, offset_hours=i * 10)
 
-        from src.services.cron_service import run_weekly_reports
-
-        sent = await run_weekly_reports(db, now=now)
+        sent = await cs.run_weekly_reports(db, now=now)
 
         # telegram_post_message 가 호출되어야 한다
         # telegram_post_message must have been called
@@ -159,9 +157,7 @@ class TestRunWeeklyReports:
         for i in range(5):
             _make_analysis(db, repo_no_chat.id, score=80, offset_hours=i * 5)
 
-        from src.services.cron_service import run_weekly_reports
-
-        sent = await run_weekly_reports(db, now=now)
+        sent = await cs.run_weekly_reports(db, now=now)
 
         # chat_id 없으므로 전송하지 않아야 한다
         # Must not send since chat_id is absent

--- a/tests/unit/services/test_cron_service.py
+++ b/tests/unit/services/test_cron_service.py
@@ -1,0 +1,320 @@
+"""cron_service 단위 테스트 — TDD Red 단계.
+Unit tests for cron_service — TDD Red phase.
+
+In-memory SQLite + Base.metadata.create_all 자체 fixture 사용.
+Uses in-memory SQLite with Base.metadata.create_all — no conftest dependency.
+telegram_post_message 는 AsyncMock 으로 격리 (실제 HTTP 호출 방지).
+telegram_post_message is isolated via AsyncMock to prevent real HTTP calls.
+"""
+# pylint: disable=redefined-outer-name
+from datetime import datetime, timezone, timedelta
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.repository import Repository
+from src.models.user import User
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — in-memory SQLite DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션을 제공한다.
+    Provide an in-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def repo(db):
+    """테스트용 Repository 레코드(chat_id 있음)를 생성하고 반환한다.
+    Create and return a test Repository record with a chat_id.
+    """
+    user = User(github_id=1, github_login="tester", email="t@x.com", display_name="Tester")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    repository = Repository(
+        full_name="owner/testrepo",
+        user_id=user.id,
+        telegram_chat_id="-100111222",
+    )
+    db.add(repository)
+    db.commit()
+    db.refresh(repository)
+    return repository
+
+
+@pytest.fixture()
+def repo_no_chat(db):
+    """chat_id 없는 Repository 레코드를 생성하고 반환한다.
+    Create and return a Repository record without any chat_id.
+    """
+    user = User(github_id=2, github_login="nochat", email="nc@x.com", display_name="NoChat")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    repository = Repository(
+        full_name="owner/nochatrepo",
+        user_id=user.id,
+        telegram_chat_id=None,
+    )
+    db.add(repository)
+    db.commit()
+    db.refresh(repository)
+    return repository
+
+
+def _make_analysis(
+    db: Session,
+    repo_id: int,
+    score: int | None,
+    offset_hours: int = 0,
+) -> Analysis:
+    """테스트용 Analysis 레코드를 생성하는 헬퍼 함수.
+    Helper to create a test Analysis record.
+    """
+    created = datetime.now(timezone.utc) - timedelta(hours=offset_hours)
+    analysis = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{score}-{offset_hours}-{id(object())}",
+        score=score,
+        grade="B",
+        created_at=created,
+    )
+    db.add(analysis)
+    db.commit()
+    db.refresh(analysis)
+    return analysis
+
+
+# ---------------------------------------------------------------------------
+# Test: run_weekly_reports
+# ---------------------------------------------------------------------------
+
+
+class TestRunWeeklyReports:
+    """run_weekly_reports — 주간 요약 전송 함수 테스트."""
+
+    @patch("src.services.cron_service.telegram_post_message", new_callable=AsyncMock)
+    async def test_run_weekly_reports_sends_for_repos_with_analyses(
+        self, mock_tg, db, repo, monkeypatch
+    ):
+        """분석이 있는 리포 → telegram_post_message 가 1회 이상 호출된다.
+        Repo with analyses → telegram_post_message is called at least once.
+        """
+        # 전역 chat_id fallback 을 비워 repo.telegram_chat_id 가 사용되도록 한다
+        # Clear global chat_id fallback so repo.telegram_chat_id is used
+        import src.services.cron_service as cs
+        monkeypatch.setattr(cs.settings, "telegram_chat_id", "")
+
+        now = datetime.now(timezone.utc)
+
+        # 7일 이내 분석 5개 삽입 (min_samples 충족)
+        # Insert 5 analyses within 7 days (satisfies min_samples)
+        for i in range(5):
+            _make_analysis(db, repo.id, score=75, offset_hours=i * 10)
+
+        from src.services.cron_service import run_weekly_reports
+
+        sent = await run_weekly_reports(db, now=now)
+
+        # telegram_post_message 가 호출되어야 한다
+        # telegram_post_message must have been called
+        assert mock_tg.called
+        assert sent == 1
+
+    @patch("src.services.cron_service.telegram_post_message", new_callable=AsyncMock)
+    async def test_run_weekly_reports_skips_repo_without_chat_id(
+        self, mock_tg, db, repo_no_chat, monkeypatch
+    ):
+        """chat_id 없는 리포 → 전송 skip, 반환값 0.
+        Repo without chat_id → skip sending, returns 0.
+        """
+        import src.services.cron_service as cs
+
+        # 전역 fallback 도 비움 → resolve_chat_id 가 None 반환
+        # Clear global fallback too → resolve_chat_id returns None
+        monkeypatch.setattr(cs.settings, "telegram_chat_id", "")
+
+        now = datetime.now(timezone.utc)
+
+        # 분석 삽입 (chat_id 없이도 weekly_summary 는 실행됨을 검증)
+        # Insert analyses (weekly_summary runs even without chat_id — skipped after resolve)
+        for i in range(5):
+            _make_analysis(db, repo_no_chat.id, score=80, offset_hours=i * 5)
+
+        from src.services.cron_service import run_weekly_reports
+
+        sent = await run_weekly_reports(db, now=now)
+
+        # chat_id 없으므로 전송하지 않아야 한다
+        # Must not send since chat_id is absent
+        mock_tg.assert_not_called()
+        assert sent == 0
+
+    @patch("src.services.cron_service.telegram_post_message", new_callable=AsyncMock)
+    async def test_run_weekly_reports_isolates_per_repo_failure(
+        self, mock_tg, db, monkeypatch
+    ):
+        """첫 번째 리포에서 HTTPError → 두 번째 리포는 정상 전송된다.
+        HTTPError on first repo → second repo is still sent successfully.
+        """
+        import src.services.cron_service as cs
+        monkeypatch.setattr(cs.settings, "telegram_chat_id", "")
+
+        # 두 번째 repo 를 User 1로 만든다
+        # Create two distinct repositories with chat_ids
+        user1 = User(github_id=10, github_login="u1", email="u1@x.com", display_name="U1")
+        user2 = User(github_id=11, github_login="u2", email="u2@x.com", display_name="U2")
+        db.add_all([user1, user2])
+        db.commit()
+
+        repo1 = Repository(
+            full_name="owner/repo-fail",
+            user_id=user1.id,
+            telegram_chat_id="-100aaa",
+        )
+        repo2 = Repository(
+            full_name="owner/repo-ok",
+            user_id=user2.id,
+            telegram_chat_id="-100bbb",
+        )
+        db.add_all([repo1, repo2])
+        db.commit()
+        db.refresh(repo1)
+        db.refresh(repo2)
+
+        now = datetime.now(timezone.utc)
+
+        # 두 리포 모두 분석 데이터 삽입
+        # Insert analyses for both repos
+        for i in range(5):
+            _make_analysis(db, repo1.id, score=70, offset_hours=i * 5)
+            _make_analysis(db, repo2.id, score=80, offset_hours=i * 5)
+
+        # 첫 번째 호출에서 HTTPError, 두 번째는 정상
+        # HTTPError on first call, second call succeeds
+        mock_tg.side_effect = [
+            httpx.HTTPError("timeout"),
+            None,
+        ]
+
+        from src.services.cron_service import run_weekly_reports
+
+        sent = await run_weekly_reports(db, now=now)
+
+        # 두 번 호출 — 첫 번째 실패, 두 번째 성공 → sent=1
+        # Called twice — first fails, second succeeds → sent=1
+        assert mock_tg.call_count == 2
+        assert sent == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: run_trend_check
+# ---------------------------------------------------------------------------
+
+
+class TestRunTrendCheck:
+    """run_trend_check — 트렌드 경고 전송 함수 테스트.
+
+    moving_average 를 mock 으로 대체한다. 실제 DB 집계 로직은
+    TestMovingAverage(analytics_service) 에서 검증하므로 이 테스트는
+    cron_service 의 제어 흐름(임계값 판정, 알림 발송, skip 조건)만 검증한다.
+    moving_average is mocked. Actual DB aggregation logic is covered by
+    TestMovingAverage in analytics_service tests. These tests only verify
+    cron_service control flow: threshold judgment, alert dispatch, skip conditions.
+    """
+
+    @patch("src.services.cron_service.telegram_post_message", new_callable=AsyncMock)
+    @patch("src.services.cron_service.moving_average")
+    async def test_run_trend_check_triggers_on_drop_10_points(
+        self, mock_ma, mock_tg, db, repo, monkeypatch
+    ):
+        """prev_avg=80, current_avg=70 → drop=10 ≥ threshold → 알림 발송.
+        prev_avg=80, current_avg=70 → drop=10 >= threshold → alert sent.
+        """
+        import src.services.cron_service as cs
+        monkeypatch.setattr(cs.settings, "telegram_chat_id", "")
+
+        now = datetime.now(timezone.utc)
+
+        # moving_average 반환값: 첫 호출=current(70), 두 번째=prev(80)
+        # moving_average return values: first call=current(70), second=prev(80)
+        mock_ma.side_effect = [70.0, 80.0]
+
+        from src.services.cron_service import run_trend_check
+
+        alerted = await run_trend_check(db, now=now)
+
+        # drop=80-70=10 ≥ _TREND_DROP_THRESHOLD=10 → 알림 발송
+        # drop=80-70=10 >= _TREND_DROP_THRESHOLD=10 → alert sent
+        assert mock_tg.called
+        assert alerted == 1
+
+    @patch("src.services.cron_service.telegram_post_message", new_callable=AsyncMock)
+    @patch("src.services.cron_service.moving_average")
+    async def test_run_trend_check_skips_below_min_samples(
+        self, mock_ma, mock_tg, db, repo, monkeypatch
+    ):
+        """current moving_average=None (min_samples 미충족) → skip.
+        current moving_average=None (below min_samples) → skip.
+        """
+        import src.services.cron_service as cs
+        monkeypatch.setattr(cs.settings, "telegram_chat_id", "")
+
+        now = datetime.now(timezone.utc)
+
+        # current_avg=None → min_samples 미충족 분기
+        # current_avg=None → triggers the min_samples insufficient branch
+        mock_ma.return_value = None
+
+        from src.services.cron_service import run_trend_check
+
+        alerted = await run_trend_check(db, now=now)
+
+        # min_samples 미충족 → Telegram 호출 없음
+        # Below min_samples → no Telegram call
+        mock_tg.assert_not_called()
+        assert alerted == 0
+
+    @patch("src.services.cron_service.telegram_post_message", new_callable=AsyncMock)
+    @patch("src.services.cron_service.moving_average")
+    async def test_run_trend_check_no_trigger_on_small_drop(
+        self, mock_ma, mock_tg, db, repo, monkeypatch
+    ):
+        """prev_avg=80, current_avg=71 → drop=9 < 10 → 알림 미발송.
+        prev_avg=80, current_avg=71 → drop=9 < 10 → no alert sent.
+        """
+        import src.services.cron_service as cs
+        monkeypatch.setattr(cs.settings, "telegram_chat_id", "")
+
+        now = datetime.now(timezone.utc)
+
+        # moving_average 반환값: current=71, prev=80 → drop=9
+        # moving_average return values: current=71, prev=80 → drop=9
+        mock_ma.side_effect = [71.0, 80.0]
+
+        from src.services.cron_service import run_trend_check
+
+        alerted = await run_trend_check(db, now=now)
+
+        # drop=9 < _TREND_DROP_THRESHOLD=10 → 알림 없음
+        # drop=9 < _TREND_DROP_THRESHOLD=10 → no alert
+        mock_tg.assert_not_called()
+        assert alerted == 0

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -1634,3 +1634,72 @@ def test_settings_has_preset_details_elements():
         assert f'id="preset-{preset}"' in r.text, f"Missing <details id=preset-{preset}>"
     for fn in ("onPresetToggle", "renderPresetDiff", "flashPresetChanges"):
         assert fn in r.text, f"Missing JS helper: {fn}"
+
+
+# ── T9: Telegram 연결 서브섹션 렌더링 테스트 ──
+# ── T9: Telegram connection subsection rendering tests ──
+
+def test_telegram_otp_section_renders_when_not_connected():
+    """미연결 user → settings 페이지에 '연결 코드 발급' 버튼이 포함된다.
+    When Telegram is not connected, the settings page shows the 'Issue Code' button.
+    """
+    # _test_user는 파일 상단에서 is_telegram_connected=False 기본값으로 설정됨
+    # _test_user at the top of this file has is_telegram_connected=False by default.
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = MagicMock(
+        id=1, full_name="owner/repo", user_id=None
+    )
+    from src.config_manager.manager import RepoConfigData
+    with patch("src.ui.routes.settings.SessionLocal", return_value=_ctx(mock_db)):
+        with patch("src.ui.routes.settings.get_repo_config",
+                   return_value=RepoConfigData(repo_full_name="owner/repo")):
+            r = client.get("/repos/owner%2Frepo/settings")
+    assert r.status_code == 200
+    html = r.text
+    # '연결 코드 발급' 버튼이 렌더링되어야 한다
+    # The 'Issue Code' button must be rendered.
+    assert "issueTelegramOtp" in html
+    assert "Issue Code" in html or "연결 코드 발급" in html
+    # 'Telegram 연결' 서브섹션 제목이 존재해야 한다
+    # The 'Telegram Connection' subsection title must be present.
+    assert "Telegram" in html and "connect" in html.lower()
+
+
+def test_telegram_connected_status_hides_otp_button():
+    """연결된 user → settings 페이지에 OTP 버튼 없이 '연결됨' 메시지를 표시한다.
+    When Telegram is connected, shows 'connected' message without the OTP button.
+    """
+    from src.auth.session import CurrentUser as CU
+    # is_telegram_connected=True 인 사용자로 의존성 오버라이드
+    # Override dependency with a user that has is_telegram_connected=True.
+    connected_user = CU(
+        id=99,
+        github_login="connected_user",
+        email="connected@example.com",
+        display_name="Connected User",
+        plaintext_token="gho_connected",
+        is_telegram_connected=True,
+    )
+    app.dependency_overrides[require_login] = lambda: connected_user
+    try:
+        mock_db = MagicMock()
+        mock_db.query.return_value.filter.return_value.first.return_value = MagicMock(
+            id=1, full_name="owner/repo", user_id=None
+        )
+        from src.config_manager.manager import RepoConfigData
+        with patch("src.ui.routes.settings.SessionLocal", return_value=_ctx(mock_db)):
+            with patch("src.ui.routes.settings.get_repo_config",
+                       return_value=RepoConfigData(repo_full_name="owner/repo")):
+                r = client.get("/repos/owner%2Frepo/settings")
+        assert r.status_code == 200
+        html = r.text
+        # 연결 완료 메시지가 있어야 한다
+        # The 'connected' status message must be present.
+        assert "연결되어 있습니다" in html or "connected" in html.lower()
+        # OTP 발급 버튼은 없어야 한다
+        # The OTP issuance button must not be present.
+        assert "issueTelegramOtp" not in html
+    finally:
+        # 다른 테스트에 영향을 주지 않도록 오버라이드 복원
+        # Restore the override so other tests are not affected.
+        app.dependency_overrides[require_login] = lambda: _test_user

--- a/tests/unit/webhook/test_telegram_provider.py
+++ b/tests/unit/webhook/test_telegram_provider.py
@@ -348,3 +348,100 @@ async def test_log_merge_attempt_exception_does_not_abort_callback():
                             await handle_gate_callback(
                                 analysis_id=77, decision="approve", decided_by="carol"
                             )
+
+
+# ---------------------------------------------------------------------------
+# Phase 10 T6: message.text 처리 + cmd: callback 위임 테스트
+# Phase 10 T6: message.text handling + cmd: callback dispatch tests
+# ---------------------------------------------------------------------------
+
+def test_message_text_routes_to_commands_handler():
+    """message.text가 있으면 handle_message_command가 호출된다.
+    message.text payload routes to handle_message_command.
+    """
+    # 실제 DB 세션을 mock SessionLocal로 대체한다
+    # Replace real DB session with mock SessionLocal
+    mock_db = MagicMock()
+    payload = {
+        "message": {
+            "text": "/stats owner/repo",
+            "from": {"id": 123},
+            "chat": {"id": 456},
+        }
+    }
+    with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
+        with patch(
+            "src.webhook.providers.telegram.handle_message_command",
+            return_value="응답 텍스트",
+        ) as mock_cmd:
+            with patch(
+                "src.webhook.providers.telegram.telegram_post_message",
+                new_callable=AsyncMock,
+            ):
+                r = client.post("/api/webhook/telegram", json=payload)
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+    # handle_message_command가 sender_id="123", text="/stats owner/repo" 로 호출됐는지 확인
+    # handle_message_command must be called with sender_id="123" and correct text
+    mock_cmd.assert_called_once()
+    _, kw = mock_cmd.call_args
+    assert kw["telegram_user_id"] == "123"
+    assert kw["text"] == "/stats owner/repo"
+
+
+def test_callback_query_gate_prefix_unchanged():
+    """gate: callback은 기존 gate 처리 로직으로 간다.
+    gate: callbacks are handled by the existing gate logic.
+    """
+    # gate: 콜백은 parse_cmd_callback을 거치지 않고 handle_gate_callback으로 라우팅돼야 한다
+    # gate: callbacks must route to handle_gate_callback, not parse_cmd_callback
+    with patch("src.webhook.providers.telegram.handle_gate_callback",
+               new_callable=AsyncMock) as mock_gate:
+        with patch("src.webhook.providers.telegram.parse_cmd_callback") as mock_cmd:
+            r = client.post("/api/webhook/telegram", json=APPROVE)
+    assert r.status_code == 200
+    mock_gate.assert_called_once()
+    # parse_cmd_callback은 gate: 접두사 데이터로 호출되지 않아야 한다
+    # parse_cmd_callback must NOT be called for gate: prefixed data
+    mock_cmd.assert_not_called()
+
+
+def test_callback_query_cmd_prefix_dispatched():
+    """cmd: callback은 parse_cmd_callback으로 위임된다.
+    cmd: callbacks are dispatched to parse_cmd_callback.
+    """
+    # cmd: 접두사 콜백이 들어올 때 parse_cmd_callback이 호출되고 handle_gate_callback은 호출 안됨
+    # When cmd: prefixed callback arrives, parse_cmd_callback is called, gate_callback is not
+    cmd_payload = {
+        "update_id": 99,
+        "callback_query": {
+            "id": "c99",
+            "from": {"id": 7, "username": "testuser"},
+            "data": "cmd:stats:42:abc123",
+            "message": {"message_id": 1, "chat": {"id": -1}},
+        },
+    }
+    with patch("src.webhook.providers.telegram.parse_cmd_callback",
+               return_value=None) as mock_cmd:
+        with patch("src.webhook.providers.telegram.handle_gate_callback",
+                   new_callable=AsyncMock) as mock_gate:
+            r = client.post("/api/webhook/telegram", json=cmd_payload)
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+    # parse_cmd_callback이 cmd: 데이터로 호출됐는지 확인
+    # parse_cmd_callback must be called with the cmd: data string
+    mock_cmd.assert_called_once_with("cmd:stats:42:abc123")
+    # gate 콜백은 호출되지 않아야 한다
+    # Gate callback must not be triggered
+    mock_gate.assert_not_called()
+
+
+def test_unknown_payload_returns_ok():
+    """message도 callback_query도 없으면 {"status": "ok"} 반환.
+    Payloads without message or callback_query return {"status": "ok"}.
+    """
+    # 알 수 없는 형식의 페이로드 — 두 키 모두 없음
+    # Unknown payload format — neither key is present
+    r = client.post("/api/webhook/telegram", json={"update_id": 1, "unknown_key": "value"})
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary

Phase 10 — Telegram 확장 (주간 리포트 cron + 트렌드 알림 + 인라인 명령 + /connect OTP 흐름).

### 신규 파일
- `alembic/versions/0017_add_user_telegram_id.py` — `users.telegram_user_id UNIQUE`, `telegram_otp`, `telegram_otp_expires_at`
- `src/services/analytics_service.py` — `weekly_summary`, `moving_average`, `top_issues`, `resolve_chat_id` (D1 naming, D2 chat_id priority chain)
- `src/services/cron_service.py` — `run_weekly_reports`, `run_trend_check` (per-repo try/except isolation)
- `src/api/internal_cron.py` — `POST /api/internal/cron/weekly|trend` (INTERNAL_CRON_API_KEY, hmac.compare_digest)
- `src/api/users.py` — `POST /api/users/me/telegram-otp` (secrets.choice, 5-min TTL, OVERWRITE semantics)
- `src/notifier/telegram_commands.py` — `/stats`, `/settings`, `/connect <otp>` handlers + `CmdCallback` dataclass

### 핵심 수정
- `src/gate/telegram_gate.py` — `_make_callback_token(scope, ...)` 일반화 + `_gate_callback_token` thin wrapper (하위 호환)
- `src/webhook/providers/telegram.py` — `message.text` + `cmd:` callback 분기 추가
- `src/models/user.py` + `src/repositories/user_repo.py` — Telegram 컬럼 + find_by_otp/set_telegram_user_id/clear_otp
- `src/auth/session.py` — `CurrentUser.is_telegram_connected` 필드 추가
- `src/templates/settings.html` — 카드 ⑤ Telegram 연결 서브섹션 (OTP 버튼 + 5분 카운트다운)
- `src/main.py` — api_users_router + api_internal_cron_router 등록
- `railway.toml` — `[[deploy.cronJobs]]` 주간(0 0 * * 1) + 트렌드(0 3 * * *) + fallback B 코멘트
- `CLAUDE.md` — Phase 10 결정사항 4개 (D1/D2/D5/D9) 반영

### 아키텍처 결정 (D-Series)
| ID | 결정 |
|----|------|
| D1 | `<domain>_service.py` 네이밍 규약 (`analytics_service.py`, `cron_service.py`) |
| D2 | chat_id 우선순위: `RepoConfig.notify_chat_id` → `Repository.telegram_chat_id` → `settings.telegram_chat_id` → None |
| D3 | `now: datetime \| None = None` 의존성 주입 (freezegun 미설치 회피) |
| D4 | 각 테스트 파일 자체 in-memory SQLite fixture |
| D5 | OTP 흐름: 6자리 숫자 + 5분 TTL + OVERWRITE semantics + IntegrityError 처리 |
| D6 | Railway `[[deploy.cronJobs]]` + fallback B 코멘트 |
| D7 | internal_cron 라우터 위치: api_users 다음, ui 이전 |
| D8 | 5-way sync 면제 (User 컬럼 직접 관리) |
| D9 | cmd: callback_data ≤ 50 bytes (Telegram 64-byte 한도) |

### 테스트
- **1417 passed** (0 failed) — +73 신규 테스트
- pylint **10.00/10** 유지
- 보너스: `test_users_api.py` dependency_overrides 상태 오염 버그 수정 (5개 사전 실패 테스트 해소)

## Test plan
- [ ] `make test` → 1417 passed, 0 failed
- [ ] `make lint` → pylint 10.00/10
- [ ] `make migrate` → 0017 적용 (telegram_user_id UNIQUE + otp 2개 컬럼)
- [ ] e2e: `curl -X POST -H 'X-API-Key: $INTERNAL_CRON_API_KEY' .../api/internal/cron/weekly`
- [ ] e2e: 설정 페이지 카드 ⑤ Telegram 연결 섹션 확인
- [ ] e2e: Telegram `/connect <otp>` 흐름 왕복 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)