### PR TITLE
fix(gate): BPR Required Checks 미설정 Repo auto-merge 큐잉 정상화

### DIFF
--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -323,6 +323,13 @@ async def _get_ci_status_safe(
     except httpx.HTTPError:
         required = None  # None 이면 모든 체크 고려 / None means "consider all checks"
 
+    # 방어층: BPR Required 미설정으로 빈 set 이 반환되면 None 으로 통일
+    # checks.py 의 fallback 과 이중 안전 — 호출 측에서도 명시적으로 처리
+    # Defense layer: unify empty set (no BPR required checks) to None
+    # — double safety with checks.py fallback, explicit handling at call site
+    if not required:
+        required = None
+
     try:
         return await get_ci_status(
             github_token, repo_name, commit_sha,

--- a/src/github_client/checks.py
+++ b/src/github_client/checks.py
@@ -67,18 +67,20 @@ async def get_ci_status(
     required_contexts:
     - None → 모든 체크 고려 / consider ALL checks
     - set (비어 있어도) → 해당 이름의 체크만 고려 / only consider checks in the set
-    - 빈 set → 필수 체크 없음 = 즉시 'failed' 반환 (선택적 체크 실패는 대기 불필요)
-      Empty set → no required checks = immediately return 'failed'
-      (optional-only failures are terminal, no point waiting)
+    - 빈 set → BPR Required Status Checks 미설정 → None 으로 fallback 후 모든 체크 고려
+      Empty set → no required status checks under BPR → fall back to None (consider all checks)
+      (이전 동작은 즉시 'failed' 였으나, BPR 미설정 Repo 가 일반적이고 그 경우 사용자
+       의도는 "informational 체크의 진행 상태로 판단" 이므로 fallback 으로 변경)
     """
-    # 빈 set: 필수 체크 없음 → 즉시 terminal 처리 / Empty set: no required checks → terminal immediately
+    # 빈 set: BPR Required Status Checks 미설정 → 모든 체크 고려 fallback
+    # Empty set: no required status checks under BPR → fall back to considering all checks
     if required_contexts is not None and len(required_contexts) == 0:
         logger.debug(
-            "required_contexts는 빈 set — 필수 체크 없음, 즉시 'failed' 반환 (%s %s)"
-            " / required_contexts is empty set — no required checks, returning 'failed' immediately (%s %s)",
+            "required_contexts는 빈 set — BPR Required 미설정, 모든 체크 고려 fallback (%s %s)"
+            " / required_contexts is empty set — no BPR required checks, falling back to all checks (%s %s)",
             repo_full_name, commit_sha, repo_full_name, commit_sha,
         )
-        return "failed"
+        required_contexts = None
 
     client = get_http_client()
 

--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -284,6 +284,13 @@ async def _get_ci_status_safe(
         required = await get_required_check_contexts(token, repo_full_name, "main")
     except httpx.HTTPError:
         required = None
+
+    # 방어층: BPR Required 미설정으로 빈 set 이 반환되면 None 으로 통일
+    # engine.py::_get_ci_status_safe 와 동일 패턴 — 단일/워커 경로 일관성 확보
+    # Defense layer: unify empty set to None for consistency with engine path
+    if not required:
+        required = None
+
     try:
         return await get_ci_status(
             token,

--- a/tests/unit/gate/test_engine.py
+++ b/tests/unit/gate/test_engine.py
@@ -1103,3 +1103,40 @@ async def test_notify_merge_failure_includes_advice_in_telegram():
         )
     sent_text = mock_tg.call_args[0][2]["text"]
     assert "충돌을 해소하세요" in sent_text
+
+
+# ---------------------------------------------------------------------------
+# _get_ci_status_safe — 빈 set 방어층 (옵션 3)
+# _get_ci_status_safe — empty set defense layer (option 3)
+# ---------------------------------------------------------------------------
+
+async def test_get_ci_status_safe_converts_empty_set_to_none():
+    """_get_ci_status_safe 가 빈 set 을 None 으로 변환해 get_ci_status 에 전달한다.
+    _get_ci_status_safe must convert empty set to None before passing to get_ci_status.
+
+    옵션 3 방어층 — checks.py 변경과 무관하게 호출 측에서도 안전하게 처리.
+    BPR Required Status Checks 미설정 Repo 에서 빈 set 이 반환되더라도
+    하위 get_ci_status 호출 시점에는 항상 None 으로 통일되어 모든 체크 평가.
+    Defense layer (option 3) — caller-side safety regardless of checks.py change.
+    Empty set returned by branch-protection lookup must be normalized to None
+    so get_ci_status falls back to evaluating all checks.
+    """
+    from src.gate.engine import _get_ci_status_safe  # 지역 import / local import
+
+    with patch(
+        "src.gate.engine.get_required_check_contexts",
+        new_callable=AsyncMock,
+    ) as mock_required, patch(
+        "src.gate.engine.get_ci_status",
+        new_callable=AsyncMock,
+    ) as mock_ci:
+        mock_required.return_value = set()  # 빈 set / empty set
+        mock_ci.return_value = "running"
+
+        result = await _get_ci_status_safe("token", "owner/repo", "sha123")
+
+    assert result == "running"
+    # 핵심 검증 — required_contexts 가 None 으로 전달되어야 함
+    # Core assertion — required_contexts must be passed as None (not empty set).
+    call_kwargs = mock_ci.call_args.kwargs
+    assert call_kwargs.get("required_contexts") is None

--- a/tests/unit/github_client/test_checks.py
+++ b/tests/unit/github_client/test_checks.py
@@ -187,19 +187,84 @@ async def test_get_ci_status_unknown_when_no_checks():
 # ── required_contexts filtering ──────────────────────────────────────────
 
 
-async def test_get_ci_status_terminal_when_required_contexts_empty_set():
-    """required_contexts=set() 이면 API 호출 없이 즉시 'failed' 반환.
-    Returns 'failed' immediately (no API calls) when required_contexts is empty set.
+async def test_get_ci_status_empty_set_falls_back_to_all_checks():
+    """required_contexts=set() 이면 None 처럼 모든 체크를 고려해 평가한다.
+    Empty required_contexts falls back to evaluating all checks (treated as None).
+
+    BPR Required Status Checks 미설정 Repo 에서 빈 set 이 반환될 때,
+    이전 동작은 즉시 'failed' 였으나 사용자 의도(CI 진행 상태로 판단) 와 어긋남.
+    이제는 None 으로 fallback 하여 실제 체크 상태로 평가한다.
+    Previous behavior returned 'failed' immediately for empty set, which mismatched
+    user intent (PR with running CI shouldn't be marked failed). Now falls back
+    to None and evaluates actual check state via API.
     """
+    check_runs_body = {
+        "check_runs": [_check_run("CI / test", "in_progress", None)],
+        "total_count": 1,
+    }
     mock_client = AsyncMock()
-    mock_client.get = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[_resp(200, check_runs_body)])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.github_client.checks.get_http_client", return_value=mock_client):
+        result = await get_ci_status(TOKEN, REPO, SHA, required_contexts=set())
+
+    # 빈 set 이어도 API 호출 후 실제 상태로 판단 / Even with empty set, API is called.
+    assert result == "running"
+    mock_client.get.assert_called()
+
+
+async def test_get_ci_status_empty_set_with_all_passed():
+    """빈 set + 모든 체크 통과 → 'passed' 반환 (fallback 동작).
+    Empty set + all checks success → 'passed' (fallback behavior verified).
+    """
+    check_runs_body = {
+        "check_runs": [
+            _check_run("SonarQube", "completed", "success"),
+            _check_run("Codecov", "completed", "success"),
+        ],
+        "total_count": 2,
+    }
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[_resp(200, check_runs_body)])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.github_client.checks.get_http_client", return_value=mock_client):
+        result = await get_ci_status(TOKEN, REPO, SHA, required_contexts=set())
+
+    assert result == "passed"
+
+
+async def test_get_ci_status_empty_set_with_failed_check():
+    """빈 set + 실제 체크 실패 → 'failed' 반환 (fallback 후에도 정확).
+    Empty set + actually failed check → 'failed' (fallback still detects real failures).
+
+    이 테스트는 결과 값(`failed`)뿐 아니라 fallback 경로를 실제로 거쳤는지
+    (= API 가 호출되었는지) 도 함께 검증한다. 옛 동작은 API 호출 없이 즉시
+    'failed' 를 반환했으므로 mock_client.get 이 호출되지 않았다.
+    Asserts API was actually called (fallback path), not just the result value.
+    Old behavior returned 'failed' without any API call — this distinguishes them.
+    """
+    check_runs_body = {
+        "check_runs": [
+            _check_run("SonarQube", "completed", "failure"),
+        ],
+        "total_count": 1,
+    }
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[_resp(200, check_runs_body)])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
 
     with patch("src.github_client.checks.get_http_client", return_value=mock_client):
         result = await get_ci_status(TOKEN, REPO, SHA, required_contexts=set())
 
     assert result == "failed"
