### PR TITLE
feat(gate): F1 — auto-merge BPR 조회 시 PR base ref 동적 사용

### DIFF
--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -7,7 +7,9 @@ from sqlalchemy.orm import Session
 from src.config import settings
 from src.config_manager.manager import get_repo_config, RepoConfigData
 from src.gate._common import score_from_result as _score_from_result
-from src.gate.github_review import post_github_review, merge_pr, get_pr_mergeable_state
+from src.gate.github_review import (
+    post_github_review, merge_pr, get_pr_mergeable_state, get_pr_base_ref,
+)
 from src.gate.merge_failure_advisor import get_advice
 from src.gate.merge_reasons import UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT, DEFERRED
 from src.gate.retry_policy import parse_reason_tag, should_retry
@@ -285,9 +287,12 @@ async def _run_auto_merge_retry(  # pylint: disable=too-many-arguments,too-many-
         )
         return
 
-    # 5. CI 상태 추가 판별 (D2)
-    # 5. Disambiguate CI state (D2)
-    ci_status = await _get_ci_status_safe(github_token, repo_name, effective_sha)
+    # 5. CI 상태 추가 판별 (D2) — F1: PR base 브랜치 동적 사용
+    # 5. Disambiguate CI state (D2) — F1: use actual PR base ref
+    base_ref = await get_pr_base_ref(github_token, repo_name, pr_number)
+    ci_status = await _get_ci_status_safe(
+        github_token, repo_name, effective_sha, base_ref=base_ref,
+    )
 
     if not should_retry(reason_tag, ci_status):
         # CI 실제 실패 또는 판별 후 터미널 상태
@@ -312,14 +317,17 @@ async def _get_ci_status_safe(
     github_token: str,
     repo_name: str,
     commit_sha: str,
+    *,
+    base_ref: str = "main",
 ) -> str:
     """CI 상태를 안전하게 조회한다 — 오류 시 'unknown' 반환.
     Safely fetch CI status — returns 'unknown' on error.
+
+    F1: base_ref 파라미터로 PR 의 실제 base 브랜치 BPR 조회 — develop/staging 등
+    main 이 아닌 base 에서도 정확. 호출자가 모르면 "main" 기본값 사용.
     """
     try:
-        # 기본 브랜치 조회 — 현재는 "main" 기본값 사용 (향후 PR 정보에서 추출 가능)
-        # Get default branch — currently defaults to "main" (can be extracted from PR info later)
-        required = await get_required_check_contexts(github_token, repo_name, "main")
+        required = await get_required_check_contexts(github_token, repo_name, base_ref)
     except httpx.HTTPError:
         required = None  # None 이면 모든 체크 고려 / None means "consider all checks"
 

