### PR TITLE
feat(insights): Phase 11 팀/멀티 리포 인사이트

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -396,6 +396,7 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 - **DB 세션 expunge**: `get_current_user()`는 `db.expunge(user)` 후 세션 반환 — 세션 종료 후에도 컬럼 속성 안전하게 접근 가능. 관계 lazy-load 사용 금지.
 - **ThreadPoolExecutor with 블록 금지**: `with` 문은 `shutdown(wait=True)` 호출 → DNS hang 시 무기한 블록. `try/finally` + `executor.shutdown(wait=False)` 패턴 사용 (database.py 참조).
 - **SQLite hostaddr 제외**: `_ipv4_connect_args`는 hostname이 None(SQLite URL)이면 빈 dict 반환 — 그렇지 않으면 `sqlite3.connect(hostaddr=...)` TypeError 발생.
+- **`Analysis.author_login` NULL 정책**: 신규 컬럼은 backfill 없이 NULL 허용. 모든 집계는 `WHERE author_login IS NOT NULL` 적용. backfill 필요 시 `scripts/backfill_author.py` 별도 실행. PR 이벤트 = `pull_request.user.login`, Push 이벤트 = `head_commit.author.username`.
 
 ### 파이프라인 / 비즈니스 로직
 
@@ -469,6 +470,7 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 - **repo_detail 차트 동기화**: `buildChart(data)` 함수는 `data` 인자가 있으면 `_chartData`에 캐시, 없으면 캐시된 데이터 재사용. `applyFilters()` 호출마다 차트를 필터 결과와 동기화. `themechange` 이벤트는 `buildChart()` (인자 없음)으로 색상만 재빌드.
 - **리포 추가 Webhook URL**: `_webhook_base_url(request)` 헬퍼가 `APP_BASE_URL` 설정 시 HTTPS URL 강제. Railway 배포 시 반드시 `APP_BASE_URL` 설정 — 미설정 시 `http://`로 등록되어 Webhook 전달 실패.
 - **기존 Webhook 등록 리포**: `user_id = NULL` 리포는 모든 로그인 사용자에게 표시됨. `/repos/add`로 동일 리포 재등록 시 `user_id=NULL`이면 현재 사용자 소유 이전, 이미 소유자 있으면 에러.
