### PR TITLE
docs: 단위 테스트 1732 → 1757 + Tier 3 PR-A 아키텍처 동기화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,8 @@ src/
 │   ├── diff.py                 # get_pr_files, get_push_files
 │   ├── issues.py               # close_issue() — Issue 종료 API
 │   ├── repos.py                # list_user_repos(), create_webhook(), delete_webhook(), commit_scamanager_files()
-│   └── checks.py               # get_ci_status, get_required_check_contexts (5분 TTL 캐시, D2+D8 페이지네이션)
+│   ├── checks.py               # get_ci_status, get_required_check_contexts (5분 TTL 캐시, D2+D8 페이지네이션)
+│   └── graphql.py              # GraphQL POST 래퍼 + enablePullRequestAutoMerge mutation + EnableAutoMergeResult 분류 (Tier 3 PR-A)
 ├── railway_client/
 │   ├── models.py               # RailwayDeployEvent (3-그룹 nested) + RailwayProjectInfo + RailwayCommitInfo
 │   ├── webhook.py              # parse_railway_payload() — deploy 실패 이벤트 파싱
@@ -145,10 +146,11 @@ src/
 │   └── manager.py              # get_repo_config(), upsert_repo_config(), RepoConfigData
 ├── gate/
 │   ├── _common.py              # score_from_result() 공용 헬퍼 (engine 과 향후 actions 공유)
-│   ├── engine.py               # run_gate_check() — 3-옵션 독립 처리 (직접 구현)
-│   ├── github_review.py        # post_github_review(), merge_pr()
+│   ├── engine.py               # run_gate_check() — 3-옵션 독립 처리. Tier 3 PR-A 후 native_enable_or_fallback() 위임
+│   ├── github_review.py        # post_github_review(), merge_pr() (REST 폴백 경로)
+│   ├── native_automerge.py     # enable_or_fallback() — GraphQL enablePullRequestAutoMerge 우선 + REST merge_pr 폴백 (Tier 3 PR-A)
 │   ├── telegram_gate.py        # send_gate_request() — 인라인 키보드 메시지
-│   ├── merge_failure_advisor.py # get_advice(reason) — reason tag → 권장 조치 텍스트 (Phase F.3, 순수 함수)
+│   ├── merge_failure_advisor.py # get_advice(reason) — reason tag → 권장 조치 텍스트 (Phase F.3 + Tier 3 PR-A enable reason 4종)
 │   └── retry_policy.py         # 순수 함수: parse_reason_tag, should_retry, compute_next_retry_at, is_expired, mergeable_state_terminality
 ├── notifier/                   # `__init__.py` 가 import 시 각 채널 모듈 자동 로드 → REGISTRY 등록 (Phase S.3-E)
 │   ├── __init__.py             # 8개 notifier 모듈 import (등록 순서 = 발송 우선순위)
@@ -553,4 +555,4 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 
 ## 현재 상태
 
