### PR TITLE
test(e2e): F 그룹 — E2E 24건 실패 → 53/53 (100%) 회복

### DIFF
--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -68,13 +68,18 @@ def _setup_e2e_db(db_path: str) -> None:
     Alembic 0009/0010 마이그레이션이 SQLite에서 NotImplementedError를 발생시키므로
     Base.metadata.create_all()로 스키마를 생성한 뒤 버전만 수동 삽입한다.
     """
+    import importlib
+    import pkgutil
+
     from sqlalchemy import create_engine, text
     from src.database import Base
-    import src.models.repository  # noqa: F401
-    import src.models.analysis    # noqa: F401
-    import src.models.repo_config  # noqa: F401
-    import src.models.gate_decision  # noqa: F401
-    import src.models.user  # noqa: F401
+    import src.models as _models_pkg
+
+    # 모든 ORM 모델을 자동 import — Base.metadata.tables 에 등록되어야 create_all 이 모든 테이블 생성
+    # Auto-import every ORM model so Base.metadata.tables is fully populated before create_all
+    # (Phase 1 PR — overview 페이지가 analysis_feedback_repo 사용, 신규 모델 추가 시 누락 방지)
+    for _, _name, _ in pkgutil.iter_modules(_models_pkg.__path__):
+        importlib.import_module(f"src.models.{_name}")
 
     engine = create_engine(f"sqlite:///{db_path}")
     Base.metadata.create_all(engine)

--- a/e2e/test_settings.py
+++ b/e2e/test_settings.py
@@ -7,10 +7,27 @@ SETTINGS_URL = "/repos/owner%2Ftestrepo/settings"
 def _expand_advanced(page):
     """고급 설정 아코디언이 접혀 있으면 펼친다 (멱등).
 
-    UI 리디자인(a1aedd1)으로 Gate 모드 버튼·임계값 슬라이더가
+    UI 리디자인(a1aedd1 + PR #89)으로 Gate 모드 버튼·임계값 슬라이더가
     <details class="advanced-details"> 안으로 이동해 기본 상태에서 invisible.
-    click() 이 필요한 테스트는 이 헬퍼를 먼저 호출해야 한다.
+    또한 Settings UI/UX 리디자인 후 'simple/advanced' 모드 토글이 추가되어
+    기본값이 'simple' 일 때 advanced-details 가 CSS `display:none !important` —
+    Playwright actionability check 에서 30s timeout 발생.
+
+    헬퍼는 두 단계 보정:
+      1) data-settings-mode 를 'advanced' 로 설정 + localStorage 영속화
+      2) <details> 가 닫혀있으면 summary 클릭으로 펼침
     """
+    # 1단계 — Simple/Advanced 모드 토글: Simple 이 기본이면 advanced-details 가
+    # display:none 이라 클릭 자체 불가능. 직접 attribute 설정으로 강제 advanced.
+    # Step 1 — Force advanced mode so .advanced-details becomes visible
+    page.evaluate(
+        "document.body.setAttribute('data-settings-mode','advanced'); "
+        "(document.querySelector('main')||{}).setAttribute"
+        "&&document.querySelector('main').setAttribute('data-settings-mode','advanced'); "
+        "try{localStorage.setItem('sca-settings-mode','advanced')}catch(e){}"
+    )
+    # 2단계 — <details> 펼침
+    # Step 2 — Open the <details> if collapsed
     is_open = page.evaluate(
         "document.querySelector('.advanced-details')?.open ?? false"
     )
@@ -186,8 +203,10 @@ def test_telegram_connect_section_visible(seeded_page, base_url):
     Telegram connection subsection must render inside card ⑤ of the settings page.
     """
     seeded_page.goto(f"{base_url}{SETTINGS_URL}")
