### PR TITLE
feat(gate): Tier 3 PR-A — GitHub native auto-merge enable + REST 폴백

### DIFF
--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -8,10 +8,11 @@ from src.config import settings
 from src.config_manager.manager import get_repo_config, RepoConfigData
 from src.gate._common import score_from_result as _score_from_result
 from src.gate.github_review import (
-    post_github_review, merge_pr, get_pr_mergeable_state, get_pr_base_ref,
+    post_github_review, get_pr_mergeable_state, get_pr_base_ref,
 )
 from src.gate.merge_failure_advisor import get_advice
 from src.gate.merge_reasons import UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT, DEFERRED
+from src.gate.native_automerge import enable_or_fallback as native_enable_or_fallback
 from src.gate.retry_policy import parse_reason_tag, should_retry
 from src.github_client.checks import get_ci_status, get_required_check_contexts
 from src.notifier.merge_failure_issue import create_merge_failure_issue
@@ -251,9 +252,9 @@ async def _run_auto_merge_retry(  # pylint: disable=too-many-arguments,too-many-
         logger.warning("get_pr_mergeable_state 실패 (pr=%d): %s", pr_number, exc)
         head_sha = ""
 
-    # 2. SHA 원자성 가드와 함께 즉시 머지 시도
-    # 2. Try merge immediately with SHA atomicity guard
-    ok, reason, observed_sha = await merge_pr(
+    # 2. Native auto-merge enable 시도 — 실패 시 REST merge_pr 폴백 (Tier 3 PR-A)
+    # 2. Try native auto-merge enable; fall back to REST merge_pr on failure (Tier 3 PR-A)
+    ok, reason, observed_sha = await native_enable_or_fallback(
         github_token, repo_name, pr_number, expected_sha=head_sha or None
     )
 
@@ -430,7 +431,11 @@ async def _run_auto_merge_legacy(  # pylint: disable=too-many-arguments
     _run_auto_merge delegates here when merge_retry_enabled=False.
     """
     try:
-        ok, reason, _head_sha = await merge_pr(github_token, repo_name, pr_number)
+        # Tier 3 PR-A: native auto-merge 우선 시도, 실패 시 REST merge_pr 폴백
+        # Tier 3 PR-A: try native auto-merge first, fall back to REST merge_pr on failure
+        ok, reason, _head_sha = await native_enable_or_fallback(
+            github_token, repo_name, pr_number,
+        )
 
         # Phase F.1: 모든 시도 DB 기록 — 관측 실패가 파이프라인을 중단시키지 않도록
         # Phase F.1: Record every attempt in DB — observability failures must not interrupt the pipeline.

--- a/src/gate/merge_failure_advisor.py
+++ b/src/gate/merge_failure_advisor.py
@@ -1,5 +1,11 @@
-"""Auto-merge 실패 사유별 권장 조치 텍스트 — Phase F.3."""
+"""Auto-merge 실패 사유별 권장 조치 텍스트 — Phase F.3 + Tier 3 PR-A."""
 from src.gate import merge_reasons
+from src.github_client.graphql import (
+    ENABLE_API_ERROR,
+    ENABLE_DISABLED_IN_REPO,
+    ENABLE_FORCE_PUSHED,
+    ENABLE_PERMISSION_DENIED,
+)
 
 _ADVICE: dict[str, str] = {
     merge_reasons.BRANCH_PROTECTION_BLOCKED: (
@@ -34,6 +40,24 @@ _ADVICE: dict[str, str] = {
     ),
     merge_reasons.NETWORK_ERROR: (
         "GitHub API 네트워크 오류 — 일시적 문제일 수 있습니다. PR 페이지에서 직접 Merge를 시도하세요."
+    ),
+    # Tier 3 PR-A — native auto-merge enable 단계 분류 사유
+    # Tier 3 PR-A — classifications from the native auto-merge enable stage
+    ENABLE_DISABLED_IN_REPO: (
+        "리포 Settings → General → 'Allow auto-merge' 토글이 OFF 입니다. "
+        "GitHub 리포 설정에서 활성화하면 다음 PR 부터 native auto-merge 가 동작합니다."
+    ),
+    ENABLE_PERMISSION_DENIED: (
+        "GitHub 토큰에 GraphQL `enablePullRequestAutoMerge` 권한이 없습니다. "
+        "OAuth 사용자 토큰의 `repo` 스코프 또는 GitHub App `pull_requests: write` 권한을 확인하세요."
+    ),
+    ENABLE_FORCE_PUSHED: (
+        "PR head SHA 가 enable 시점과 달라 force-push 가 감지됐습니다. "
+        "새 SHA 도착 시 자동 재분석 + 재시도가 수행됩니다 (사용자 액션 불필요)."
+    ),
+    ENABLE_API_ERROR: (
+        "GitHub GraphQL API 에러로 native auto-merge 활성화 실패. "
+        "PR 페이지에서 직접 'Enable auto-merge' 버튼을 눌러 시도하거나 잠시 후 재시도하세요."
     ),
 }
 

--- a/src/gate/native_automerge.py
+++ b/src/gate/native_automerge.py
@@ -1,0 +1,149 @@
+"""Native Auto-Merge orchestration — Tier 3 PR-A.
+Native Auto-Merge orchestration — Tier 3 PR-A.
+
+GitHub `enablePullRequestAutoMerge` 를 우선 시도하고, 활성화 불가 / 권한 부족 /
+강제 푸시 등의 상황에서는 기존 `merge_pr()` 동기 머지로 폴백한다.
+
+Try GitHub `enablePullRequestAutoMerge` first; on conditions like
+auto-merge-disabled-in-repo, permission denied, or force-push, fall back to
+the existing synchronous `merge_pr()`.
+
+설계 의도 (Tier 3 PR-A):
+  - PR-A 단계는 폴백 + Issue 생성 양쪽 유지 — 기존 동작과 호환 (gentle migration)
+  - PR-B 에서 1주일 검증 후 폴백 제거 + `merge_retry_service` 폐기 평가
+  - **MergeAttempt 로깅은 호출자(engine.py) 책임** — 본 모듈은 결과 튜플만 반환,
+    `merge_pr()` 와 동일한 시그니처/의미. 호출자가 ok/reason 으로 분기 + 로깅.
+
+Design intent (Tier 3 PR-A):
+  - PR-A keeps both fallback and issue creation — backward-compatible (gentle migration).
+  - PR-B will reassess once dogfooded for a week (drop fallback + retire merge_retry_service).
+  - MergeAttempt logging is the caller's (engine.py) responsibility — this module just
+    returns the result tuple with the same signature/semantics as `merge_pr()`. The caller
+    branches on ok/reason and performs logging.
+"""
+from __future__ import annotations
+
+import logging
+
+import httpx
+
+from src.gate.github_review import (
+    get_pr_mergeable_state,
+    merge_pr,
+)
+from src.github_client.graphql import (
+    ENABLE_DISABLED_IN_REPO,
+    ENABLE_FORCE_PUSHED,
+    ENABLE_OK,
+    ENABLE_PERMISSION_DENIED,
+    enable_pull_request_auto_merge,
+    get_pr_node_id,
+)
+
+logger = logging.getLogger(__name__)
+
+# 폴백을 시도해야 하는 enable 실패 status 집합
+# Set of enable failure statuses where fallback to merge_pr() makes sense
+# - ENABLE_DISABLED_IN_REPO: 리포 settings 에 "Allow auto-merge" 미설정 — 직접 머지 시도
+# - ENABLE_PERMISSION_DENIED: GraphQL mutation 권한 없음 — REST 권한은 있을 수 있어 시도
+# - ENABLE_DISABLED_IN_REPO: repo settings has "Allow auto-merge" off — try direct merge
+# - ENABLE_PERMISSION_DENIED: no GraphQL permission — REST might still work
+_FALLBACK_STATUSES = frozenset({ENABLE_DISABLED_IN_REPO, ENABLE_PERMISSION_DENIED})
+
+# 폴백 없이 즉시 실패 처리해야 하는 status
+# Statuses that should be treated as immediate failure without fallback
+# - ENABLE_FORCE_PUSHED: head SHA 가 이미 변경됨 — REST 머지도 stale 상태로 실패
+# - ENABLE_FORCE_PUSHED: head SHA already changed — REST merge would also fail stale
+_NO_FALLBACK_STATUSES = frozenset({ENABLE_FORCE_PUSHED})
+
+
+async def enable_or_fallback(
+    github_token: str,
+    repo_full_name: str,
+    pr_number: int,
+    *,
+    expected_sha: str | None = None,
+    merge_method: str = "SQUASH",
+) -> tuple[bool, str | None, str]:
+    """Native auto-merge enable 시도 후 필요 시 폴백.
+    Try native auto-merge enable, falling back when appropriate.
+
+    `merge_pr()` 와 동일한 시그니처/반환 형식 — 호출자(engine.py)가 그대로 교체 가능.
+    Same signature/return shape as `merge_pr()` so the caller can drop-in replace.
+
+    Args:
+        expected_sha: PR head SHA — 호출자가 이미 조회했다면 전달해 중복 GET 회피.
+                      None 이면 본 함수가 직접 조회.
+                      Pass to skip duplicate GET when caller already fetched it.
+
+    Returns:
+        (True, None, head_sha) — enable 성공 (GitHub 가 머지 책임 인수)
+                                 또는 폴백 머지 즉시 성공
+        (False, reason, head_sha) — enable 실패 + 폴백도 실패 / 폴백 미시도
+        Caller should branch on ok and inspect reason for failure tag.
+
+    참고: enable 성공 시 GitHub 가 비동기로 머지를 수행 — 실제 머지 commit 발생은
+    `pull_request.closed merged=true` webhook 으로 별도 추적해야 한다 (PR-B 범위).
+    Note: on enable success, GitHub will merge asynchronously; the actual merge
+    commit must be tracked via the `pull_request.closed merged=true` webhook (PR-B).
+    """
+    # 1. PR head SHA — 호출자가 전달했으면 재사용, 아니면 조회
+    # 1. PR head SHA — reuse if caller passed, otherwise fetch
+    head_sha = expected_sha or ""
+    if not head_sha:
+        try:
+            _state, head_sha = await get_pr_mergeable_state(
+                github_token, repo_full_name, pr_number,
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("get_pr_mergeable_state 실패 (pr=%d): %s", pr_number, exc)
+
+    # 2. PR node_id 조회 — GraphQL mutation 의 첫 번째 인자
+    # 2. Fetch PR node_id — first argument of the GraphQL mutation
+    pr_node_id = await get_pr_node_id(github_token, repo_full_name, pr_number)
+    if pr_node_id is None:
+        # node_id 조회 실패 — GraphQL 시도 자체 불가, 즉시 폴백
+        # node_id lookup failed — can't try GraphQL, fall back immediately
+        logger.warning(
+            "PR node_id 조회 실패, REST merge_pr 폴백 (repo=%s, pr=%d)",
+            repo_full_name, pr_number,
+        )
+        return await merge_pr(
+            github_token, repo_full_name, pr_number,
+            expected_sha=head_sha or None,
+        )
+
+    # 3. enablePullRequestAutoMerge 시도
+    # 3. Try enablePullRequestAutoMerge
+    result = await enable_pull_request_auto_merge(
+        github_token,
+        pr_node_id,
+        expected_head_oid=head_sha or None,
+        merge_method=merge_method,
+    )
+
+    # 4. 성공 — GitHub 가 머지 책임 인수
+    # 4. Success — GitHub now owns the merge
+    if result.status == ENABLE_OK:
+        logger.info(
+            "PR #%d native auto-merge enabled: %s (head=%s)",
+            pr_number, repo_full_name, head_sha[:7] if head_sha else "?",
+        )
+        return (True, None, head_sha)
+
+    # 5. 폴백 부적합 (force-push 등) — 즉시 실패 보고
+    # 5. Not fallback-eligible (force-push etc.) — return failure immediately
+    if result.status in _NO_FALLBACK_STATUSES:
+        reason = f"{result.status}: {result.detail or ''}".rstrip(": ")
+        return (False, reason, head_sha)
+
+    # 6. 폴백 시도 — _FALLBACK_STATUSES 또는 분류 외 status 모두 폴백
+    # 6. Try fallback — both _FALLBACK_STATUSES and unclassified statuses fall back
+    logger.info(
+        "PR #%d native enable=%s 폴백 (REST merge_pr): %s",
+        pr_number, result.status, result.detail or "-",
+    )
+    return await merge_pr(
+        github_token, repo_full_name, pr_number,
+        expected_sha=head_sha or None,
+    )

--- a/src/github_client/graphql.py
+++ b/src/github_client/graphql.py
@@ -1,0 +1,236 @@
+"""GitHub GraphQL API 클라이언트 — Phase Tier-3 native auto-merge 진입점.
+GitHub GraphQL API client — entry point for Phase Tier-3 native auto-merge.
+
+Tier 3 의 핵심 — `enablePullRequestAutoMerge` mutation 으로 GitHub 가
+머지 대기/CI 통과 후 자동 머지 책임을 가져간다. REST `PUT /merge` 와
+달리 활성화만 하고 실제 머지는 GitHub 가 비동기로 처리.
+
+Tier 3 core — `enablePullRequestAutoMerge` mutation lets GitHub take
+ownership of waiting for required checks and merging when ready,
+unlike REST `PUT /merge` which is synchronous.
+
+공개 API:
+  - graphql_request(token, query, variables) — generic POST 래퍼
+  - get_pr_node_id(token, repo_full_name, pr_number) — REST 로 node_id 조회
+    (full GraphQL query 보다 비용 저렴)
+  - enable_pull_request_auto_merge(token, pr_node_id, ...) — mutation 호출
+    + 422 분류된 EnableAutoMergeResult 반환
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from src.github_client.helpers import github_api_headers
+from src.shared.http_client import get_http_client
+
+logger = logging.getLogger(__name__)
+
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+
+# GraphQL 응답에서 분류 가능한 결과 코드
+# Result codes for classifying GraphQL responses
+ENABLE_OK = "ok"
+ENABLE_DISABLED_IN_REPO = "auto_merge_disabled_in_repo_settings"
+ENABLE_FORCE_PUSHED = "force_pushed"
+ENABLE_API_ERROR = "enable_api_error"
+ENABLE_PERMISSION_DENIED = "enable_permission_denied"
+
+
+@dataclass(frozen=True)
+class EnableAutoMergeResult:
+    """enable_pull_request_auto_merge 결과 — 분류된 status + 원문 메시지.
+    Result of enable_pull_request_auto_merge — classified status + raw message.
+    """
+
+    status: str
+    """ENABLE_* 상수 중 하나 — 분기 판별용 정규 태그.
+    One of ENABLE_* constants — canonical tag for branching.
+    """
+
+    detail: str | None = None
+    """GitHub 측 원문 메시지 (운영 디버깅용). 성공 시 None.
+    Raw GitHub message for ops debugging. None on success.
+    """
+
+    @property
+    def ok(self) -> bool:
+        """Convenience helper — status == ENABLE_OK."""
+        return self.status == ENABLE_OK
+
+
+async def graphql_request(
+    token: str,
+    query: str,
+    variables: dict | None = None,
+) -> dict[str, Any]:
+    """GitHub GraphQL POST — 응답 JSON 반환.
+    POST a GraphQL query to GitHub — return parsed JSON.
+
+    HTTPStatusError 는 호출자에게 전파. GraphQL-level errors 는 응답 dict 의
+    "errors" 키에 포함되므로 호출자가 검사해야 한다.
+    HTTPStatusError propagates to the caller. GraphQL-level errors are present
+    under the "errors" key of the response and must be inspected by the caller.
+    """
+    payload: dict[str, Any] = {"query": query}
+    if variables:
+        payload["variables"] = variables
+
+    client = get_http_client()  # 싱글톤 / singleton
+    r = await client.post(
+        GITHUB_GRAPHQL_URL,
+        json=payload,
+        headers=github_api_headers(token),
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+async def get_pr_node_id(
+    token: str,
+    repo_full_name: str,
+    pr_number: int,
+) -> str | None:
+    """PR 의 GraphQL node_id 조회 — REST 경로 사용 (GraphQL 보다 저렴).
+    Fetch the PR's GraphQL node_id via REST (cheaper than a GraphQL round-trip).
+
+    실패 시 None 반환 (호출자가 분기 처리).
+    Returns None on failure (caller handles fallback).
+    """
+    url = f"https://api.github.com/repos/{repo_full_name}/pulls/{pr_number}"
+    try:
+        client = get_http_client()
+        r = await client.get(url, headers=github_api_headers(token))
+        r.raise_for_status()
+        return r.json().get("node_id")
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "get_pr_node_id 실패 (repo=%s, pr=%d): %s",
+            repo_full_name, pr_number, exc,
+        )
+        return None
+
+
+# enable_pull_request_auto_merge GraphQL mutation
+# expectedHeadOid 로 force-push 보호 (REST `PUT /merge` 의 sha 파라미터와 동일 의미)
+# expectedHeadOid guards against force-push (same semantics as REST `PUT /merge` sha param)
+_ENABLE_AUTO_MERGE_MUTATION = """
+mutation EnableAutoMerge(
+  $pullRequestId: ID!,
+  $mergeMethod: PullRequestMergeMethod!,
+  $expectedHeadOid: GitObjectID
+) {
+  enablePullRequestAutoMerge(input: {
+    pullRequestId: $pullRequestId,
+    mergeMethod: $mergeMethod,
+    expectedHeadOid: $expectedHeadOid
+  }) {
+    pullRequest {
+      number
+      autoMergeRequest {
+        enabledAt
+        mergeMethod
+      }
+    }
+  }
+}
+"""
+
+
+def _classify_graphql_errors(errors: list[dict]) -> EnableAutoMergeResult:
+    """GraphQL errors 배열을 EnableAutoMergeResult 로 분류.
+    Classify GraphQL errors array into an EnableAutoMergeResult.
+
+    GitHub 의 errors[].type / message 패턴을 기반으로 ENABLE_* 태그 결정.
+    Based on GitHub's errors[].type / message patterns to choose ENABLE_* tag.
+    """
+    # 첫 번째 에러만 검사 — GitHub 은 보통 단일 에러만 반환
+    # Inspect only the first error — GitHub typically returns a single error
+    err = errors[0] if errors else {}
+    err_type = (err.get("type") or "").upper()
+    err_msg = err.get("message") or ""
+    msg_lower = err_msg.lower()
+
+    # "Auto merge is not allowed for this repository"
+    if "auto merge is not allowed" in msg_lower or "auto-merge is not allowed" in msg_lower:
+        return EnableAutoMergeResult(ENABLE_DISABLED_IN_REPO, err_msg)
+
+    # "Head sha didn't match" — force-push 발생
+    # "Head sha didn't match" — force-push detected
+    if "head sha" in msg_lower and "match" in msg_lower:
+        return EnableAutoMergeResult(ENABLE_FORCE_PUSHED, err_msg)
+
+    # FORBIDDEN — 권한 부족
+    # FORBIDDEN — insufficient permissions
+    if err_type == "FORBIDDEN":
+        return EnableAutoMergeResult(ENABLE_PERMISSION_DENIED, err_msg)
+
+    # 기타 — generic enable_api_error 로 묶음
+    # Other — bucket as generic enable_api_error
+    return EnableAutoMergeResult(ENABLE_API_ERROR, err_msg or err_type or None)
+
+
+async def enable_pull_request_auto_merge(
+    token: str,
+    pr_node_id: str,
+    *,
+    expected_head_oid: str | None = None,
+    merge_method: str = "SQUASH",
+) -> EnableAutoMergeResult:
+    """`enablePullRequestAutoMerge` mutation 호출 + 에러 분류.
+    Call `enablePullRequestAutoMerge` mutation and classify errors.
+
+    Args:
+        token: GitHub token (OAuth User Token 또는 App installation token)
+        pr_node_id: PR 의 GraphQL node_id (`get_pr_node_id` 로 사전 조회)
+        expected_head_oid: PR head SHA — 지정 시 force-push 방지
+        merge_method: SQUASH/MERGE/REBASE — 기본 SQUASH (Tier 3 결정 #1)
+
+    Returns:
+        EnableAutoMergeResult — status 가 ENABLE_OK 이면 GitHub 가 머지 책임 인수.
+        그 외 status 는 호출자가 분기 처리 (폴백 또는 Issue 생성).
+
+        EnableAutoMergeResult — when status is ENABLE_OK, GitHub now owns the
+        merge. Other statuses must be branched by the caller (fallback / issue).
+    """
+    variables: dict[str, Any] = {
+        "pullRequestId": pr_node_id,
+        "mergeMethod": merge_method,
+    }
+    if expected_head_oid:
+        variables["expectedHeadOid"] = expected_head_oid
+
+    try:
+        response = await graphql_request(token, _ENABLE_AUTO_MERGE_MUTATION, variables)
+    except httpx.HTTPStatusError as exc:
+        # HTTP-level 오류 — 401/403/5xx 등
+        # HTTP-level error — 401/403/5xx etc.
+        if exc.response.status_code in (401, 403):
+            return EnableAutoMergeResult(
+                ENABLE_PERMISSION_DENIED,
+                f"HTTP {exc.response.status_code}",
+            )
+        return EnableAutoMergeResult(
+            ENABLE_API_ERROR,
+            f"HTTP {exc.response.status_code}: {exc}",
+        )
+    except httpx.HTTPError as exc:
+        return EnableAutoMergeResult(ENABLE_API_ERROR, f"network: {exc}")
+
+    # GraphQL-level errors
+    if response.get("errors"):
+        return _classify_graphql_errors(response["errors"])
+
+    # 성공 — data.enablePullRequestAutoMerge 가 존재해야 함
+    # Success — data.enablePullRequestAutoMerge must exist
+    data = (response.get("data") or {}).get("enablePullRequestAutoMerge")
+    if data is None:
+        return EnableAutoMergeResult(
+            ENABLE_API_ERROR,
+            "missing enablePullRequestAutoMerge in response",
+        )
+
+    return EnableAutoMergeResult(ENABLE_OK)

--- a/tests/unit/gate/test_auto_merge_enqueue.py
+++ b/tests/unit/gate/test_auto_merge_enqueue.py
@@ -60,7 +60,7 @@ async def test_run_auto_merge_enqueues_when_ci_running():
     enqueue_result = _make_enqueue_result(is_first_deferral=True)
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -112,7 +112,7 @@ async def test_run_auto_merge_terminal_when_ci_failed():
     config = _config()
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -160,7 +160,7 @@ async def test_run_auto_merge_success_no_enqueue():
     config = _config()
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -199,7 +199,7 @@ async def test_run_auto_merge_terminal_on_dirty_conflict():
     config = _config()
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo, \
@@ -241,7 +241,7 @@ async def test_run_auto_merge_deferred_no_notify_on_bump():
     enqueue_result = _make_enqueue_result(is_first_deferral=False)
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -285,7 +285,7 @@ async def test_run_auto_merge_skips_when_score_below_threshold():
     config = _config(auto_merge=True, merge_threshold=75)
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo:
 
         mock_settings.merge_retry_enabled = True
@@ -312,7 +312,7 @@ async def test_run_auto_merge_skips_when_auto_merge_disabled():
     config = _config(auto_merge=False, merge_threshold=75)
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo:
 
         mock_settings.merge_retry_enabled = True
@@ -371,7 +371,7 @@ async def test_run_auto_merge_terminal_when_ci_status_unknown():
     config = _config()
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -414,7 +414,7 @@ async def test_run_auto_merge_no_analysis_id_skips_enqueue():
     config = _config()
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \

--- a/tests/unit/gate/test_engine.py
+++ b/tests/unit/gate/test_engine.py
@@ -60,7 +60,7 @@ async def test_review_comment_on_calls_post_pr_comment():
     with patch("src.gate.engine.get_repo_config", return_value=config):
         with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock) as mock_comment:
             with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
-                with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                     with patch("src.gate.engine.send_gate_request", new_callable=AsyncMock):
                         with patch("src.gate.engine.save_gate_decision"):
                             await run_gate_check(
@@ -104,7 +104,7 @@ async def test_auto_approve_high_score():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
             with patch("src.gate.engine.save_gate_decision"):
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -128,7 +128,7 @@ async def test_auto_reject_low_score():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
             with patch("src.gate.engine.save_gate_decision"):
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -151,7 +151,7 @@ async def test_auto_skip_middle_score():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
             with patch("src.gate.engine.save_gate_decision"):
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -228,7 +228,7 @@ async def test_auto_merge_independent_of_approve_mode():
         pr_review_comment=False,
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                     with patch("src.gate.engine.save_gate_decision"):
@@ -257,7 +257,7 @@ async def test_auto_merge_with_auto_approve():
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
-            with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+            with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
                 with patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state:
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                         with patch("src.gate.engine.save_gate_decision"):
@@ -285,7 +285,7 @@ async def test_auto_merge_below_threshold():
         pr_review_comment=False,
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                 with patch("src.gate.engine.save_gate_decision"):
                     await run_gate_check(
@@ -311,7 +311,7 @@ async def test_auto_merge_false_no_merge():
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
-            with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+            with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                     with patch("src.gate.engine.save_gate_decision"):
                         await run_gate_check(
@@ -343,7 +343,7 @@ async def test_push_event_no_gate_actions():
     with patch("src.gate.engine.get_repo_config", return_value=config):
         with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock) as mock_comment:
             with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
-                with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+                with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
                     with patch("src.gate.engine.send_gate_request", new_callable=AsyncMock) as mock_send:
                         with patch("src.gate.engine.save_gate_decision"):
                             await run_gate_check(
@@ -373,7 +373,7 @@ async def testsave_gate_decision_called_on_approve():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
             with patch("src.gate.engine.save_gate_decision") as mock_save:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -393,7 +393,7 @@ async def testsave_gate_decision_called_on_reject():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
             with patch("src.gate.engine.save_gate_decision") as mock_save:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -413,7 +413,7 @@ async def testsave_gate_decision_skip_on_middle_score():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
             with patch("src.gate.engine.save_gate_decision") as mock_save:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -439,7 +439,7 @@ async def test_merge_pr_failure_does_not_raise():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
             with patch("src.gate.engine.save_gate_decision") as mock_save:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
                         with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock):
                             mock_merge.return_value = (False, "forbidden: no permission", "abc123")
                             # 예외 없이 완료되어야 한다
@@ -469,7 +469,7 @@ async def test_post_pr_comment_exception_does_not_abort_gate():
         with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock, side_effect=httpx.ConnectError("comment failed")):
             with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
                 with patch("src.gate.engine.save_gate_decision"):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
                             result={"score": 80, "grade": "B"}, github_token="tok", db=mock_db,
@@ -485,7 +485,7 @@ async def test_post_github_review_exception_does_not_crash():
     with patch("src.gate.engine.get_repo_config", return_value=config):
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock, side_effect=httpx.ConnectError("GitHub API error")):
             with patch("src.gate.engine.save_gate_decision"):
-                with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                         # 예외 없이 완료되어야 한다
                         # Must complete without raising an exception.
@@ -500,7 +500,7 @@ async def test_merge_pr_exception_does_not_crash():
     mock_db = MagicMock()
     config = _config(approve_mode="disabled", auto_merge=True, merge_threshold=75, pr_review_comment=False)
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock, side_effect=httpx.ConnectError("merge error")):
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock, side_effect=httpx.ConnectError("merge error")):
             with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                 with patch("src.gate.engine.save_gate_decision"):
                     await run_gate_check(
@@ -623,7 +623,7 @@ async def test_approve_at_exact_threshold():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
             with patch("src.gate.engine.save_gate_decision"):
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
                             result={"score": 75}, github_token="tok", db=mock_db,
@@ -641,7 +641,7 @@ async def test_reject_threshold_boundary_is_excluded():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
             with patch("src.gate.engine.save_gate_decision") as mock_save:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
                             result={"score": 50}, github_token="tok", db=mock_db,
@@ -655,7 +655,7 @@ async def test_merge_at_exact_threshold():
     mock_db = MagicMock()
     config = _config(approve_mode="disabled", auto_merge=True, merge_threshold=75, pr_review_comment=False)
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                     with patch("src.gate.engine.save_gate_decision"):
@@ -681,7 +681,7 @@ async def test_post_pr_comment_keyerror_does_not_abort_gate():
                    side_effect=KeyError("missing_field")):
             with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
                 with patch("src.gate.engine.save_gate_decision"):
