### PR TITLE
docs: 5-agent audit 최종 수정 — 파일 경로 정정 + health 응답 명세 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,8 +480,7 @@ ANTHROPIC_API_KEY     = sk-ant-...                       ← recommended
 uvicorn src.main:app --host 0.0.0.0 --port 8000 --proxy-headers
 ```
 
-**DB Failover** — Set `DATABASE_URL_FALLBACK` to a secondary DB URL for automatic failover on primary failure.
-Status: `GET /health` → `{"active_db": "primary" | "fallback"}`
+**DB Failover** — Set `DATABASE_URL_FALLBACK` to a secondary DB URL for automatic failover on primary failure. The `/health` endpoint returns `{"status": "ok"}` regardless of which DB is active.
 
 See the [on-premises migration guide](docs/guides/onpremise-migration-guide.md) for details.
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -27,7 +27,7 @@
 | 파일 | 역할 |
 |------|------|
 | `src/constants.py` | 전역 상수 단일 출처 — 점수배점·감점·AI기본값·등급·알림한도·TTL·타임아웃 |
-| `src/analyzer/registry.py` | Analyzer Protocol + REGISTRY + register() + AnalyzeContext + AnalysisIssue |
+| `src/analyzer/pure/registry.py` | Analyzer Protocol + REGISTRY + register() + AnalyzeContext + AnalysisIssue + Category/Severity StrEnum |
 | `src/analyzer/tools/*.py` | 개별 분석기 — 모듈 로드 시 자동 register() 호출 |
 | `src/notifier/_common.py` | notifier 공통 헬퍼 — format_ref, get_all_issues, truncate_message |
 | `src/notifier/_http.py` | HTTP_CLIENT_TIMEOUT 적용 httpx 클라이언트 빌더 |


### PR DESCRIPTION
## Summary

5-agent 전체 감사의 마지막 수정 항목 2건 반영.

- **STATE.md**: `src/analyzer/registry.py` → `src/analyzer/pure/registry.py` (Phase S.3-B 이후 pure/io 분리 구조 반영, Category/Severity StrEnum 설명 추가)
- **README.md**: `/health` 응답 명세 오류 수정 — `{"active_db": "primary" | "fallback"}` 제거, 실제 코드(src/main.py)가 반환하는 `{"status": "ok"}` 만 명시

## Background

PR #66 (3-agent audit) 머지 후, 5-agent 전체 감사에서 추가 발견된 2건:
- Agent B: `src/analyzer/registry.py` 경로가 Phase S.3-B 구조 개편 이후 `src/analyzer/pure/registry.py`로 이동했으나 STATE.md 미갱신
- Agent C: README.md DB Failover 섹션의 `/health` 응답이 `FailoverSessionFactory` 구현 이전 설계 명세를 그대로 유지 — 현재 구현과 불일치

## Test plan

- [ ] 코드 변경 없음 — 문서 전용 수정
- [ ] `src/analyzer/pure/registry.py` 경로 실존 확인 (git ls-files 검증 완료)
- [ ] `src/main.py` health 엔드포인트 반환값 확인 완료: `{"status": "ok"}` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)