-    assert seeded_page.locator("#telegram-connect-section").count() == 1
-    assert seeded_page.locator("#telegram-connect-section").is_visible()
+    # Settings UI/UX 리디자인 (PR #89) 으로 id 가 -notify suffix 로 갱신됨
+    # Settings UI/UX redesign (PR #89) renamed the section id with `-notify` suffix
+    assert seeded_page.locator("#telegram-connect-section-notify").count() == 1
+    assert seeded_page.locator("#telegram-connect-section-notify").is_visible()
 
 
 def test_telegram_otp_button_visible_when_not_connected(seeded_page, base_url):
@@ -362,9 +381,11 @@ def test_six_card_titles_present(seeded_page, base_url):
     body = seeded_page.content()
     # ① 빠른 설정 제목은 기존 유지 — 개별 프리셋 카드로 대체
     # ① Quick settings heading is preserved — replaced by individual preset cards.
-    assert "PR 들어왔을 때" in body, "카드 ② PR 들어왔을 때 누락"
-    assert "이벤트 후 피드백" in body, "카드 ③ 이벤트 후 피드백 누락"
-    assert "시스템 &amp; 토큰" in body or "시스템 & 토큰" in body, "카드 ⑤ 시스템 & 토큰 누락"
+    # PR #89 카드명 변경 — 의도 기반 명칭으로 갱신
+    # PR #89 renamed cards to intent-based labels
+    assert "분석 동작 규칙" in body, "카드 ② 분석 동작 규칙 누락"
+    assert "Push / 배포 이벤트" in body, "카드 ③ Push / 배포 이벤트 누락"
+    assert "통합 &amp; 연결" in body or "통합 & 연결" in body, "카드 ⑤ 통합 & 연결 누락"
     assert "위험 구역" in body, "카드 ⑥ 위험 구역 누락"
 
 
@@ -482,7 +503,11 @@ def test_save_success_keeps_advanced_accordion_closed(seeded_page, base_url):
 
 
 def test_auto_merge_in_pr_card_not_push_card(seeded_page, base_url):
-    """auto_merge 체크박스가 PR 카드('PR 들어왔을 때') 안에 있어야 한다 (Push 카드 아님)."""
+    """auto_merge 체크박스가 PR 카드('분석 동작 규칙') 안에 있어야 한다 (Push 카드 아님).
+
+    PR #89 Settings UI/UX 리디자인으로 카드명이 의도 기반('분석 동작 규칙') 으로 갱신됨.
+    PR #89 renamed the card to intent-based '분석 동작 규칙'.
+    """
     seeded_page.goto(f"{base_url}{SETTINGS_URL}")
     # auto_merge input 의 가장 가까운 s-card 헤더 타이틀 확인
     card_title = seeded_page.evaluate(
@@ -495,8 +520,8 @@ def test_auto_merge_in_pr_card_not_push_card(seeded_page, base_url):
             return title ? title.textContent.trim() : null;
         }"""
     )
-    assert card_title == "PR 들어왔을 때", (
-        f"auto_merge 의 상위 카드 타이틀이 'PR 들어왔을 때' 여야 하는데 '{card_title}' 임"
+    assert card_title == "분석 동작 규칙", (
+        f"auto_merge 의 상위 카드 타이틀이 '분석 동작 규칙' 여야 하는데 '{card_title}' 임"
     )
 
 


### PR DESCRIPTION
## Summary

14-에이전트 감사에서 식별된 E2E 24건 실패의 3 카테고리 결함을 수정. **53/53 (100%)** 달성, 9분 → 42초 단축.

## 변경 (모두 테스트 코드만)
1. `e2e/conftest.py` 모델 import 자동화 (pkgutil) — 12건 해결
2. `e2e/test_settings.py::_expand_advanced` 헬퍼에 simple→advanced 모드 강제 — 9건 해결
3. `e2e/test_settings.py` 카드명/id 갱신 (PR #89 동기화) — 3건 해결

## 측정 (Before / After)
- 통과: 29 → **53**
- 실패: 24 → **0**
- 시간: 548s → **42s**

## production 영향
- 코드 변경 0
- CI 미영향 (E2E 는 ci.yml 미등록)

## Test plan
- [x] `make test-e2e` 53/53 통과 (실측)
- [ ] CI 통과 (pytest unit 회귀 0)