### PR TITLE
docs: 3-agent audit 반영 — 문서 정확성 수정 (CLAUDE.md/STATE.md/README.md)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@ src/
 │   ├── stage_metrics.py        # stage_timer context manager — pipeline 단계 타이밍 (Phase E.2c)
 │   └── merge_metrics.py        # parse_reason_tag + log_merge_attempt — auto-merge 관측 (Phase F.1)
 ├── services/                   # use case 계층 — 신규 오케스트레이션 모듈의 배치 장소 (기존 pipeline/engine/manager 는 도메인 위치 유지)
+│   ├── analytics_service.py    # 집계 단일 출처 — weekly_summary, moving_average, top_issues, resolve_chat_id
+│   └── cron_service.py         # 주기적 실행 — run_weekly_reports, run_trend_check
 ├── auth/
 │   ├── session.py              # get_current_user() + require_login Depends
 │   └── github.py               # /login, /auth/github, /auth/callback, /auth/logout
@@ -105,7 +107,7 @@ src/
 │   │   ├── ai_review.py        # review_code() — Claude API, AiReviewResult (detected_languages 포함)
 │   │   └── tools/
 │   │       ├── python.py       # _PylintAnalyzer, _Flake8Analyzer, _BanditAnalyzer (모듈 로드 시 자동 등록)
-│   │       ├── semgrep.py      # _SemgrepAnalyzer — 23개 언어, graceful degradation
+│   │       ├── semgrep.py      # _SemgrepAnalyzer — 22개 언어, graceful degradation
 │   │       ├── eslint.py       # _ESLintAnalyzer — JS/TS, flat config
 │   │       ├── shellcheck.py   # _ShellCheckAnalyzer — shell 스크립트
 │   │       ├── cppcheck.py     # _CppCheckAnalyzer — C/C++, XML v2 stderr 파싱
@@ -125,7 +127,8 @@ src/
 │   └── merge_failure_advisor.py # get_advice(reason) — reason tag → 권장 조치 텍스트 (Phase F.3, 순수 함수)
 ├── notifier/                   # `__init__.py` 가 import 시 각 채널 모듈 자동 로드 → REGISTRY 등록 (Phase S.3-E)
 │   ├── __init__.py             # 8개 notifier 모듈 import (등록 순서 = 발송 우선순위)
-│   ├── _common.py              # 공통 헬퍼 — format_ref, get_all_issues, truncate_message, truncate_issue_msg
+│   ├── _common.py              # 공통 헬퍼 — format_ref, get_all_issues, get_issue_samples, truncate_message, truncate_issue_msg
+│   ├── telegram_commands.py    # Telegram 인라인 명령 처리 — /stats, /settings, /connect OTP 흐름
 │   ├── _http.py                # build_safe_client() — HTTP_CLIENT_TIMEOUT + follow_redirects=False (SSRF 방어)
 │   ├── registry.py             # NotifyContext + Notifier Protocol + REGISTRY + register() (채널 확장)
 │   ├── telegram.py             # send_analysis_result() + _TelegramNotifier (항상 활성, global chat_id fallback)
@@ -383,7 +386,7 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 - **E2E 격리**: `e2e/`를 최상위 별도 디렉토리로 분리 (`tests/` 아래 금지) — `tests/e2e/`가 있으면 `asyncio_mode=auto`와 `sys.modules` 삭제가 충돌해 단위 테스트 98개 실패. E2E 서버는 `uvicorn.Server.serve()`를 `asyncio.new_event_loop()` + `loop.run_until_complete()`로 실행.
 - **require_login 우회**: `tests/test_ui_router.py`는 `app.dependency_overrides[require_login] = lambda: _test_user`로 의존성 override. 신규 UI 라우트 테스트 작성 시 동일 패턴 사용.
 - **Mock side_effect 재귀**: `mock.add.side_effect = fn` 설정 후 fn 내에서 `original_add(obj)` 호출 시 재귀 발생. side_effect 함수에서는 원본 mock을 호출하지 말 것 — 캡처만 하고 return None.
