### PR TITLE
chore(ci): sonarcloud-github-action → sonarqube-scan-action@v5 교체

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: SonarCloud scan
-        uses: SonarSource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: https://sonarcloud.io


### PR DESCRIPTION
## Summary

- `SonarSource/sonarcloud-github-action@master` deprecated 경고 해소
- drop-in replacement `SonarSource/sonarqube-scan-action@v5` 로 교체
- `SONAR_HOST_URL=https://sonarcloud.io` 환경변수 추가 (v5 필수 파라미터)

## Test plan

- [ ] CI 실행 후 SonarCloud scan step 에서 deprecated warning 미출력 확인
- [ ] `ANALYSIS SUCCESSFUL` 로그 정상 출력 확인
- [ ] SonarCloud Quality Gate OK 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)