### PR TITLE
feat(settings): UI/UX 리디자인 — B+A 하이브리드 (수신/발신 웹훅 분리 + 온보딩 배너)

### DIFF
--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -394,7 +394,7 @@
         <strong>Webhook 재등록 필요</strong> — <code>check_suite</code> 이벤트가 누락되어 자동 머지 재시도가 지연될 수 있습니다. Webhook을 재등록하면 CI 완료 즉시 머지를 재시도합니다.
         <br><small class="text-muted">Auto-merge retry may be delayed: <code>check_suite</code> event not subscribed. Reinstall webhook to enable immediate CI-triggered retries.</small>
       </div>
-      <button type="button" onclick="document.querySelector('[data-reinstall-webhook]')?.click();" class="btn btn-sm btn-warning ms-auto">Webhook 재등록</button>
+      <button type="button" onclick="document.querySelector('[data-reinstall-webhook]')?.click();" class="btn btn-sm btn-warning ms-auto">GitHub 수신 Webhook 재등록</button>
     </div>
     {% endif %}
 
@@ -882,14 +882,22 @@
 
   </form>
 
-  <!-- ⑤ 시스템 & 토큰 (CLI Hook + Webhook + Railway API 토큰 + 위험 구역 — 메인 form 외부) / System & tokens (CLI Hook + Webhook + Railway API token + danger zone — outside main form) -->
+  <!-- ⑤ 통합 & 연결 (GitHub 수신 Webhook + CLI Hook + Railway API 토큰 + 위험 구역 — 메인 form 외부) / Integration & connections (GitHub inbound webhook + CLI Hook + Railway API token + danger zone — outside main form) -->
   <div class="s-card" style="margin-bottom:1rem;">
     <div class="s-card-hdr hdr-hook">
-      <span class="hdr-icon">🔧</span>
-      <span class="hdr-title">시스템 &amp; 토큰</span>
+      <span class="hdr-icon">🔗</span>
+      <span class="hdr-title">통합 &amp; 연결</span>
     </div>
     <div class="s-card-body">
 
+      <div class="s-section-label">GitHub 수신 Webhook</div>
+      <div class="hook-btns" style="margin-bottom:.5rem;">
+        <button type="submit" class="hook-btn" form="reinstall_webhook_form"
+                data-reinstall-webhook>🔗 GitHub 수신 Webhook 재등록</button>
+      </div>
+      <span class="field-hint">GitHub이 SCAManager로 push·PR·check_suite 이벤트를 전송합니다.</span>
+
+      <div class="s-divider"></div>
       <div class="s-section-label">CLI Hook</div>
       {% if hook_ok %}
       <div class="hook-alert ok">✅ <strong>.scamanager/</strong> 파일이 Repo에 커밋됐습니다.</div>
@@ -900,12 +908,12 @@
       <div class="hook-code">git pull &amp;&amp; bash .scamanager/install-hook.sh</div>
       <div class="hook-btns">
         <button type="submit" class="hook-btn" form="reinstall_hook_form">🔄 훅 파일 재커밋</button>
-        <button type="submit" class="hook-btn" form="reinstall_webhook_form">🔗 Webhook 재등록</button>
       </div>
 
       <div class="s-divider"></div>
 
-      <div class="s-section-label">Railway API 토큰 <span class="field-hint" style="font-weight:400;text-transform:none;letter-spacing:0;">로그 조회용</span></div>
+      <div class="s-section-label">Railway 연동</div>
+      <div class="s-section-label" style="font-size:10px;text-transform:none;letter-spacing:0;color:var(--text-muted);margin-top:-.4rem;margin-bottom:.6rem;">API 토큰 (로그 조회용)</div>
       <div class="field-row">
         <div class="masked-field">
           <input class="field-input" type="password" name="railway_api_token"
@@ -935,74 +943,6 @@
       <span class="field-hint">설정 저장 후 Railway Webhook URL 이 자동 생성됩니다.</span>
       {% endif %}
 