-                    with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
                             result={"score": 80}, github_token="tok", db=mock_db,
@@ -697,7 +697,7 @@ async def test_post_github_review_keyerror_does_not_crash():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock,
                    side_effect=KeyError("pr_number")):
             with patch("src.gate.engine.save_gate_decision"):
-                with patch("src.gate.engine.merge_pr", new_callable=AsyncMock):
+                with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
@@ -720,7 +720,7 @@ async def test_auto_merge_success_no_telegram():
         notify_chat_id="-100123",
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock) as mock_tg:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                     with patch("src.gate.engine.save_gate_decision"):
@@ -749,7 +749,7 @@ async def test_auto_merge_failure_sends_telegram():
         notify_chat_id="-100123",
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock) as mock_tg:
                 with patch("src.gate.engine.settings") as mock_settings:
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
@@ -792,7 +792,7 @@ async def test_auto_merge_failure_no_chat_id_only_logs():
         notify_chat_id=None,  # repo 전용 chat_id 없음
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock) as mock_tg:
                 with patch("src.gate.engine.settings") as mock_settings:
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
@@ -823,7 +823,7 @@ async def test_auto_merge_failure_global_fallback_chat_id():
         notify_chat_id=None,  # repo 전용 chat_id 없음
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock) as mock_tg:
                 with patch("src.gate.engine.settings") as mock_settings:
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
@@ -937,7 +937,7 @@ async def test_run_auto_merge_records_successful_merge_attempt():
         notify_chat_id="-100123",
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state:
                 with patch("src.gate.engine.log_merge_attempt") as mock_log:
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
@@ -978,7 +978,7 @@ async def test_run_auto_merge_records_failed_merge_attempt_with_reason_tag():
     )
     full_reason = "branch_protection_blocked: 머지 조건 미충족 (state=blocked)"
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state:
                 with patch("src.gate.engine.log_merge_attempt") as mock_log:
                     with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock):
