### PR TITLE
chore(log): F3 silent skip warning 격상 + m2 sanitize_for_log 일관 적용

### DIFF
--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -355,9 +355,14 @@ async def _enqueue_merge_retry(  # pylint: disable=too-many-arguments
     Enqueue for merge retry and send Telegram notification on first deferral.
     """
     if analysis_id is None or db is None:
-        logger.info(
-            "PR #%d auto-merge 지연 (analysis_id/db 없음, 재시도 큐 생략)",
+        # F3: warning 격상 — 큐잉 미수행은 정상 동작이 아닌 호출 누락 신호
+        # F3: elevated to warning — missing queue is not normal, indicates caller omission
+        logger.warning(
+            "PR #%d auto-merge 큐잉 생략 (analysis_id=%s, db=%s) — "
+            "레거시 호출 또는 인자 누락. 재시도 추적 불가.",
             pr_number,
+            "set" if analysis_id is not None else "None",
+            "set" if db is not None else "None",
         )
         return
 

--- a/src/github_client/checks.py
+++ b/src/github_client/checks.py
@@ -7,6 +7,7 @@ import time
 
 from src.constants import GITHUB_API
 from src.shared.http_client import get_http_client
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +79,8 @@ async def get_ci_status(
         logger.debug(
             "required_contexts는 빈 set — BPR Required 미설정, 모든 체크 고려 fallback (%s %s)"
             " / required_contexts is empty set — no BPR required checks, falling back to all checks (%s %s)",
-            repo_full_name, commit_sha, repo_full_name, commit_sha,
+            sanitize_for_log(repo_full_name), sanitize_for_log(commit_sha),
+            sanitize_for_log(repo_full_name), sanitize_for_log(commit_sha),
         )
         required_contexts = None
 
@@ -99,8 +101,8 @@ async def get_ci_status(
             logger.warning(
                 "체크런 페이지 %d 초과 — 결과 불확실, 'unknown' 반환 (%s %s)"
                 " / check-run page count exceeded %d — returning 'unknown' (%s %s)",
-                _MAX_PAGES, repo_full_name, commit_sha,
-                _MAX_PAGES, repo_full_name, commit_sha,
+                _MAX_PAGES, sanitize_for_log(repo_full_name), sanitize_for_log(commit_sha),
+                _MAX_PAGES, sanitize_for_log(repo_full_name), sanitize_for_log(commit_sha),
             )
             return "unknown"
 


### PR DESCRIPTION
## F3 — _enqueue_merge_retry silent skip 가시화

`src/gate/engine.py:357-362` — analysis_id/db None 시 info 레벨로 조용히 스킵하던 로직을 warning 으로 격상. 큐잉 미수행은 정상 동작이 아니라
호출 누락 신호이므로 운영 로그에서 즉시 식별되어야 함.

- 로그 메시지에 `analysis_id` 와 `db` 각각이 어느 쪽이 None 인지 명시
- "재시도 추적 불가" 라는 사용자 영향도 함께 기록

## m2 — checks.py 로그에 sanitize_for_log 일관 적용

`src/github_client/checks.py` 의 logger 호출 2곳에 `sanitize_for_log()` 적용 (CLAUDE.md "주의사항/보안" 규약 준수).
- `repo_full_name`, `commit_sha` 는 GitHub 가 검증한 값이라 실질 위험은 낮으나, 로그 인젝션 방어 일관성을 위해 모든 외부 입력 경유.

## 회귀

- 1718 passed (변화 없음)
- pylint 10.00/10
- bandit 0 issue

## 부수 발견 추적

3-에이전트 분석 보고서의 Tier 3 발견 항목 중:
- ✅ F3 silent skip 격상 — 본 PR
- ✅ m2 sanitize_for_log 일관 적용 — 본 PR
- ⏳ F1 main 하드코딩 — 다음 PR
- ⏳ F2 Telegram 큐잉 통합 — 별도 세션 (범위 큼)
- ⏳ F4 Webhook 재등록 — 사용자 액션
- ⏳ m1 broad except 분리 — 다음 PR

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
