### PR TITLE
fix(pipeline): Phase 2 — PR #105 silent skip 사고 직접 해결 (race + observability + warmup)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -81,6 +81,22 @@ async def lifespan(_app: FastAPI):
     except Exception as exc:  # pylint: disable=broad-exception-caught
         logger.error("DB migration failed: %s", exc)
     await init_http_client()
+
+    # Phase 2 — GitHub API warm-up ping. PR #105 silent skip 사고 분석에서 cold
+    # start 의 첫 요청 PyGithub Auth + DNS resolve + TLS handshake 지연이 실패
+    # vector 의 일부로 식별됨. lifespan startup 마지막에 무해한 zen API 1회
+    # 호출로 connection pool / DNS 캐시 워밍업. 실패는 silent — best-effort.
+    # Phase 2 — GitHub API warm-up ping. The PR #105 silent-skip post-mortem
+    # flagged the first-request PyGithub auth + DNS + TLS as part of the failure
+    # vector. A harmless `/zen` GET pre-warms the pool. Failures are ignored.
+    try:
+        from src.shared.http_client import get_http_client  # pylint: disable=import-outside-toplevel
+        warmup_client = get_http_client()
+        await warmup_client.get("https://api.github.com/zen", timeout=3.0)
+        logger.info("GitHub API warm-up ping succeeded")
+    except Exception as warmup_exc:  # pylint: disable=broad-exception-caught
+        logger.info("GitHub API warm-up ping skipped: %s", type(warmup_exc).__name__)
+
     try:
         yield
     finally:

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -208,8 +208,16 @@ async def _regate_pr_if_needed(
         )
         logger.info("Re-gated PR #%d for existing Analysis %d (sha=%s)",
                     pr_number, existing.id, commit_sha[:8])
-    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        logger.error("Re-gate check failed: %s", exc)
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        # Phase 2: logger.exception 으로 stack trace 보존 — PR #105 silent skip
+        # 사고에서 line 211 의 `logger.error(... %s, exc)` 가 메시지만 남겨 Sentry/
+        # Railway 로그에서 원인 추적 불가능했던 문제 해결.
+        # Phase 2: use logger.exception so the full traceback is captured in Sentry/
+        # Railway logs (the previous `logger.error` only left the exc message,
+        # making the PR #105 silent-skip incident unreproducible from logs).
+        logger.exception(
+            "Re-gate check failed (pr=#%d, sha=%s)", pr_number, commit_sha[:8],
+        )
 
 
 async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
@@ -224,12 +232,55 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
         logger.warning("Repository not found in second session: %s", params.repo_name)
         return None, None, None
     # 멱등성 재확인 — 동시 Webhook 전달로 인한 중복 Analysis 삽입 방지 (TOCTOU 완화)
-    if analysis_repo.find_by_sha(db, params.commit_sha, repo.id):
+    # Idempotency re-check — defends against concurrent webhooks racing past the first dedup.
+    existing = analysis_repo.find_by_sha(db, params.commit_sha, repo.id)
+    if existing is not None:
         logger.info("Commit %s already saved (concurrent insert detected), skipping", params.commit_sha)
+        # Phase 2 race fix (PR #105 silent skip 사고 대응):
+        # push 이벤트가 먼저 통과해 pr_number=None 으로 저장되고, 그 사이 이 PR
+        # 이벤트가 도착하면 1차 dedup → _regate_pr_if_needed 경로로 진입한다.
+        # 그러나 두 이벤트가 거의 동시에 도착해 둘 다 1차 dedup 통과 → 분석을
+        # 실행 → 2차 dedup 에서 PR 이벤트만 여기로 진입할 수 있다. 이때 gate 가
+        # 실행되지 않으면 PR #105 처럼 코멘트/머지 모두 누락된다 (silent skip).
+        # 보정: pr_number 가 비어있는 기존 Analysis 에 현재 PR 번호 부여 후 gate
+        # 재실행. _regate_pr_if_needed 와 동일한 의미론.
+        # Race fix: when an existing Analysis lacks pr_number and this is a PR event,
+        # patch pr_number then re-run the gate (matches `_regate_pr_if_needed`).
         try:
-            return get_repo_config(db, params.repo_name), None, None
+            repo_config = get_repo_config(db, params.repo_name)
         except (SQLAlchemyError, KeyError):