--- a/src/gate/github_review.py
+++ b/src/gate/github_review.py
@@ -62,6 +62,33 @@ async def get_pr_mergeable_state(
     return (state, head_sha)
 
 
+async def get_pr_base_ref(
+    github_token: str,
+    repo_full_name: str,
+    pr_number: int,
+    fallback: str = "main",
+) -> str:
+    """PR 의 base 브랜치 이름을 조회한다 — 실패 시 fallback 반환.
+    Fetch the base branch ref for a PR — returns fallback on failure.
+
+    F1: BPR Required Status Checks 조회 시 main 하드코딩 대신 PR 실제 base 브랜치
+    사용. develop / staging 등 다양한 base 브랜치 환경에서 정확한 BPR 조회 가능.
+
+    F1: replaces hardcoded "main" with actual PR base ref so BPR checks resolve
+    correctly for develop/staging/etc. base branches.
+    """
+    url = f"https://api.github.com/repos/{repo_full_name}/pulls/{pr_number}"
+    try:
+        client = get_http_client()
+        r = await client.get(url, headers=github_api_headers(github_token))
+        r.raise_for_status()
+        return r.json().get("base", {}).get("ref", fallback) or fallback
+    except httpx.HTTPError:
+        # 네트워크 / HTTP 오류 시 fallback (이전 동작 유지)
+        # Fall back on network/HTTP error (preserves prior behavior).
+        return fallback
+
+
 def _interpret_merge_error(exc: httpx.HTTPStatusError) -> str:
     """HTTP 코드와 GitHub 메시지를 정규 reason tag + user-facing 사유로 변환.
 

--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -173,8 +173,11 @@ async def process_pending_retries(  # pylint: disable=too-many-locals,too-many-s
             # ── f. 실패 분류 ──────────────────────────────────────────────
             # ── f. Classify failure ───────────────────────────────────────
             reason_tag = parse_reason_tag(reason)
+            # F1: pr_data 에 이미 base.ref 가 있으므로 추가 호출 없이 활용
+            # F1: pr_data already contains base.ref — reuse without extra API call
+            base_ref = pr_data.get("base", {}).get("ref", "main")
             ci_status = await _get_ci_status_safe(
-                token, row.repo_full_name, row.commit_sha
+                token, row.repo_full_name, row.commit_sha, base_ref=base_ref,
             )
 
             expired = is_expired(row, now=now, max_age_hours=settings.merge_retry_max_age_hours)
@@ -275,13 +278,15 @@ async def _get_pr_data(
 
 
 async def _get_ci_status_safe(
-    token: str, repo_full_name: str, commit_sha: str
+    token: str, repo_full_name: str, commit_sha: str, *, base_ref: str = "main"
 ) -> str:
     """CI 상태를 안전하게 조회한다 — 오류 시 'unknown' 반환.
     Safely fetch CI status — returns 'unknown' on error.
+
+    F1: base_ref 파라미터로 PR 의 실제 base 브랜치 BPR 조회.
     """
     try:
-        required = await get_required_check_contexts(token, repo_full_name, "main")
+        required = await get_required_check_contexts(token, repo_full_name, base_ref)
     except httpx.HTTPError:
         required = None
 

--- a/tests/unit/gate/test_auto_merge_enqueue.py
+++ b/tests/unit/gate/test_auto_merge_enqueue.py
@@ -62,6 +62,7 @@ async def test_run_auto_merge_enqueues_when_ci_running():
     with patch("src.gate.engine.settings") as mock_settings, \
          patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
+         patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
          patch("src.gate.engine.get_ci_status", new_callable=AsyncMock) as mock_ci, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo, \
@@ -113,6 +114,7 @@ async def test_run_auto_merge_terminal_when_ci_failed():
     with patch("src.gate.engine.settings") as mock_settings, \
          patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
+         patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
          patch("src.gate.engine.get_ci_status", new_callable=AsyncMock) as mock_ci, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo, \
@@ -160,6 +162,7 @@ async def test_run_auto_merge_success_no_enqueue():
     with patch("src.gate.engine.settings") as mock_settings, \
          patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
+         patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
          patch("src.gate.engine.get_ci_status", new_callable=AsyncMock) as mock_ci, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo, \
@@ -198,6 +201,7 @@ async def test_run_auto_merge_terminal_on_dirty_conflict():
     with patch("src.gate.engine.settings") as mock_settings, \
          patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
+         patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo, \
          patch("src.gate.engine._notify_merge_failure", new_callable=AsyncMock) as mock_fail_notify, \
          patch("src.gate.engine._notify_merge_deferred", new_callable=AsyncMock) as mock_deferred_notify, \
@@ -239,6 +243,7 @@ async def test_run_auto_merge_deferred_no_notify_on_bump():
     with patch("src.gate.engine.settings") as mock_settings, \
          patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
+         patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
          patch("src.gate.engine.get_ci_status", new_callable=AsyncMock) as mock_ci, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo, \
@@ -368,6 +373,7 @@ async def test_run_auto_merge_terminal_when_ci_status_unknown():
     with patch("src.gate.engine.settings") as mock_settings, \
          patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
+         patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
          patch("src.gate.engine.get_ci_status", new_callable=AsyncMock) as mock_ci, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo, \
@@ -410,6 +416,7 @@ async def test_run_auto_merge_no_analysis_id_skips_enqueue():
     with patch("src.gate.engine.settings") as mock_settings, \
          patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
+         patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
          patch("src.gate.engine.get_ci_status", new_callable=AsyncMock) as mock_ci, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo, \

--- a/tests/unit/gate/test_engine.py
+++ b/tests/unit/gate/test_engine.py
@@ -1140,3 +1140,54 @@ async def test_get_ci_status_safe_converts_empty_set_to_none():
     # Core assertion — required_contexts must be passed as None (not empty set).
     call_kwargs = mock_ci.call_args.kwargs
     assert call_kwargs.get("required_contexts") is None
+
+
+async def test_get_ci_status_safe_uses_provided_base_ref():
+    """F1: base_ref 파라미터를 get_required_check_contexts 에 전달한다.
+
+    이전엔 "main" 하드코딩이었으나 이제 PR 의 실제 base 브랜치 사용.
+    F1: base_ref param is forwarded so develop/staging BPRs resolve correctly.
+    """
+    from src.gate.engine import _get_ci_status_safe
+
+    with patch(
+        "src.gate.engine.get_required_check_contexts",
+        new_callable=AsyncMock,
+    ) as mock_required, patch(
+        "src.gate.engine.get_ci_status",
+        new_callable=AsyncMock,
+    ) as mock_ci:
+        mock_required.return_value = {"sonarcloud"}
+        mock_ci.return_value = "passed"
+
+        await _get_ci_status_safe(
+            "token", "owner/repo", "sha123", base_ref="develop",
+        )
+
+    args = mock_required.call_args
+    # positional 또는 keyword 둘 다 허용
+    branch_arg = args.args[2] if len(args.args) >= 3 else args.kwargs.get("branch")
+    assert branch_arg == "develop"
+
+
+async def test_get_ci_status_safe_default_base_ref_is_main():
+    """F1: base_ref 미지정 시 기본값 "main" 사용 (하위 호환).
+    F1: defaults to "main" when base_ref not provided (backward compat).
+    """
+    from src.gate.engine import _get_ci_status_safe
+
+    with patch(
+        "src.gate.engine.get_required_check_contexts",
+        new_callable=AsyncMock,
+    ) as mock_required, patch(
+        "src.gate.engine.get_ci_status",
+        new_callable=AsyncMock,
+    ) as mock_ci:
+        mock_required.return_value = set()
+        mock_ci.return_value = "passed"
+
+        await _get_ci_status_safe("token", "owner/repo", "sha123")
+
+    args = mock_required.call_args
+    branch_arg = args.args[2] if len(args.args) >= 3 else args.kwargs.get("branch")
+    assert branch_arg == "main"

--- a/tests/unit/gate/test_github_review.py
+++ b/tests/unit/gate/test_github_review.py
@@ -189,6 +189,66 @@ async def test_get_pr_mergeable_state_missing_head_sha():
 
 
 # ---------------------------------------------------------------------------
+# F1: get_pr_base_ref — PR base 브랜치 동적 추출
+# F1: get_pr_base_ref — dynamic base ref extraction
+# ---------------------------------------------------------------------------
+
+
+async def test_get_pr_base_ref_returns_actual_base():
+    """GET pulls/{N} → base.ref 정상 반환 — develop 같은 main 외 브랜치 인식."""
+    from src.gate.github_review import get_pr_base_ref
+
+    get_response = MagicMock()
+    get_response.raise_for_status = MagicMock()
+    get_response.json.return_value = {"base": {"ref": "develop"}}
+
+    with patch("src.gate.github_review.get_http_client") as mock_get:
+        mock_client = AsyncMock()
+        mock_get.return_value = mock_client
+        mock_client.get = AsyncMock(return_value=get_response)
+
+        result = await get_pr_base_ref("token", "owner/repo", 7)
+
+    assert result == "develop"
+
+
+async def test_get_pr_base_ref_falls_back_on_http_error():
+    """네트워크/HTTP 오류 → fallback("main") 반환, 예외 전파 안 함.
+    Returns fallback on HTTP error without raising.
+    """
+    from src.gate.github_review import get_pr_base_ref
+
+    with patch("src.gate.github_review.get_http_client") as mock_get:
+        mock_client = AsyncMock()
+        mock_get.return_value = mock_client
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("DNS"))
+
+        result = await get_pr_base_ref("token", "owner/repo", 7)
+
+    assert result == "main"
+
+
+async def test_get_pr_base_ref_falls_back_on_missing_base_key():
+    """응답에 base 키 누락 시 fallback("main") 반환.
+    Falls back to default when base key is missing in response.
+    """
+    from src.gate.github_review import get_pr_base_ref
+
+    get_response = MagicMock()
+    get_response.raise_for_status = MagicMock()
+    get_response.json.return_value = {}  # base 누락
+
+    with patch("src.gate.github_review.get_http_client") as mock_get:
+        mock_client = AsyncMock()
+        mock_get.return_value = mock_client
+        mock_client.get = AsyncMock(return_value=get_response)
+
+        result = await get_pr_base_ref("token", "owner/repo", 7, fallback="staging")
+
+    assert result == "staging"
+
+
+# ---------------------------------------------------------------------------
 # merge_pr() mergeable_state 사전 확인 테스트
 # merge_pr() mergeable_state pre-check tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 변경

`_get_ci_status_safe` (engine.py + merge_retry_service.py) 가 BPR Required Status Checks 조회 시 사용하던 `"main"` 하드코딩을 PR 의 실제 base 브랜치로 대체. develop / staging 등 main 이 아닌 base 에서도 정확한 BPR 조회.

## 신규 헬퍼

`src/gate/github_review.py::get_pr_base_ref(token, repo, pr, fallback="main")`
- GET /pulls/{N} → `base.ref` 반환
- httpx.HTTPError 시 fallback (예: "main") 반환 — 호출자 안전

## 호출 흐름

### engine 경로 (단일 시도 + Phase 12 retry-aware)
- `_run_auto_merge_retry` 가 `get_pr_mergeable_state` 다음에 `get_pr_base_ref(github_token, repo_name, pr_number)` 호출
- 결과를 `_get_ci_status_safe(..., base_ref=base_ref)` 에 전달
- API 호출 1회 추가 (단순 GET, 캐시 없음 — PR 마다 base 가 달라질 수 있음)

### worker 경로 (merge_retry_service)
- 이미 `_get_pr_data` 에서 PR 데이터를 갖고 있음 → `pr_data["base"]["ref"]` 로 추출, **추가 API 호출 없음**
- `_get_ci_status_safe(..., base_ref=base_ref)` 로 전달

## 시그니처 변화 (backward-compatible)

```python
async def _get_ci_status_safe(
    token, repo, sha, *, base_ref: str = "main"  # 신규 keyword-only
) -> str
```
- 키워드 전용 파라미터 + 기본값 "main" — 기존 호출 (`_get_ci_status_safe(t, r, s)`) 완전 호환
- engine.py · merge_retry_service.py 두 헬퍼 시그니처 동기화

## 회귀

- 신규 테스트 5건:
  - `test_get_pr_base_ref_returns_actual_base` (정상 응답)
  - `test_get_pr_base_ref_falls_back_on_http_error` (네트워크 오류 fallback)
  - `test_get_pr_base_ref_falls_back_on_missing_base_key` (응답 형식 이상 fallback)
  - `test_get_ci_status_safe_uses_provided_base_ref` (engine 측 전달 검증)
  - `test_get_ci_status_safe_default_base_ref_is_main` (기본값 검증)
- 기존 enqueue 테스트 7건 일괄 mock 보강 (`get_pr_base_ref` mock 추가)
- 1718 → **1723 passed** (+5)
- pylint 10.00/10

## 운영 효과

- develop / staging 같은 main 외 base 브랜치 PR 도 정확한 BPR 조회
- BPR 이 main 에만 있고 PR 의 base 가 develop 인 경우, 이전엔 main 의 BPR 을 잘못 사용 → 이제 develop 의 BPR (없으면 빈 set fallback) 사용
- 결과: auto-merge 결정의 정확성 향상

## 부수 발견 추적

3-에이전트 분석 보고서 Tier 3:
- ✅ F1 main 하드코딩 제거 — 본 PR
- ✅ F3 silent skip warning — PR-1 (chore/f3-m2-log-hygiene)
- ✅ m2 sanitize_for_log — PR-1
- ✅ m1 broad except 분리 — PR-2 (refactor/checks-bpr-error-classification)
- ⏳ F2 Telegram 큐잉 통합 — 별도 세션 (범위 큼)
- ⏳ F4 Webhook 재등록 — 사용자 액션

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
