### PR TITLE
docs: README 경쟁사 비교표 제거 + 한글 README 뱃지 동기화

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -18,11 +18,11 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
-[![Tests](https://img.shields.io/badge/Tests-1275_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-1417_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
 [![E2E](https://img.shields.io/badge/E2E-49_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)
-[![Coverage](https://img.shields.io/badge/Coverage-96.2%25-brightgreen?style=flat-square&logo=codecov&logoColor=white)](tests/)
+[![Coverage](https://img.shields.io/badge/Coverage-96.5%25-brightgreen?style=flat-square&logo=codecov&logoColor=white)](tests/)
 
 [🇺🇸 English](README.md)
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ Most code review tools make you choose between static analysis precision and AI 
 
 | | SCAManager | CodeRabbit | SonarCloud | GitHub Copilot Review |
 |---|---|---|---|---|
-| **Self-hosted** | ✅ Your infrastructure | ❌ SaaS only | ❌ SaaS only | ❌ GitHub-managed |
-| **Static + AI combined** | ✅ 10 tools + Claude AI | AI + linter integrations | Static + AI CodeFix (2024+) | AI only |
-| **Score-based PR Gate** | ✅ Auto / Semi / Manual | ❌ | ❌ | ❌ |
+| **Self-hosted** | ✅ Your infrastructure | ⚠️ Enterprise only (500+ seats) | ❌ SaaS only (SonarQube = separate self-hosted product) | ❌ GitHub-managed |
+| **Static + AI combined** | ✅ 10 tools + Claude AI | AI + 50 linter integrations | Static + AI CodeFix (2024+) | AI + ESLint/PMD/CodeQL (Nov 2025+) |
+| **Score-based PR Gate** | ✅ Auto / Semi / Manual | ❌ | ❌ (pass/fail quality gate only) | ❌ |
 | **Approve from phone** | ✅ Telegram inline buttons | ❌ | ❌ | ❌ |
-| **Push event analysis** | ✅ Auto Issue + Commit comment | ❌ PR only | ❌ | ❌ |
-| **50-language AI review** | ✅ Language-specific checklists | ✅ | ❌ | ✅ |
+| **Push event analysis** | ✅ Auto Issue + Commit comment | ❌ PR only | ⚠️ Main branch only (free); all branches (Team+) | ❌ PR only |
+| **50-language AI review** | ✅ Language-specific checklists | ✅ | ❌ AI fixes: 8 languages only | ✅ All languages |
 | **DB failover** | ✅ Built-in | ❌ | ❌ | ❌ |
-| **Cost** | API usage only | Freemium (free for public repos) | Freemium | GitHub plan |
+| **Cost** | API usage only | Freemium (free for public repos) | Freemium | GitHub Copilot plan |
 
 **Best for:** Solo developers and small teams who want full control over their code quality pipeline without vendor lock-in.
 

--- a/README.md
+++ b/README.md
@@ -46,18 +46,16 @@ For teams that push directly to `main`, it also supports **automatic commit comm
 
 Most code review tools make you choose between static analysis precision and AI understanding. SCAManager runs both in parallel and combines the results into a single score — then acts on it automatically.
 
-| | SCAManager | CodeRabbit | SonarCloud | GitHub Copilot Review |
-|---|---|---|---|---|
-| **Self-hosted** | ✅ Your infrastructure | ⚠️ Enterprise only (500+ seats) | ❌ SaaS only (SonarQube = separate self-hosted product) | ❌ GitHub-managed |
-| **Static + AI combined** | ✅ 10 tools + Claude AI | AI + 50 linter integrations | Static + AI CodeFix (2024+) | AI + ESLint/PMD/CodeQL (Nov 2025+) |
-| **Score-based PR Gate** | ✅ Auto / Semi / Manual | ❌ | ❌ (pass/fail quality gate only) | ❌ |
-| **Approve from phone** | ✅ Telegram inline buttons | ❌ | ❌ | ❌ |
-| **Push event analysis** | ✅ Auto Issue + Commit comment | ❌ PR only | ⚠️ Main branch only (free); all branches (Team+) | ❌ PR only |
-| **50-language AI review** | ✅ Language-specific checklists | ✅ | ❌ AI fixes: 8 languages only | ✅ All languages |
-| **DB failover** | ✅ Built-in | ❌ | ❌ | ❌ |
-| **Cost** | API usage only | Freemium (free for public repos) | Freemium | GitHub Copilot plan |
+**What makes it different:**
 
-**Best for:** Solo developers and small teams who want full control over their code quality pipeline without vendor lock-in.
+- **Self-hosted** — runs entirely on your own infrastructure; no vendor lock-in, no data leaves your environment
+- **Static + AI in one pipeline** — 10 linters/analyzers run alongside Claude AI review; results feed into a single score
+- **Score-based PR Gate** — automatically approve, reject, or request human decision via Telegram based on numeric thresholds
+- **Approve from phone** — Telegram inline buttons let you review and merge PRs from anywhere, no laptop required
+- **Push + PR analysis** — not just PRs; bare pushes also trigger analysis, auto-create GitHub Issues, and post commit comments
+- **50-language AI review** — language-specific checklists for every supported language, not a generic prompt
+
+**Best for:** Solo developers and small teams who want full control over their code quality pipeline.
 
 ---
 


### PR DESCRIPTION
## Summary

경쟁사 비교표를 README에서 완전히 제거하고 SCAManager 고유 기능 설명으로 대체.

## 변경 이유

타사 비교표는 두 가지 구조적 리스크가 있다:
1. **기능 변화 추적 부담** — 경쟁사 기능은 수시로 업데이트됨 (이번 감사에서도 GitHub Copilot이 2025년 11월 linter 추가, CodeRabbit 자체호스팅 존재 등 3건 사실 오류 발견)
2. **신뢰도 리스크** — 하나라도 틀리면 전체 문서의 신뢰도가 손상됨

## 변경 내용

- **README.md**: 경쟁사 비교 테이블 전체 제거 → SCAManager 자체 차별점 6개 불릿 목록으로 대체 (self-hosted / static+AI / score gate / Telegram approval / push analysis / 50-language)
- **README.ko.md**: 뱃지 수치 동기화 (테스트 1275 → 1417, 커버리지 96.2% → 96.5%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)