### PR TITLE
chore: 기술 부채 정리 — Telegram 카드 E2E +4 · batch_alter_table 예외 명시

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,7 +391,7 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 
 ### DB / 마이그레이션
 
-- **Alembic batch_alter_table 금지**: SQLite 전용 패턴. PostgreSQL에서는 `op.create_unique_constraint('이름', '테이블', ['컬럼'])` 직접 사용. 잘못 사용 시 lifespan 마이그레이션 실패 → Railway 헬스체크 실패.
+- **Alembic batch_alter_table 금지**: SQLite 전용 패턴. PostgreSQL에서는 `op.create_unique_constraint('이름', '테이블', ['컬럼'])` 직접 사용. 잘못 사용 시 lifespan 마이그레이션 실패 → Railway 헬스체크 실패. **예외**: `0005_add_users_and_user_id.py`, `0006_phase8b_github_oauth.py`는 이미 프로덕션에 적용된 이력 마이그레이션이므로 수정 금지 — `alembic downgrade` 경로 파괴 위험. 신규 마이그레이션(0007 이후)에만 이 규칙을 적용한다.
 - **FailoverSessionFactory**: `DATABASE_URL_FALLBACK` 설정 시 Primary `OperationalError` → Fallback DB 자동 전환. `_probe_primary_loop` daemon 스레드가 복구 확인 후 자동 복귀. 미설정 시 단일 엔진 모드(probe 스레드 없음). 소비자 코드(`SessionLocal()`)는 변경 없이 그대로 사용. `engine = SessionLocal._primary_engine`으로 alembic/env.py 호환성 유지.
 - **DB 세션 expunge**: `get_current_user()`는 `db.expunge(user)` 후 세션 반환 — 세션 종료 후에도 컬럼 속성 안전하게 접근 가능. 관계 lazy-load 사용 금지.
 - **ThreadPoolExecutor with 블록 금지**: `with` 문은 `shutdown(wait=True)` 호출 → DNS hang 시 무기한 블록. `try/finally` + `executor.shutdown(wait=False)` 패턴 사용 (database.py 참조).