@@ -1013,7 +1013,7 @@ async def test_run_auto_merge_log_merge_attempt_db_failure_does_not_block_notifi
         notify_chat_id="-100123",
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.log_merge_attempt", side_effect=RuntimeError("DB down")):
                 with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock) as mock_tg:
                     with patch("src.gate.engine.settings") as mock_settings:
@@ -1053,7 +1053,7 @@ async def test_run_auto_merge_creates_issue_when_enabled():
         notify_chat_id=None,
     )
     with (
-        patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge,
+        patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge,
         patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state,
         patch("src.gate.engine.create_merge_failure_issue", new_callable=AsyncMock) as mock_issue,
         patch("src.gate.engine.log_merge_attempt"),
@@ -1077,7 +1077,7 @@ async def test_run_auto_merge_skips_issue_when_disabled():
         notify_chat_id=None,
     )
     with (
-        patch("src.gate.engine.merge_pr", new_callable=AsyncMock) as mock_merge,
+        patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge,
         patch("src.gate.engine.create_merge_failure_issue", new_callable=AsyncMock) as mock_issue,
         patch("src.gate.engine.log_merge_attempt"),
         patch("src.gate.engine._notify_merge_failure", new_callable=AsyncMock),

--- a/tests/unit/gate/test_native_automerge.py
+++ b/tests/unit/gate/test_native_automerge.py
@@ -1,0 +1,275 @@
+"""Native Auto-Merge orchestration 단위 테스트 — Tier 3 PR-A.
+Native Auto-Merge orchestration unit tests — Tier 3 PR-A.
+
+테스트 대상 — `src.gate.native_automerge.enable_or_fallback`
+  - enable 성공 / 폴백 / 즉시 실패 분기 (6 가지 status 경로)
+  - expected_sha 전달 여부에 따른 get_pr_mergeable_state 호출 제어
+  - merge_pr 폴백 결과 그대로 반환 검증
+"""
+import os
+
+# 환경변수는 src 임포트 전 주입 필수
+# Env vars must be injected before any src import
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-key")
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+
+from src.gate.native_automerge import enable_or_fallback
+from src.github_client.graphql import (
+    ENABLE_API_ERROR,
+    ENABLE_DISABLED_IN_REPO,
+    ENABLE_FORCE_PUSHED,
+    ENABLE_OK,
+    ENABLE_PERMISSION_DENIED,
+    EnableAutoMergeResult,
+)
+
+TOKEN = "ghp_testtoken"
+REPO = "owner/myrepo"
+PR = 17
+NODE_ID = "PR_kwDO_NodeId123"
+HEAD_SHA = "deadbeef1234567890"
+CALLER_SHA = "caller_sha_aabbccdd"
+
+
+# ── 헬퍼 ────────────────────────────────────────────────────────────────────
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _patch_native(
+    *,
+    enable_result: EnableAutoMergeResult,
+    merge_result: tuple = (True, None, HEAD_SHA),
+    node_id: str | None = NODE_ID,
+    state_result: tuple | Exception = ("clean", HEAD_SHA),
+):
+    """공통 patch helper — enable, merge_pr, get_pr_node_id, get_pr_mergeable_state mock 묶음.
+    Common patch helper that wires up enable, merge_pr, node_id, mergeable_state mocks.
+
+    호출자가 with-stack 으로 사용해 각 mock 의 호출 검증 가능.
+    Caller uses as a with-stack to assert call counts on each mock.
+    """
+    enable_mock = AsyncMock(return_value=enable_result)
+    merge_mock = AsyncMock(return_value=merge_result)
+    node_id_mock = AsyncMock(return_value=node_id)
+    if isinstance(state_result, Exception):
+        state_mock = AsyncMock(side_effect=state_result)
+    else:
+        state_mock = AsyncMock(return_value=state_result)
+
+    return (
+        patch("src.gate.native_automerge.enable_pull_request_auto_merge", enable_mock),
+        patch("src.gate.native_automerge.merge_pr", merge_mock),
+        patch("src.gate.native_automerge.get_pr_node_id", node_id_mock),
+        patch("src.gate.native_automerge.get_pr_mergeable_state", state_mock),
+        enable_mock, merge_mock, node_id_mock, state_mock,
+    )
+
+
+# ── 시나리오 1: enable 성공 ────────────────────────────────────────────────
+# ── Scenario 1: enable success ─────────────────────────────────────────────
+
+
+async def test_enable_success_returns_ok():
+    """enable → ENABLE_OK → (True, None, head_sha) 반환, merge_pr 미호출.
+    enable → ENABLE_OK → returns (True, None, head_sha); merge_pr is NOT called.
+    """
+    p_enable, p_merge, p_node, p_state, enable_mock, merge_mock, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_OK),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        ok, reason, sha = await enable_or_fallback(
+            TOKEN, REPO, PR, expected_sha=CALLER_SHA,
+        )
+
+    assert ok is True
+    assert reason is None
+    assert sha == CALLER_SHA
+    enable_mock.assert_awaited_once()
+    merge_mock.assert_not_called()
+
+
+# ── 시나리오 2: 폴백 가능 status — DISABLED / PERMISSION_DENIED ────────────
+# ── Scenario 2: fallback-eligible status — DISABLED / PERMISSION_DENIED ────
+
+
+async def test_enable_disabled_in_repo_falls_back_to_merge_pr():
+    """enable → ENABLE_DISABLED_IN_REPO → merge_pr 폴백 결과 그대로 반환.
+    enable → ENABLE_DISABLED_IN_REPO → falls back to merge_pr and returns its result.
+    """
+    fallback_result = (True, None, HEAD_SHA)
+    p_enable, p_merge, p_node, p_state, enable_mock, merge_mock, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_DISABLED_IN_REPO, "settings off"),
+        merge_result=fallback_result,
+    )
+    with p_enable, p_merge, p_node, p_state:
+        result = await enable_or_fallback(TOKEN, REPO, PR, expected_sha=HEAD_SHA)
+
+    assert result == fallback_result
+    enable_mock.assert_awaited_once()
+    merge_mock.assert_awaited_once()
+
+
+async def test_enable_permission_denied_falls_back_to_merge_pr():
+    """enable → ENABLE_PERMISSION_DENIED → merge_pr 폴백 (REST 권한은 있을 수 있음).
+    enable → ENABLE_PERMISSION_DENIED → falls back to merge_pr (REST may still work).
+    """
+    fallback_result = (True, None, HEAD_SHA)
+    p_enable, p_merge, p_node, p_state, _, merge_mock, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_PERMISSION_DENIED, "no graphql perm"),
+        merge_result=fallback_result,
+    )
+    with p_enable, p_merge, p_node, p_state:
+        result = await enable_or_fallback(TOKEN, REPO, PR, expected_sha=HEAD_SHA)
+
+    assert result == fallback_result
+    merge_mock.assert_awaited_once()
+
+
+# ── 시나리오 3: 폴백 불가 — FORCE_PUSHED ────────────────────────────────────
+# ── Scenario 3: no-fallback — FORCE_PUSHED ─────────────────────────────────
+
+
+async def test_enable_force_pushed_returns_failure_without_fallback():
+    """enable → ENABLE_FORCE_PUSHED → 즉시 (False, "force_pushed: ...", head_sha) 반환.
+    enable → ENABLE_FORCE_PUSHED → immediate (False, "force_pushed: ...", head_sha).
+    merge_pr 호출 안 됨 (REST 도 stale 상태로 실패할 것).
+    merge_pr is NOT called (REST would also fail stale).
+    """
+    p_enable, p_merge, p_node, p_state, _, merge_mock, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_FORCE_PUSHED, "Head sha didn't match"),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        ok, reason, sha = await enable_or_fallback(
+            TOKEN, REPO, PR, expected_sha=HEAD_SHA,
+        )
+
+    assert ok is False
+    assert reason is not None
+    assert reason.startswith("force_pushed")
+    assert sha == HEAD_SHA
+    merge_mock.assert_not_called()
+
+
+# ── 시나리오 4: node_id 조회 실패 — 즉시 폴백 ─────────────────────────────
+# ── Scenario 4: node_id lookup failure — immediate fallback ────────────────
+
+
+async def test_node_id_lookup_failure_falls_back_immediately():
+    """get_pr_node_id → None → enable 시도 자체 안 하고 merge_pr 호출.
+    get_pr_node_id → None → skip enable entirely and call merge_pr.
+    """
+    fallback_result = (True, None, HEAD_SHA)
+    p_enable, p_merge, p_node, p_state, enable_mock, merge_mock, node_id_mock, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_OK),  # enable 호출되면 성공이 되겠지만 호출 안 돼야 함
+        merge_result=fallback_result,
+        node_id=None,
+    )
+    with p_enable, p_merge, p_node, p_state:
+        result = await enable_or_fallback(TOKEN, REPO, PR, expected_sha=HEAD_SHA)
+
+    assert result == fallback_result
+    node_id_mock.assert_awaited_once()
+    enable_mock.assert_not_called()
+    merge_mock.assert_awaited_once()
+
+
+# ── 시나리오 5: 미분류 status — 폴백 ───────────────────────────────────────
+# ── Scenario 5: unclassified status — fallback ─────────────────────────────
+
+
+async def test_unclassified_status_falls_back():
+    """enable → ENABLE_API_ERROR (분류 외) → merge_pr 폴백 시도.
+    enable → ENABLE_API_ERROR (unclassified bucket) → falls back to merge_pr.
+    """
+    fallback_result = (True, None, HEAD_SHA)
+    p_enable, p_merge, p_node, p_state, _, merge_mock, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_API_ERROR, "weird"),
+        merge_result=fallback_result,
+    )
+    with p_enable, p_merge, p_node, p_state:
+        result = await enable_or_fallback(TOKEN, REPO, PR, expected_sha=HEAD_SHA)
+
+    assert result == fallback_result
+    merge_mock.assert_awaited_once()
+
+
+# ── 시나리오 6: expected_sha 처리 ──────────────────────────────────────────
+# ── Scenario 6: expected_sha handling ──────────────────────────────────────
+
+
+async def test_expected_sha_caller_provided_skips_get_pr_state():
+    """expected_sha 가 전달되면 get_pr_mergeable_state 호출 안 됨 (중복 GET 회피).
+    When expected_sha is passed, get_pr_mergeable_state is NOT called (avoid duplicate GET).
+    """
+    p_enable, p_merge, p_node, p_state, _, _, _, state_mock = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_OK),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        await enable_or_fallback(TOKEN, REPO, PR, expected_sha=CALLER_SHA)
+
+    state_mock.assert_not_called()
+
+
+async def test_expected_sha_none_calls_get_pr_state():
+    """expected_sha=None 이면 get_pr_mergeable_state 직접 호출.
+    expected_sha=None → get_pr_mergeable_state is called by the function.
+    """
+    p_enable, p_merge, p_node, p_state, _, _, _, state_mock = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_OK),
+        state_result=("clean", HEAD_SHA),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        ok, _reason, sha = await enable_or_fallback(TOKEN, REPO, PR, expected_sha=None)
+
+    state_mock.assert_awaited_once()
+    assert ok is True
+    assert sha == HEAD_SHA
+
+
+async def test_get_pr_state_failure_does_not_block_enable():
+    """get_pr_mergeable_state 가 httpx.HTTPError 던져도 enable 시도는 진행 (head_sha="").
+    Even if get_pr_mergeable_state raises httpx.HTTPError, enable is still attempted (head_sha="").
+    """
+    p_enable, p_merge, p_node, p_state, enable_mock, _, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_OK),
+        state_result=httpx.ConnectError("DNS down"),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        ok, _reason, sha = await enable_or_fallback(TOKEN, REPO, PR, expected_sha=None)
+
+    enable_mock.assert_awaited_once()
+    # head_sha 가 빈 문자열인 채로 enable 호출 → expected_head_oid 는 None 으로 전달
+    # head_sha is empty → expected_head_oid is passed as None
+    call_kwargs = enable_mock.await_args.kwargs
+    assert call_kwargs.get("expected_head_oid") is None
+    assert ok is True
+    assert sha == ""
+
+
+# ── 시나리오 7: 폴백 실패 reason 보존 ─────────────────────────────────────
+# ── Scenario 7: fallback failure reason preserved ──────────────────────────
+
+
+async def test_fallback_failure_returns_rest_reason():
+    """폴백 머지 실패 시 merge_pr 의 reason 그대로 반환.
+    On fallback merge failure, the merge_pr reason is returned verbatim.
+    """
+    rest_failure = (False, "branch_protection_blocked: required check missing", HEAD_SHA)
+    p_enable, p_merge, p_node, p_state, _, _, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_DISABLED_IN_REPO, "off"),
+        merge_result=rest_failure,
+    )
+    with p_enable, p_merge, p_node, p_state:
+        result = await enable_or_fallback(TOKEN, REPO, PR, expected_sha=HEAD_SHA)
+
+    assert result == rest_failure
+    assert result[0] is False
+    assert result[1] == "branch_protection_blocked: required check missing"