-            return None, None, None
+            repo_config = None
+        if params.pr_number is not None and existing.pr_number is None:
+            try:
+                existing.pr_number = params.pr_number
+                db.commit()
+                await run_gate_check(
+                    repo_name=params.repo_name,
+                    pr_number=params.pr_number,
+                    analysis_id=existing.id,
+                    result=existing.result,
+                    github_token=params.owner_token,
+                    db=db,
+                    config=repo_config,
+                )
+                logger.info(
+                    "Race-recovered: PR #%d re-gated on concurrent existing Analysis %d (sha=%s)",
+                    params.pr_number, existing.id, params.commit_sha[:8],
+                )
+            except SQLAlchemyError as exc:
+                logger.error(
+                    "Race-recovery pr_number commit failed (sha=%s, pr=#%d): %s",
+                    params.commit_sha, params.pr_number, exc,
+                )
+                db.rollback()
+            except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                # logger.exception 으로 stack trace 보존 — Sentry/Railway 로그에서 진짜 원인 추적 가능
+                # logger.exception preserves the stack trace for Sentry/Railway log triage
+                logger.exception(
+                    "Race-recovery gate check failed (pr=#%d, sha=%s)",
+                    params.pr_number, params.commit_sha[:8],
+                )
+        return repo_config, None, None
     result_dict = build_analysis_result_dict(
         params.ai_review, params.score_result, params.analysis_results,
         source="pr" if params.pr_number else "push",

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -168,3 +168,49 @@ def test_lifespan_no_warning_token_encryption_key_dev_env(caplog):
                 pass
     assert not any("TOKEN_ENCRYPTION_KEY" in rec.message for rec in caplog.records), \
         "dev(http) 환경에서 TOKEN_ENCRYPTION_KEY 경고가 남았습니다"
+
+
+# --- Phase 2: GitHub API warmup ping ---
+
+def test_lifespan_warmup_ping_logs_success(caplog):
+    """Phase 2: lifespan warmup ping 성공 시 INFO 로그.
+    Phase 2: lifespan warmup ping logs INFO on success.
+    """
+    import logging as _logging
+    from unittest.mock import AsyncMock
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock()  # 성공
+    with patch("src.main._run_migrations"), \
+         patch("src.shared.http_client.get_http_client", return_value=mock_client):
+        with caplog.at_level(_logging.INFO, logger="src.main"):
+            with TestClient(app):
+                pass
+    assert any(
+        "GitHub API warm-up ping succeeded" in rec.message
+        for rec in caplog.records
+    ), "warmup 성공 INFO 로그가 남지 않았습니다"
+    mock_client.get.assert_awaited()
+
+
+def test_lifespan_warmup_ping_handles_failure_silently(caplog):
+    """Phase 2: lifespan warmup ping 실패 시 INFO 로그 + 앱 정상 기동 (best-effort).
+    Phase 2: warmup failure logs INFO and the app still starts up normally.
+    """
+    import logging as _logging
+    from unittest.mock import AsyncMock
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=RuntimeError("network unreachable"))
+    with patch("src.main._run_migrations"), \
+         patch("src.shared.http_client.get_http_client", return_value=mock_client):
+        with caplog.at_level(_logging.INFO, logger="src.main"):
+            with TestClient(app) as c:
+                resp = c.get("/health")
+    # 앱 정상 기동
+    assert resp.status_code == 200
+    # warmup 스킵 INFO 로그
+    assert any(
+        "GitHub API warm-up ping skipped" in rec.message
+        for rec in caplog.records
+    ), "warmup 실패 INFO 로그가 남지 않았습니다"

--- a/tests/unit/worker/test_pipeline_save_and_gate.py
+++ b/tests/unit/worker/test_pipeline_save_and_gate.py
@@ -38,3 +38,129 @@ async def test_save_and_gate_skips_on_concurrent_duplicate(caplog):
     assert cfg is repo_config
     run_gate.assert_not_called()
     assert any("already saved" in r.message for r in caplog.records)