-- **모듈 레벨 캐시 격리**: `src/webhook/router.py`의 `_webhook_secret_cache`는 모듈 레벨 dict. `tests/conftest.py`의 `_clear_webhook_secret_cache` autouse fixture가 테스트마다 자동 클리어. 신규 모듈 레벨 캐시 추가 시 동일한 autouse fixture 패턴 적용 필수 — 미적용 시 테스트 순서 의존성 버그 발생.
+- **모듈 레벨 캐시 격리**: `src/webhook/_helpers.py`의 `_webhook_secret_cache`는 모듈 레벨 dict. `tests/conftest.py`의 `_clear_webhook_secret_cache` autouse fixture가 테스트마다 자동 클리어. 신규 모듈 레벨 캐시 추가 시 동일한 autouse fixture 패턴 적용 필수 — 미적용 시 테스트 순서 의존성 버그 발생.
 - **`services/analytics_service.py` 테스트 패턴**: `db: Session` 인자 + `now: datetime | None = None` 의존성 주입(freezegun 미사용). 각 테스트 파일은 자체 in-memory SQLite engine fixture (`tests/unit/repositories/test_analysis_feedback_repo.py:20-58` 참조). `func.count/avg/min/max` 호출 시 `# pylint: disable=not-callable` 인라인 주석 필수 (E1102 false positive).
 
 ### DB / 마이그레이션
@@ -427,7 +430,7 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 - **Webhook 서명**: `X-Hub-Signature-256` 헤더 없거나 서명 불일치 시 401 반환 — 로컬 테스트 시 서명 생성 필요. 빈 시크릿(`GITHUB_WEBHOOK_SECRET` 미설정)이면 즉시 401.
 - **Webhook 서명 실패 일관성**: GitHub / Telegram webhook 모두 서명 불일치 시 `HTTPException(401)` 반환. 200 OK 반환 금지 — 공격자에게 성공 응답 노출 방지 (2026-04-24 P1-4 정정).
 - **알림 독립성**: `_build_notify_tasks()` 디스패처, `asyncio.gather(return_exceptions=True)`로 실행 — 한 채널 실패해도 나머지 채널은 정상 전송. `repo_config` 로드 실패 시에도 Telegram은 global fallback으로 항상 발송.
-- **PR Gate 3-옵션 독립**: `pr_review_comment`·`approve_mode`·`auto_merge+merge_threshold` 완전 독립. `post_pr_comment_from_result(result: dict, ...)` 사용 — `AiReviewResult` 객체 불필요. `run_gate_check` 시그니처: `(repo_name, pr_number, analysis_id, result, github_token, db)`.
+- **PR Gate 3-옵션 독립**: `pr_review_comment`·`approve_mode`·`auto_merge+merge_threshold` 완전 독립. `post_pr_comment_from_result(result: dict, ...)` 사용 — `AiReviewResult` 객체 불필요. `run_gate_check` 시그니처: `(repo_name, pr_number, analysis_id, result, github_token, db, config: RepoConfigData | None = None)`.
 - **build_analysis_result_dict**: `src/worker/pipeline.py` 모듈 레벨 함수. pipeline과 hook.py 두 곳에서 Analysis.result dict를 생성할 때 사용. `score`·`grade` 필드 포함 — gate engine이 이를 기반으로 결정.
 - **GRADE 상수 단일 출처**: `src/constants.py`에 `GRADE_EMOJI`, `GRADE_COLOR_DISCORD`, `GRADE_COLOR_HTML`, `GRADE_COLOR_ANSI` 정의. 각 모듈에 로컬 정의 금지.
 - **ChangedFile / github_api_headers 단일 출처**: `src/github_client/models.py`가 ChangedFile 정의 출처. `src/github_client/helpers.py`의 `github_api_headers(token)` 사용 — 새 GitHub API 호출 시 직접 dict를 만들지 말 것.
