### PR TITLE
fix(loop-guard): Layer 3-b 리미터를 화이트리스트 봇 한정으로

### DIFF
--- a/src/webhook/loop_guard.py
+++ b/src/webhook/loop_guard.py
@@ -38,6 +38,26 @@ def is_bot_sender(data: dict) -> bool:
     return login not in BOT_LOGIN_WHITELIST
 
 
+def is_whitelisted_bot(data: dict) -> bool:
+    """화이트리스트 봇 발신 여부 — sender.type == "Bot" 이고 BOT_LOGIN_WHITELIST 에 포함.
+    Whitelisted bot sender — sender.type == "Bot" AND login is in BOT_LOGIN_WHITELIST.
+
+    Layer 3-b 레이트 리미터를 화이트리스트 봇 한정으로 적용하기 위한 헬퍼.
+    Helper used to scope the Layer 3-b rate limiter to whitelisted bots only.
+    Phase 9 가이드: 사람 발신과 sender 누락은 무한 통과, 비-화이트리스트 봇은
+    이미 Layer 2 (`is_bot_sender`) 에서 차단된다.
+    Per Phase 9: human senders and missing-sender events pass freely; non-whitelisted
+    bots are already blocked at Layer 2 (`is_bot_sender`).
+    """
+    sender = data.get("sender")
+    if not sender:
+        return False
+    if sender.get("type") != "Bot":
+        return False
+    login = sender.get("login", "")
+    return login in BOT_LOGIN_WHITELIST
+
+
 def has_skip_marker(commit_message: str) -> bool:
     """커밋 메시지에 분석 skip 마커가 포함되어 있는지 확인 (대소문자 무시).
     Check whether a commit message contains any analysis skip marker (case-insensitive).

--- a/src/webhook/providers/github.py
+++ b/src/webhook/providers/github.py
@@ -25,7 +25,12 @@ from src.repositories import merge_retry_repo, repository_repo
 from src.services.merge_retry_service import process_pending_retries
 from src.shared.log_safety import sanitize_for_log
 from src.webhook._helpers import get_webhook_secret
-from src.webhook.loop_guard import BotInteractionLimiter, has_skip_marker, is_bot_sender
+from src.webhook.loop_guard import (
+    BotInteractionLimiter,
+    has_skip_marker,
+    is_bot_sender,
+    is_whitelisted_bot,
+)
 from src.webhook.validator import verify_github_signature
 from src.worker.pipeline import run_analysis_pipeline
 
@@ -186,11 +191,18 @@ def _loop_guard_check(data: dict) -> dict | None:
         )
         return {"status": "skipped", "reason": "skip_marker"}
 
-    # 레이어 3-b: 리포별 봇 이벤트 슬라이딩 윈도우 레이트 리밋
-    # Layer 3-b: per-repo sliding-window bot event rate limit
-    if not _bot_limiter.allow(full_name):
+    # 레이어 3-b: 리포별 화이트리스트 봇 이벤트 슬라이딩 윈도우 레이트 리밋
+    # Layer 3-b: per-repo sliding-window rate limit for whitelisted bots only
+    #
+    # 사람 발신과 sender 누락 이벤트는 무한 통과 — Phase 9 loop vector 분석 결과
+    # 사람·OAuth 토큰 기반 자기 액션은 HANDLED_EVENTS (push/pull_request/issues/
+    # check_suite) 를 재트리거하지 않으므로 SHA dedup 만으로 충분.
+    # Human senders and missing-sender events pass freely — Phase 9 loop-vector
+    # analysis showed user/OAuth-token self-actions do not re-trigger HANDLED_EVENTS,
+    # so SHA dedup alone suffices.
+    if is_whitelisted_bot(data) and not _bot_limiter.allow(full_name):
         logger.warning(
-            "loop_guard: bot rate limit exceeded repo=%s",
+            "loop_guard: whitelisted bot rate limit exceeded repo=%s",
             sanitize_for_log(full_name),
         )
         return {"status": "skipped", "reason": "bot_rate_limit"}

--- a/tests/unit/webhook/providers/test_loop_guard_check_policy.py
+++ b/tests/unit/webhook/providers/test_loop_guard_check_policy.py
@@ -1,0 +1,170 @@
+"""_loop_guard_check 정책 변경 — 봇만 rate-limit, 사람은 무제한 통과 (TDD Red).
+
+Tests for _loop_guard_check policy change: Layer 3-b rate limit applies
+only to whitelisted bots (sender.type=="Bot" AND login in BOT_LOGIN_WHITELIST).
+Human senders (sender.type=="User" or missing sender) bypass the rate limit.
+
+Layer 1 (kill-switch), Layer 2 (non-whitelisted bot block), and Layer 3-a
+(skip marker) behavior must remain unchanged.
+"""
+# pylint: disable=redefined-outer-name,import-outside-toplevel
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+# src 임포트 전 환경변수 주입 필수 — Settings()는 import 시점에 인스턴스화됨
+# Inject env vars before importing src — Settings() instantiates at import time
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "")
+
+
+@pytest.fixture(autouse=True)
+def reset_bot_limiter():
+    """모듈 레벨 _bot_limiter 싱글톤을 매 테스트마다 클리어 — 테스트 간 격리.
+    Clear the module-level _bot_limiter singleton between tests for isolation.
+    """
+    from src.webhook.providers import github as gh_module
+    gh_module._bot_limiter._events.clear()
+    yield
+    gh_module._bot_limiter._events.clear()
+
+
+def _make_push_data(
+    *,
+    sender_type: str = "User",
+    sender_login: str = "xzawed",
+    commit_msg: str = "normal commit",
+    repo: str = "xzawed/SCAManager",
+    include_sender: bool = True,
+) -> dict:
+    """push 이벤트 페이로드 헬퍼 — sender 필드 포함/누락 제어 가능.
+    Push event payload helper — controls inclusion/omission of the sender field.
+    """
+    data: dict = {
+        "repository": {"full_name": repo},
+        "head_commit": {"message": commit_msg},
+    }
+    if include_sender:
+        data["sender"] = {"type": sender_type, "login": sender_login}
+    return data
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 4 핵심 시나리오 — 정책 변경 검증 (#1, #4 는 Red 예상)
+# Four core scenarios — policy change verification (#1, #4 expected Red)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_human_sender_passes_without_rate_limit():
+    """사람 발신(User) 100회 push 가 모두 None 을 반환 — 파이프라인 정상 진행.
+    Human sender (User) sending 100 pushes — all return None (pipeline proceeds).
+    """
+    from src.webhook.providers.github import _loop_guard_check
+
+    data = _make_push_data(sender_type="User", sender_login="xzawed")
+    for _ in range(100):
+        result = _loop_guard_check(data)
+        assert result is None, "사람 발신은 rate-limit 대상이 아니어야 한다"
+
+
+def test_whitelisted_bot_blocked_after_limit():
+    """화이트리스트 봇(github-actions)은 시간당 6회 통과 후 7회째에 bot_rate_limit 차단.
+    Whitelisted bot (github-actions) — 6 events pass, 7th returns bot_rate_limit.
+    """
+    from src.webhook.providers.github import _loop_guard_check
+
+    data = _make_push_data(
+        sender_type="Bot",
+        sender_login="github-actions[bot]",
+    )
+    # 처음 6회는 통과 (None) — Layer 2 통과 + Layer 3-b 한도 내
+    # First 6 calls pass (None) — clears Layer 2 + within Layer 3-b cap
+    for i in range(6):
+        result = _loop_guard_check(data)
+        assert result is None, f"화이트리스트 봇 {i+1}회차는 통과해야 한다"
+
+    # 7회째는 차단 — bot_rate_limit
+    # 7th call blocked — bot_rate_limit
+    seventh = _loop_guard_check(data)
+    assert seventh == {"status": "skipped", "reason": "bot_rate_limit"}
+
+
+def test_non_whitelisted_bot_blocked_at_layer2():
+    """비-화이트리스트 봇(renovate)은 첫 호출에서 Layer 2 로 즉시 bot_sender 차단.
+    Non-whitelisted bot (renovate) — blocked immediately by Layer 2 (bot_sender).
+    """
+    from src.webhook.providers.github import _loop_guard_check
+
+    data = _make_push_data(
+        sender_type="Bot",
+        sender_login="renovate[bot]",
+    )
+    result = _loop_guard_check(data)
+    assert result == {"status": "skipped", "reason": "bot_sender"}
+
+
+def test_missing_sender_passes_without_rate_limit():
+    """sender 필드 자체가 없는 페이로드도 사람과 동일하게 무제한 통과.
+    Payload with missing sender field — bypasses rate limit (treated as human).
+    """
+    from src.webhook.providers.github import _loop_guard_check
+
+    data = _make_push_data(include_sender=False)
+    assert "sender" not in data, "sender 필드가 페이로드에 없어야 한다"
+
+    for _ in range(100):
+        result = _loop_guard_check(data)
+        assert result is None, "sender 누락 페이로드는 무제한 통과해야 한다"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 회귀 테스트 — 기존 동작 유지 확인 (#5, #6 Green 예상)
+# Regression tests — verifying existing behavior is preserved (#5, #6 expected Green)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_skip_marker_in_commit_msg_blocks():
+    """사람 발신이라도 commit message 에 [skip-sca] 마커가 있으면 skip_marker 반환.
+    Even human senders are blocked when commit message contains a [skip-sca] marker.
+    """
+    from src.webhook.providers.github import _loop_guard_check
+
+    data = _make_push_data(
+        sender_type="User",
+        sender_login="xzawed",
+        commit_msg="chore: routine update [skip-sca]",
+    )
+    result = _loop_guard_check(data)
+    assert result == {"status": "skipped", "reason": "skip_marker"}
+
+
+def test_kill_switch_disables_everything():
+    """kill-switch 활성화 시 모든 이벤트가 self_analysis_disabled 로 즉시 차단.
+    When kill-switch is enabled, every event is blocked with self_analysis_disabled.
+
+    settings 싱글톤 직접 mutate 대신 모듈 참조를 patch — 테스트 격리 보장.
+    Patch the module-level settings reference instead of mutating the singleton —
+    ensures test isolation when run alongside test_router.py and others.
+    """
+    from src.webhook.providers.github import _loop_guard_check
+
+    # 사람 / 화이트리스트 봇 / 비-화이트리스트 봇 / sender 누락 — 전부 차단
+    # Human / whitelisted bot / non-whitelisted bot / missing sender — all blocked
+    payloads = [
+        _make_push_data(sender_type="User", sender_login="xzawed"),
+        _make_push_data(sender_type="Bot", sender_login="github-actions[bot]"),
+        _make_push_data(sender_type="Bot", sender_login="renovate[bot]"),
+        _make_push_data(include_sender=False),
+    ]
+    with patch("src.webhook.providers.github.settings") as mock_settings:
+        mock_settings.scamanager_self_analysis_disabled = True
+        for data in payloads:
+            result = _loop_guard_check(data)
+            assert result == {"status": "skipped", "reason": "self_analysis_disabled"}


### PR DESCRIPTION
## Summary

PR #98 push 시점에 사람 사용자(xzawed)가 시간당 7회의 정상 활동 (push 4 + PR opened 3) 으로 `BotInteractionLimiter` (한도 6/h) 에 차단되어 SCAManager 분석 자체가 실행되지 않은 사고를 수정. Layer 3-b 레이트 리미터를 **화이트리스트 봇 (`github-actions[bot]`, `dependabot[bot]`) 한정** 으로 좁히고 사람 발신은 무제한 통과시킵니다.

## 의사결정 근거 — 3-에이전트 loop vector 역공학

Chesterton's Fence 원칙으로 limiter 의 진짜 목적을 역추적한 결과:
- SCAManager 의 모든 자기 발신 액션 (PR comment, Review, Issue 생성) 의 webhook 은 `HANDLED_EVENTS` ({push, pull_request, issues, check_suite}) 에 포함되지 않거나 분석 파이프라인을 트리거하지 않음
- 유일한 분석 재트리거 vector 는 `머지 → push 새 SHA` 이며 SHA dedup 으로 차단됨
- 진짜 위험한 시나리오 (n8n 자동 fix PR 봇 체인) 은 이미 Layer 2 + PR prefix 가드로 차단 중
→ **사람 발신 limiter 적용은 over-engineering 이었음**

## 변경 면적

- `src/webhook/loop_guard.py`: `is_whitelisted_bot(data)` 헬퍼 추가
- `src/webhook/providers/github.py`: Layer 3-b 게이트 조건 `is_whitelisted_bot(data) and not _bot_limiter.allow(...)` 로 좁힘
- `tests/unit/webhook/providers/test_loop_guard_check_policy.py`: 6개 정책 테스트 신규 (사람 100회 통과 / 화이트리스트 봇 7회째 차단 / 비-화이트리스트 봇 Layer 2 차단 / sender 누락 통과 / skip marker 회귀 / kill switch 회귀)

## 회귀
- ✅ 단위 테스트 1688 passed / 0 failed (신규 6개 포함)
- ✅ pylint 10.00/10 유지
- ✅ bandit 0 HIGH

## 후속 작업 (별도 PR)
- Tier 3: GitHub native `enablePullRequestAutoMerge` 통합 → `merge_retry_service.py` 폐기 후보
- 장기: GitHub App 마이그레이션 (멀티 테넌트 확장 시점에)

## Test plan
- [ ] CI 통과 확인 (`pytest + Codecov + SonarCloud`)
- [ ] 머지 후 차기 push (이 PR 자체) 가 실제 분석되는지 SCAManager 대시보드 확인
- [ ] Telegram 분석 알림 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)