### PR TITLE
docs: ORM 컬럼 추가 시 마이그레이션 필수 규칙 기재 (leaderboard_opt_in 500 재발 방지)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,6 +401,7 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 - **ThreadPoolExecutor with 블록 금지**: `with` 문은 `shutdown(wait=True)` 호출 → DNS hang 시 무기한 블록. `try/finally` + `executor.shutdown(wait=False)` 패턴 사용 (database.py 참조).
 - **SQLite hostaddr 제외**: `_ipv4_connect_args`는 hostname이 None(SQLite URL)이면 빈 dict 반환 — 그렇지 않으면 `sqlite3.connect(hostaddr=...)` TypeError 발생.
 - **`Analysis.author_login` NULL 정책**: 신규 컬럼은 backfill 없이 NULL 허용. 모든 집계는 `WHERE author_login IS NOT NULL` 적용. backfill 필요 시 `scripts/backfill_author.py` 별도 실행. PR 이벤트 = `pull_request.user.login`, Push 이벤트 = `head_commit.author.username`.
+- **ORM 컬럼 추가 시 마이그레이션 필수 동반**: `models/*.py`에 `Column(...)` 추가 후 반드시 `make revision m="설명"` 으로 마이그레이션 파일을 함께 생성해야 한다. 단위 테스트는 in-memory SQLite(`Base.metadata.create_all`)로 ORM 정의 그대로 테이블을 만들기 때문에 마이그레이션 파일이 없어도 테스트가 통과한다. 그러나 실제 DB(PostgreSQL/Railway)에는 컬럼이 생성되지 않아 운영 환경에서 500 에러가 발생한다. 전례: `leaderboard_opt_in` 컬럼 (PR #72·#74, 2026-04-26).
 
 ### 파이프라인 / 비즈니스 로직
 

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -86,6 +86,14 @@
 **테스트 증분**: +31 (1417 → **1448** passed)
 **품질**: pylint 10.00 · bandit HIGH 0 · 커버리지 95% (신규 파일 전체 100%)
 
+### 그룹 44 (2026-04-26 · hotfix — 설정 페이지 500 에러 수정 PR #74)
+
+**원인**: Phase 11(PR #72)에서 `RepoConfig` ORM에 `leaderboard_opt_in` 컬럼을 추가했으나 Alembic 마이그레이션 파일이 누락됨. 단위 테스트는 in-memory SQLite로 ORM 정의에서 직접 테이블을 생성하기 때문에 테스트 통과 → 그러나 운영 DB에는 컬럼 미생성 → `GET /repos/{name}/settings` 500 Internal Server Error.
+
+**수정**: `alembic/versions/0019_add_repo_config_leaderboard_opt_in.py` 신규 작성 (`server_default='0'`).
+
+**재발 방지**: CLAUDE.md "DB / 마이그레이션" 섹션에 **ORM 컬럼 추가 시 마이그레이션 필수 동반** 규칙 명시.
+
 ### 그룹 42 (2026-04-26 · Phase 10 Telegram 확장 완료 — PR #64)
 
 **목표**: 주간 리포트 cron + 트렌드 알림 + Telegram 인라인 명령 (`/stats`, `/settings`, `/connect`) + OTP 연결 흐름.


### PR DESCRIPTION
## Summary

PR #74(leaderboard_opt_in 500 에러) 재발 방지를 위한 규칙 문서화.

### 변경 내용

**CLAUDE.md — DB / 마이그레이션 섹션**
- `ORM 컬럼 추가 시 마이그레이션 필수 동반` 규칙 신규 추가
- 왜 테스트가 통과해도 운영에서 터지는지 이유 설명 (in-memory SQLite vs 실제 PostgreSQL)
- 전례: `leaderboard_opt_in` (PR #72·#74, 2026-04-26)

**docs/STATE.md**
- 그룹 44 항목 추가 — hotfix 원인·수정·재발 방지 이력 기록

### 재발 방지 규칙 요약

> `models/*.py`에 `Column(...)` 추가 후 반드시 `make revision m="설명"`으로 마이그레이션 파일을 함께 생성해야 한다. 단위 테스트는 in-memory SQLite로 ORM에서 직접 테이블을 만들기 때문에 마이그레이션 없이도 통과한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)