### PR TITLE
chore(ci): SonarSource scan action v5 → v6 업그레이드

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: SonarCloud scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- `SonarSource/sonarqube-scan-action@v5` → `@v6` 한 줄 교체 (`.github/workflows/ci.yml:72`)
- GitHub 가 v5 에 보안 취약점 + deprecated 경고를 표시 중. CI 런 #184 (PR #95) 가 SonarCloud 단계에서 `exit code 3` 으로 단발성 실패한 사건의 재발 방지 + 경고 해소.

## 배경
| 런# | 커밋 | 결과 |
|-----|------|------|
| #182 | `1af5708` (PR #97) | success |
| **#184** | **`6109e7f` (PR #95)** | **failure (SonarCloud only)** |
| #185 | `1267d25` (PR #96) | success |

pytest · Codecov · 빌드 단계는 모두 통과했고, 실패는 SonarCloud scan 단 한 곳. 동일 워크플로의 직후 런이 통과한 점에서 v5 의 서버측 일시 거부 또는 인증 오류로 추정.

## Test plan
- [ ] CI 워크플로가 v6 로 통과하는지 확인
- [ ] SonarCloud 대시보드에서 정상 분석 확인
- [ ] GitHub Actions 경고 메시지 사라졌는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)