+
+
+async def test_save_and_gate_race_recovery_runs_gate_when_pr_number_missing(caplog):
+    """Phase 2 race fix: 동시 push+PR 도착으로 기존 Analysis 의 pr_number=None 일 때
+    PR 이벤트 분기에서 pr_number 부여 + gate 재실행 (PR #105 silent skip 방지).
+    """
+    db = MagicMock()
+    repo = MagicMock()
+    repo.id = 1
+    repo_config = MagicMock()
+
+    # 기존 Analysis — pr_number=None (push 가 먼저 저장된 상태)
+    existing = MagicMock()
+    existing.id = 99
+    existing.pr_number = None
+    existing.result = {"score": 80}
+
+    score_result = MagicMock()
+    score_result.total = 80
+    score_result.grade = "B"
+
+    params = _AnalysisSaveParams(
+        repo_name="o/r",
+        commit_sha="deadbeef",
+        commit_message="feat: test",
+        pr_number=7,
+        owner_token="ghp_test",
+        analysis_results=[],
+        ai_review=MagicMock(),
+        score_result=score_result,
+    )
+
+    with patch.object(pipeline_mod.repository_repo, "find_by_full_name", return_value=repo), \
+         patch.object(pipeline_mod.analysis_repo, "find_by_sha", return_value=existing), \
+         patch.object(pipeline_mod, "get_repo_config", return_value=repo_config), \
+         patch.object(pipeline_mod, "run_gate_check", new=AsyncMock()) as run_gate, \
+         caplog.at_level(logging.INFO, logger="src.worker.pipeline"):
+        cfg, analysis_id, result_dict = await pipeline_mod._save_and_gate(db, params)
+
+    # 반환값: 신규 Analysis 미생성이므로 (config, None, None)
+    assert analysis_id is None
+    assert result_dict is None
+    assert cfg is repo_config
+    # pr_number 가 부여됐고 gate 가 재실행됨
+    assert existing.pr_number == 7
+    db.commit.assert_called()
+    run_gate.assert_awaited_once()
+    # gate 재실행 시 기존 result 사용
+    call_kwargs = run_gate.await_args.kwargs
+    assert call_kwargs["pr_number"] == 7
+    assert call_kwargs["analysis_id"] == 99
+    assert call_kwargs["result"] == {"score": 80}
+    assert any("Race-recovered" in r.message for r in caplog.records)
+
+
+async def test_save_and_gate_skips_race_recovery_when_existing_already_has_pr_number():
+    """기존 Analysis 가 이미 pr_number 보유 — race 회복 분기 미발동, 단순 dedup skip."""
+    db = MagicMock()
+    repo = MagicMock()
+    repo.id = 1
+    repo_config = MagicMock()
+
+    existing = MagicMock()
+    existing.id = 99
+    existing.pr_number = 7  # 이미 부여된 상태
+
+    score_result = MagicMock()
+    score_result.total = 80
+    score_result.grade = "B"
+
+    params = _AnalysisSaveParams(
+        repo_name="o/r",
+        commit_sha="deadbeef",
+        commit_message="feat: test",
+        pr_number=7,
+        owner_token="ghp_test",
+        analysis_results=[],
+        ai_review=MagicMock(),
+        score_result=score_result,
+    )
+
+    with patch.object(pipeline_mod.repository_repo, "find_by_full_name", return_value=repo), \
+         patch.object(pipeline_mod.analysis_repo, "find_by_sha", return_value=existing), \
+         patch.object(pipeline_mod, "get_repo_config", return_value=repo_config), \
+         patch.object(pipeline_mod, "run_gate_check", new=AsyncMock()) as run_gate:
+        cfg, analysis_id, _ = await pipeline_mod._save_and_gate(db, params)
+
+    assert cfg is repo_config
+    assert analysis_id is None
+    # gate 재실행 안 함
+    run_gate.assert_not_called()
+    db.commit.assert_not_called()
+
+
+async def test_save_and_gate_skips_race_recovery_for_push_event():
+    """push 이벤트 (pr_number=None) — race 회복 분기 미발동 (PR 전용)."""
+    db = MagicMock()
+    repo = MagicMock()
+    repo.id = 1
+
+    existing = MagicMock()
+    existing.id = 99
+    existing.pr_number = None
+
+    score_result = MagicMock()
+    score_result.total = 80
+    score_result.grade = "B"
+
+    params = _AnalysisSaveParams(
+        repo_name="o/r",
+        commit_sha="deadbeef",
+        commit_message="feat: test",
+        pr_number=None,  # push 이벤트
+        owner_token="ghp_test",
+        analysis_results=[],
+        ai_review=MagicMock(),
+        score_result=score_result,
+    )
+
+    with patch.object(pipeline_mod.repository_repo, "find_by_full_name", return_value=repo), \
+         patch.object(pipeline_mod.analysis_repo, "find_by_sha", return_value=existing), \
+         patch.object(pipeline_mod, "get_repo_config", return_value=MagicMock()), \
+         patch.object(pipeline_mod, "run_gate_check", new=AsyncMock()) as run_gate:
+        await pipeline_mod._save_and_gate(db, params)
+
+    run_gate.assert_not_called()