-최신 수치는 [docs/STATE.md](docs/STATE.md) 참조 — 단위 테스트 1732개 | E2E 53개 | pylint 10.00 | 커버리지 95% | SonarCloud QG OK · Security A · Reliability A · Maintainability A · Tier1 정적분석 10종 · Observability (Sentry + Claude metrics + stage timing + MergeAttempt) · AI 점수 피드백 루프 · Settings Minimal Mode · Onboarding 3단계 튜토리얼 · 5-렌즈 감사 95+ 통과 · Phase F Quick Win + F.1/F.3 완료 · Phase G 완료 (P1-5건 수정) · Phase 9 자기 분석 루프 방지 완료 · Phase 10 Telegram 확장 완료 (cron + /stats·/connect 명령) · Phase 11 팀/멀티 리포 인사이트 완료 (author_trend + leaderboard + /insights 대시보드) · 툴링 안전장치 (testpaths + ORM-마이그레이션 완전성 검사 67개) · Phase 12 CI-aware Auto Merge 재시도 완료 (merge_retry_queue + check_suite 웹훅 + 1분 cron) · Settings UI/UX 리디자인 완료 (수신/발신 웹훅 분리 + 온보딩 배너) · Loop Guard Layer 3-b 화이트리스트 봇 한정 (PR #100 — `is_whitelisted_bot()` 헬퍼 + 사람 발신 무제한 통과)
+최신 수치는 [docs/STATE.md](docs/STATE.md) 참조 — 단위 테스트 1757개 | E2E 53개 | pylint 10.00 | 커버리지 95% | SonarCloud QG OK · Security A · Reliability A · Maintainability A · Tier1 정적분석 10종 · Observability (Sentry + Claude metrics + stage timing + MergeAttempt) · AI 점수 피드백 루프 · Settings Minimal Mode · Onboarding 3단계 튜토리얼 · 5-렌즈 감사 95+ 통과 · Phase F Quick Win + F.1/F.3 완료 · Phase G 완료 (P1-5건 수정) · Phase 9 자기 분석 루프 방지 완료 · Phase 10 Telegram 확장 완료 (cron + /stats·/connect 명령) · Phase 11 팀/멀티 리포 인사이트 완료 (author_trend + leaderboard + /insights 대시보드) · 툴링 안전장치 (testpaths + ORM-마이그레이션 완전성 검사 67개) · Phase 12 CI-aware Auto Merge 재시도 완료 (merge_retry_queue + check_suite 웹훅 + 1분 cron) · Settings UI/UX 리디자인 완료 (수신/발신 웹훅 분리 + 온보딩 배너) · Loop Guard Layer 3-b 화이트리스트 봇 한정 (PR #100 — `is_whitelisted_bot()` 헬퍼 + 사람 발신 무제한 통과) · **Tier 3 PR-A 완료 (PR #103) — `enablePullRequestAutoMerge` GraphQL mutation + REST 폴백 (`src/gate/native_automerge.py`, `src/github_client/graphql.py`); 1주일 dogfooding 후 PR-B 에서 `merge_retry_service` 폐기 평가**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
-[![Tests](https://img.shields.io/badge/Tests-1732_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-1757_passing-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
 [![E2E](https://img.shields.io/badge/E2E-53_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,11 +2,11 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-04-27 기준 — Loop Guard 봇 한정 정책 완료)
+## 현재 수치 (2026-04-29 기준 — Tier 3 PR-A native auto-merge 완료)
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 단위 테스트 | **1732개** | pytest 9.0.3 (0 failed, 5 skipped — 3 Postgres-gated + 2 pre-existing) — 2026-04-27 로컬 실측. PR #93/#95/#96/#97/#98/#100 누적 +18 |
+| 단위 테스트 | **1757개** | pytest 9.0.3 (0 failed, 5 skipped — 3 Postgres-gated + 2 pre-existing) — 2026-04-29 로컬 실측. PR #103 (Tier 3 PR-A) +25 추가 (test_graphql 15 + test_native_automerge 10) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
 | SonarCloud Reliability Rating | **A** | Bugs 0 |


### PR DESCRIPTION
## Summary

PR #103 (Tier 3 PR-A) 머지 직후 누락된 **CLAUDE.md 5-step 5번 (아키텍처 섹션 동기화)** 보완. 신규 파일 2개를 src/ 트리에 반영하고 단위 테스트 수치를 실측값(1757) 으로 갱신.

## 변경 면적
- `docs/STATE.md` line 5/9: 날짜 + 1757 (PR #103 +25 누적)
- `README.md` line 21: Tests 배지 1732 → 1757
- `CLAUDE.md`:
  - line 114-115: `src/github_client/` 에 `graphql.py` 추가
  - line 150-153: `src/gate/` 에 `native_automerge.py` 추가 + 인접 파일 역할 갱신 (engine.py, github_review.py, merge_failure_advisor.py)
  - line 556: 현재 상태 줄에 Tier 3 PR-A 항목 추가

## 자기 검증
이 PR 자체의 push 가 SCAManager webhook 을 트리거 → **PR-A 의 native enable 경로가 production 에서 처음 사용되는 검증 케이스** 가 됩니다. Telegram 알림 + 대시보드에서 native auto-merge enable 시도 여부 확인 가능.

## Test plan
- [ ] CI 통과 (문서 전용 변경)
- [ ] SCAManager 자기 분석 정상 트리거 (Telegram 알림 수신)
- [ ] PR-A native enable 경로 작동 확인 (성공 또는 폴백 분기)

🤖 Generated with [Claude Code](https://claude.com/claude-code)