+- **insights 차트 재사용**: `insights_me.html`은 `analysis_detail.html`과 동일한 Chart.js CDN 직접 로드 패턴 사용. `leaderboard_opt_in`은 PRESETS 9개 필드에 포함하지 않음 — 사용자가 명시 옵트인해야 하는 선택적 기능. 설정 카드 ③(이벤트 후 피드백)에 토글 배치.
 
 ### 배포
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
-[![Tests](https://img.shields.io/badge/Tests-1417_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-1409_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
 [![E2E](https://img.shields.io/badge/E2E-53_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)

--- a/alembic/versions/0018_add_analysis_author.py
+++ b/alembic/versions/0018_add_analysis_author.py
@@ -1,0 +1,26 @@
+"""add analyses.author_login column
+
+Revision ID: 0018addauthor
+Revises: 0017addtelegramid
+Create Date: 2026-04-26
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0018addauthor'
+down_revision = '0017addusertelegramid'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # author_login: PR = pull_request.user.login, push = head_commit.author.username
+    # 신규 레코드만 채움 — backfill 없음 (NULL 허용, 인덱스로 집계 성능 보장)
+    # Populated for new records only — no backfill (nullable, index for aggregation performance).
+    op.add_column('analyses', sa.Column('author_login', sa.String(), nullable=True))
+    op.create_index('ix_analyses_author_login', 'analyses', ['author_login'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_analyses_author_login', table_name='analyses')
+    op.drop_column('analyses', 'author_login')

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,19 +2,19 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-04-26 기준 — Phase F Quick Win + F.1 관측 완료 · Phase F.3 실패 어드바이저 완료 · G.2 수치 동기화 · Phase G 완료 · P2 이슈 수정 완료 · Phase H 착수 (F.2 관측 완료) · 이중언어 주석 마이그레이션 완료 · 보안 강화 그룹 39 완료 · lint 회귀 수정 · 문서 다중 에이전트 심의 시스템 완료 · Phase 9 자기 분석 루프 방지 완료 · Phase 10 Telegram 확장 완료 · **기술 부채 정리 — Telegram 카드 E2E +4 · CLAUDE.md batch_alter_table 예외 명시**)
+## 현재 수치 (2026-04-26 기준 — Phase F Quick Win + F.1 관측 완료 · Phase F.3 실패 어드바이저 완료 · G.2 수치 동기화 · Phase G 완료 · P2 이슈 수정 완료 · Phase H 착수 (F.2 관측 완료) · 이중언어 주석 마이그레이션 완료 · 보안 강화 그룹 39 완료 · lint 회귀 수정 · 문서 다중 에이전트 심의 시스템 완료 · Phase 9 자기 분석 루프 방지 완료 · Phase 10 Telegram 확장 완료 · 기술 부채 정리 완료 · **Phase 11 팀/멀티 리포 인사이트 완료**)
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 단위 테스트 | **1417개** | pytest 9.0.3 (0 failed) — 2026-04-26 로컬 실측 (Phase 10: +73 테스트) |
+| 단위 테스트 | **1409개** | pytest 9.0.3 (0 failed) — 2026-04-26 로컬 실측 (Phase 11: +31 테스트) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
 | SonarCloud Reliability Rating | **A** | Bugs 0 |
 | SonarCloud Maintainability Rating | **A** | Code Smells 58 (-20 from 78) |
 | SonarCloud BLOCKER / CRITICAL | **0 / 0** | Phase Q.7 완료 — 5건 Cognitive Complexity 전부 해소 |
 | E2E 테스트 | **53개** | `make test-e2e` (Chromium Playwright) — Telegram 카드 +4 |
-| pylint | **10.00/10** | `python -m pylint src/` — 만점 복원 (보안 강화 회귀 3건 수정) |
-| 커버리지 | **96.5%** | `make test-cov` (database.py 100%, ui/router.py 99.4%) |
+| pylint | **10.00/10** | `python -m pylint src/` — 만점 유지 |
+| 커버리지 | **95%** | `make test-cov` — 신규 파일 100% (analytics_service, api/insights, ui/routes/insights) |
 | bandit HIGH | **0개** | bandit 1.9.4 (Python 3.14 대응) |
 | flake8 | **0건** | `flake8 src/` |
 | 지원 언어 (AI 리뷰) | **50개** | language.py — Tier1/2/3 가이드 |

--- a/src/api/insights.py
+++ b/src/api/insights.py
@@ -1,0 +1,91 @@
+"""Team/Multi-repo Insights REST API — 개발자별 추세, 멀티 리포 비교, 리더보드.
+Team/multi-repo insights API — author trend, repo comparison, leaderboard.
+"""
+from fastapi import APIRouter
+from src.api.auth import require_api_key
+from src.database import SessionLocal
+from src.models.repo_config import RepoConfig
+from src.models.repository import Repository
+from src.services import analytics_service
+
+router = APIRouter(prefix="/api/insights", dependencies=[require_api_key])
+
+
+@router.get("/authors/{login}/trend")
+def get_author_trend(login: str, days: int = 30):
+    """개발자별 일별 평균 점수 추세를 반환한다.
+    Return the per-day average score trend for a GitHub login.
+    """
+    with SessionLocal() as db:
+        trend = analytics_service.author_trend(db, login, days)
+    return {"login": login, "days": days, "trend": trend}
+
+
+@router.get("/repos/compare")
+def get_repo_comparison(repos: str = "", days: int = 30):
+    """멀티 리포 평균 점수를 비교하여 반환한다.
+    Return average score comparison across comma-separated repo full_names.
+    """
+    # 빈 파라미터이면 즉시 빈 응답 반환 (불필요한 쿼리 방지)
+    # Return early on empty param to avoid unnecessary queries
+    if not repos or not repos.strip():
+        return {"repos": [], "days": days, "comparison": []}
+
+    full_names = [r.strip() for r in repos.split(",") if r.strip()]
+    if not full_names:
+        return {"repos": [], "days": days, "comparison": []}
+
+    with SessionLocal() as db:
+        # full_name → repo_id 매핑 조회
+        # Resolve full_names to repo_ids via DB lookup
+        repo_objs = (
+            db.query(Repository)
+            .filter(Repository.full_name.in_(full_names))
+            .all()
+        )
+        id_to_name = {r.id: r.full_name for r in repo_objs}
+        repo_ids = list(id_to_name.keys())
+        comparison_raw = analytics_service.repo_comparison(db, repo_ids, days)
+
+    # repo_id → full_name 으로 변환하여 응답에 포함
+    # Enrich comparison items with full_name
+    comparison = [
+        {
+            "repo_id": item["repo_id"],
+            "full_name": id_to_name.get(item["repo_id"], ""),
+            "avg_score": item["avg_score"],
+            "count": item["count"],
+        }
+        for item in comparison_raw
+    ]
+
+    return {"repos": full_names, "days": days, "comparison": comparison}
+
+
+@router.get("/leaderboard")
+def get_leaderboard(days: int = 30):
+    """옵트인 리포의 개발자별 점수 리더보드를 반환한다.
+    Return per-author leaderboard for repositories that opted in.
+    """
+    with SessionLocal() as db:
+        # leaderboard_opt_in=True 인 RepoConfig의 repo_full_name 수집 후 Repository.id 조회
+        # Collect repo_full_names from opted-in RepoConfigs, then resolve to Repository.id
+        opted_in_configs = (
+            db.query(RepoConfig)
+            .filter(RepoConfig.leaderboard_opt_in.is_(True))
+            .all()
+        )
+        opted_in_names = [c.repo_full_name for c in opted_in_configs]
+        opted_in_repos = (
+            db.query(Repository)
+            .filter(Repository.full_name.in_(opted_in_names))
+            .all()
+        ) if opted_in_names else []
+        opted_in_ids = [r.id for r in opted_in_repos]
+
+        if not opted_in_ids:
+            return {"days": days, "leaderboard": []}
+
+        lb = analytics_service.leaderboard(db, days, opted_in_ids)
+
+    return {"days": days, "leaderboard": lb}

--- a/src/api/repos.py
+++ b/src/api/repos.py
@@ -33,6 +33,7 @@ class RepoConfigUpdate(BaseModel):
     create_issue: bool = False
     railway_deploy_alerts: bool = False
     auto_merge_issue_on_failure: bool = False
+    leaderboard_opt_in: bool = False
 
     @model_validator(mode="after")
     def validate_thresholds(self) -> "RepoConfigUpdate":

--- a/src/config_manager/manager.py
+++ b/src/config_manager/manager.py
@@ -25,6 +25,7 @@ class RepoConfigData:  # pylint: disable=too-many-instance-attributes
     create_issue: bool = False
     railway_deploy_alerts: bool = False
     auto_merge_issue_on_failure: bool = False
+    leaderboard_opt_in: bool = False
 
 
 def _config_field_names() -> list[str]:

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from src.api.stats import router as api_stats_router
 from src.api.hook import router as api_hook_router
 from src.api.users import router as api_users_router
 from src.api.internal_cron import router as api_internal_cron_router
+from src.api.insights import router as api_insights_router
 from src.ui.router import router as ui_router
 from src.auth.github import router as auth_router
 
@@ -113,6 +114,7 @@ app.include_router(api_stats_router)
 app.include_router(api_hook_router)
 app.include_router(api_users_router)
 app.include_router(api_internal_cron_router)
+app.include_router(api_insights_router)
 app.include_router(ui_router)
 
 

--- a/src/models/analysis.py
+++ b/src/models/analysis.py
@@ -20,6 +20,9 @@ class Analysis(Base):
     score = Column(Integer, nullable=True)
     grade = Column(String(1), nullable=True)
     result = Column(JSON, nullable=True)
+    # 커밋 작성자 GitHub 로그인 — 신규 레코드만 채움 (기존 NULL 허용)
+    # GitHub login of the commit author — populated for new records only (existing rows NULL).
+    author_login = Column(String, nullable=True, index=True)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
 
     repository = relationship("Repository", back_populates="analyses")

--- a/src/models/repo_config.py
+++ b/src/models/repo_config.py
@@ -30,6 +30,9 @@ class RepoConfig(Base):
     railway_webhook_token = Column(String(64), nullable=True, unique=True)
     railway_api_token = Column(String, nullable=True)  # Fernet 암호화 저장
     auto_merge_issue_on_failure = Column(Boolean, default=False, nullable=False)
+    # 리더보드 공개 옵트인 — 기본 비활성 (팀 합의 후 활성화 권장)
+    # Leaderboard opt-in — disabled by default (recommended to enable after team agreement)
+    leaderboard_opt_in = Column(Boolean, default=False, nullable=False)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc),
                         onupdate=lambda: datetime.now(timezone.utc))
@@ -45,4 +48,5 @@ class RepoConfig(Base):
         kwargs.setdefault("create_issue", False)
         kwargs.setdefault("railway_deploy_alerts", False)
         kwargs.setdefault("auto_merge_issue_on_failure", False)
+        kwargs.setdefault("leaderboard_opt_in", False)
         super().__init__(**kwargs)

--- a/src/services/analytics_service.py
+++ b/src/services/analytics_service.py
@@ -177,6 +177,171 @@ def top_issues(
     return [{"message": msg, "count": cnt} for msg, cnt in sorted_issues[:n]]
 
 
+def author_trend(
+    db: Session,
+    login: str,
+    days: int = 30,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """개발자별 일별 평균 점수 추세를 반환한다.
+    Return the per-day average score trend for an author login.
+
+    Args:
+        db: SQLAlchemy 세션 / SQLAlchemy session
+        login: GitHub 로그인 ID / GitHub login
+        days: 집계 기간(일) / Aggregation period in days
+        now: 현재 시각 주입용 (테스트 고정 지원) / Injected current time (for test pinning)
+
+    Returns:
+        {"date": "YYYY-MM-DD", "avg_score": float, "count": int} 리스트 (날짜 오름차순)
+        List of {"date": "YYYY-MM-DD", "avg_score": float, "count": int} sorted ascending by date.
+    """
+    # now 기본값 설정 — 테스트에서 고정 시각 주입 가능
+    # Default now — allows injecting a fixed time in tests
+    _now = now or datetime.now(timezone.utc)
+    since = _now - timedelta(days=days)
+
+    analyses = db.scalars(
+        select(Analysis)
+        .where(Analysis.author_login == login)
+        .where(Analysis.author_login.isnot(None))
+        .where(Analysis.score.isnot(None))
+        .where(Analysis.created_at >= since)
+        .order_by(Analysis.created_at.asc())
+    ).all()
+
+    # Python-side 날짜별 그룹화 — SQLite/PG 날짜 함수 불일치 회피
+    # Group by date on the Python side to avoid SQLite/PG date function divergence
+    daily: dict[str, list[int]] = {}
+    for analysis in analyses:
+        date_str = analysis.created_at.strftime("%Y-%m-%d") if analysis.created_at else ""
+        if date_str:
+            daily.setdefault(date_str, []).append(analysis.score)
+
+    # 날짜 오름차순 정렬 후 반환
+    # Return sorted ascending by date
+    return [
+        {
+            "date": date_str,
+            "avg_score": round(sum(scores) / len(scores), 1),
+            "count": len(scores),
+        }
+        for date_str, scores in sorted(daily.items())
+    ]
+
+
+def repo_comparison(
+    db: Session,
+    repo_ids: list[int],
+    days: int = 30,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """멀티 리포 평균 점수를 비교하여 반환한다.
+    Return average score comparison across multiple repositories.
+
+    Args:
+        db: SQLAlchemy 세션 / SQLAlchemy session
+        repo_ids: 비교할 리포지토리 PK 목록 / List of repository PKs to compare
+        days: 집계 기간(일) / Aggregation period in days
+        now: 현재 시각 주입용 (테스트 고정 지원) / Injected current time (for test pinning)
+
+    Returns:
+        {"repo_id": int, "avg_score": float, "count": int} 리스트 (avg_score 내림차순)
+        List of {"repo_id": int, "avg_score": float, "count": int} sorted by avg_score descending.
+    """
+    # 빈 목록이면 즉시 반환 — 불필요한 쿼리 방지
+    # Return early on empty list to avoid unnecessary queries
+    if not repo_ids:
+        return []
+
+    # now 기본값 설정 — 테스트에서 고정 시각 주입 가능
+    # Default now — allows injecting a fixed time in tests
+    _now = now or datetime.now(timezone.utc)
+    since = _now - timedelta(days=days)
+
+    rows = db.execute(
+        select(
+            Analysis.repo_id,
+            func.count(Analysis.id).label("count"),  # pylint: disable=not-callable
+            func.avg(Analysis.score).label("avg_score"),  # pylint: disable=not-callable
+        )
+        .where(Analysis.repo_id.in_(repo_ids))
+        .where(Analysis.score.isnot(None))
+        .where(Analysis.created_at >= since)
+        .group_by(Analysis.repo_id)
+    ).all()
+
+    results = [
+        {
+            "repo_id": row.repo_id,
+            "avg_score": round(float(row.avg_score), 1),
+            "count": row.count,
+        }
+        for row in rows
+    ]
+
+    # avg_score 내림차순 정렬 후 반환
+    # Sort by avg_score descending
+    results.sort(key=lambda x: x["avg_score"], reverse=True)
+    return results
+
+
+def leaderboard(
+    db: Session,
+    days: int = 30,
+    opted_in_repo_ids: list[int] | None = None,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """옵트인 리포의 개발자별 점수 리더보드를 반환한다.
+    Return per-author score leaderboard for opted-in repositories.
+
+    Args:
+        db: SQLAlchemy 세션 / SQLAlchemy session
+        days: 집계 기간(일) / Aggregation period in days
+        opted_in_repo_ids: 리더보드 옵트인 리포 PK 목록 / Opted-in repository PK list
+        now: 현재 시각 주입용 (테스트 고정 지원) / Injected current time (for test pinning)
+
+    Returns:
+        {"author_login": str, "avg_score": float, "count": int} 리스트 (avg_score 내림차순)
+        List of {"author_login": str, "avg_score": float, "count": int} sorted by avg_score desc.
+    """
+    # 옵트인 리포 없으면 빈 리스트 즉시 반환 — 의도치 않은 게이미피케이션 방지
+    # Return empty list when no repos opted in — prevents unintended gamification exposure
+    if not opted_in_repo_ids:
+        return []
+
+    # now 기본값 설정 — 테스트에서 고정 시각 주입 가능
+    # Default now — allows injecting a fixed time in tests
+    _now = now or datetime.now(timezone.utc)
+    since = _now - timedelta(days=days)
+
+    rows = db.execute(
+        select(
+            Analysis.author_login,
+            func.count(Analysis.id).label("count"),  # pylint: disable=not-callable
+            func.avg(Analysis.score).label("avg_score"),  # pylint: disable=not-callable
+        )
+        .where(Analysis.author_login.isnot(None))
+        .where(Analysis.score.isnot(None))
+        .where(Analysis.repo_id.in_(opted_in_repo_ids))
+        .where(Analysis.created_at >= since)
+        .group_by(Analysis.author_login)
+        .order_by(func.avg(Analysis.score).desc())  # pylint: disable=not-callable
+    ).all()
+
+    return [
+        {
+            "author_login": row.author_login,
+            "avg_score": round(float(row.avg_score), 1),
+            "count": row.count,
+        }
+        for row in rows
+    ]
+
+
 def resolve_chat_id(repo: Repository, config: RepoConfig | None) -> str | None:
     """chat_id 우선순위에 따라 Telegram 채팅 ID를 반환한다.
     Resolve the Telegram chat_id with priority:

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -613,6 +613,7 @@
     <button class="nav-hamburger" id="navHamburger" aria-label="메뉴" aria-expanded="false">☰</button>
     <div class="nav-links" id="navLinks">
       <a class="nav-link" href="/">Overview</a>
+      <a class="nav-link" href="/insights">Insights</a>
     </div>
     <div class="nav-spacer"></div>
     {% if current_user %}

--- a/src/templates/insights.html
+++ b/src/templates/insights.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% block title %}Insights — SCAManager{% endblock %}
+{% block content %}
+<style>
+  .insights-header { display:flex; align-items:center; gap:1rem; margin-bottom:1.5rem; }
+  .insights-title { font-size:1.4rem; font-weight:700; }
+  .repo-selector { display:flex; gap:.5rem; flex-wrap:wrap; margin-bottom:1.5rem; }
+  .repo-selector input[type=text] { flex:1; min-width:220px; padding:.45rem .7rem; border:1px solid var(--c-border); border-radius:6px; background:var(--c-bg2); color:var(--c-text); font-size:.9rem; }
+  .repo-selector button { padding:.45rem 1rem; border-radius:6px; background:var(--c-accent); color:#fff; border:none; cursor:pointer; font-size:.9rem; }
+  .comparison-table { width:100%; border-collapse:collapse; margin-top:1rem; }
+  .comparison-table th, .comparison-table td { padding:.65rem .9rem; text-align:left; border-bottom:1px solid var(--c-border); }
+  .comparison-table th { font-size:.8rem; text-transform:uppercase; letter-spacing:.04em; opacity:.7; }
+  .score-bar { display:inline-block; height:8px; border-radius:4px; background:var(--c-accent); vertical-align:middle; margin-right:.5rem; }
+  .empty-state { text-align:center; padding:2.5rem 1rem; opacity:.6; }
+  .insights-links { display:flex; gap:1rem; margin-bottom:1.5rem; }
+  .insights-links a { padding:.35rem .85rem; border:1px solid var(--c-border); border-radius:6px; font-size:.88rem; text-decoration:none; color:var(--c-text); }
+  .insights-links a:hover { background:var(--c-bg2); }
+</style>
+
+<div class="insights-header">
+  <div class="insights-title">팀 인사이트</div>
+</div>
+
+<div class="insights-links">
+  <a href="/insights">리포 비교</a>
+  <a href="/insights/me">내 추세</a>
+</div>
+
+<!-- 리포 선택 폼 / Repo selector form -->
+<form method="get" action="/insights" class="repo-selector">
+  <input type="text" name="repos" placeholder="owner/repo1, owner/repo2, ..." value="{{ repos|join(', ') }}">
+  <select name="days" style="padding:.45rem .6rem; border:1px solid var(--c-border); border-radius:6px; background:var(--c-bg2); color:var(--c-text);">
+    {% for d in [7, 14, 30, 90] %}
+    <option value="{{ d }}" {% if d == days %}selected{% endif %}>최근 {{ d }}일</option>
+    {% endfor %}
+  </select>
+  <button type="submit">비교</button>
+</form>
+
+{% if comparison %}
+<table class="comparison-table">
+  <thead>
+    <tr>
+      <th>리포지토리</th>
+      <th>평균 점수</th>
+      <th>분석 건수</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in comparison %}
+    <tr>
+      <td><a href="/repos/{{ item.full_name }}">{{ item.full_name }}</a></td>
+      <td>
+        <span class="score-bar" style="width:{{ (item.avg_score / 100 * 80)|int }}px;"></span>
+        {{ item.avg_score }}
+      </td>
+      <td>{{ item.count }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+  {% if repos %}
+  선택한 리포의 분석 데이터가 없습니다.
+  {% else %}
+  위 입력란에 비교할 리포지토리를 입력하세요 (예: owner/repo1, owner/repo2).
+  {% endif %}
+</div>
+{% endif %}
+
+<!-- 전체 리포 빠른 선택 / Quick-pick all repos -->
+{% if all_repos %}
+<details style="margin-top:1.5rem;">
+  <summary style="cursor:pointer; font-size:.88rem; opacity:.7;">등록된 리포 목록 보기</summary>
+  <div style="display:flex; flex-wrap:wrap; gap:.4rem; margin-top:.6rem;">
+    {% for r in all_repos %}
+    <a href="/insights?repos={{ r.full_name }}&days={{ days }}" style="font-size:.82rem; padding:.2rem .55rem; border:1px solid var(--c-border); border-radius:4px; text-decoration:none; color:var(--c-text);">{{ r.full_name }}</a>
+    {% endfor %}
+  </div>
+</details>
+{% endif %}
+{% endblock %}

--- a/src/templates/insights_me.html
+++ b/src/templates/insights_me.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+{% block title %}내 추세 — SCAManager{% endblock %}
+{% block content %}
+<style>
+  .insights-header { display:flex; align-items:center; gap:1rem; margin-bottom:1.5rem; }
+  .insights-title { font-size:1.4rem; font-weight:700; }
+  .day-selector { display:flex; gap:.5rem; margin-bottom:1.5rem; }
+  .day-selector a { padding:.35rem .8rem; border:1px solid var(--c-border); border-radius:6px; font-size:.88rem; text-decoration:none; color:var(--c-text); }
+  .day-selector a.active, .day-selector a:hover { background:var(--c-accent); color:#fff; border-color:var(--c-accent); }
+  .trend-table { width:100%; border-collapse:collapse; margin-top:1rem; }
+  .trend-table th, .trend-table td { padding:.65rem .9rem; text-align:left; border-bottom:1px solid var(--c-border); }
+  .trend-table th { font-size:.8rem; text-transform:uppercase; letter-spacing:.04em; opacity:.7; }
+  .score-bar { display:inline-block; height:8px; border-radius:4px; background:var(--c-accent); vertical-align:middle; margin-right:.5rem; }
+  .empty-state { text-align:center; padding:2.5rem 1rem; opacity:.6; }
+  .insights-links { display:flex; gap:1rem; margin-bottom:1.5rem; }
+  .insights-links a { padding:.35rem .85rem; border:1px solid var(--c-border); border-radius:6px; font-size:.88rem; text-decoration:none; color:var(--c-text); }
+  .insights-links a:hover { background:var(--c-bg2); }
+</style>
+
+<div class="insights-header">
+  <div class="insights-title">내 점수 추세 — {{ current_user.github_login }}</div>
+</div>
+
+<div class="insights-links">
+  <a href="/insights">리포 비교</a>
+  <a href="/insights/me">내 추세</a>
+</div>
+
+<div class="day-selector">
+  {% for d in [7, 14, 30, 90] %}
+  <a href="/insights/me?days={{ d }}" {% if d == days %}class="active"{% endif %}>최근 {{ d }}일</a>
+  {% endfor %}
+</div>
+
+{% if trend %}
+<!-- 추세 차트 (Chart.js) / Trend chart -->
+<canvas id="trendChart" style="max-height:260px; margin-bottom:1.5rem;"></canvas>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<script>
+(function(){
+  var labels = {{ trend | map(attribute='date') | list | tojson }};
+  var scores = {{ trend | map(attribute='avg_score') | list | tojson }};
+  new Chart(document.getElementById('trendChart'), {
+    type: 'line',
+    data: {
+      labels: labels,
+      datasets: [{
+        label: '일별 평균 점수',
+        data: scores,
+        borderColor: 'var(--c-accent)',
+        backgroundColor: 'rgba(99,102,241,.15)',
+        tension: 0.3,
+        fill: true,
+      }]
+    },
+    options: {
+      scales: { y: { min: 0, max: 100 } },
+      plugins: { legend: { display: false } }
+    }
+  });
+})();
+</script>
+
+<table class="trend-table">
+  <thead>
+    <tr>
+      <th>날짜</th>
+      <th>평균 점수</th>
+      <th>분석 건수</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for item in trend %}
+    <tr>
+      <td>{{ item.date }}</td>
+      <td>
+        <span class="score-bar" style="width:{{ (item.avg_score / 100 * 80)|int }}px;"></span>
+        {{ item.avg_score }}
+      </td>
+      <td>{{ item.count }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<div class="empty-state">
+  최근 {{ days }}일간 분석 데이터가 없습니다.<br>
+  <small>push 또는 PR 이벤트가 처리되면 여기에 표시됩니다.</small>
+</div>
+{% endif %}
+{% endblock %}

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -686,6 +686,21 @@
             </label>
           </div>
 
+          <!-- 팀 인사이트 리더보드 옵트인 (기본 비활성) / Team Insights leaderboard opt-in (disabled by default) -->
+          <div class="toggle-row" style="margin-top:.75rem;">
+            <div class="toggle-info">
+              <div class="t-title">팀 리더보드 공개</div>
+              <div class="t-desc">이 리포를 팀 인사이트 리더보드에 포함<br>
+                <span style="color:var(--c-warning,#f59e0b);font-size:.78rem;">옵션 기능 — 팀 합의 후 활성화 권장</span>
+              </div>
+            </div>
+            <label class="toggle-switch">
+              <input type="checkbox" name="leaderboard_opt_in" value="on"
+                     {% if config.leaderboard_opt_in %}checked{% endif %}>
+              <span class="toggle-track"></span>
+            </label>
+          </div>
+
         </div>
       </div>
 

--- a/src/ui/router.py
+++ b/src/ui/router.py
@@ -13,6 +13,7 @@ from src.ui.routes import (
     actions,
     add_repo,
     detail,
+    insights,
     overview,
     settings,
 )
@@ -22,6 +23,7 @@ router = APIRouter()
 # 구체 경로 → 일반 경로 순
 # Specific routes first, catch-all route last.
 router.include_router(overview.router)       # GET /
+router.include_router(insights.router)       # GET /insights, /insights/me
 router.include_router(add_repo.router)       # GET/POST /repos/add, /api/github/repos
 router.include_router(settings.router)       # /repos/{name}/settings, reinstall-*
 router.include_router(actions.router)        # /repos/{name}/delete

--- a/src/ui/routes/insights.py
+++ b/src/ui/routes/insights.py
@@ -1,0 +1,99 @@
+"""Team/Multi-repo Insights UI 라우트 — 멀티 리포 비교 및 개인 추세 대시보드.
+Team/multi-repo insights UI routes — multi-repo comparison and personal trend dashboard.
+"""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+
+from src.auth.session import CurrentUser, require_login
+from src.database import SessionLocal
+from src.models.repository import Repository
+from src.services import analytics_service
+from src.ui._helpers import templates
+
+router = APIRouter()
+
+
+@router.get("/insights", response_class=HTMLResponse)
+def insights_comparison(
+    request: Request,
+    current_user: Annotated[CurrentUser, Depends(require_login)],
+    repos: str = "",
+    days: int = 30,
+):
+    """멀티 리포 평균 점수 비교 페이지.
+    Multi-repo average score comparison page.
+    """
+    full_names = [r.strip() for r in repos.split(",") if r.strip()] if repos else []
+
+    with SessionLocal() as db:
+        # 사용자 접근 가능한 모든 리포 목록 (리포 셀렉터 용도)
+        # All accessible repos for the repo selector
+        all_repos = (
+            db.query(Repository)
+            .filter(
+                (Repository.user_id == current_user.id) | (Repository.user_id.is_(None))
+            )
+            .order_by(Repository.full_name.asc())
+            .all()
+        )
+
+        # 선택된 리포의 full_name → repo_id 매핑
+        # Resolve selected full_names to repo_ids
+        comparison: list[dict] = []
+        if full_names:
+            selected_repos = (
+                db.query(Repository)
+                .filter(Repository.full_name.in_(full_names))
+                .all()
+            )
+            id_to_name = {r.id: r.full_name for r in selected_repos}
+            repo_ids = list(id_to_name.keys())
+            raw = analytics_service.repo_comparison(db, repo_ids, days)
+            comparison = [
+                {
+                    "repo_id": item["repo_id"],
+                    "full_name": id_to_name.get(item["repo_id"], ""),
+                    "avg_score": item["avg_score"],
+                    "count": item["count"],
+                }
+                for item in raw
+            ]
+
+    return templates.TemplateResponse(
+        request,
+        "insights.html",
+        {
+            "current_user": current_user,
+            "comparison": comparison,
+            "repos": full_names,
+            "days": days,
+            "all_repos": all_repos,
+        },
+    )
+
+
+@router.get("/insights/me", response_class=HTMLResponse)
+def insights_me(
+    request: Request,
+    current_user: Annotated[CurrentUser, Depends(require_login)],
+    days: int = 30,
+):
+    """개인 개발자 점수 추세 페이지.
+    Personal developer score trend page.
+    """
+    with SessionLocal() as db:
+        trend = analytics_service.author_trend(db, current_user.github_login, days)
+
+    return templates.TemplateResponse(
+        request,
+        "insights_me.html",
+        {
+            "current_user": current_user,
+            "trend": trend,
+            "days": days,
+        },
+    )

--- a/src/ui/routes/settings.py
+++ b/src/ui/routes/settings.py
@@ -154,6 +154,7 @@ async def update_repo_settings(
                 create_issue=form.get("create_issue") == "on",
                 railway_deploy_alerts=form.get("railway_deploy_alerts") == "on",
                 auto_merge_issue_on_failure=form.get("auto_merge_issue_on_failure") == "on",
+                leaderboard_opt_in=form.get("leaderboard_opt_in") == "on",
             ))
             # railway_webhook_token, railway_api_token — RepoConfigData 외부 관리
             config_orm = repo_config_repo.find_by_full_name(db, repo_name)

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -39,6 +39,7 @@ class _AnalysisSaveParams:  # pylint: disable=too-many-instance-attributes
     analysis_results: list
     ai_review: object  # AiReviewResult
     score_result: object  # ScoreResult
+    author_login: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -91,6 +92,21 @@ def _extract_commit_message(event: str, data: dict) -> str:
         return head.get("message", "")
     commits = data.get("commits", [])
     return commits[-1]["message"] if commits else ""
+
+
+def _extract_author_login(event_type: str, data: dict) -> str | None:
+    """Webhook 페이로드에서 커밋 작성자 GitHub 로그인을 추출한다.
+    Extract the commit author's GitHub login from the webhook payload.
+
+    PR: data["pull_request"]["user"]["login"]
+    push: data["head_commit"]["author"]["username"]
+    키 누락 시 None 반환 — 조용히 실패.
+    On missing keys, returns None silently.
+    """
+    if event_type == "pull_request":
+        return (data.get("pull_request") or {}).get("user", {}).get("login")
+    head = data.get("head_commit") or {}
+    return (head.get("author") or {}).get("username")
 
 
 async def _run_static_analysis(files: list[ChangedFile]) -> list[StaticAnalysisResult]:
@@ -226,6 +242,7 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
         score=params.score_result.total,
         grade=params.score_result.grade,
         result=result_dict,
+        author_login=params.author_login,
     ))
     analysis_id = analysis.id
     try:
@@ -339,6 +356,7 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
                     analysis_results=analysis_results,
                     ai_review=ai_review,
                     score_result=score_result,
+                    author_login=_extract_author_login(event, data),
                 )
                 with SessionLocal() as db:
                     repo_config, analysis_id, result_dict = await _save_and_gate(db, save_params)

--- a/tests/unit/api/test_insights_api.py
+++ b/tests/unit/api/test_insights_api.py
@@ -24,6 +24,7 @@ import pytest  # noqa: E402
 from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 from src.main import app
+from src.api import auth as _auth_mod
 from src.api.auth import require_api_key  # require_api_key dependency — dependency_overrides 키로 사용
 
 client = TestClient(app)
@@ -105,7 +106,6 @@ def test_author_trend_requires_api_key():
     # autouse fixture sets the override; explicitly remove it for this test
     app.dependency_overrides.pop(require_api_key, None)
 
-    import src.api.auth as _auth_mod
     # API_KEY 환경변수를 설정하고 settings를 패치하여 강제로 인증 실패를 유도한다
     # Patch settings.api_key to a non-empty value to force authentication check
     _original = _auth_mod.settings.api_key

--- a/tests/unit/api/test_insights_api.py
+++ b/tests/unit/api/test_insights_api.py
@@ -1,0 +1,301 @@
+"""tests/unit/api/test_insights_api.py — Red-phase tests for GET /api/insights/* endpoints.
+
+테스트 대상: src/api/insights.py (아직 존재하지 않음 — ImportError 또는 404 실패 예상)
+Target: src/api/insights.py (does not exist yet — expect ImportError or 404 failures)
+
+엔드포인트 3개:
+  GET /api/insights/authors/{login}/trend?days=30
+  GET /api/insights/repos/compare?repos=a,b,c
+  GET /api/insights/leaderboard?days=30
+"""
+import os
+
+# 환경변수는 src 임포트 전 주입 필수
+# Env vars must be injected before any src.* import that triggers Settings()
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "")
+os.environ.setdefault("API_KEY", "")
+
+import pytest  # noqa: E402
+from unittest.mock import MagicMock, patch
+from fastapi.testclient import TestClient
+from src.main import app
+from src.api.auth import require_api_key  # require_api_key dependency — dependency_overrides 키로 사용
+
+client = TestClient(app)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _override_api_key():
+    """require_api_key를 no-op으로 override하여 인증 없이 라우트를 테스트한다.
+    Override require_api_key to no-op so routes are tested without auth friction."""
+    app.dependency_overrides[require_api_key] = lambda: None
+    yield
+    # 테스트 후 override 제거 — 다른 테스트 격리 보장
+    # Remove override after test to ensure isolation for other tests
+    app.dependency_overrides.pop(require_api_key, None)
+
+
+# ---------------------------------------------------------------------------
+# Author Trend — 3 tests
+# ---------------------------------------------------------------------------
+
+def test_author_trend_returns_data():
+    """analytics_service.author_trend 가 샘플 목록을 반환할 때 200 + 올바른 JSON 구조를 확인한다.
+    When author_trend returns sample data, expect 200 and correct JSON shape."""
+    sample_trend = [
+        {"date": "2026-04-01", "avg_score": 82.5, "count": 3},
+        {"date": "2026-04-02", "avg_score": 88.0, "count": 2},
+    ]
+    with patch("src.api.insights.analytics_service.author_trend", return_value=sample_trend):
+        with patch("src.api.insights.SessionLocal") as mock_session_cls:
+            mock_db = MagicMock()
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=mock_db)
+            ctx.__exit__ = MagicMock(return_value=False)
+            mock_session_cls.return_value = ctx
+
+            r = client.get("/api/insights/authors/octocat/trend?days=30")
+
+    assert r.status_code == 200
+    data = r.json()
+    # 응답에 login, days, trend 키가 있어야 한다
+    # Response must contain login, days, trend keys
+    assert data["login"] == "octocat"
+    assert data["days"] == 30
+    assert data["trend"] == sample_trend
+
+
+def test_author_trend_respects_days_param():
+    """?days=7 쿼리 파라미터가 author_trend 호출 시 days=7 로 전달되는지 확인한다.
+    Verify days=7 query param is forwarded correctly to author_trend call."""
+    with patch("src.api.insights.analytics_service.author_trend", return_value=[]) as mock_trend:
+        with patch("src.api.insights.SessionLocal") as mock_session_cls:
+            mock_db = MagicMock()
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=mock_db)
+            ctx.__exit__ = MagicMock(return_value=False)
+            mock_session_cls.return_value = ctx
+
+            r = client.get("/api/insights/authors/devuser/trend?days=7")
+
+    assert r.status_code == 200
+    # author_trend가 days=7 로 호출됐는지 keyword 인자 검증
+    # Verify author_trend was called with days=7 (keyword argument)
+    _call_kwargs = mock_trend.call_args
+    assert _call_kwargs is not None
+    # days 인자 위치 또는 키워드로 7이 전달되어야 함
+    # days value 7 must appear either positionally or as a keyword
+    args, kwargs = _call_kwargs
+    days_value = kwargs.get("days") if "days" in kwargs else (args[2] if len(args) > 2 else None)
+    assert days_value == 7
+
+
+def test_author_trend_requires_api_key():
+    """require_api_key override 없이 요청 시 401 또는 503을 반환해야 한다.
+    Without the api-key override, request must be rejected with 401 or 503."""
+    # autouse fixture가 override를 걸었으므로, 여기서 명시적으로 제거한다
+    # autouse fixture sets the override; explicitly remove it for this test
+    app.dependency_overrides.pop(require_api_key, None)
+
+    import src.api.auth as _auth_mod
+    # API_KEY 환경변수를 설정하고 settings를 패치하여 강제로 인증 실패를 유도한다
+    # Patch settings.api_key to a non-empty value to force authentication check
+    _original = _auth_mod.settings.api_key
+    try:
+        _auth_mod.settings.api_key = "required-secret"
+        r = client.get("/api/insights/authors/octocat/trend")
+        # X-API-Key 헤더 없이 요청했으므로 401이어야 한다
+        # No X-API-Key header → must return 401
+        assert r.status_code == 401
+    finally:
+        _auth_mod.settings.api_key = _original
+        # autouse fixture의 teardown이 다시 override를 제거하므로 여기서는 복원만 한다
+        # autouse fixture teardown will clean up; only restore the key here
+        app.dependency_overrides[require_api_key] = lambda: None
+
+
+# ---------------------------------------------------------------------------
+# Repo Comparison — 2 tests
+# ---------------------------------------------------------------------------
+
+def test_repo_compare_returns_data():
+    """DB에서 repo_ids를 조회하고 repo_comparison 결과에 full_name을 포함해 반환하는지 확인한다.
+    Verify DB lookup of repo_ids and enrichment of comparison results with full_name."""
+    # DB 에서 repo 조회 시 사용될 mock 객체
+    # Mock Repository objects returned from the DB query
+    mock_repo_a = MagicMock()
+    mock_repo_a.id = 1
+    mock_repo_a.full_name = "owner/repo-a"
+    mock_repo_b = MagicMock()
+    mock_repo_b.id = 2
+    mock_repo_b.full_name = "owner/repo-b"
+
+    comparison_result = [
+        {"repo_id": 1, "avg_score": 85.0, "count": 10},
+        {"repo_id": 2, "avg_score": 72.3, "count": 5},
+    ]
+
+    with patch("src.api.insights.analytics_service.repo_comparison", return_value=comparison_result):
+        with patch("src.api.insights.SessionLocal") as mock_session_cls:
+            mock_db = MagicMock()
+            # DB 쿼리가 [mock_repo_a, mock_repo_b] 를 반환하도록 설정
+            # Configure DB query to return the two mock repos
+            mock_db.query.return_value.filter.return_value.all.return_value = [
+                mock_repo_a, mock_repo_b
+            ]
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=mock_db)
+            ctx.__exit__ = MagicMock(return_value=False)
+            mock_session_cls.return_value = ctx
+
+            r = client.get("/api/insights/repos/compare?repos=owner%2Frepo-a,owner%2Frepo-b")
+
+    assert r.status_code == 200
+    data = r.json()
+    # 응답에 repos, days, comparison 키가 있어야 한다
+    # Response must contain repos, days, comparison keys
+    assert "repos" in data
+    assert "days" in data
+    assert "comparison" in data
+    # comparison 항목에 full_name 이 포함돼야 한다
+    # Each comparison item must contain full_name
+    full_names_in_resp = {item["full_name"] for item in data["comparison"] if "full_name" in item}
+    assert "owner/repo-a" in full_names_in_resp or len(data["comparison"]) >= 1
+
+
+def test_repo_compare_empty_when_no_repos_param():
+    """repos 파라미터가 없거나 빈 문자열이면 comparison=[] 와 200을 반환해야 한다.
+    When repos param is absent or empty, return comparison=[] with 200."""
+    with patch("src.api.insights.SessionLocal") as mock_session_cls:
+        mock_db = MagicMock()
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=mock_db)
+        ctx.__exit__ = MagicMock(return_value=False)
+        mock_session_cls.return_value = ctx
+
+        # repos 파라미터 없이 요청
+        # Request without repos param
+        r = client.get("/api/insights/repos/compare")
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["comparison"] == []
+    assert data["repos"] == []
+
+
+# ---------------------------------------------------------------------------
+# Leaderboard — 3 tests
+# ---------------------------------------------------------------------------
+
+def test_leaderboard_returns_data():
+    """leaderboard_opt_in=True 인 리포가 있을 때 leaderboard 결과를 올바른 구조로 반환한다.
+    When opted-in repos exist, return leaderboard with correct shape."""
+    # leaderboard_opt_in=True 인 RepoConfig 목 객체
+    # Mock RepoConfig with leaderboard_opt_in=True
+    mock_config = MagicMock()
+    mock_config.repo_id = 42
+
+    leaderboard_result = [
+        {"author_login": "alice", "avg_score": 91.5, "count": 8},
+        {"author_login": "bob", "avg_score": 78.2, "count": 5},
+    ]
+
+    with patch("src.api.insights.analytics_service.leaderboard", return_value=leaderboard_result):
+        with patch("src.api.insights.SessionLocal") as mock_session_cls:
+            mock_db = MagicMock()
+            # 옵트인 리포 쿼리 — leaderboard_opt_in=True 인 RepoConfig 1건 반환
+            # Opted-in repo query returns one RepoConfig with leaderboard_opt_in=True
+            mock_db.query.return_value.filter.return_value.all.return_value = [mock_config]
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=mock_db)
+            ctx.__exit__ = MagicMock(return_value=False)
+            mock_session_cls.return_value = ctx
+
+            r = client.get("/api/insights/leaderboard?days=30")
+
+    assert r.status_code == 200
+    data = r.json()
+    # 응답에 days, leaderboard 키가 있어야 한다
+    # Response must contain days and leaderboard keys
+    assert data["days"] == 30
+    assert data["leaderboard"] == leaderboard_result
+
+
+def test_leaderboard_empty_when_no_opted_in():
+    """옵트인 리포가 없으면 leaderboard=[] 와 200을 반환해야 한다.
+    When no repos have opted in, return leaderboard=[] with 200."""
+    with patch("src.api.insights.analytics_service.leaderboard", return_value=[]) as mock_lb:
+        with patch("src.api.insights.SessionLocal") as mock_session_cls:
+            mock_db = MagicMock()
+            # 옵트인 리포 없음 — 빈 목록 반환
+            # No opted-in repos — return empty list
+            mock_db.query.return_value.filter.return_value.all.return_value = []
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=mock_db)
+            ctx.__exit__ = MagicMock(return_value=False)
+            mock_session_cls.return_value = ctx
+
+            r = client.get("/api/insights/leaderboard?days=30")
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["leaderboard"] == []
+    # 옵트인 리포가 없으므로 leaderboard는 호출될 수도, 안 될 수도 있다 —
+    # 핵심은 응답이 빈 리스트여야 한다는 것
+    # leaderboard service may or may not be called when no repos opted in;
+    # the key assertion is that the response contains an empty list
+
+
+def test_leaderboard_respects_days_param():
+    """?days=14 쿼리 파라미터가 leaderboard 호출 시 days=14 로 전달되는지 확인한다.
+    Verify days=14 query param is forwarded correctly to the leaderboard call."""
+    mock_config = MagicMock()
+    mock_config.repo_id = 7
+
+    with patch("src.api.insights.analytics_service.leaderboard", return_value=[]) as mock_lb:
+        with patch("src.api.insights.SessionLocal") as mock_session_cls:
+            mock_db = MagicMock()
+            mock_db.query.return_value.filter.return_value.all.return_value = [mock_config]
+            ctx = MagicMock()
+            ctx.__enter__ = MagicMock(return_value=mock_db)
+            ctx.__exit__ = MagicMock(return_value=False)
+            mock_session_cls.return_value = ctx
+
+            r = client.get("/api/insights/leaderboard?days=14")
+
+    assert r.status_code == 200
+    # leaderboard 서비스가 days=14 로 호출됐는지 검증
+    # Verify leaderboard service was called with days=14
+    assert mock_lb.call_count >= 1
+    _call_kwargs = mock_lb.call_args
+    args, kwargs = _call_kwargs
+    days_value = kwargs.get("days") if "days" in kwargs else (args[1] if len(args) > 1 else None)
+    assert days_value == 14
+
+
+def test_repo_compare_empty_when_repos_all_whitespace():
+    """repos 파라미터가 쉼표와 공백만 있으면 comparison=[] 와 200을 반환해야 한다.
+    When repos param contains only commas/spaces, return comparison=[] with 200."""
+    with patch("src.api.insights.SessionLocal") as mock_session_cls:
+        mock_db = MagicMock()
+        ctx = MagicMock()
+        ctx.__enter__ = MagicMock(return_value=mock_db)
+        ctx.__exit__ = MagicMock(return_value=False)
+        mock_session_cls.return_value = ctx
+
+        # repos 파라미터가 공백/쉼표만 있을 때
+        # repos param with only whitespace/commas after strip → empty list
+        r = client.get("/api/insights/repos/compare?repos=%2C%2C+%2C")
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["comparison"] == []
+    assert data["repos"] == []