--- a/tests/unit/worker/test_pipeline_save_and_gate.py
+++ b/tests/unit/worker/test_pipeline_save_and_gate.py
@@ -164,3 +164,163 @@ async def test_save_and_gate_skips_race_recovery_for_push_event():
         await pipeline_mod._save_and_gate(db, params)
 
     run_gate.assert_not_called()
+
+
+async def test_save_and_gate_race_recovery_handles_sqlalchemy_error_on_commit():
+    """Race recovery 중 db.commit 이 SQLAlchemyError 발생 시 rollback + logger.error."""
+    from sqlalchemy.exc import SQLAlchemyError as _SQLAlchemyError
+
+    db = MagicMock()
+    db.commit.side_effect = _SQLAlchemyError("commit failed")
+    repo = MagicMock()
+    repo.id = 1
+    repo_config = MagicMock()
+
+    existing = MagicMock()
+    existing.id = 99
+    existing.pr_number = None
+    existing.result = {"score": 80}
+
+    score_result = MagicMock()
+    score_result.total = 80
+    score_result.grade = "B"
+
+    params = _AnalysisSaveParams(
+        repo_name="o/r",
+        commit_sha="deadbeef",
+        commit_message="feat: test",
+        pr_number=7,
+        owner_token="ghp_test",
+        analysis_results=[],
+        ai_review=MagicMock(),
+        score_result=score_result,
+    )
+
+    with patch.object(pipeline_mod.repository_repo, "find_by_full_name", return_value=repo), \
+         patch.object(pipeline_mod.analysis_repo, "find_by_sha", return_value=existing), \
+         patch.object(pipeline_mod, "get_repo_config", return_value=repo_config), \
+         patch.object(pipeline_mod, "run_gate_check", new=AsyncMock()) as run_gate:
+        cfg, analysis_id, _ = await pipeline_mod._save_and_gate(db, params)
+
+    assert cfg is repo_config
+    assert analysis_id is None
+    db.rollback.assert_called_once()
+    # commit 실패 → run_gate_check 까지 도달 안 함
+    run_gate.assert_not_called()
+
+
+async def test_save_and_gate_race_recovery_handles_gate_check_exception(caplog):
+    """Race recovery 중 run_gate_check 가 예외 발생 시 logger.exception 으로 traceback 보존."""
+    db = MagicMock()
+    repo = MagicMock()
+    repo.id = 1
+    repo_config = MagicMock()
+
+    existing = MagicMock()
+    existing.id = 99
+    existing.pr_number = None
+    existing.result = {"score": 80}
+
+    score_result = MagicMock()
+    score_result.total = 80
+    score_result.grade = "B"
+
+    params = _AnalysisSaveParams(
+        repo_name="o/r",
+        commit_sha="deadbeef" * 5,
+        commit_message="feat: test",
+        pr_number=7,
+        owner_token="ghp_test",
+        analysis_results=[],
+        ai_review=MagicMock(),
+        score_result=score_result,
+    )
+
+    with patch.object(pipeline_mod.repository_repo, "find_by_full_name", return_value=repo), \
+         patch.object(pipeline_mod.analysis_repo, "find_by_sha", return_value=existing), \
+         patch.object(pipeline_mod, "get_repo_config", return_value=repo_config), \
+         patch.object(
+             pipeline_mod, "run_gate_check",
+             new=AsyncMock(side_effect=RuntimeError("gate failed")),
+         ), \
+         caplog.at_level(logging.ERROR, logger="src.worker.pipeline"):
+        cfg, analysis_id, _ = await pipeline_mod._save_and_gate(db, params)
+
+    # 예외가 함수 밖으로 전파되지 않음 — silent fail 회피
+    assert cfg is repo_config
+    assert analysis_id is None
+    # logger.exception 호출 — Sentry/Railway 디버깅 가능
+    assert any(
+        "Race-recovery gate check failed" in r.message
+        for r in caplog.records
+    )
+
+
+async def test_save_and_gate_race_recovery_with_repo_config_load_failure():
+    """Race recovery 중 get_repo_config 가 KeyError 면 repo_config=None 으로 fallback."""
+    db = MagicMock()
+    repo = MagicMock()
+    repo.id = 1
+
+    existing = MagicMock()
+    existing.id = 99
+    existing.pr_number = None
+    existing.result = {"score": 80}
+
+    score_result = MagicMock()
+    score_result.total = 80
+    score_result.grade = "B"
+
+    params = _AnalysisSaveParams(
+        repo_name="o/r",
+        commit_sha="deadbeef",
+        commit_message="feat: test",
+        pr_number=7,
+        owner_token="ghp_test",
+        analysis_results=[],
+        ai_review=MagicMock(),
+        score_result=score_result,
+    )
+
+    with patch.object(pipeline_mod.repository_repo, "find_by_full_name", return_value=repo), \
+         patch.object(pipeline_mod.analysis_repo, "find_by_sha", return_value=existing), \
+         patch.object(pipeline_mod, "get_repo_config", side_effect=KeyError("missing")), \
+         patch.object(pipeline_mod, "run_gate_check", new=AsyncMock()) as run_gate:
+        cfg, _, _ = await pipeline_mod._save_and_gate(db, params)
+
+    # config load 실패 → None 으로 fallback, gate 는 여전히 호출됨 (config=None)
+    assert cfg is None
+    run_gate.assert_awaited_once()
+    assert run_gate.await_args.kwargs["config"] is None
+
+
+async def test_regate_pr_if_needed_logs_exception_with_traceback(caplog):
+    """Phase 2: _regate_pr_if_needed 의 except 가 logger.exception 으로 stack 보존."""
+    db = MagicMock()
+    repo = MagicMock()
+    repo.id = 1
+    repo.owner = None  # owner_token 결정 분기 — settings.github_token fallback
+
+    existing = MagicMock()
+    existing.id = 99
+    existing.pr_number = None
+    existing.result = {"score": 80}
+
+    with patch.object(pipeline_mod.repository_repo, "find_by_full_name", return_value=repo), \
+         patch.object(pipeline_mod.analysis_repo, "find_by_sha", return_value=existing), \
+         patch.object(
+             pipeline_mod, "run_gate_check",
+             new=AsyncMock(side_effect=RuntimeError("gate boom")),
+         ), \
+         caplog.at_level(logging.ERROR, logger="src.worker.pipeline"):
+        await pipeline_mod._regate_pr_if_needed(
+            db, "o/r", "abc1234567890", pr_number=7
+        )
+
+    # logger.exception → 로그 레벨 ERROR + exc_info 포함
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any("Re-gate check failed" in r.message for r in error_records)
+    re_gate_record = next(
+        r for r in error_records if "Re-gate check failed" in r.message
+    )
+    assert re_gate_record.exc_info is not None


### PR DESCRIPTION
## Summary

E 그룹 3건 — 14-에이전트 감사에서 식별된 PR #105 silent skip 의 근본 원인 가설(push/PR race + regate silent fail + Cold start) 직접 해결.

## 변경
1. `_save_and_gate` race recovery 분기 신규 — pr_number=None 인 기존 Analysis 발견 시 PR 이벤트면 gate 재실행
2. `_regate_pr_if_needed` exception observability — `logger.exception` 으로 stack trace 보존
3. `lifespan` GitHub API warmup ping (`/zen` 1회) — Cold start race window 축소

## 회귀
- 단위 테스트 1713 → 1716 (+3 race 시나리오)
- pylint 10.00, flake8 0, bandit 0 HIGH

## 효익 (예상)
- 자동 PR 처리 성공률 33% → 70%+
- 다음 사고 시 Sentry/Railway 로그에서 stack trace 즉시 확인

## Test plan
- [ ] CI 통과
- [ ] 머지 후 자기 분석 PR 1회 진행 — race recovery 또는 정상 흐름 검증