### PR TITLE
docs: README Phase 10 Telegram Insights 섹션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,54 @@ All channels run independently via `asyncio.gather(return_exceptions=True)` — 
 
 ---
 
+### 📡 Telegram Insights (Phase 10)
+
+Beyond real-time push/PR alerts, SCAManager's Telegram integration provides scheduled reports, trend detection, and interactive bot commands.
+
+#### Weekly Report
+Every Monday at 09:00 KST, SCAManager sends a weekly summary to each repo's configured Telegram chat:
+
+```
+📊 Weekly Report — owner/myrepo
+Period: Apr 21 – Apr 27
+
+Analyses: 12  |  Avg score: 81.4 (B)
+High: 94 (A)  |  Low: 62 (C)
+
+Top issues this week:
+  · security: 8 occurrences
+  · code_quality: 14 occurrences
+```
+
+#### Trend Alert
+Every day at 12:00 KST, SCAManager checks the 7-day moving average. If it drops **10+ points** below the prior period (minimum 5 analyses required), a trend alert is sent automatically:
+
+```
+⚠️ Score trend alert — owner/myrepo
+7-day moving avg dropped: 83.2 → 71.5 (−11.7)
+Recent low-score analyses may need attention.
+```
+
+#### Bot Commands
+After linking your Telegram account (see below), send these commands to the bot:
+
+| Command | Description |
+|---------|-------------|
+| `/stats <repo>` | Weekly avg score, analysis count, top issues for the repo |
+| `/settings <repo>` | Current gate mode, thresholds, and notification settings |
+| `/connect <OTP>` | Link your Telegram account to your SCAManager profile |
+
+#### Linking Your Telegram Account (`/connect` OTP flow)
+
+1. Go to **Settings → Card ⑤ → Telegram Connection** and click **"🔗 Issue Code"**
+2. A 6-digit OTP appears (valid for 5 minutes)
+3. Send `/connect 123456` to the SCAManager bot in Telegram
+4. The bot replies "✅ Account linked" — bot commands are now available
+
+> Each new OTP immediately invalidates the previous one. The link is per-user, not per-repo.
+
+---
+
 ### ⚡ PR Gate Engine
 
 Score-based PR automation.


### PR DESCRIPTION
## Summary

Phase 10에서 구현된 Telegram 확장 기능이 README에 설명되지 않아 추가.

## 추가된 섹션: `📡 Telegram Insights (Phase 10)`

Notification Channels 섹션 직후에 독립 섹션으로 삽입.

### 포함 내용

| 항목 | 설명 |
|------|------|
| **Weekly Report** | 매주 월요일 KST 09:00 자동 발송 — 분석 건수·평균 점수·고저점·상위 이슈 |
| **Trend Alert** | 매일 KST 12:00 체크 — 7일 이동평균 -10점 이하 시 경보 (최소 5건 필요) |
| **Bot Commands** | `/stats`, `/settings`, `/connect` 명령표 |
| **OTP 연결 흐름** | 설정 페이지 → 코드 발급 → Telegram `/connect 123456` → 계정 연결 4단계 |

실제 Telegram 메시지 예시를 코드 블록으로 포함해 기능을 직관적으로 설명.

🤖 Generated with [Claude Code](https://claude.com/claude-code)