--- a/tests/unit/services/test_analytics_service_insights.py
+++ b/tests/unit/services/test_analytics_service_insights.py
@@ -1,0 +1,390 @@
+"""analytics_service 팀 인사이트 함수 TDD Red 단계 테스트.
+TDD Red-phase tests for team-insights functions in analytics_service.
+
+대상 함수 (아직 미구현 — ImportError/AttributeError 발생):
+Target functions (not yet implemented — will raise ImportError/AttributeError):
+  - author_trend(db, login, days=30, *, now=None) -> list[dict]
+  - repo_comparison(db, repo_ids, days=30, *, now=None) -> list[dict]
+  - leaderboard(db, days=30, opted_in_repo_ids=None, *, now=None) -> list[dict]
+
+In-memory SQLite + Base.metadata.create_all 자체 fixture 사용.
+Uses in-memory SQLite with Base.metadata.create_all — no shared conftest dependency.
+"""
+# pylint: disable=redefined-outer-name
+from datetime import datetime, timezone, timedelta
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.repository import Repository
+from src.models.user import User
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — in-memory SQLite DB (per-file pattern, no shared conftest)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션을 제공한다.
+    Provide an in-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def user(db):
+    """테스트용 User 레코드를 생성하고 반환한다.
+    Create and return a test User record.
+    """
+    u = User(github_id=99, github_login="tester", email="t@x.com", display_name="Tester")
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def repo(db, user):
+    """테스트용 Repository 레코드를 생성하고 반환한다.
+    Create and return a test Repository record.
+    """
+    r = Repository(full_name="owner/repo-a", user_id=user.id)
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+@pytest.fixture()
+def repo2(db, user):
+    """두 번째 테스트용 Repository 레코드를 생성하고 반환한다.
+    Create and return a second test Repository record.
+    """
+    r = Repository(full_name="owner/repo-b", user_id=user.id)
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _make_analysis(
+    db: Session,
+    repo_id: int,
+    score: int | None,
+    *,
+    author_login: str | None = None,
+    created_at: datetime | None = None,
+    offset_hours: int = 0,
+) -> Analysis:
+    """테스트용 Analysis 레코드를 생성하는 헬퍼 함수.
+    Helper to create a test Analysis record.
+
+    created_at이 주어지면 그대로 사용하고, 없으면 offset_hours만큼 과거 시각을 계산한다.
+    Use the provided created_at directly; otherwise compute past time via offset_hours.
+    """
+    ts = created_at or (datetime.now(timezone.utc) - timedelta(hours=offset_hours))
+    analysis = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{repo_id}-{score}-{offset_hours}-{id(object())}",
+        score=score,
+        grade="B",
+        author_login=author_login,
+        created_at=ts,
+    )
+    db.add(analysis)
+    db.commit()
+    db.refresh(analysis)
+    return analysis
+
+
+# ---------------------------------------------------------------------------
+# Test: author_trend
+# ---------------------------------------------------------------------------
+
+
+class TestAuthorTrend:
+    """author_trend — 작성자별 일별 평균 점수 추세 함수 테스트.
+    Tests for per-author daily average score trend.
+    """
+
+    def test_author_trend_returns_daily_averages(self, db, repo):
+        """3개 분석을 2일에 분산 — 날짜별 평균 점수와 건수가 올바르게 집계된다.
+        3 analyses spread across 2 days → 2 entries with correct avg_score and count.
+        """
+        # 구현 전 import 시 AttributeError 발생 — Red 상태 확인
+        # AttributeError expected before implementation — confirms Red state
+        from src.services.analytics_service import author_trend  # noqa: F401
+
+        now = datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+
+        # day1: 2026-04-25 — 2개 분석 (alice): 점수 80, 90 → 평균 85
+        # day1: 2026-04-25 — 2 analyses (alice): scores 80, 90 → avg 85
+        day1 = datetime(2026, 4, 25, 10, 0, 0, tzinfo=timezone.utc)
+        _make_analysis(db, repo.id, 80, author_login="alice", created_at=day1)
+        _make_analysis(db, repo.id, 90, author_login="alice",
+                       created_at=day1.replace(hour=14))
+
+        # day2: 2026-04-26 — 1개 분석 (alice): 점수 70
+        # day2: 2026-04-26 — 1 analysis (alice): score 70
+        day2 = datetime(2026, 4, 26, 8, 0, 0, tzinfo=timezone.utc)
+        _make_analysis(db, repo.id, 70, author_login="alice", created_at=day2)
+
+        result = author_trend(db, "alice", days=30, now=now)
+
+        # 2일치 항목이 날짜 오름차순으로 반환되어야 한다
+        # 2 daily entries returned in ascending date order
+        assert len(result) == 2
+
+        # 날짜 오름차순 검증 (첫 항목이 더 이른 날짜)
+        # Verify ascending date order (first entry is the earlier date)
+        assert result[0]["date"] < result[1]["date"]
+
+        # 각 항목에 date, avg_score, count 키가 존재해야 한다
+        # Each entry must have date, avg_score, count keys
+        for entry in result:
+            assert "date" in entry
+            assert "avg_score" in entry
+            assert "count" in entry
+
+        # 첫 날 (2026-04-25): count=2, avg=85.0
+        # First day (2026-04-25): count=2, avg=85.0
+        assert result[0]["count"] == 2
+        assert result[0]["avg_score"] == pytest.approx(85.0, abs=0.1)
+
+        # 두 번째 날 (2026-04-26): count=1, avg=70.0
+        # Second day (2026-04-26): count=1, avg=70.0
+        assert result[1]["count"] == 1
+        assert result[1]["avg_score"] == pytest.approx(70.0, abs=0.1)
+
+    def test_author_trend_filters_by_login(self, db, repo):
+        """alice와 bob의 분석이 섞여 있을 때 author_trend("alice")는 alice 데이터만 반환한다.
+        With analyses for "alice" and "bob", author_trend("alice") returns only alice's data.
+        """
+        from src.services.analytics_service import author_trend  # noqa: F401
+
+        now = datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+        ts = datetime(2026, 4, 25, 10, 0, 0, tzinfo=timezone.utc)
+
+        _make_analysis(db, repo.id, 80, author_login="alice", created_at=ts)
+        _make_analysis(db, repo.id, 60, author_login="bob",
+                       created_at=ts.replace(hour=11))
+
+        result = author_trend(db, "alice", days=30, now=now)
+
+        # bob의 분석은 포함되지 않아야 한다
+        # Bob's analyses must not appear
+        assert len(result) == 1
+        assert result[0]["avg_score"] == pytest.approx(80.0, abs=0.1)
+
+    def test_author_trend_empty_when_no_data(self, db, repo):
+        """분석 레코드가 없으면 빈 리스트를 반환한다.
+        Return an empty list when no analyses exist.
+        """
+        from src.services.analytics_service import author_trend  # noqa: F401
+
+        now = datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+        result = author_trend(db, "alice", days=30, now=now)
+
+        assert result == []
+
+    def test_author_trend_respects_days_window(self, db, repo):
+        """days 윈도우보다 오래된 분석은 결과에서 제외된다.
+        Analyses older than the days window are excluded from the result.
+        """
+        from src.services.analytics_service import author_trend  # noqa: F401
+
+        now = datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+
+        # 윈도우 내 (10일 전) — 포함 대상
+        # Within window (10 days ago) — should be included
+        inside_ts = now - timedelta(days=10)
+        _make_analysis(db, repo.id, 85, author_login="alice", created_at=inside_ts)
+
+        # 윈도우 밖 (40일 전) — 제외 대상
+        # Outside window (40 days ago) — should be excluded
+        outside_ts = now - timedelta(days=40)
+        _make_analysis(db, repo.id, 50, author_login="alice", created_at=outside_ts)
+
+        result = author_trend(db, "alice", days=30, now=now)
+
+        # 윈도우 내 1개만 반환되어야 한다
+        # Only the 1 entry within the window must be returned
+        assert len(result) == 1
+        assert result[0]["avg_score"] == pytest.approx(85.0, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# Test: repo_comparison
+# ---------------------------------------------------------------------------
+
+
+class TestRepoComparison:
+    """repo_comparison — 리포 간 평균 점수 비교 함수 테스트.
+    Tests for cross-repo average score comparison.
+    """
+
+    def test_repo_comparison_returns_per_repo_stats(self, db, repo, repo2):
+        """2개 리포에 다른 평균 점수 — 두 항목 모두 avg_score 내림차순으로 반환된다.
+        2 repos with different avg scores → both appear, sorted by avg_score descending.
+        """
+        from src.services.analytics_service import repo_comparison  # noqa: F401
+
+        now = datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+        ts = now - timedelta(days=5)
+
+        # repo: 점수 80, 90 → 평균 85
+        # repo: scores 80, 90 → avg 85
+        _make_analysis(db, repo.id, 80, created_at=ts)
+        _make_analysis(db, repo.id, 90, created_at=ts.replace(hour=11))
+
+        # repo2: 점수 60, 70 → 평균 65
+        # repo2: scores 60, 70 → avg 65
+        _make_analysis(db, repo2.id, 60, created_at=ts)
+        _make_analysis(db, repo2.id, 70, created_at=ts.replace(hour=11))
+
+        result = repo_comparison(db, [repo.id, repo2.id], days=30, now=now)
+
+        # 두 리포 모두 반환되어야 한다
+        # Both repos must be returned
+        assert len(result) == 2
+
+        # 각 항목에 repo_id, avg_score, count 키가 존재해야 한다
+        # Each entry must have repo_id, avg_score, count keys
+        for entry in result:
+            assert "repo_id" in entry
+            assert "avg_score" in entry
+            assert "count" in entry
+
+        # avg_score 내림차순 정렬 검증 — repo(85) > repo2(65)
+        # Verify descending avg_score order — repo(85) > repo2(65)
+        assert result[0]["repo_id"] == repo.id
+        assert result[0]["avg_score"] == pytest.approx(85.0, abs=0.1)
+        assert result[0]["count"] == 2
+
+        assert result[1]["repo_id"] == repo2.id
+        assert result[1]["avg_score"] == pytest.approx(65.0, abs=0.1)
+        assert result[1]["count"] == 2
+
+    def test_repo_comparison_empty_when_no_repo_ids(self, db):
+        """repo_ids가 빈 리스트이면 빈 리스트를 반환한다 (안전 가드).
+        Return an empty list when repo_ids is an empty list (safety guard).
+        """
+        from src.services.analytics_service import repo_comparison  # noqa: F401
+
+        now = datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+        result = repo_comparison(db, [], days=30, now=now)
+
+        # 빈 repo_ids → 빈 결과
+        # Empty repo_ids → empty result
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Test: leaderboard
+# ---------------------------------------------------------------------------
+
+
+class TestLeaderboard:
+    """leaderboard — opted-in 리포 기준 작성자별 순위표 함수 테스트.
+    Tests for per-author leaderboard filtered to opted-in repos.
+    """
+
+    def test_leaderboard_returns_sorted_by_score(self, db, repo):
+        """3명 작성자의 분석이 있을 때 avg_score 내림차순으로 정렬된다.
+        With analyses from 3 authors, entries are sorted by avg_score descending.
+        """
+        from src.services.analytics_service import leaderboard  # noqa: F401
+
+        now = datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+        ts = now - timedelta(days=5)
+
+        # alice: 평균 90, bob: 평균 75, carol: 평균 60
+        # alice: avg 90, bob: avg 75, carol: avg 60
+        _make_analysis(db, repo.id, 90, author_login="alice", created_at=ts)
+        _make_analysis(db, repo.id, 75, author_login="bob",
+                       created_at=ts.replace(hour=11))
+        _make_analysis(db, repo.id, 60, author_login="carol",
+                       created_at=ts.replace(hour=12))
+
+        result = leaderboard(db, days=30, opted_in_repo_ids=[repo.id], now=now)
+
+        # 3명 모두 반환되어야 한다
+        # All 3 authors must be returned
+        assert len(result) == 3
+
+        # 각 항목에 author_login, avg_score, count 키가 존재해야 한다
+        # Each entry must have author_login, avg_score, count keys
+        for entry in result:
+            assert "author_login" in entry
+            assert "avg_score" in entry
+            assert "count" in entry
+
+        # avg_score 내림차순 정렬 검증
+        # Verify descending avg_score order
+        assert result[0]["author_login"] == "alice"
+        assert result[0]["avg_score"] == pytest.approx(90.0, abs=0.1)
+
+        assert result[1]["author_login"] == "bob"
+        assert result[1]["avg_score"] == pytest.approx(75.0, abs=0.1)
+
+        assert result[2]["author_login"] == "carol"
+        assert result[2]["avg_score"] == pytest.approx(60.0, abs=0.1)
+
+    def test_leaderboard_empty_when_no_opted_in_repos(self, db, repo):
+        """opted_in_repo_ids가 None 또는 빈 리스트이면 빈 리스트를 반환한다 (안전 가드).
+        Return an empty list when opted_in_repo_ids is None or [] (safety guard).
+        """
+        from src.services.analytics_service import leaderboard  # noqa: F401
+
+        now = datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+        ts = now - timedelta(days=5)
+        _make_analysis(db, repo.id, 85, author_login="alice", created_at=ts)
+
+        # opted_in_repo_ids=None — 아무도 opt-in 하지 않음
+        # opted_in_repo_ids=None — no one has opted in
+        result_none = leaderboard(db, days=30, opted_in_repo_ids=None, now=now)
+        assert result_none == []
+
+        # opted_in_repo_ids=[] — 빈 opt-in 목록
+        # opted_in_repo_ids=[] — empty opt-in list
+        result_empty = leaderboard(db, days=30, opted_in_repo_ids=[], now=now)
+        assert result_empty == []
+
+    def test_leaderboard_filters_to_opted_in_repos(self, db, repo, repo2):
+        """repo1만 opt-in 했을 때 repo2의 분석은 리더보드에 나타나지 않는다.
+        When only repo1 is opted in, repo2's analyses must not appear in the leaderboard.
+        """
+        from src.services.analytics_service import leaderboard  # noqa: F401
+
+        now = datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+        ts = now - timedelta(days=5)
+
+        # alice는 repo1에서 분석 (opt-in 대상) → 포함
+        # alice has analyses in repo1 (opted in) → should appear
+        _make_analysis(db, repo.id, 90, author_login="alice", created_at=ts)
+
+        # bob은 repo2에서 분석 (opt-in 미대상) → 제외
+        # bob has analyses in repo2 (not opted in) → should be excluded
+        _make_analysis(db, repo2.id, 95, author_login="bob",
+                       created_at=ts.replace(hour=11))
+
+        # repo1만 opt-in — bob이 더 높은 점수지만 제외되어야 한다
+        # Only repo1 is opted in — bob has higher score but must be excluded
+        result = leaderboard(db, days=30, opted_in_repo_ids=[repo.id], now=now)
+
+        author_logins = [entry["author_login"] for entry in result]
+
+        # alice만 반환되어야 한다
+        # Only alice must be returned
+        assert "alice" in author_logins
+        assert "bob" not in author_logins
+        assert len(result) == 1

--- a/tests/unit/ui/test_insights_routes.py
+++ b/tests/unit/ui/test_insights_routes.py
@@ -1,0 +1,251 @@
+"""TDD Red — GET /insights 및 GET /insights/me UI 라우트 테스트.
+TDD Red — Tests for GET /insights and GET /insights/me UI routes.
+
+src/ui/routes/insights.py 는 아직 존재하지 않으므로,
+이 테스트 모음은 전부 실패해야 한다 (ImportError 또는 404).
+Since src/ui/routes/insights.py does not yet exist,
+all tests in this suite must fail (ImportError or 404).
+"""
+import os
+
+# 환경변수 주입 — src 모듈 import 이전에 반드시 선행
+# Inject env vars before any src.* import triggers Settings()
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "")
+os.environ.setdefault("API_KEY", "")
+os.environ.setdefault("GITHUB_CLIENT_ID", "test-github-client-id")
+os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-github-client-secret")
+os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from src.main import app  # noqa: E402
+from src.auth.session import CurrentUser, require_login  # noqa: E402
+
+# 로그인 사용자 픽스처 — CurrentUser dataclass 사용 (User ORM 모델 아님)
+# Test user fixture — use CurrentUser dataclass (not the User ORM model)
+_test_user = CurrentUser(
+    id=1,
+    github_login="testuser",
+    email="test@example.com",
+    display_name="Test User",
+    plaintext_token="gho_test",
+    is_telegram_connected=False,
+)
+
+
+def _ctx(db_mock: MagicMock) -> MagicMock:
+    """SessionLocal() 컨텍스트 매니저를 흉내내는 헬퍼.
+    Helper that mimics the SessionLocal() context manager.
+    """
+    ctx = MagicMock()
+    ctx.__enter__ = MagicMock(return_value=db_mock)
+    ctx.__exit__ = MagicMock(return_value=False)
+    return ctx
+
+
+def test_insights_page_requires_login():
+    """비로그인 상태에서 GET /insights 는 302 리다이렉트 또는 비-200 응답을 반환해야 한다.
+    Without login override, GET /insights must redirect (302) or return a non-200 status.
+
+    require_login 미재정의 상태 → /login 으로 302 리다이렉트 발생.
+    Without dependency override → 302 redirect to /login.
+    """
+    # require_login 재정의가 없으면 302 리다이렉트 발생
+    # Remove any existing override so the real require_login runs
+    overrides_backup = dict(app.dependency_overrides)
+    app.dependency_overrides.pop(require_login, None)
+    try:
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/insights")
+        # 라우트가 존재하면 비로그인 → 302, 라우트 없으면 404 — 둘 다 비-200
+        # If route exists: 302 redirect; if route missing: 404 — both are non-200
+        assert response.status_code != 200, (
+            f"Expected non-200 (login redirect or 404), got {response.status_code}"
+        )
+    finally:
+        # 다른 테스트 영향 방지를 위해 원본 overrides 복원
+        # Restore overrides so other tests are not affected
+        app.dependency_overrides.clear()
+        app.dependency_overrides.update(overrides_backup)
+
+
+def test_insights_page_returns_200():
+    """로그인 상태 + mock DB + mock analytics_service → GET /insights 는 200을 반환해야 한다.
+    With login override, mocked DB and analytics_service → GET /insights returns 200.
+
+    analytics_service.repo_comparison 과 TemplateResponse 를 모킹하여
+    템플릿 파일 없이도 200 검증 가능.
+    Mock repo_comparison and TemplateResponse to validate 200 without template files.
+    """
+    # 기존 require_login override 저장 후 교체 — 타 모듈의 모듈-레벨 설정 보호
+    # Save previous require_login override to protect module-level setups in other test modules
+    _prev_login = app.dependency_overrides.get(require_login)
+    app.dependency_overrides[require_login] = lambda: _test_user
+    try:
+        client = TestClient(app)
+        mock_db = MagicMock()
+        # 사용자 접근 가능한 리포 목록 — all_repos 쿼리용
+        # Repository list for the all_repos query
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+        fake_comparison = [
+            {"repo_id": 1, "full_name": "owner/repo", "avg_score": 85.0, "count": 10}
+        ]
+
+        with patch("src.ui.routes.insights.SessionLocal", return_value=_ctx(mock_db)), \
+             patch(
+                 "src.ui.routes.insights.analytics_service.repo_comparison",
+                 return_value=fake_comparison,
+             ), \
+             patch("src.ui.routes.insights.templates.TemplateResponse") as mock_tr:
+            # TemplateResponse 는 FastAPI Response 처럼 동작해야 함
+            # TemplateResponse must behave like a FastAPI Response
+            from fastapi.responses import HTMLResponse
+            mock_tr.return_value = HTMLResponse(content="<html>insights</html>", status_code=200)
+            response = client.get("/insights")
+
+        # 라우트가 구현되면 200, 아직 없으면 404 — Red 단계에서는 404
+        # 200 when route is implemented; 404 in Red phase
+        assert response.status_code == 200, (
+            f"Expected 200 after implementation, got {response.status_code} "
+            f"(route not yet implemented — this test must FAIL in Red phase)"
+        )
+    finally:
+        # 이전 값이 있었으면 복원, 없었으면 제거 — 타 모듈 격리 보장
+        # Restore previous value if it existed, otherwise remove — ensures cross-module isolation
+        if _prev_login is not None:
+            app.dependency_overrides[require_login] = _prev_login
+        else:
+            app.dependency_overrides.pop(require_login, None)
+
+
+def test_insights_me_returns_200():
+    """로그인 상태 + mock analytics_service.author_trend → GET /insights/me 는 200을 반환해야 한다.
+    With login override and mocked author_trend → GET /insights/me returns 200.
+
+    TemplateResponse 를 모킹하여 templates/insights_me.html 없이도 동작 검증.
+    Mock TemplateResponse so insights_me.html template absence does not block validation.
+    """
+    _prev_login = app.dependency_overrides.get(require_login)
+    app.dependency_overrides[require_login] = lambda: _test_user
+    try:
+        client = TestClient(app)
+
+        fake_trend = [
+            {"date": "2026-04-01", "avg_score": 82.0, "count": 3},
+            {"date": "2026-04-02", "avg_score": 88.5, "count": 2},
+        ]
+
+        with patch(
+            "src.ui.routes.insights.analytics_service.author_trend",
+            return_value=fake_trend,
+        ) as mock_trend, \
+             patch("src.ui.routes.insights.templates.TemplateResponse") as mock_tr:
+            from fastapi.responses import HTMLResponse
+            mock_tr.return_value = HTMLResponse(content="<html>me</html>", status_code=200)
+            response = client.get("/insights/me")
+
+        # Red 단계 — 라우트 미구현 시 404 로 실패
+        # Red phase — 404 expected until route is implemented
+        assert response.status_code == 200, (
+            f"Expected 200 after implementation, got {response.status_code} "
+            f"(route not yet implemented — this test must FAIL in Red phase)"
+        )
+    finally:
+        if _prev_login is not None:
+            app.dependency_overrides[require_login] = _prev_login
+        else:
+            app.dependency_overrides.pop(require_login, None)
+
+
+def test_insights_me_respects_days_param():
+    """GET /insights/me?days=7 → analytics_service.author_trend 가 days=7 로 호출되어야 한다.
+    GET /insights/me?days=7 must call analytics_service.author_trend with days=7.
+
+    days 쿼리 파라미터가 서비스 계층까지 올바르게 전달되는지 검증.
+    Verifies that the days query param is correctly forwarded to the service layer.
+    """
+    _prev_login = app.dependency_overrides.get(require_login)
+    app.dependency_overrides[require_login] = lambda: _test_user
+    try:
+        client = TestClient(app)
+
+        with patch(
+            "src.ui.routes.insights.analytics_service.author_trend",
+            return_value=[],
+        ) as mock_trend, \
+             patch("src.ui.routes.insights.templates.TemplateResponse") as mock_tr:
+            from fastapi.responses import HTMLResponse
+            mock_tr.return_value = HTMLResponse(content="<html>me</html>", status_code=200)
+            response = client.get("/insights/me?days=7")
+
+        # days=7 파라미터가 author_trend 에 전달됐는지 확인
+        # Verify days=7 was forwarded to author_trend
+        if response.status_code == 200:
+            # 라우트 구현 후 검증: author_trend 호출 인자에 days=7 포함
+            # After implementation: assert author_trend was called with days=7
+            assert mock_trend.called, "author_trend must be called"
+            call_kwargs = mock_trend.call_args
+            # positional 또는 keyword 인자 중 days=7 확인
+            # days=7 must appear as positional or keyword argument
+            days_passed = (
+                call_kwargs.kwargs.get("days")
+                if call_kwargs.kwargs
+                else (call_kwargs.args[2] if len(call_kwargs.args) > 2 else None)
+            )
+            assert days_passed == 7, f"Expected days=7, got {days_passed}"
+        else:
+            # Red 단계 — 라우트가 없으면 404 로 실패 (의도된 동작)
+            # Red phase — 404 means route is not implemented yet (expected failure)
+            assert response.status_code == 200, (
+                f"Route not implemented yet — expected failure in Red phase, "
+                f"got {response.status_code}"
+            )
+    finally:
+        if _prev_login is not None:
+            app.dependency_overrides[require_login] = _prev_login
+        else:
+            app.dependency_overrides.pop(require_login, None)
+
+
+def test_insights_page_with_repos_param_returns_200():
+    """repos 파라미터가 있을 때 비교 데이터를 포함하여 200을 반환해야 한다.
+    With repos param, /insights should return 200 and call repo_comparison."""
+    _prev_login = app.dependency_overrides.get(require_login)
+    app.dependency_overrides[require_login] = lambda: _test_user
+    try:
+        client = TestClient(app)
+        mock_db = MagicMock()
+        mock_repo = MagicMock()
+        mock_repo.id = 10
+        mock_repo.full_name = "owner/myrepo"
+        # 첫 번째 쿼리(selected_repos)와 두 번째(all_repos) 모두 같은 mock 반환
+        # Both selected_repos and all_repos queries return same mock for simplicity
+        mock_db.query.return_value.filter.return_value.all.return_value = [mock_repo]
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+        fake_comparison = [{"repo_id": 10, "avg_score": 88.0, "count": 4}]
+
+        with patch("src.ui.routes.insights.SessionLocal", return_value=_ctx(mock_db)), \
+             patch(
+                 "src.ui.routes.insights.analytics_service.repo_comparison",
+                 return_value=fake_comparison,
+             ), \
+             patch("src.ui.routes.insights.templates.TemplateResponse") as mock_tr:
+            from fastapi.responses import HTMLResponse
+            mock_tr.return_value = HTMLResponse(content="<html>ok</html>", status_code=200)
+            response = client.get("/insights?repos=owner%2Fmyrepo")
+
+        assert response.status_code == 200
+    finally:
+        if _prev_login is not None:
+            app.dependency_overrides[require_login] = _prev_login
+        else:
+            app.dependency_overrides.pop(require_login, None)

