### PR TITLE
chore: pytest testpaths 고정 + ORM-마이그레이션 완전성 자동 검사

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -18,7 +18,7 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
-[![Tests](https://img.shields.io/badge/Tests-1448_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-1515_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
 [![E2E](https://img.shields.io/badge/E2E-53_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
-[![Tests](https://img.shields.io/badge/Tests-1448_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-1515_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
 [![E2E](https://img.shields.io/badge/E2E-53_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,11 +2,11 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-04-26 기준 — Phase 9 자기 분석 완료 · Phase 10 Telegram 확장 완료 · 기술 부채 정리 완료 · Phase 11 팀/멀티 리포 인사이트 완료 — PR #72 머지)
+## 현재 수치 (2026-04-26 기준 — Phase 9·10·11 완료 · 툴링 안전장치 추가 — PR #76)
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 단위 테스트 | **1448개** | pytest 9.0.3 (0 failed) — 2026-04-26 로컬 실측 (Phase 11 완료 후 최종) |
+| 단위 테스트 | **1515개** | pytest 9.0.3 (0 failed) — 2026-04-26 로컬 실측 (ORM-마이그레이션 완전성 검사 67개 추가) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
 | SonarCloud Reliability Rating | **A** | Bugs 0 |
@@ -44,6 +44,25 @@
 | `tests/conftest.py` | 환경변수 주입 + _webhook_secret_cache autouse 클리어 |
 
 ## 작업 이력 (그룹별)
+
+### 그룹 45 (2026-04-26 · 툴링 안전장치 — PR #76)
+
+**배경**: PR #74(leaderboard_opt_in 500 에러)와 PR #75(pytest e2e 혼입 446건 실패) 발견 사항의 **재발 방지** 자동화.
+
+**변경 내용**:
+
+| 파일 | 변경 | 역할 |
+|------|------|------|
+| `pytest.ini` | `testpaths = tests` 추가 | 경로 없이 `python -m pytest` 실행 시 `e2e/` 수집 방지 |
+| `tests/unit/test_migration_completeness.py` | 신규 (67 parametrized) | ORM 컬럼 전수 검사 — Alembic 마이그레이션 파일에 컬럼명 존재 여부 정적 확인 |
+
+**migration completeness 테스트 동작 원리**:
+1. 7개 ORM 모델 import → `Base.metadata` 테이블/컬럼 등록
+2. `alembic/versions/*.py` 전체 읽어 단일 검색 텍스트로 합침
+3. `(테이블명, 컬럼명)` 쌍마다 정규식 검색 (`'column'` 또는 `\bcolumn\b`)
+4. 누락 시 `make revision m="설명"` 안내 메시지와 함께 실패
+
+**테스트 증분**: +67 (1448 → **1515** passed)
 
 ### 그룹 43 (2026-04-26 · Phase 11 팀/멀티 리포 인사이트 완료 — PR #72)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 pythonpath = .
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
+testpaths = tests
 markers =
     slow: tests that run real subprocesses (linters, compilers) — automatically
         applied to files under tests/integration/ via integration/conftest.py

--- a/tests/unit/test_migration_completeness.py
+++ b/tests/unit/test_migration_completeness.py
@@ -43,7 +43,11 @@ _MIGRATIONS_DIR = os.path.join(
 def _load_migration_text() -> str:
     pattern = os.path.join(_MIGRATIONS_DIR, "*.py")
     files = glob.glob(pattern)
-    return "\n".join(open(f, encoding="utf-8").read() for f in sorted(files))
+    contents = []
+    for f in sorted(files):
+        with open(f, encoding="utf-8") as migration_file:
+            contents.append(migration_file.read())
+    return "\n".join(contents)
 
 
 _MIGRATION_TEXT: str = _load_migration_text()

--- a/tests/unit/test_migration_completeness.py
+++ b/tests/unit/test_migration_completeness.py
@@ -1,0 +1,113 @@
+"""ORM 모델과 Alembic 마이그레이션 파일의 컬럼 완전성 정적 검사.
+
+Static check: every non-PK column in every ORM model must appear by name
+in at least one alembic/versions/*.py file.  Catches the class of bug where
+a developer adds a Column to the ORM but forgets to write the migration —
+unit tests still pass (Base.metadata.create_all on in-memory SQLite) but
+the production DB is missing the column and raises a 500 on first access.
+
+How it works
+------------
+- All ORM models are imported so SQLAlchemy registers their tables.
+- All migration files are read and concatenated into one search blob.
+- For each (table, column) pair we do a plain substring search.
+- Primary-key columns named "id" are skipped (always present, never migrated
+  individually).  Columns whose names are unambiguous enough to match across
+  all migration files are accepted.
+"""
+
+import glob
+import os
+import re
+
+import pytest
+
+# --- import every ORM model so SQLAlchemy registers the tables ---
+import src.models.analysis  # noqa: F401
+import src.models.analysis_feedback  # noqa: F401
+import src.models.gate_decision  # noqa: F401
+import src.models.merge_attempt  # noqa: F401
+import src.models.repo_config  # noqa: F401
+import src.models.repository  # noqa: F401
+import src.models.user  # noqa: F401
+from src.database import Base
+
+# 마이그레이션 파일을 통합한 검색 텍스트 — 모든 버전 파일 내용을 합침
+# Concatenation of all migration file contents used as the search blob.
+_MIGRATIONS_DIR = os.path.join(
+    os.path.dirname(__file__), "..", "..", "alembic", "versions"
+)
+
+# 마이그레이션 텍스트를 모듈 레벨에서 한 번만 읽음 (성능 최적화)
+# Read once at module level to avoid repeated I/O per parameterised test.
+def _load_migration_text() -> str:
+    pattern = os.path.join(_MIGRATIONS_DIR, "*.py")
+    files = glob.glob(pattern)
+    return "\n".join(open(f, encoding="utf-8").read() for f in sorted(files))
+
+
+_MIGRATION_TEXT: str = _load_migration_text()
+
+# 검사에서 제외할 컬럼 이름 — 모든 테이블에서 공통으로 사용되는 이름이거나
+# 마이그레이션 파일이 아닌 초기 스키마로 생성된 컬럼.
+# Column names to skip: either always-present PKs, or so generic that a plain
+# substring match would produce false positives.
+_SKIP_COLUMNS = frozenset({"id"})
+
+# 검사에서 제외할 테이블 — alembic_version 등 내부 관리 테이블
+# Tables managed by Alembic itself, not by our models.
+_SKIP_TABLES = frozenset({"alembic_version"})
+
+
+def _columns_to_check():
+    """Base.metadata에 등록된 모든 (테이블명, 컬럼명) 쌍을 반환.
+
+    Returns every (table_name, column_name) pair that should be verified.
+    """
+    pairs = []
+    for table_name, table in Base.metadata.tables.items():
+        if table_name in _SKIP_TABLES:
+            continue
+        for col in table.columns:
+            if col.name in _SKIP_COLUMNS:
+                continue
+            pairs.append((table_name, col.name))
+    return pairs
+
+
+@pytest.mark.parametrize("table_name,column_name", _columns_to_check())
+def test_column_appears_in_migration(table_name: str, column_name: str) -> None:
+    """각 ORM 컬럼이 Alembic 마이그레이션 파일에 언급되어 있는지 확인.
+
+    Verifies that ``column_name`` appears somewhere in the combined text of all
+    migration files.  A missing column means the developer added it to the ORM
+    but forgot to write a migration — the production DB will be missing the
+    column and return a 500 on first access.
+
+    Fix: run ``make revision m="설명"`` and add ``op.add_column(...)`` for the
+    missing column before merging.
+    """
+    # 컬럼명이 마이그레이션 텍스트에 나타나는지 단어 경계로 검색
+    # Search with word-boundary to avoid substring false positives
+    # (e.g. "id" inside "repo_id").  We accept either a quoted string form
+    # ('column_name' or "column_name") or unquoted as a Python identifier.
+    pattern = (
+        r"""(?x)                 # verbose mode
+        (?:                      # quoted form
+            ['"]""" + re.escape(column_name) + r"""['"]
+        )
+        |
+        (?:                      # unquoted identifier form
+            \b""" + re.escape(column_name) + r"""\b
+        )
+    """
+    )
+    found = bool(re.search(pattern, _MIGRATION_TEXT))
+    assert found, (
+        f"\n\nORM 컬럼 '{table_name}.{column_name}'이 Alembic 마이그레이션 파일에 없습니다.\n"
+        f"ORM column '{table_name}.{column_name}' not found in any migration file.\n\n"
+        f"수정 방법 / Fix:\n"
+        f"  make revision m=\"add {column_name} to {table_name}\"\n"
+        f"  # 생성된 파일에 op.add_column('{table_name}', sa.Column('{column_name}', ...)) 추가\n"
+        f"  # Then add op.add_column('{table_name}', sa.Column('{column_name}', ...)) in the new file\n"
+    )


### PR DESCRIPTION
## Summary

- `pytest.ini`에 `testpaths = tests` 추가 — 경로 없이 `python -m pytest` 실행 시 `e2e/` 디렉토리를 수집하지 않도록 기본 탐색 경로 고정
- `tests/unit/test_migration_completeness.py` 신규 — 모든 ORM 컬럼이 Alembic 마이그레이션 파일(alembic/versions/*.py)에 존재하는지 정적으로 검사하는 67개 파라미터화 테스트

## Background

이번 PR은 이전 두 hotfix(#74 leaderboard_opt_in 마이그레이션 누락, #75 pytest 경로 발견)에서 확인된 **재발 방지 안전장치** 구현이다.

- **leaderboard_opt_in 500 에러**: ORM 컬럼을 추가했지만 마이그레이션 파일을 생성하지 않아 프로덕션 DB에 컬럼이 없어 500 발생 → 단위 테스트는 `Base.metadata.create_all()` (in-memory SQLite)로 통과해 감지 불가
- **e2e 혼입 446건 실패**: `python -m pytest`(경로 없음)가 `e2e/`를 수집 → 포트 8001 충돌 → 카스케이드 실패

## How the migration completeness test works

1. 7개 ORM 모델을 모두 import → `Base.metadata`에 테이블/컬럼 등록
2. `alembic/versions/*.py` 전체를 읽어 단일 검색 텍스트로 결합
3. 각 `(테이블명, 컬럼명)` 쌍을 정규식으로 검색 (`'column'` 또는 `\bcolumn\b` 형태)
4. 누락 시 `make revision m="설명"` 안내 메시지와 함께 실패

## Test plan

- [x] `python -m pytest tests/unit/test_migration_completeness.py -v` → 67 passed
- [x] `python -m pytest tests/ -q` → 1515 passed, 1 skipped (1448 + 67 신규)
- [x] 기존 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)