@@ -437,7 +440,7 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 - **http_client 싱글톤 원칙**: 신뢰 API (GitHub/Telegram/Railway) 호출은 `src/shared/http_client.py::get_http_client()` 를 통해 연결 풀 재사용. 외부 untrusted URL (Discord/Slack/custom_webhook/n8n) 은 `src/notifier/_http.py::build_safe_client()` 사용. `async with httpx.AsyncClient()` 매번 생성 금지 (2026-04-24 P1-3).
 - **MergeAttempt 관측 (Phase F.1+F.2)**: `src/gate/engine.py::_run_auto_merge`(자동) 및 `src/webhook/providers/telegram.py::handle_gate_callback`(반자동) 양쪽에서 `merge_pr` 직후 `log_merge_attempt()`(`src/shared/merge_metrics.py`)로 모든 시도(성공·실패)를 DB에 기록. `failure_reason`은 `src/gate/merge_reasons.py`의 정규 태그(`branch_protection_blocked`, `unstable_ci`, `permission_denied` 등). 관측 실패는 notify 경로를 막지 않도록 nested try/except로 격리 — DB 오류 시 rollback 후 WARNING + None. **Phase F.3**: `engine.py::_run_auto_merge` 실패 시 `get_advice(reason)` + 조건부 `create_merge_failure_issue()` 호출 — `auto_merge_issue_on_failure` 필드(5-way sync 적용)로 Issue 생성 제어.
 - **notifier 공통 헬퍼**: `src/notifier/_common.py`의 `format_ref()`, `get_all_issues()`, `get_issue_samples()`, `truncate_message()`, `truncate_issue_msg()`를 사용. 각 notifier 모듈에 이슈 수집 루프나 메시지 절단 로직 직접 작성 금지.
-- **webhook secret TTL 캐시**: `_get_webhook_secret(full_name)` 함수가 `_webhook_secret_cache` dict에 5분(WEBHOOK_SECRET_CACHE_TTL=300초) TTL로 per-repo 시크릿을 캐시. 리포 시크릿 변경 후 최대 5분간 구 시크릿으로 검증 — 인지하고 있을 것.
+- **webhook secret TTL 캐시**: `get_webhook_secret(full_name)` 함수가 `_webhook_secret_cache` dict에 5분(WEBHOOK_SECRET_CACHE_TTL=300초) TTL로 per-repo 시크릿을 캐시. 리포 시크릿 변경 후 최대 5분간 구 시크릿으로 검증 — 인지하고 있을 것.
 - **Telegram 콜백 도메인 분리**: `_make_callback_token(bot_token, scope, payload_id)`이 `scope ∈ {"gate","cmd"}`별 다른 HMAC 생성. 신규 명령 추가 시 `cmd:<verb>:<id>:<token>` 준수, 64-byte 한도 검증 (numeric id). `_gate_callback_token()`은 `_make_callback_token(..., "gate", analysis_id)` thin wrapper. `test_callback_data_within_64_bytes_all_commands` 단위 테스트 강제.
 - **Cron 엔드포인트 인증**: `POST /api/internal/cron/*`는 `INTERNAL_CRON_API_KEY` 전용 (admin key와 분리). Railway `[[deploy.cronJobs]]` 트리거. `hmac.compare_digest` 타이밍 안전 비교. `INTERNAL_CRON_API_KEY` 미설정 시 503 반환.
 - **Telegram chat_id 라우팅 우선순위**: cron 알림의 chat_id 결정은 `analytics_service.resolve_chat_id(repo, config)` 단일 헬퍼 — `RepoConfig.notify_chat_id` → `Repository.telegram_chat_id` → `settings.telegram_chat_id` → None(skip + WARNING).
@@ -451,7 +454,7 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 - **TOKEN_ENCRYPTION_KEY prod 감지**: lifespan startup 에서 `APP_BASE_URL` 이 https:// 로 시작하고 키가 비어있으면 WARNING 배너 출력. dev 환경(http 또는 빈 URL)에서는 침묵. 키 생성 명령은 로그 메시지에 포함 (2026-04-24 P1-5).
 - **Jinja2 autoescape**: `Jinja2Templates`는 `.html` 파일에 대해 autoescape=True(기본값). 템플릿 변수는 자동 이스케이프됨 — `| safe` 필터 사용 금지. notifier HTML 출력엔 `html.escape()` 직접 적용 필수.
 - **OAuth CSRF state**: Authlib `authorize_access_token()`이 session state 검증을 내부 처리. `/auth/github`를 거치지 않은 직접 콜백(`/auth/callback`) 접근은 에러(500)로 차단됨 — 정상 동작.