--- a/README.ko.md
+++ b/README.ko.md
@@ -19,7 +19,7 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
 [![Tests](https://img.shields.io/badge/Tests-1417_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
-[![E2E](https://img.shields.io/badge/E2E-49_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
+[![E2E](https://img.shields.io/badge/E2E-53_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)
 [![Coverage](https://img.shields.io/badge/Coverage-96.5%25-brightgreen?style=flat-square&logo=codecov&logoColor=white)](tests/)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
 [![Tests](https://img.shields.io/badge/Tests-1417_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
-[![E2E](https://img.shields.io/badge/E2E-49_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
+[![E2E](https://img.shields.io/badge/E2E-53_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)
 [![Coverage](https://img.shields.io/badge/Coverage-96.5%25-brightgreen?style=flat-square&logo=codecov&logoColor=white)](tests/)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,7 +2,7 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-04-26 기준 — Phase F Quick Win + F.1 관측 완료 · Phase F.3 실패 어드바이저 완료 · G.2 수치 동기화 · Phase G 완료 · P2 이슈 수정 완료 · Phase H 착수 (F.2 관측 완료) · 이중언어 주석 마이그레이션 완료 · 보안 강화 그룹 39 완료 · lint 회귀 수정 · 문서 다중 에이전트 심의 시스템 완료 · Phase 9 자기 분석 루프 방지 완료 · **Phase 10 Telegram 확장 완료**)
+## 현재 수치 (2026-04-26 기준 — Phase F Quick Win + F.1 관측 완료 · Phase F.3 실패 어드바이저 완료 · G.2 수치 동기화 · Phase G 완료 · P2 이슈 수정 완료 · Phase H 착수 (F.2 관측 완료) · 이중언어 주석 마이그레이션 완료 · 보안 강화 그룹 39 완료 · lint 회귀 수정 · 문서 다중 에이전트 심의 시스템 완료 · Phase 9 자기 분석 루프 방지 완료 · Phase 10 Telegram 확장 완료 · **기술 부채 정리 — Telegram 카드 E2E +4 · CLAUDE.md batch_alter_table 예외 명시**)
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
@@ -12,7 +12,7 @@
 | SonarCloud Reliability Rating | **A** | Bugs 0 |
 | SonarCloud Maintainability Rating | **A** | Code Smells 58 (-20 from 78) |
 | SonarCloud BLOCKER / CRITICAL | **0 / 0** | Phase Q.7 완료 — 5건 Cognitive Complexity 전부 해소 |
-| E2E 테스트 | **49개** | `make test-e2e` (Chromium Playwright) |
+| E2E 테스트 | **53개** | `make test-e2e` (Chromium Playwright) — Telegram 카드 +4 |
 | pylint | **10.00/10** | `python -m pylint src/` — 만점 복원 (보안 강화 회귀 3건 수정) |
 | 커버리지 | **96.5%** | `make test-cov` (database.py 100%, ui/router.py 99.4%) |
 | bandit HIGH | **0개** | bandit 1.9.4 (Python 3.14 대응) |

--- a/e2e/test_settings.py
+++ b/e2e/test_settings.py
@@ -177,6 +177,68 @@ def test_reject_slider_updates_number_input(seeded_page, base_url):
     assert seeded_page.input_value("#rejectVal") == "30"
 
 
+# ── Telegram 연결 카드 E2E 테스트 ──────────────────────────────────────
+# ── Telegram connect card E2E tests ──────────────────────────────────────
+
+
+def test_telegram_connect_section_visible(seeded_page, base_url):
+    """카드 ⑤ 내 Telegram 연결 서브섹션이 설정 페이지에 렌더링되어야 한다.
+    Telegram connection subsection must render inside card ⑤ of the settings page.
+    """
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    assert seeded_page.locator("#telegram-connect-section").count() == 1
+    assert seeded_page.locator("#telegram-connect-section").is_visible()
+
+
+def test_telegram_otp_button_visible_when_not_connected(seeded_page, base_url):
+    """미연결 사용자에게는 '연결 코드 발급' 버튼이 표시되어야 한다.
+    The 'Issue Code' button must be visible for a user without a linked Telegram account.
+
+    E2E 시드 사용자는 telegram_user_id = NULL 이므로 미연결 상태.
+    The E2E seeded user has telegram_user_id = NULL, so it is in the unlinked state.
+    """
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    btn = seeded_page.locator("#issueTelegramOtp")
+    assert btn.count() == 1
+    assert btn.is_visible()
+    assert not btn.is_disabled()
+
+
+def test_telegram_otp_issue_shows_six_digit_code(seeded_page, base_url):
+    """'연결 코드 발급' 버튼 클릭 시 6자리 숫자 OTP가 화면에 표시되어야 한다.
+    Clicking 'Issue Code' must display a 6-digit numeric OTP on screen.
+    """
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    # OTP 표시 영역은 초기에 숨겨져 있어야 한다 / OTP display must be hidden initially.
+    assert seeded_page.evaluate(
+        "document.getElementById('telegramOtpDisplay').style.display === 'none' || "
+        "!document.getElementById('telegramOtpDisplay')"
+    )
+    seeded_page.locator("#issueTelegramOtp").click()
+    # OTP API 응답 및 DOM 업데이트 대기 / Wait for OTP API response and DOM update.
+    seeded_page.wait_for_selector("#telegramOtpDisplay", state="visible", timeout=5000)
+    otp_text = seeded_page.locator("#telegramOtpCode").inner_text()
+    # 6자리 숫자 문자열이어야 한다 / Must be a 6-digit numeric string.
+    assert len(otp_text) == 6, f"OTP 길이 오류: {otp_text!r}"
+    assert otp_text.isdigit(), f"OTP에 비숫자 문자 포함: {otp_text!r}"
+
+
+def test_telegram_otp_button_disabled_while_timer_runs(seeded_page, base_url):
+    """OTP 발급 후 타이머 실행 중에는 버튼이 비활성화되어야 한다.
+    The issue button must be disabled while the countdown timer is running.
+    """
+    seeded_page.goto(f"{base_url}{SETTINGS_URL}")
+    seeded_page.locator("#issueTelegramOtp").click()
+    seeded_page.wait_for_selector("#telegramOtpDisplay", state="visible", timeout=5000)
+    # 타이머 실행 중이므로 버튼은 비활성화 상태여야 한다
+    # Button must be disabled while the timer is running.
+    assert seeded_page.locator("#issueTelegramOtp").is_disabled()
+    # 카운트다운 텍스트가 "4:" 또는 "5:" 로 시작해야 한다 (5분 이내)
+    # Countdown text must start with "4:" or "5:" (within 5 minutes).
+    countdown = seeded_page.locator("#telegramOtpCountdown").inner_text()
+    assert countdown.startswith(("5:", "4:")), f"카운트다운 형식 오류: {countdown!r}"
+
+
 def test_approve_threshold_hidden_when_disabled(seeded_page, base_url):
     """Approve 모드 비활성 시 임계값 슬라이더 영역이 숨겨져야 한다."""
     seeded_page.goto(f"{base_url}{SETTINGS_URL}")


### PR DESCRIPTION
## Summary

알려진 기술 부채 2건 정리.

## 1. settings.html Telegram 연결 카드 — E2E 테스트 4개 추가

Phase 10에서 구현한 Telegram OTP 연결 카드(`#telegram-connect-section`)가 UI 변경임에도 E2E 테스트가 없었던 문제 해소.

| 테스트 | 검증 내용 |
|--------|----------|
| `test_telegram_connect_section_visible` | 카드 ⑤ 서브섹션이 설정 페이지에 렌더링됨 |
| `test_telegram_otp_button_visible_when_not_connected` | 미연결 사용자(telegram_user_id=NULL)에게 발급 버튼 표시 |
| `test_telegram_otp_issue_shows_six_digit_code` | 버튼 클릭 → `/api/users/me/telegram-otp` 호출 → 6자리 숫자 OTP 화면 표시 |
| `test_telegram_otp_button_disabled_while_timer_runs` | OTP 발급 후 5분 타이머 실행 중 버튼 비활성화 |

E2E: 49 → **53개**

## 2. 구 마이그레이션 batch_alter_table — CLAUDE.md 예외 명시

`0005`, `0006` 마이그레이션이 `batch_alter_table`(SQLite 전용 패턴)을 사용하는 것이 부채로 기록돼 있었으나, 이미 프로덕션에 적용된 이력 마이그레이션은 수정 시 `alembic downgrade` 경로가 파괴되므로 수정 금지가 올바른 처리.

CLAUDE.md `batch_alter_table 금지` 항목에 **예외 절** 추가:
- `0005`, `0006`은 수정 금지 (이력 마이그레이션)
- 신규 마이그레이션(0007 이후)에만 금지 규칙 적용

## 수치 동기화

STATE.md / README.md / README.ko.md E2E 뱃지: 49 → 53

🤖 Generated with [Claude Code](https://claude.com/claude-code)