-    # 빈 set은 필수 체크 없음 → API 호출 불필요 / No API call needed for empty required set.
-    mock_client.get.assert_not_called()
+    # fallback 경로 검증 — API 가 실제로 호출되어야 함 (옛 동작은 즉시 반환)
+    # Verify fallback path — API must have been called (old behavior returned immediately).
+    mock_client.get.assert_called()
 
 
 async def test_get_ci_status_ignores_non_required_checks():

--- a/tests/unit/services/test_merge_retry_service.py
+++ b/tests/unit/services/test_merge_retry_service.py
@@ -713,3 +713,37 @@ class TestProcessPendingRetries:
         assert result["released"] == 1
         assert result["abandoned"] == 0
         assert result["skipped"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _get_ci_status_safe — 빈 set fallback 방어층 (engine.py 와 일관)
+# _get_ci_status_safe — empty-set fallback defense layer (consistent with engine)
+# ---------------------------------------------------------------------------
+
+
+async def test_worker_get_ci_status_safe_converts_empty_set_to_none():
+    """워커 측 _get_ci_status_safe 도 빈 set 을 None 으로 변환한다.
+
+    Phase 12 — engine.py::_get_ci_status_safe 와 동일 패턴 적용.
+    BPR Required Status Checks 미설정 시 빈 set 이 반환되는데, 그대로
+    get_ci_status 에 전달하면 호출 측이 'failed' 라 오해할 위험이 있어
+    None 으로 통일 (모든 체크 고려 의미).
+    """
+    from src.services.merge_retry_service import _get_ci_status_safe
+
+    with patch(
+        "src.services.merge_retry_service.get_required_check_contexts",
+        new_callable=AsyncMock,
+    ) as mock_required, patch(
+        "src.services.merge_retry_service.get_ci_status",
+        new_callable=AsyncMock,
+    ) as mock_ci:
+        mock_required.return_value = set()  # 빈 set — BPR 미설정 시나리오
+        mock_ci.return_value = "running"
+
+        result = await _get_ci_status_safe("token", "owner/repo", "sha123")
+
+    assert result == "running"
+    # 핵심 검증 — required_contexts 가 None 으로 전달되어야 함
+    call_kwargs = mock_ci.call_args.kwargs
+    assert call_kwargs.get("required_contexts") is None


### PR DESCRIPTION
## 문제

운영 데이터(SCAManager + 5 외부 Repo, 30일 누적 74건):
- auto-merge 시도 74건 / 성공 0건
- 95.9% (71건) 가 unstable_ci 로 단일 fail 후 종료
- merge_retry_queue 사용 0건 — Phase 12 큐잉이 한 번도 작동 안 함

## 근본 원인 (3-에이전트 병렬 분석)

`src/github_client/checks.py:75-81` 가 `required_contexts=set()` 을 받으면 즉시 `"failed"` 반환. BPR Required Status Checks 미설정 Repo 에서 `get_required_check_contexts` 가 항상 빈 set 을 반환하므로
`should_retry(UNSTABLE_CI, "failed") = False` → 큐잉 스킵.

## 수정 (옵션 1 + 옵션 3 하이브리드)

### 1. checks.py — 근원지 (빈 set → None fallback)
빈 set 을 "필수 체크 없음 = 즉시 failed" 로 해석하던 동작을
"필수 체크 없음 = 모든 체크 고려" 로 의미 변경. BPR 미설정이 일반적이고
사용자 의도(CI 진행 상태로 판단) 와 부합.

### 2. engine.py::_get_ci_status_safe — 방어층
호출 측에서도 빈 set / None 을 None 으로 통일. checks.py fallback 과 이중 안전.

### 3. merge_retry_service.py::_get_ci_status_safe — 워커 일관성 pipeline-reviewer Major M1 반영 — engine 경로와 워커(cron / webhook 트리거) 경로의 동작 일치. 일관성 확보.

## 의미론적 변화

| 입력 | AS-IS | TO-BE |
|------|-------|-------|
| `required_contexts={"sonarcloud"}` | 해당 체크만 평가 | 동일 (영향 없음) | | `required_contexts=set()` (BPR 미설정) | 즉시 "failed" | 모든 체크 평가 | | `required_contexts=None` | 모든 체크 평가 | 동일 |

BPR 설정 Repo 는 영향 없음. BPR 미설정 Repo (현재 6/6) 만 fallback 동작.

## 회귀 검증

- 신규 테스트 4건: checks.py 3건 (모든 통과/실패/running 시나리오) + engine.py 1건 (방어층) + service.py 1건 (워커 일관성)
- 기존 `test_get_ci_status_terminal_when_required_contexts_empty_set` 는 의미 반전 (이름·assertion 갱신)
- make test-isolated: **1718 passed** (이전 1714 → +4)
- pylint 10.00/10 · bandit 0 issue

## 부수 발견 (Tier 3 별도 PR 권장)

- F1: `engine.py:322` "main" 브랜치 하드코딩 (PR base_ref 미사용)
- F2: `webhook/providers/telegram.py::handle_gate_callback` 큐잉 미통합
- F3: `_enqueue_merge_retry` analysis_id/db None 시 silent skip
- F4: 기존 webhook 의 check_suite 이벤트 누락 가능성 (사용자 액션)

## 운영 검증 (머지 후)

PR #91 이 자동 재시도되거나, 다음 PR 부터 큐잉 동작 확인.
머지 24h 내 다음 쿼리로 검증:
```sql
SELECT COUNT(*) FROM merge_retry_queue WHERE created_at >= NOW() - INTERVAL '24 hours';
SELECT success, COUNT(*) FROM merge_attempts
WHERE attempted_at >= NOW() - INTERVAL '24 hours' GROUP BY success;
```

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