-- **로그 인젝션 방어 (`sanitize_for_log`)**: `src/log_safety.py`의 `sanitize_for_log(value, max_len=200)` 헬퍼로 user-controlled 입력을 logger 에 전달하기 전 반드시 경유. CR/LF/TAB/NUL 제거 + 길이 제한. `%r` 포맷만으로는 SonarCloud `pythonsecurity:S5145` taint analysis 를 통과 못 함 — 명시적 함수 호출 필요. 예: `logger.info("...%s...", sanitize_for_log(body.repo))`.
+- **로그 인젝션 방어 (`sanitize_for_log`)**: `src/shared/log_safety.py`의 `sanitize_for_log(value, max_len=200)` 헬퍼로 user-controlled 입력을 logger 에 전달하기 전 반드시 경유. CR/LF/TAB/NUL 제거 + 길이 제한. `%r` 포맷만으로는 SonarCloud `pythonsecurity:S5145` taint analysis 를 통과 못 함 — 명시적 함수 호출 필요. 예: `logger.info("...%s...", sanitize_for_log(body.repo))`.
 - **URL Path 방어적 인코딩 (`_repo_path`)**: `src/github_client/repos.py::_repo_path(full_name)` 으로 `urllib.parse.quote(safe='/')` 적용. GitHub API URL 에 `repo_full_name`/path 변수 삽입 시 반드시 경유 — SonarCloud `pythonsecurity:S7044` 경고 회피 + 실질적 path injection 차단.
 - **FastAPI Annotated 패턴 강제**: `Depends(...)`/`Header(...)` 는 `Annotated[Type, Depends(require_login)]` / `Annotated[str | None, Header()] = None` 형식으로 작성. `python:S8410` 규칙. `default 있는 param 뒤에 Annotated (default 없음)` 오면 SyntaxError — 함수 시그니처에서 `Annotated` 를 앞으로 이동 필요.
 - **SonarCloud FP suppress 규약**: `sonar-project.properties` 의 `sonar.issue.ignore.multicriteria` 에 규칙별 예외 추가. 개별 라인 예외는 `# NOSONAR <ruleKey> — 이유` 주석. 커스텀 sanitizer 를 SonarCloud taint analysis 가 인식 못 할 때 NOSONAR 주석 + 이유 명시가 표준.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 [![E2E](https://img.shields.io/badge/E2E-49_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)
-[![Coverage](https://img.shields.io/badge/Coverage-96.2%25-brightgreen?style=flat-square&logo=codecov&logoColor=white)](tests/)
+[![Coverage](https://img.shields.io/badge/Coverage-96.5%25-brightgreen?style=flat-square&logo=codecov&logoColor=white)](tests/)
 
 [🇰🇷 한국어](README.ko.md)
 
@@ -49,13 +49,13 @@ Most code review tools make you choose between static analysis precision and AI 
 | | SCAManager | CodeRabbit | SonarCloud | GitHub Copilot Review |
 |---|---|---|---|---|
 | **Self-hosted** | ✅ Your infrastructure | ❌ SaaS only | ❌ SaaS only | ❌ GitHub-managed |
-| **Static + AI combined** | ✅ 10 tools + Claude AI | AI only | Static only | AI only |
+| **Static + AI combined** | ✅ 10 tools + Claude AI | AI + linter integrations | Static + AI CodeFix (2024+) | AI only |
 | **Score-based PR Gate** | ✅ Auto / Semi / Manual | ❌ | ❌ | ❌ |
 | **Approve from phone** | ✅ Telegram inline buttons | ❌ | ❌ | ❌ |
 | **Push event analysis** | ✅ Auto Issue + Commit comment | ❌ PR only | ❌ | ❌ |
 | **50-language AI review** | ✅ Language-specific checklists | ✅ | ❌ | ✅ |
 | **DB failover** | ✅ Built-in | ❌ | ❌ | ❌ |
-| **Cost** | API usage only | Paid SaaS | Freemium | GitHub plan |
+| **Cost** | API usage only | Freemium (free for public repos) | Freemium | GitHub plan |
 
 **Best for:** Solo developers and small teams who want full control over their code quality pipeline without vendor lock-in.
 
@@ -74,7 +74,7 @@ Most code review tools make you choose between static analysis precision and AI 
 | Solidity | slither | `.sol` — reentrancy · tx.origin · weak-prng · Category-aware |
 | Ruby | RuboCop | `.rb` — Security cops detected separately |
 | Go | golangci-lint | `.go` — meta-linter (gosec / errcheck / staticcheck / unused, auto `go.mod`) |
-| AI Review | Claude Haiku 4.5 | **50 languages** with language-specific checklists |
+| AI Review | Claude Sonnet 4.6 | **50 languages** with language-specific checklists |
 | Commit Message | Claude AI | Push / PR messages |
 
 - Handles `push` and PR (`opened` / `synchronize` / `reopened`) events automatically
@@ -230,9 +230,9 @@ git push origin main
 | **Web Framework** | FastAPI + Uvicorn |
 | **Auth** | GitHub OAuth2 (authlib) + Starlette SessionMiddleware |
 | **Database** | PostgreSQL · SQLAlchemy 2 · Alembic · FailoverSessionFactory |
-| **AI (Server)** | Anthropic Claude API (claude-haiku-4-5) |
+| **AI (Server)** | Anthropic Claude API (claude-sonnet-4-6) |
 | **AI (Local Hook)** | Claude Code CLI (`claude -p`) |
-| **Static Analysis** | pylint · flake8 · bandit (Python) + Semgrep (23+) + ESLint (JS/TS) + ShellCheck (shell) + cppcheck (C/C++) + slither (Solidity) + RuboCop (Ruby) + golangci-lint (Go) |
+| **Static Analysis** | pylint · flake8 · bandit (Python) + Semgrep (22+) + ESLint (JS/TS) + ShellCheck (shell) + cppcheck (C/C++) + slither (Solidity) + RuboCop (Ruby) + golangci-lint (Go) |
 | **Testing** | pytest · pytest-asyncio · httpx TestClient |
 | **E2E Testing** | Playwright (Chromium) |
 | **Web UI** | Jinja2 · Chart.js · CSS Variables (3 themes) |
@@ -377,6 +377,7 @@ POST /repos/{repo}/delete            Delete repo (including Webhook + history)
 ```
 POST /webhooks/github                GitHub Webhook (HMAC-SHA256 verified)
 POST /api/webhook/telegram           Telegram Gate callback (HMAC auth)
+POST /webhooks/railway/{token}       Railway deploy event (token auth)
 ```
 
 **REST API** (X-API-Key header required)
@@ -395,9 +396,20 @@ GET  /api/hook/verify                Verify hook registration
 POST /api/hook/result                Save code review result
 ```
 
+**User API** (OAuth session required)
+```
+POST /api/users/me/telegram-otp      Issue 6-digit OTP for Telegram /connect linking
+```
+
+**Internal Cron** (INTERNAL_CRON_API_KEY required)
+```
+POST /api/internal/cron/weekly       Trigger weekly Telegram summary report
+POST /api/internal/cron/trend        Trigger trend alert check (7-day moving avg)
+```
+
 **Health Check**
 ```
-GET  /health                         {"status":"ok","active_db":"primary"|"fallback"}
+GET  /health                         {"status":"ok"}
 ```
 
 </details>

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -14,11 +14,11 @@
 | SonarCloud BLOCKER / CRITICAL | **0 / 0** | Phase Q.7 완료 — 5건 Cognitive Complexity 전부 해소 |
 | E2E 테스트 | **49개** | `make test-e2e` (Chromium Playwright) |
 | pylint | **10.00/10** | `python -m pylint src/` — 만점 복원 (보안 강화 회귀 3건 수정) |
-| 커버리지 | **96.2%** | `make test-cov` (database.py 100%, ui/router.py 99.4%) |
+| 커버리지 | **96.5%** | `make test-cov` (database.py 100%, ui/router.py 99.4%) |
 | bandit HIGH | **0개** | bandit 1.9.4 (Python 3.14 대응) |
 | flake8 | **0건** | `flake8 src/` |
 | 지원 언어 (AI 리뷰) | **50개** | language.py — Tier1/2/3 가이드 |
-| 지원 언어 (정적분석) | **38개+** | Semgrep 23 + ESLint 2 + ShellCheck 1 + cppcheck 1 + slither 1 + rubocop 1 + golangci-lint 1 + Python 3 도구 |
+| 지원 언어 (정적분석) | **37개+** | Semgrep 22 + ESLint 2 + ShellCheck 1 + cppcheck 1 + slither 1 + rubocop 1 + golangci-lint 1 + Python 3 도구 |
 | Tier1 정적분석 도구 | **10종** | pylint·flake8·bandit·semgrep·eslint·shellcheck·cppcheck·slither·**rubocop**·**golangci-lint** |
 | pytest-asyncio | **1.3.0** | Python 3.14 DeprecationWarning 제거 완료 |
 
@@ -31,7 +31,8 @@
 | `src/analyzer/tools/*.py` | 개별 분석기 — 모듈 로드 시 자동 register() 호출 |
 | `src/notifier/_common.py` | notifier 공통 헬퍼 — format_ref, get_all_issues, truncate_message |
 | `src/notifier/_http.py` | HTTP_CLIENT_TIMEOUT 적용 httpx 클라이언트 빌더 |
-| `src/webhook/router.py` | GitHub Webhook 수신 + per-repo secret TTL 캐시(5분) |
+| `src/webhook/_helpers.py` | `get_webhook_secret()` + `_webhook_secret_cache` per-repo TTL 캐시(5분) |
+| `src/webhook/router.py` | Webhook 라우터 aggregator — providers 3개 include |
 | `src/gate/engine.py` | 3-옵션 Gate + GateDecision upsert (중복 INSERT 방지) + MergeAttempt 관측(Phase F.1) |
 | `src/gate/merge_reasons.py` | auto-merge 실패 사유 정규 태그 상수 (Phase F QW5) |
 | `src/gate/merge_failure_advisor.py` | `get_advice(reason)` — reason tag → 권장 조치 텍스트 (Phase F.3, 순수 함수) |
@@ -43,6 +44,42 @@
 | `tests/conftest.py` | 환경변수 주입 + _webhook_secret_cache autouse 클리어 |
 
 ## 작업 이력 (그룹별)
+
+### 그룹 42 (2026-04-26 · Phase 10 Telegram 확장 완료 — PR #64)
+
+**목표**: 주간 리포트 cron + 트렌드 알림 + Telegram 인라인 명령 (`/stats`, `/settings`, `/connect`) + OTP 연결 흐름.
+
+**신규 파일**:
+
+| 파일 | 역할 |
+|------|------|
+| `src/services/analytics_service.py` | 집계 단일 출처 — `weekly_summary`, `moving_average`, `top_issues`, `resolve_chat_id` |
+| `src/services/cron_service.py` | 주기적 실행 — `run_weekly_reports`, `run_trend_check` |
+| `src/api/internal_cron.py` | `POST /api/internal/cron/weekly|trend` — `INTERNAL_CRON_API_KEY` 전용 인증 |
+| `src/api/users.py` | `POST /api/users/me/telegram-otp` — 6자리 OTP 발급 (5분 만료) |
+| `src/notifier/telegram_commands.py` | `/stats`, `/settings`, `/connect` 명령 처리 + OTP 검증 |
+| `alembic/versions/0017_add_user_telegram_id.py` | `users.telegram_user_id UNIQUE` + `telegram_otp` + `telegram_otp_expires_at` |
+
+**수정 파일**: `src/webhook/providers/telegram.py` (message.text / cmd: 분기), `src/gate/telegram_gate.py` (`_make_callback_token` scope 일반화), `src/models/user.py`, `src/repositories/user_repo.py`, `src/main.py` (라우터 등록), `src/config.py` (`internal_cron_api_key`), `railway.toml` (cron 2개), `src/templates/settings.html` (OTP 카드 ⑤)
+
+**테스트 증분**: +73 (1344 → **1417** passed)
+**품질**: pylint 10.00 · bandit HIGH 0 · 커버리지 96.5%
+
+### 그룹 41 (2026-04-26 · Phase 9 자기 분석 루프 방지 완료 — PR #62)
+
+**목표**: SCAManager 자체 리포를 등록해 dogfooding하면서 봇 발신/자기 분석 무한 루프를 3-layer 방어로 차단.
+
+**신규 파일**:
+
+| 파일 | 역할 |
+|------|------|
+| `src/webhook/loop_guard.py` | `is_bot_sender()` + `has_skip_marker()` + `BotInteractionLimiter` (시간당 6회 상한) |
+| `docs/runbooks/self-analysis.md` | 자기 분석 활성화/비활성화 운영 가이드 |
+
+**수정 파일**: `src/webhook/providers/github.py` (`_loop_guard_check()` 삽입 — Kill-switch + BOT_LOGIN_WHITELIST 체크)
+
+**테스트 증분**: +29 (1315 → **1344** passed)
+**품질**: pylint 10.00 · bandit HIGH 0
 
 ### 그룹 40 (2026-04-26 · 문서 다중 에이전트 심의 시스템)
 
@@ -630,7 +667,7 @@ README 배지를 Claude/자체 산출 수치가 아닌 **외부 SaaS 가 직접 
 ## 갱신 방법
 
 ```bash
-make test          # 1107 유지 확인
+make test          # 1417 통과 확인
 make lint          # pylint 10.00 + flake8 0건 + bandit HIGH 0개
 make test-cov      # 96%+ 유지 확인 (소폭 변동 가능)
 


### PR DESCRIPTION
## Summary

Phase 10 착수 전 3개 병렬 에이전트(CLAUDE.md · STATE.md · README.md 감사)가 발견한 사실 오류 및 누락 항목을 일괄 수정합니다.

### CLAUDE.md
- Semgrep 언어 수 23 → **22개** (실측값)
- `services/` 트리 파일 목록 추가 (`analytics_service.py`, `cron_service.py`)
- `notifier/` 트리에 `telegram_commands.py` 추가 + `_common.py`에 `get_issue_samples` 추가
- `_webhook_secret_cache` 위치 `router.py` → **`_helpers.py`** (실제 위치)
- `_get_webhook_secret` → **`get_webhook_secret`** (선행 밑줄 오타)
- `src/log_safety.py` → **`src/shared/log_safety.py`** (실제 경로)
- `run_gate_check` 시그니처에 `config: RepoConfigData | None = None` 추가

### STATE.md
- 커버리지 96.2% → **96.5%** (SonarCloud 실측)
- 지원 언어(정적분석) 38개+/Semgrep 23 → **37개+/Semgrep 22**
- `_helpers.py` 파일 참조 추가 (webhook secret 캐시 실제 위치)
- `make test # 1107` → **`1417`** (갱신 가이드 수치 동기화)
- **그룹 41** (Phase 9 자기 분석 루프 방지) + **그룹 42** (Phase 10 Telegram 확장) 작업 이력 추가

### README.md
- AI 모델 `Claude Haiku 4.5` → **`Claude Sonnet 4.6`** (Features 표 + Tech Stack, 2곳)
- 비교표 CodeRabbit: `AI only` → `AI + linter integrations` (ESLint, Ruff, golangci-lint 등 통합)
- 비교표 CodeRabbit: `Paid SaaS` → `Freemium (free for public repos)` (OSS 무료 플랜 존재)
- 비교표 SonarCloud: `Static only` → `Static + AI CodeFix (2024+)` (Sonar AI 출시)
- 커버리지 배지 96.2% → **96.5%**
- Semgrep `23+` → `22+`
- `POST /webhooks/railway/{token}` 엔드포인트 추가
- Phase 10 신규 엔드포인트 3개 추가 (OTP, cron weekly/trend)
- `GET /health` 응답 단순화 (`active_db` 필드 제거 반영)

## Test plan

- [ ] 문서 전용 변경 — 코드 변경 없음, 테스트 실행 불필요
- [ ] README 비교표 각 셀이 사실을 정확히 반영하는지 검토
- [ ] CLAUDE.md 아키텍처 트리 파일 목록이 실제 `src/` 구조와 일치하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)