--- a/tests/unit/github_client/test_graphql.py
+++ b/tests/unit/github_client/test_graphql.py
@@ -1,0 +1,355 @@
+"""GitHub GraphQL 클라이언트 단위 테스트 — Tier 3 PR-A.
+GitHub GraphQL client unit tests — Tier 3 PR-A.
+
+테스트 대상 — `src.github_client.graphql`
+  - graphql_request: POST + JSON 파싱 기본 동작
+  - get_pr_node_id: REST 로 node_id 조회 + 실패 처리
+  - enable_pull_request_auto_merge: GraphQL 응답 분류 (성공/disabled/force-push/permission/error)
+"""
+import os
+
+# 환경변수는 src 임포트 전 주입 필수
+# Env vars must be injected before any src import
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-key")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from src.github_client.graphql import (
+    ENABLE_API_ERROR,
+    ENABLE_DISABLED_IN_REPO,
+    ENABLE_FORCE_PUSHED,
+    ENABLE_OK,
+    ENABLE_PERMISSION_DENIED,
+    EnableAutoMergeResult,
+    enable_pull_request_auto_merge,
+    get_pr_node_id,
+    graphql_request,
+)
+
+TOKEN = "ghp_testtoken"
+REPO = "owner/myrepo"
+NODE_ID = "PR_kwDO_NodeId123"
+
+
+# ── 헬퍼 ────────────────────────────────────────────────────────────────────
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _make_response(json_body: dict, status_code: int = 200) -> MagicMock:
+    """정상 httpx 응답 mock 생성 — raise_for_status 는 no-op.
+    Build a successful httpx response mock — raise_for_status is a no-op.
+    """
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+def _make_http_status_error(status_code: int) -> httpx.HTTPStatusError:
+    """HTTPStatusError 인스턴스 생성 헬퍼 — response.status_code 속성 포함.
+    Helper to construct an HTTPStatusError with response.status_code set.
+    """
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = f"HTTP {status_code}"
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code}",
+        request=MagicMock(),
+        response=response,
+    )
+
+
+def _make_status_response(json_body: dict, status_code: int) -> MagicMock:
+    """HTTPStatusError 를 raise_for_status 시 던지는 응답 mock.
+    Response mock that raises HTTPStatusError on raise_for_status.
+    """
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_body
+    resp.raise_for_status = MagicMock(side_effect=_make_http_status_error(status_code))
+    return resp
+
+
+# ── enable_pull_request_auto_merge — 분류 로직 ─────────────────────────────
+# ── enable_pull_request_auto_merge — classification ────────────────────────
+
+
+async def test_enable_returns_ok_on_successful_response():
+    """data.enablePullRequestAutoMerge 가 채워진 응답 → status == ENABLE_OK.
+    A populated data.enablePullRequestAutoMerge node yields ENABLE_OK.
+    """
+    success_body = {
+        "data": {
+            "enablePullRequestAutoMerge": {
+                "pullRequest": {
+                    "number": 42,
+                    "autoMergeRequest": {
+                        "enabledAt": "2026-04-27T00:00:00Z",
+                        "mergeMethod": "SQUASH",
+                    },
+                }
+            }
+        }
+    }
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_response(success_body))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+
+    assert isinstance(result, EnableAutoMergeResult)
+    assert result.status == ENABLE_OK
+    assert result.ok is True
+    assert result.detail is None
+
+
+async def test_enable_classifies_disabled_in_repo():
+    """리포 settings 에 auto-merge 미활성 메시지 → ENABLE_DISABLED_IN_REPO.
+    Message "Auto merge is not allowed for this repository" → ENABLE_DISABLED_IN_REPO.
+    """
+    err_body = {
+        "errors": [
+            {"message": "Auto merge is not allowed for this repository"}
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_response(err_body))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+
+    assert result.status == ENABLE_DISABLED_IN_REPO
+    assert "Auto merge is not allowed" in (result.detail or "")
+
+
+async def test_enable_classifies_force_pushed():
+    """"Head sha didn't match expected" 메시지 → ENABLE_FORCE_PUSHED.
+    "Head sha didn't match expected" message → ENABLE_FORCE_PUSHED.
+    """
+    err_body = {
+        "errors": [
+            {"message": "Head sha didn't match expected"}
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_response(err_body))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+
+    assert result.status == ENABLE_FORCE_PUSHED
+
+
+async def test_enable_classifies_permission_denied_via_type():
+    """errors[].type == "FORBIDDEN" → ENABLE_PERMISSION_DENIED.
+    errors[].type == "FORBIDDEN" → ENABLE_PERMISSION_DENIED.
+    """
+    err_body = {
+        "errors": [
+            {"type": "FORBIDDEN", "message": "Resource not accessible"}
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_response(err_body))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+
+    assert result.status == ENABLE_PERMISSION_DENIED
+
+
+async def test_enable_classifies_unknown_as_api_error():
+    """알 수 없는 type/message → ENABLE_API_ERROR (generic bucket).
+    Unknown type/message classified as ENABLE_API_ERROR (generic bucket).
+    """
+    err_body = {
+        "errors": [
+            {"type": "BAD_THING", "message": "weird unknown error"}
+        ]
+    }
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_response(err_body))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+
+    assert result.status == ENABLE_API_ERROR
+
+
+async def test_enable_returns_api_error_on_missing_data():
+    """errors 없고 data.enablePullRequestAutoMerge 도 None → ENABLE_API_ERROR.
+    No errors and no data.enablePullRequestAutoMerge → ENABLE_API_ERROR.
+    """
+    body = {"data": {"enablePullRequestAutoMerge": None}}
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_response(body))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+
+    assert result.status == ENABLE_API_ERROR
+    assert "missing" in (result.detail or "")
+
+
+async def test_enable_returns_permission_denied_on_403():
+    """HTTP 403 응답 → ENABLE_PERMISSION_DENIED.
+    HTTP 403 response → ENABLE_PERMISSION_DENIED.
+    """
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_status_response({}, 403))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+
+    assert result.status == ENABLE_PERMISSION_DENIED
+    assert "403" in (result.detail or "")
+
+
+async def test_enable_returns_api_error_on_500():
+    """HTTP 500 응답 → ENABLE_API_ERROR.
+    HTTP 500 response → ENABLE_API_ERROR.
+    """
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_status_response({}, 500))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+
+    assert result.status == ENABLE_API_ERROR
+    assert "500" in (result.detail or "")
+
+
+async def test_enable_returns_api_error_on_network_failure():
+    """httpx.ConnectError → ENABLE_API_ERROR (network: prefix).
+    httpx.ConnectError → ENABLE_API_ERROR (network: prefix).
+    """
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(side_effect=httpx.ConnectError("DNS failure"))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+
+    assert result.status == ENABLE_API_ERROR
+    assert "network" in (result.detail or "").lower()
+
+
+# ── get_pr_node_id ─────────────────────────────────────────────────────────
+
+
+async def test_get_pr_node_id_returns_value_on_success():
+    """REST 응답 {"node_id": "..."} → 해당 값 반환.
+    REST response with "node_id" → returns that value.
+    """
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=_make_response({"node_id": "PR_123"}))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await get_pr_node_id(TOKEN, REPO, 7)
+
+    assert result == "PR_123"
+
+
+async def test_get_pr_node_id_returns_none_on_http_error():
+    """httpx.HTTPError 발생 시 None 반환 (warning 로그 출력).
+    On httpx.HTTPError, returns None (and logs a warning).
+    """
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=httpx.ConnectError("boom"))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await get_pr_node_id(TOKEN, REPO, 7)
+
+    assert result is None
+
+
+# ── variables 페이로드 검증 ────────────────────────────────────────────────
+# ── variables payload verification ─────────────────────────────────────────
+
+
+async def test_enable_passes_squash_as_default_merge_method():
+    """기본 호출 시 GraphQL variables 에 mergeMethod: "SQUASH" 포함.
+    Default call sends mergeMethod: "SQUASH" in GraphQL variables.
+    """
+    success_body = {"data": {"enablePullRequestAutoMerge": {"pullRequest": {"number": 1}}}}
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_response(success_body))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+
+    call_kwargs = mock_client.post.call_args.kwargs
+    payload = call_kwargs["json"]
+    variables = payload["variables"]
+    assert variables["mergeMethod"] == "SQUASH"
+    assert variables["pullRequestId"] == NODE_ID
+
+
+async def test_enable_omits_expected_head_oid_when_none():
+    """expected_head_oid=None (기본) → variables 에 expectedHeadOid 키 없음.
+    expected_head_oid=None (default) → no expectedHeadOid key in variables.
+    """
+    success_body = {"data": {"enablePullRequestAutoMerge": {"pullRequest": {"number": 1}}}}
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_response(success_body))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        await enable_pull_request_auto_merge(TOKEN, NODE_ID, expected_head_oid=None)
+
+    payload = mock_client.post.call_args.kwargs["json"]
+    variables = payload["variables"]
+    assert "expectedHeadOid" not in variables
+
+
+async def test_enable_includes_expected_head_oid_when_provided():
+    """expected_head_oid="abc" → variables 에 그대로 포함.
+    expected_head_oid="abc" → included in variables verbatim.
+    """
+    success_body = {"data": {"enablePullRequestAutoMerge": {"pullRequest": {"number": 1}}}}
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_response(success_body))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        await enable_pull_request_auto_merge(TOKEN, NODE_ID, expected_head_oid="abc")
+
+    payload = mock_client.post.call_args.kwargs["json"]
+    variables = payload["variables"]
+    assert variables["expectedHeadOid"] == "abc"
+
+
+# ── graphql_request 기본 동작 — 보너스 sanity check ────────────────────────
+# ── graphql_request basic behaviour — bonus sanity check ───────────────────
+
+
+async def test_graphql_request_returns_parsed_json():
+    """graphql_request 가 응답 JSON 을 그대로 반환하는지 sanity check.
+    Sanity check that graphql_request returns parsed JSON as-is.
+    """
+    body = {"data": {"viewer": {"login": "octocat"}}}
+
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=_make_response(body))
+
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+        result = await graphql_request(TOKEN, "{ viewer { login } }", None)
+
+    assert result == body
+    # variables 미전달 시 payload 에 키 없음 / no variables key when omitted.
+    payload = mock_client.post.call_args.kwargs["json"]
+    assert "variables" not in payload