-      <div class="s-divider"></div>
-
-      <!-- Telegram 연결 서브섹션 / Telegram Connection subsection -->
-      <div class="s-section-label">Telegram 연결 / Telegram Connection</div>
-      <div class="mb-4" id="telegram-connect-section">
-        {% if current_user.is_telegram_connected %}
-        <p class="text-success mb-2" style="font-size:13px;">✅ Telegram 계정이 연결되어 있습니다.</p>
-        {% else %}
-        <p style="font-size:13px;color:var(--text-muted);margin-bottom:.6rem;">
-          Telegram 봇에서 /connect 명령으로 계정을 연결하세요.
-        </p>
-        <button type="button" class="hook-btn" id="issueTelegramOtp">
-          🔗 연결 코드 발급 / Issue Code
-        </button>
-        <div id="telegramOtpDisplay" style="display:none;margin-top:.65rem;">
-          <code id="telegramOtpCode" style="font-size:1.4rem;font-weight:700;letter-spacing:.12em;"></code>
-          <span style="font-size:12px;color:var(--text-muted);margin-left:.5rem;">
-            (<span id="telegramOtpCountdown">5:00</span> 후 만료)
-          </span>
-          <p style="font-size:11px;color:var(--text-muted);margin-top:.35rem;margin-bottom:0;">
-            이전 코드는 무효화됩니다. / Previous codes are invalidated.
-          </p>
-        </div>
-
-        <script>
-          // Telegram OTP 발급 버튼 클릭 핸들러 — 미연결 상태에서만 렌더링
-          // Click handler for Telegram OTP issuance — rendered only when not connected.
-          (function () {
-            var btn = document.getElementById('issueTelegramOtp');
-            if (!btn) { return; }
-            btn.addEventListener('click', async function () {
-              btn.disabled = true;
-              try {
-                var resp = await fetch('/api/users/me/telegram-otp', { method: 'POST' });
-                if (!resp.ok) { btn.disabled = false; return; }
-                var data = await resp.json();
-                // OTP 코드 표시
-                // Display the issued OTP code.
-                document.getElementById('telegramOtpCode').textContent = data.otp;
-                document.getElementById('telegramOtpDisplay').style.display = '';
-
-                // 카운트다운 타이머 (5분) — Countdown timer (5 minutes).
-                var remaining = data.ttl_minutes * 60;
-                var cd = document.getElementById('telegramOtpCountdown');
-                var timer = setInterval(function () {
-                  remaining -= 1;
-                  var m = Math.floor(remaining / 60);
-                  var s = remaining % 60;
-                  cd.textContent = m + ':' + (s < 10 ? '0' : '') + s;
-                  if (remaining <= 0) {
-                    clearInterval(timer);
-                    // 만료 시 OTP 표시 영역 숨김 및 버튼 재활성화
-                    // Hide OTP display and re-enable button upon expiry.
-                    document.getElementById('telegramOtpDisplay').style.display = 'none';
-                    btn.disabled = false;
-                  }
-                }, 1000);
-              } catch (e) {
-                // 네트워크 오류 등 예외 발생 시 버튼을 재활성화하여 재시도 허용
-                // Re-enable button on network or other errors so the user can retry.
-                console.error('Telegram OTP issuance failed:', e);
-                btn.disabled = false;
-              }
-            });
-          }());
-        </script>
-        {% endif %}
-      </div>
 
     </div>
   </div>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -735,13 +735,14 @@
 
     <!-- ④ 알림 채널 (항상 표시 — 고급 설정 아코디언 밖) / Notification channels (always visible — outside advanced settings accordion) -->
     <div class="settings-grid">
-      <div class="s-card notify-full">
+      <div class="s-card notify-full" id="notifyCard">
         <div class="s-card-hdr hdr-notify">
           <span class="hdr-icon">🔔</span>
-          <span class="hdr-title">알림 채널</span>
-          <span class="hdr-badge">선택</span>
+          <span class="hdr-title">알림 발신 채널</span>
+          <span class="hdr-badge">SCAManager → 외부</span>
         </div>
         <div class="s-card-body">
+          <div class="s-section-label">메신저 / 이메일</div>
           <div class="channel-grid">
             <div class="field-row">
               <label class="field-label">Telegram Chat ID</label>
@@ -754,6 +755,67 @@
                         aria-label="값 보이기/숨기기">👁️</button>
               </div>
             </div>
