### PR TITLE
refactor(checks): m1 — BPR 조회 HTTP 오류 분류 로깅

### DIFF
--- a/src/github_client/checks.py
+++ b/src/github_client/checks.py
@@ -5,8 +5,11 @@ import logging
 import re
 import time
 
+import httpx
+
 from src.constants import GITHUB_API
 from src.shared.http_client import get_http_client
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +180,54 @@ def _legacy_state_to_ci_status(state: str) -> str:
     return "unknown"
 
 
+def _classify_bpr_http_error(
+    exc: httpx.HTTPStatusError,
+    repo_full_name: str,
+    branch: str,
+) -> set[str]:
+    """BPR 조회 HTTP 오류를 코드별로 분류해 로깅하고 빈 set 반환.
+
+    - 404: 정상 — BPR 미설정. debug 로그.
+    - 401/403: 토큰 권한 부족. warning — auto-merge 진단 어려움 신호.
+    - 429: GitHub rate limit. warning — 잠시 후 캐시 만료 시 재시도.
+    - 그 외: 예상치 못한 응답. error.
+
+    Classify BPR-fetch HTTP errors and log accordingly. Always returns empty set
+    so callers proceed with the "no required checks" semantics (which now means
+    "consider all checks" after the empty-set fallback).
+    """
+    code = exc.response.status_code
+    safe_repo = sanitize_for_log(repo_full_name)
+    safe_branch = sanitize_for_log(branch)
+    if code == 404:
+        # 가장 흔한 정상 경로 — BPR 자체가 없거나 Required Status Checks 미설정
+        # Most common normal case — no BPR or no Required Status Checks
+        logger.debug(
+            "BPR 미설정 (404) — 빈 set 반환 (%s/%s)"
+            " / no BPR configured (404) — returning empty set",
+            safe_repo, safe_branch,
+        )
+    elif code in (401, 403):
+        logger.warning(
+            "BPR 조회 권한 부족 (HTTP %d) — 토큰 점검 필요 (%s/%s)"
+            " / BPR fetch unauthorized — token review needed",
+            code, safe_repo, safe_branch,
+        )
+    elif code == 429:
+        logger.warning(
+            "BPR 조회 rate limit (HTTP 429) — 빈 set 반환, 캐시 TTL 후 재조회 (%s/%s)"
+            " / BPR fetch rate-limited — returning empty set",
+            safe_repo, safe_branch,
+        )
+    else:
+        logger.error(
+            "BPR 조회 HTTP 오류 (HTTP %d) — 예상치 못한 응답 (%s/%s)"
+            " / BPR fetch unexpected HTTP status",
+            code, safe_repo, safe_branch,
+        )
+    return set()
+
+
 async def get_required_check_contexts(
     token: str,
     repo_full_name: str,
@@ -212,8 +263,19 @@ async def get_required_check_contexts(
         resp.raise_for_status()
         data = resp.json()
         contexts: set[str] = set(data.get("contexts") or [])
-    except Exception:  # pylint: disable=broad-except
-        # 404 또는 기타 오류: 브랜치 보호 없음 / 404 or other error: no branch protection
+    except httpx.HTTPStatusError as exc:
+        # HTTP 오류 분류 — 운영 진단을 위해 로그 레벨 분리
+        # Classify HTTP error — separate log levels for ops diagnostics
+        contexts = _classify_bpr_http_error(exc, repo_full_name, branch)
+    except httpx.HTTPError as exc:
+        # 네트워크/연결 오류 (DNS, timeout, ConnectError 등)
+        # Network/connection error (DNS, timeout, ConnectError, etc.)
+        logger.warning(
+            "BPR 조회 네트워크 오류 (%s) — 빈 set 반환 (%s/%s)"
+            " / BPR fetch network error — returning empty set",
+            type(exc).__name__,
+            sanitize_for_log(repo_full_name), sanitize_for_log(branch),
+        )
         contexts = set()
 
     # 결과 캐시 저장 / Store result in cache

--- a/tests/unit/github_client/test_checks.py
+++ b/tests/unit/github_client/test_checks.py
@@ -440,20 +440,98 @@ async def test_get_required_check_contexts_returns_contexts():
     assert result == {"CI / test", "CI / lint"}
 
 
-async def test_get_required_check_contexts_returns_empty_on_404():
-    """브랜치 보호가 없으면(404) 빈 set 반환.
-    Returns empty set when branch has no protection rules (404).
+async def test_get_required_check_contexts_returns_empty_on_404(caplog):
+    """브랜치 보호가 없으면(404) 빈 set 반환 + debug 레벨 로그.
+    Returns empty set + debug log when no branch protection (404).
     """
+    import logging
+    import httpx as _httpx
+
     mock_resp = _resp(404, {"message": "Branch not protected"})
-    mock_resp.raise_for_status.side_effect = Exception("404 Not Found")
+    mock_resp.status_code = 404
+    mock_resp.raise_for_status.side_effect = _httpx.HTTPStatusError(
+        "404 Not Found", request=MagicMock(), response=mock_resp,
+    )
 
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=mock_resp)
 
-    with patch("src.github_client.checks.get_http_client", return_value=mock_client):
+    # m1: 404 는 정상 — warning/error 레벨 로그가 없어야 함
+    with patch("src.github_client.checks.get_http_client", return_value=mock_client), \
+         caplog.at_level(logging.WARNING, logger="src.github_client.checks"):
         result = await get_required_check_contexts(TOKEN, REPO, BRANCH)
 
     assert result == set()
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
+
+
+async def test_get_required_check_contexts_returns_empty_on_403_with_warning(caplog):
+    """권한 부족(403) — 빈 set + warning 로그.
+    Permission denied (403) — empty set + warning log.
+    """
+    import logging
+    import httpx as _httpx
+
+    mock_resp = _resp(403, {"message": "Resource not accessible by integration"})
+    mock_resp.status_code = 403
+    mock_resp.raise_for_status.side_effect = _httpx.HTTPStatusError(
+        "403 Forbidden", request=MagicMock(), response=mock_resp,
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+
+    with patch("src.github_client.checks.get_http_client", return_value=mock_client), \
+         caplog.at_level(logging.WARNING, logger="src.github_client.checks"):
+        result = await get_required_check_contexts(TOKEN, REPO, "branch-403")
+
+    assert result == set()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("권한" in r.getMessage() or "unauthorized" in r.getMessage() for r in warnings)
+
+
+async def test_get_required_check_contexts_returns_empty_on_429_with_warning(caplog):
+    """rate limit(429) — 빈 set + warning 로그.
+    Rate limit (429) — empty set + warning log.
+    """
+    import logging
+    import httpx as _httpx
+
+    mock_resp = _resp(429, {"message": "API rate limit exceeded"})
+    mock_resp.status_code = 429
+    mock_resp.raise_for_status.side_effect = _httpx.HTTPStatusError(
+        "429 Too Many Requests", request=MagicMock(), response=mock_resp,
+    )
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+
+    with patch("src.github_client.checks.get_http_client", return_value=mock_client), \
+         caplog.at_level(logging.WARNING, logger="src.github_client.checks"):
+        result = await get_required_check_contexts(TOKEN, REPO, "branch-429")
+
+    assert result == set()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("rate limit" in r.getMessage().lower() for r in warnings)
+
+
+async def test_get_required_check_contexts_returns_empty_on_network_error(caplog):
+    """네트워크 오류(ConnectError 등) — 빈 set + warning 로그.
+    Network error — empty set + warning log.
+    """
+    import logging
+    import httpx as _httpx
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=_httpx.ConnectError("DNS failure"))
+
+    with patch("src.github_client.checks.get_http_client", return_value=mock_client), \
+         caplog.at_level(logging.WARNING, logger="src.github_client.checks"):
+        result = await get_required_check_contexts(TOKEN, REPO, "branch-net")
+
+    assert result == set()
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("네트워크" in r.getMessage() or "network" in r.getMessage() for r in warnings)
 
 
 async def test_get_required_check_contexts_caches_result():


### PR DESCRIPTION
## 변경

`get_required_check_contexts` 의 broad `except Exception` 을 HTTP 코드별로 분류해 운영 진단성을 높임:

- **404**: 정상 (BPR 미설정) → debug 로그
- **401/403**: 토큰 권한 부족 → warning ("토큰 점검 필요")
- **429**: GitHub rate limit → warning (캐시 TTL 후 재조회)
- **기타 HTTP**: 예상치 못한 응답 → error
- **네트워크 (ConnectError 등)**: warning ("네트워크 오류")

모든 경로에서 빈 set 반환 (호출자 동작 변화 없음 — 의미는 fix PR #93 의
"BPR 미설정 = 모든 체크 고려" fallback 적용 후 그대로).

## 추가 사항
- `_classify_bpr_http_error` private helper 분리 (단일 책임)
- `httpx` 명시적 import (이전엔 broad except 로 회피)
- `sanitize_for_log()` 적용 (CLAUDE.md 보안 규약)

## 회귀
- 신규 테스트 3건 (403/429/네트워크), 기존 404 테스트 갱신
- 1721 passed (이전 1718 → +3)
- pylint 10.00/10 · bandit 0 issue

## 운영 효과
- 6 등록 Repo 중 토큰 만료/회수 발생 시 warning 로그로 즉시 발견
- 기존 `Exception` 으로 silenced 되던 진짜 문제 (rate limit, 권한 회수) 가 운영 로그/Sentry 에서 가시화됨

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