### PR DESCRIPTION
## Summary

PR #102 설계의 **PR-A 단계** — `enablePullRequestAutoMerge` GraphQL mutation 으로 머지 책임을 GitHub 에 위임. 활성화 불가/권한 부족/강제푸시 등의 상황에서는 기존 `merge_pr()` 동기 머지로 폴백 (gentle migration).

## 신규 모듈
- **`src/github_client/graphql.py`** (~200줄) — GraphQL POST 래퍼 + `enablePullRequestAutoMerge` mutation + `EnableAutoMergeResult` dataclass + 5가지 status 분류
- **`src/gate/native_automerge.py`** (~140줄) — `enable_or_fallback()` orchestration. `merge_pr()` 와 동일한 시그니처 (drop-in 교체 가능)

## 통합 변경
- **`src/gate/engine.py`**: `_run_auto_merge_retry`, `_run_auto_merge_legacy` 두 경로의 `merge_pr()` 호출을 `native_enable_or_fallback()` 로 교체. `merge_pr` import 제거.
- **`src/gate/merge_failure_advisor.py`**: 신규 reason 4개 advice 텍스트 추가 (사용자에게 정확한 조치 안내)

## 테스트
- 신규 25개 (`test_graphql.py` 15 + `test_native_automerge.py` 10)
- 기존 39개 patch 타겟 갱신 (`src.gate.engine.merge_pr` → `src.gate.engine.native_enable_or_fallback`)
- **단위 테스트 1713 passed / 0 failed** (1688 baseline + 25 신규)
- pylint 10.00/10 유지, bandit 0 HIGH

## Tier 3 결정 (PR #102 5가지)
| # | 결정 |
|---|------|
| 1 | 머지 메서드: SQUASH 단일 (MVP) |
| 2 | 폴백 정책: PR-A 는 폴백 + Issue 양쪽 유지 |
| 3 | Repo settings 사전 검사: 안 함 (enable mutation 422 → 분기) |
| 4 | MergeAttempt status: 기존 행 그대로, 신규 reason tag 만 추가 |
| 5 | PR-A 시기: 즉시 |

## PR-B 로 미룬 항목
- `pull_request.auto_merge_disabled` webhook 핸들러 — GitHub 측 disable 이벤트의 MergeAttempt 로깅 (성공/실패 구분 로직 별도 설계 필요)
- `merge_retry_service.py` 폐기 평가 — 1주일 dogfooding 후 결정

## Test plan
- [ ] CI 통과
- [ ] 머지 후 next PR 의 auto-merge 가 native enable 경로 확인 (대시보드/Telegram)
- [ ] 리포 Settings → 'Allow auto-merge' OFF 시 폴백 로직 작동 확인

관련: #100 (Loop Guard), #102 (Tier 3 설계서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)