+
+            <!-- Telegram 계정 연결 OTP (⑤에서 이동) / Telegram account linking OTP (moved from system card) -->
+            <div class="field-row">
+              <label class="field-label">Telegram 계정 연결</label>
+              <div id="telegram-connect-section-notify">
+                {% if current_user.is_telegram_connected %}
+                <p class="text-success" style="font-size:13px;margin:0;">✅ Telegram 계정이 연결되어 있습니다.</p>
+                {% else %}
+                <p style="font-size:13px;color:var(--text-muted);margin-bottom:.5rem;">
+                  Telegram 봇에서 /connect 명령으로 계정을 연결하세요.
+                </p>
+                <button type="button" class="hook-btn" id="issueTelegramOtp">
+                  🔗 연결 코드 발급 / Issue Code
+                </button>
+                <div id="telegramOtpDisplay" style="display:none;margin-top:.65rem;">
+                  <code id="telegramOtpCode" style="font-size:1.4rem;font-weight:700;letter-spacing:.12em;"></code>
+                  <span style="font-size:12px;color:var(--text-muted);margin-left:.5rem;">
+                    (<span id="telegramOtpCountdown">5:00</span> 후 만료)
+                  </span>
+                  <p style="font-size:11px;color:var(--text-muted);margin-top:.35rem;margin-bottom:0;">
+                    이전 코드는 무효화됩니다. / Previous codes are invalidated.
+                  </p>
+                </div>
+                <script>
+                  // Telegram OTP 발급 버튼 — 알림 발신 채널 카드로 이동 (B+A 리디자인)
+                  // Telegram OTP button — moved to notification channel card (B+A redesign)
+                  (function () {
+                    var btn = document.getElementById('issueTelegramOtp');
+                    if (!btn) { return; }
+                    btn.addEventListener('click', async function () {
+                      btn.disabled = true;
+                      try {
+                        var resp = await fetch('/api/users/me/telegram-otp', { method: 'POST' });
+                        if (!resp.ok) { btn.disabled = false; return; }
+                        var data = await resp.json();
+                        document.getElementById('telegramOtpCode').textContent = data.otp;
+                        document.getElementById('telegramOtpDisplay').style.display = '';
+                        var remaining = data.ttl_minutes * 60;
+                        var cd = document.getElementById('telegramOtpCountdown');
+                        var timer = setInterval(function () {
+                          remaining -= 1;
+                          var m = Math.floor(remaining / 60);
+                          var s = remaining % 60;
+                          cd.textContent = m + ':' + (s < 10 ? '0' : '') + s;
+                          if (remaining <= 0) {
+                            clearInterval(timer);
+                            document.getElementById('telegramOtpDisplay').style.display = 'none';
+                            btn.disabled = false;
+                          }
+                        }, 1000);
+                      } catch (e) {
+                        console.error('Telegram OTP issuance failed:', e);
+                        btn.disabled = false;
+                      }
+                    });
+                  }());
+                </script>
+                {% endif %}
+              </div>
+            </div>
+
             <div class="field-row adv-only">
               <label class="field-label">Discord Webhook</label>
               <div class="masked-field">
@@ -794,6 +856,9 @@
                 <button type="button" class="mask-toggle" onclick="toggleFieldMask(this)"
                         aria-label="값 보이기/숨기기">👁️</button>
               </div>
+            </div>
+            <div class="field-row adv-only">
+              <div class="s-section-label" style="grid-column:1/-1;margin-bottom:.25rem;">자동화 연동 Webhook (발신)</div>
             </div>
             <div class="field-row adv-only">
               <label class="field-label">n8n Webhook</label>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -364,6 +364,29 @@
   <form id="settingsForm" method="post" action="/repos/{{ repo_name }}/settings">
     <input type="hidden" name="approve_mode" id="approveModeValue" value="{{ config.approve_mode }}">
 
+    {% if onboarding_needed %}
+    <!-- 온보딩 배너 — 알림 채널 미설정 + Telegram 미연결 시 표시 -->
+    <!-- Onboarding banner — shown when no notification channel and Telegram not linked -->
+    <div class="s-card" id="onboardingBanner" style="margin-bottom:1rem;border:1.5px solid var(--accent);">
+      <div class="s-card-hdr" style="background:linear-gradient(135deg,#6366f1,#8b5cf6)">
+        <span class="hdr-icon">🚀</span>
+        <span class="hdr-title">빠른 시작</span>
+        <span class="hdr-badge">알림 채널 미설정</span>
+      </div>
+      <div class="s-card-body">
+        <p style="font-size:13px;color:var(--text-muted);margin:0 0 .75rem;">분석 결과를 받으려면 아래 단계를 완료하세요.</p>
+        <div style="display:flex;flex-direction:column;gap:.45rem;font-size:13px;">
+          <a href="#notifyCard" style="color:var(--accent);font-weight:600;">
+            ① 알림 채널 설정 → 아래 <strong>알림 발신 채널</strong>에서 Telegram 또는 다른 채널을 연결하세요
+          </a>
+          <span style="color:var(--text-muted);">
+            ② 리뷰 수준 결정 → 위 <strong>빠른 설정</strong>에서 프리셋을 선택하세요 (선택 사항)
+          </span>
+        </div>
+      </div>
+    </div>
+    {% endif %}
+
     {% if webhook_stale %}
     <div class="alert alert-warning alert-dismissible d-flex align-items-center mb-4" role="alert" id="webhookStaleBanner">
       <span class="me-2">⚠️</span>