--- a/tests/unit/worker/test_extract_author_login.py
+++ b/tests/unit/worker/test_extract_author_login.py
@@ -17,7 +17,6 @@ os.environ.setdefault("GITHUB_CLIENT_ID", "test-github-client-id")
 os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-github-client-secret")
 os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
 
-import pytest  # noqa: E402
 from src.worker.pipeline import _extract_author_login  # noqa: E402
 
 

--- a/tests/unit/worker/test_extract_author_login.py
+++ b/tests/unit/worker/test_extract_author_login.py
@@ -1,0 +1,98 @@
+"""tests/unit/worker/test_extract_author_login.py — _extract_author_login() 단위 테스트 (Red 상태).
+tests/unit/worker/test_extract_author_login.py — Unit tests for _extract_author_login() (Red state).
+
+환경변수는 src 임포트 전 반드시 주입해야 한다.
+Environment variables must be injected before any src.* imports.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "")
+os.environ.setdefault("API_KEY", "")
+os.environ.setdefault("GITHUB_CLIENT_ID", "test-github-client-id")
+os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-github-client-secret")
+os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+
+import pytest  # noqa: E402
+from src.worker.pipeline import _extract_author_login  # noqa: E402
+
+
+# ── 픽스처: PR 이벤트 페이로드 샘플 ──
+# ── Fixture: sample PR event payload ──
+_PR_DATA = {
+    "pull_request": {
+        "user": {
+            "login": "octocat"
+        }
+    }
+}
+
+# ── 픽스처: push 이벤트 페이로드 샘플 ──
+# ── Fixture: sample push event payload ──
+_PUSH_DATA = {
+    "head_commit": {
+        "author": {
+            "username": "monalisa"
+        }
+    }
+}
+
+
+def test_pr_event_returns_pull_request_user_login():
+    # PR 이벤트에서 pull_request.user.login 값을 반환한다
+    # Returns pull_request.user.login for a PR event.
+    result = _extract_author_login("pull_request", _PR_DATA)
+    assert result == "octocat"
+
+
+def test_push_event_returns_head_commit_author_username():
+    # push 이벤트에서 head_commit.author.username 값을 반환한다
+    # Returns head_commit.author.username for a push event.
+    result = _extract_author_login("push", _PUSH_DATA)
+    assert result == "monalisa"
+
+
+def test_pr_event_missing_pull_request_key_returns_none():
+    # PR 이벤트에서 pull_request 키가 없으면 None을 반환한다
+    # Returns None when pull_request key is absent in a PR event.
+    result = _extract_author_login("pull_request", {})
+    assert result is None
+
+
+def test_push_event_missing_head_commit_key_returns_none():
+    # push 이벤트에서 head_commit 키가 없으면 None을 반환한다
+    # Returns None when head_commit key is absent in a push event.
+    result = _extract_author_login("push", {})
+    assert result is None
+
+
+def test_push_event_missing_author_key_returns_none():
+    # push 이벤트에서 head_commit.author 키가 없으면 None을 반환한다
+    # Returns None when head_commit.author key is absent in a push event.
+    result = _extract_author_login("push", {"head_commit": {}})
+    assert result is None
+
+
+def test_unknown_event_type_returns_none():
+    # 알 수 없는 event_type이면 None을 반환한다
+    # Returns None for an unrecognized event_type.
+    result = _extract_author_login("unknown_event", _PR_DATA)
+    assert result is None
+
+
+def test_pr_event_missing_user_key_returns_none():
+    # PR 이벤트에서 pull_request.user 키가 없으면 None을 반환한다
+    # Returns None when pull_request.user key is absent.
+    result = _extract_author_login("pull_request", {"pull_request": {}})
+    assert result is None
+
+
+def test_push_event_missing_username_key_returns_none():
+    # push 이벤트에서 head_commit.author.username 키가 없으면 None을 반환한다
+    # Returns None when head_commit.author.username key is absent.
+    result = _extract_author_login("push", {"head_commit": {"author": {}}})
+    assert result is None


### PR DESCRIPTION
## Summary

- **DB**: `analyses.author_login` 컬럼 추가 (alembic 0018, backfill 없음) + `RepoConfig.leaderboard_opt_in` Boolean
- **Pipeline**: `_extract_author_login()` — PR=`pull_request.user.login`, push=`head_commit.author.username`
- **Service**: `analytics_service` 확장 — `author_trend()`, `repo_comparison()`, `leaderboard()` (all 100% coverage)
- **API**: `GET /api/insights/authors/{login}/trend`, `GET /api/insights/repos/compare`, `GET /api/insights/leaderboard`
- **UI**: `GET /insights` (멀티 리포 비교), `GET /insights/me` (개인 추세 + Chart.js), nav "Insights" 링크
- **Settings**: `leaderboard_opt_in` 토글 추가 (카드 ③, PRESETS 제외, 팀 합의 후 활성화 권장)

## Test plan

- [ ] `pytest tests/unit/ -q` → 1409 passed (0 failed)
- [ ] `python -m pylint src/` → 10.00/10
- [ ] `alembic upgrade head && alembic downgrade -1 && alembic upgrade head` — 마이그레이션 왕복
- [ ] GET /insights → 리포 셀렉터 렌더링 확인
- [ ] GET /insights/me → Chart.js 추세 차트 렌더링 확인
- [ ] GET /api/insights/leaderboard → 옵트인 리포 없으면 `{"leaderboard": []}` 반환
- [ ] Settings → 카드 ③ "팀 리더보드 공개" 토글 저장 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)