### PR TITLE
fix: 0019 마이그레이션 — repo_configs.leaderboard_opt_in 누락으로 설정 페이지 500

### DIFF
--- a/alembic/versions/0019_add_repo_config_leaderboard_opt_in.py
+++ b/alembic/versions/0019_add_repo_config_leaderboard_opt_in.py
@@ -1,0 +1,26 @@
+"""add repo_configs.leaderboard_opt_in column
+
+Revision ID: 0019leaderboardoptin
+Revises: 0018addauthor
+Create Date: 2026-04-26
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0019leaderboardoptin'
+down_revision = '0018addauthor'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # leaderboard_opt_in: 기본 False — 팀 합의 후 명시 옵트인 필요
+    # Default False — requires explicit opt-in after team agreement.
+    op.add_column(
+        'repo_configs',
+        sa.Column('leaderboard_opt_in', sa.Boolean(), nullable=False, server_default='0'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column('repo_configs', 'leaderboard_opt_in')


### PR DESCRIPTION
## 원인

Phase 11(PR #72)에서 `RepoConfig` ORM 모델에 `leaderboard_opt_in = Column(Boolean, ...)` 컬럼을 추가했으나 대응하는 Alembic 마이그레이션이 누락됨.

앱 시작 시 `alembic upgrade head`가 실행되어도 이 컬럼이 DB에 생성되지 않아, 설정 페이지(`GET /repos/{name}/settings`)에서 `RepoConfig`를 조회할 때:

```
sqlalchemy.exc.ProgrammingError: column "leaderboard_opt_in" does not exist
→ 500 Internal Server Error
```

## 수정

`alembic/versions/0019_add_repo_config_leaderboard_opt_in.py` 신규 작성:
- `repo_configs.leaderboard_opt_in BOOLEAN NOT NULL DEFAULT false`
- `server_default='0'` — 기존 레코드와 호환
- upgrade/downgrade 왕복 검증 통과

## Test plan

- [x] `alembic upgrade head` → 0019 정상 적용
- [x] `alembic downgrade -1` → 정상 롤백
- [x] `alembic upgrade head` → 재적용 성공
- [x] UI 라우트 86개 통과 (test_router.py + test_insights_routes.py)
- [ ] CI 전체 통과 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)