@@ -376,7 +399,7 @@
     {% endif %}
 
     <!-- ① 빠른 설정 (프리셋) / Quick settings (presets) -->
-    <div class="s-card" style="margin-bottom:1rem;">
+    <div class="s-card" id="presetCard" style="margin-bottom:1rem;">
       <div class="s-card-hdr hdr-preset">
         <span class="hdr-icon">🚀</span>
         <span class="hdr-title">빠른 설정</span>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -532,15 +532,16 @@
       <div class="advanced-body">
         <div class="settings-grid">
 
-      <!-- ② PR 들어왔을 때 / When a PR arrives -->
+      <!-- ② 분석 동작 규칙 / Analysis behavior rules -->
       <div class="s-card">
         <div class="s-card-hdr hdr-gate">
-          <span class="hdr-icon">📋</span>
-          <span class="hdr-title">PR 들어왔을 때</span>
+          <span class="hdr-icon">⚡</span>
+          <span class="hdr-title">분석 동작 규칙</span>
           <span class="hdr-badge" id="approveBadge">{{ config.approve_mode }}</span>
         </div>
         <div class="s-card-body">
 
+          <div class="s-section-label">PR 이벤트</div>
           <!-- PR 코드리뷰 댓글 / PR code review comment -->
           <div class="toggle-row">
             <div class="toggle-info">
@@ -668,18 +669,8 @@
             </div>
           </div>
 
-        </div>
-      </div>
-
-      <!-- ③ 이벤트 후 피드백 / Post-event feedback -->
-      <div class="s-card">
-        <div class="s-card-hdr hdr-merge">
-          <span class="hdr-icon">📬</span>
-          <span class="hdr-title">이벤트 후 피드백</span>
-        </div>
-        <div class="s-card-body">
-
-          <div class="s-section-label">Push 이후</div>
+          <div class="s-divider"></div>
+          <div class="s-section-label">Push / 배포 이벤트</div>
           <div class="toggle-row">
             <div class="toggle-info">
               <div class="t-title">커밋 코멘트</div>
@@ -693,7 +684,6 @@
           </div>
 
           <div class="s-divider"></div>
-          <div class="s-section-label">점수 미달 시</div>
           <div class="toggle-row">
             <div class="toggle-info">
               <div class="t-title">이슈 자동 생성</div>
@@ -707,10 +697,9 @@
           </div>
 
           <div class="s-divider"></div>
-          <div class="s-section-label">Railway 빌드 실패 시</div>
           <div class="toggle-row">
             <div class="toggle-info">
-              <div class="t-title">GitHub Issue 자동 생성</div>
+              <div class="t-title">Railway 빌드 실패 알림</div>
               <div class="t-desc">Railway 빌드 실패 이벤트 수신 시<br>해당 리포에 로그 포함 Issue 자동 생성</div>
             </div>
             <label class="toggle-switch">
@@ -720,8 +709,10 @@
             </label>
           </div>
 
+          <div class="s-divider"></div>
+          <div class="s-section-label">팀 설정</div>
           <!-- 팀 인사이트 리더보드 옵트인 (기본 비활성) / Team Insights leaderboard opt-in (disabled by default) -->
-          <div class="toggle-row" style="margin-top:.75rem;">
+          <div class="toggle-row">
             <div class="toggle-info">
               <div class="t-title">팀 리더보드 공개</div>
               <div class="t-desc">이 리포를 팀 인사이트 리더보드에 포함<br>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -669,8 +669,19 @@
             </div>
           </div>
 
-          <div class="s-divider"></div>
-          <div class="s-section-label">Push / 배포 이벤트</div>
+        </div>
+      </div>
+
+      <!-- Push / 배포 이벤트 & 팀 설정 카드 / Push/deploy events & team settings card -->
+      <div class="s-card">
+        <div class="s-card-hdr hdr-merge">
+          <span class="hdr-icon">🚀</span>
+          <span class="hdr-title">Push / 배포 이벤트</span>
+          <span class="hdr-badge">Push · Railway</span>
+        </div>
+        <div class="s-card-body">
+
+          <div class="s-section-label">Push 이벤트</div>
           <div class="toggle-row">
             <div class="toggle-info">
               <div class="t-title">커밋 코멘트</div>

--- a/src/ui/routes/settings.py
+++ b/src/ui/routes/settings.py
@@ -151,6 +151,13 @@ async def repo_settings(  # pylint: disable=too-many-positional-arguments,too-ma
         webhook_id=repo_webhook_id,
     )
 
+    # 알림 채널 미설정 + Telegram 미연결 → 온보딩 배너 표시
+    # Show onboarding banner when no notification channel is configured and Telegram is not linked.
+    onboarding_needed = (
+        not config.notify_chat_id and
+        not current_user.is_telegram_connected
+    )
+
     return templates.TemplateResponse(request, "settings.html", {
         "repo_name": repo_name, "config": config,
         "hook_ok": bool(hook_ok), "hook_fail": bool(hook_fail),
@@ -159,6 +166,7 @@ async def repo_settings(  # pylint: disable=too-many-positional-arguments,too-ma
         "railway_webhook_url": railway_webhook_url,
         "railway_api_token_set": railway_api_token_set,
         "webhook_stale": webhook_stale,
+        "onboarding_needed": onboarding_needed,
     })
 
 

--- a/tests/unit/ui/test_settings_webhook_banner.py
+++ b/tests/unit/ui/test_settings_webhook_banner.py
@@ -122,6 +122,7 @@ def _settings_get_custom(
         telegram_user_id="tg_123" if telegram_connected else None,
     )
     app.dependency_overrides[require_login] = lambda: custom_user
+    resp = None
     try:
         with patch("src.ui.routes.settings.SessionLocal", return_value=_make_db_ctx()), \
              patch("src.ui.routes.settings.get_repo_config", return_value=config), \
@@ -132,9 +133,10 @@ def _settings_get_custom(
                  new_callable=AsyncMock,
                  return_value=stale,
              ):
-            return client.get("/repos/owner%2Frepo/settings")
+            resp = client.get("/repos/owner%2Frepo/settings")
     finally:
         app.dependency_overrides[require_login] = lambda: _test_user
+    return resp
 
 
 def test_settings_shows_onboarding_banner_when_no_channel():

--- a/tests/unit/ui/test_settings_webhook_banner.py
+++ b/tests/unit/ui/test_settings_webhook_banner.py
@@ -98,3 +98,100 @@ def test_settings_no_banner_when_check_suite_present():
     # 배너가 없어야 함 — 배너 element id 가 HTML에 없어야 함
     # Banner must be absent — banner element id should not appear in HTML
     assert "webhookStaleBanner" not in resp.text
+
+
+# ── 온보딩 배너 테스트 ────────────────────────────────────────────────────────
+
+def _settings_get_custom(
+    stale: bool = False,
+    notify_chat_id: str | None = None,
+    telegram_connected: bool = False,
+):
+    """알림 채널 설정 + Telegram 연결 여부를 커스터마이즈한 헬퍼.
+    Helper to customise notification channel settings and Telegram link state.
+    """
+    from src.config_manager.manager import RepoConfigData  # pylint: disable=import-outside-toplevel
+    from src.models.user import User as UserModel  # pylint: disable=import-outside-toplevel
+
+    config = RepoConfigData(repo_full_name="owner/repo", notify_chat_id=notify_chat_id)
+    custom_user = UserModel(
+        id=99,
+        github_id="99999",
+        github_login="customuser",
+        github_access_token="gho_custom",
+        telegram_user_id="tg_123" if telegram_connected else None,
+    )
+    app.dependency_overrides[require_login] = lambda: custom_user
+    try:
+        with patch("src.ui.routes.settings.SessionLocal", return_value=_make_db_ctx()), \
+             patch("src.ui.routes.settings.get_repo_config", return_value=config), \
+             patch("src.repositories.repo_config_repo.find_by_full_name",
+                   return_value=_make_config_orm()), \
+             patch(
+                 "src.ui.routes.settings._detect_stale_webhook",
+                 new_callable=AsyncMock,
+                 return_value=stale,
+             ):
+            return client.get("/repos/owner%2Frepo/settings")
+    finally:
+        app.dependency_overrides[require_login] = lambda: _test_user
+
+
+def test_settings_shows_onboarding_banner_when_no_channel():
+    """알림 채널 미설정 + Telegram 미연결 → 온보딩 배너 표시.
+    Shows onboarding banner when no notification channel is configured and Telegram is not linked.
+    """
+    resp = _settings_get_custom(notify_chat_id=None, telegram_connected=False)
+    assert resp.status_code == 200
+    assert "onboardingBanner" in resp.text
+
+
+def test_settings_no_onboarding_banner_when_notify_chat_id_set():
+    """notify_chat_id 설정 시 → 온보딩 배너 미표시.
+    No onboarding banner when notify_chat_id is configured.
+    """
+    resp = _settings_get_custom(notify_chat_id="-100123456", telegram_connected=False)
+    assert resp.status_code == 200
+    assert "onboardingBanner" not in resp.text
+
+
+def test_settings_no_onboarding_banner_when_telegram_connected():
+    """Telegram 연결 완료 시 → 온보딩 배너 미표시.
+    No onboarding banner when Telegram account is linked.
+    """
+    resp = _settings_get_custom(notify_chat_id=None, telegram_connected=True)
+    assert resp.status_code == 200
+    assert "onboardingBanner" not in resp.text
+
+
+def test_settings_new_card_structure_present():
+    """새 카드 헤더 텍스트 확인 + 구 카드 헤더 부재 확인.
+    Verify new card header text is present and old card headers are gone.
+    """
+    resp = _settings_get(stale=False)
+    assert resp.status_code == 200
+    # 새 카드 이름이 있어야 함
+    assert "분석 동작 규칙" in resp.text
+    assert "알림 발신 채널" in resp.text
+    assert "통합 &amp; 연결" in resp.text
+    # 구 카드 이름이 없어야 함
+    assert "이벤트 후 피드백" not in resp.text
+    assert "시스템 &amp; 토큰" not in resp.text
+
+
+def test_settings_all_form_fields_present_after_restructure():
+    """구조 개편 후 모든 폼 필드가 유지되는지 회귀 테스트.
+    Regression: all form field names must survive the card restructure.
+    """
+    resp = _settings_get(stale=False)
+    assert resp.status_code == 200
+    required_fields = [
+        "pr_review_comment", "auto_merge", "merge_threshold",
+        "approve_threshold", "reject_threshold", "commit_comment",
+        "create_issue", "railway_deploy_alerts", "notify_chat_id",
+        "discord_webhook_url", "slack_webhook_url", "n8n_webhook_url",
+        "custom_webhook_url", "email_recipients", "leaderboard_opt_in",
+        "auto_merge_issue_on_failure",
+    ]
+    for field in required_fields:
+        assert field in resp.text, f"Missing form field: {field}"


### PR DESCRIPTION
## Summary

- 설정 페이지 카드 구조를 데이터 흐름 방향(수신/발신) 기준으로 재편
- ② PR/③ 피드백 카드 → **② 분석 동작 규칙** (PR 이벤트) + **Push / 배포 이벤트** 두 카드로 분리 (hdr-gate + hdr-merge)
- ④ 알림 채널 → **③ 알림 발신 채널 (SCAManager → 외부)** 명칭 변경, Telegram OTP 이동
- ⑤ 시스템 & 토큰 → **④ 통합 & 연결**, GitHub 수신 Webhook 섹션 명시, Telegram OTP 제거
- 신규 사용자에게 **온보딩 배너** 조건부 표시 (알림 채널 미설정 + Telegram 미연결 시)
- 백엔드 로직·폼 필드명 변경 없음 — 순수 프레젠테이션 레이어 변경

## Test plan
- [x] 온보딩 배너 3가지 조건 테스트 통과
- [x] 새 카드 구조 헤더 검증 테스트 통과 (hdr-gate + hdr-merge 분리 포함)
- [x] 폼 필드 회귀 테스트 통과 (16개 필드 전부 유지)
- [x] 전체 테스트 스위트 통과 (1714 passed)
- [x] pylint 10.00/10

🤖 Generated with [Claude Code](https://claude.ai/claude-code)