### PR TITLE
feat(gate): Phase 3 PR-B1 — MergeAttempt lifecycle 추적 + auto_merge_disabled webhook

### DIFF
--- a/alembic/versions/0022_add_merge_attempt_lifecycle.py
+++ b/alembic/versions/0022_add_merge_attempt_lifecycle.py
@@ -1,0 +1,60 @@
+"""add merge_attempts.state lifecycle columns (Phase 3 PR-B1)
+
+Tier 3 PR-A 후속 — native enable 성공 시 즉시 success=True 로 기록되는
+관측 갭 해소. state/enabled_at/merged_at/disabled_at 4 컬럼 추가.
+
+state 값:
+  - legacy               : 0022 이전 모든 행 (backfill 기본값)
+  - enabled_pending_merge: native enable 성공, GitHub 측 머지 대기
+  - actually_merged      : pull_request.closed merged=true webhook 수신
+  - disabled_externally  : pull_request.auto_merge_disabled webhook 수신
+  - direct_merged        : REST merge_pr() 즉시 성공
+
+PostgreSQL 11+ 에서 server_default 가 metadata-only ADD COLUMN 으로 처리되어
+다운타임 ~0초. SQLite (테스트) 는 batch_alter_table 로 table rebuild.
+
+Revision ID: 0022mergeattemptlifecycle
+Revises: 0021analysescreatedatindex
+Create Date: 2026-04-29
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = '0022mergeattemptlifecycle'
+down_revision = '0021analysescreatedatindex'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # batch_alter_table 로 SQLite/PostgreSQL 양쪽 호환 (CLAUDE.md 규약: 0007 이후
+    # 신규 마이그레이션은 op.add_column 직접 사용 권장이지만 SQLite 호환을 위해
+    # 이번 4컬럼 추가는 batch 컨텍스트 안에서 server_default 일괄 적용).
+    # batch_alter_table for SQLite/PostgreSQL compatibility — server_default ensures
+    # all existing rows get backfilled to "legacy" on PostgreSQL too (metadata-only).
+    with op.batch_alter_table('merge_attempts') as batch:
+        batch.add_column(sa.Column(
+            'state', sa.String(),
+            nullable=False, server_default='legacy',
+        ))
+        batch.add_column(sa.Column('enabled_at', sa.DateTime(), nullable=True))
+        batch.add_column(sa.Column('merged_at', sa.DateTime(), nullable=True))
+        batch.add_column(sa.Column('disabled_at', sa.DateTime(), nullable=True))
+
+    # 대시보드 / 집계가 (state, repo_name) 으로 자주 그룹화 — 인덱스 추가
+    # Dashboard/aggregation queries group by (state, repo_name) — add index.
+    op.create_index(
+        'ix_merge_attempts_state_repo',
+        'merge_attempts',
+        ['state', 'repo_name'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_merge_attempts_state_repo', table_name='merge_attempts')
+    with op.batch_alter_table('merge_attempts') as batch:
+        batch.drop_column('disabled_at')
+        batch.drop_column('merged_at')
+        batch.drop_column('enabled_at')
+        batch.drop_column('state')

--- a/src/constants.py
+++ b/src/constants.py
@@ -98,7 +98,14 @@ WEBHOOK_SECRET_CACHE_TTL = 300  # per-repo webhook secret 캐시 TTL (초, 5분)
 HANDLED_EVENTS: frozenset[str] = frozenset({"push", "pull_request", "issues", "check_suite"})
 # check_suite: CI-aware Auto Merge 재시도 트리거 (Phase 12)
 # check_suite: Trigger for CI-aware Auto Merge retry (Phase 12)
-PR_HANDLED_ACTIONS: frozenset[str] = frozenset({"opened", "synchronize", "reopened", "closed"})
+PR_HANDLED_ACTIONS: frozenset[str] = frozenset({
+    "opened", "synchronize", "reopened", "closed",
+    # Phase 3 PR-B1 — Tier 3 native auto-merge lifecycle 추적용
+    # GitHub 가 force-push, required check 실패, 사용자 수동 해제 시 발사
+    # Phase 3 PR-B1 — for tracking Tier 3 native auto-merge lifecycle
+    # GitHub fires this on force-push, required check failure, or manual disable
+    "auto_merge_disabled",
+})
 
 # ── 봇 발신 / 자기 분석 루프 방지 상수 ────────────────────────────────────
 # ── Bot sender / self-analysis loop guard constants ────────────────────────

--- a/src/gate/_merge_attempt_states.py
+++ b/src/gate/_merge_attempt_states.py
@@ -1,0 +1,48 @@
+"""MergeAttempt.state 정규 상수 + 전이표 (Phase 3 PR-B1).
+
+Tier 3 PR-A 후속 — native enable 성공 시 즉시 success=True 로 기록되는
+관측 갭 해소. state 컬럼으로 lifecycle 추적.
+
+MergeAttempt.state canonical constants + transition table (Phase 3 PR-B1).
+Closes the observability gap from Tier 3 PR-A where native-enable success
+was recorded as success=True without tracking actual merge completion.
+"""
+from __future__ import annotations
+
+# 정규 state 값 — `merge_attempt_repo` 의 mark_* 함수와 일치해야 함
+# Canonical state values — must match `merge_attempt_repo` mark_* functions
+
+#: 0022 마이그레이션 이전 모든 행의 backfill 기본값. 갱신 금지.
+#: Backfill default for all pre-0022 rows. Read-only.
+LEGACY = "legacy"
+
+#: native `enablePullRequestAutoMerge` mutation 성공 직후 — GitHub 가 비동기 머지 대기.
+#: Right after a successful native enable mutation; GitHub will merge asynchronously.
+ENABLED_PENDING_MERGE = "enabled_pending_merge"
+
+#: `pull_request.closed merged=true` webhook 수신 → enabled_pending_merge 에서 전이.
+#: After receiving a `pull_request.closed merged=true` webhook (transitions from enabled_pending_merge).
+ACTUALLY_MERGED = "actually_merged"
+
+#: `pull_request.auto_merge_disabled` webhook 수신 (force-push, check fail, 수동 해제 등).
+#: After a `pull_request.auto_merge_disabled` webhook (force-push, check failure, manual disable).
+DISABLED_EXTERNALLY = "disabled_externally"
+
+#: REST `merge_pr()` 즉시 성공 — fallback 또는 legacy `_run_auto_merge_legacy` 경로.
+#: REST `merge_pr()` immediate success — fallback or legacy path.
+DIRECT_MERGED = "direct_merged"
+
+
+# 허용된 전이만 정의 — 그 외 전이는 idempotent no-op (mark_* 함수에서 WHERE 절로 강제)
+# Allowed transitions only — others are idempotent no-ops (enforced via mark_* WHERE clauses)
+ALLOWED_TRANSITIONS: frozenset[tuple[str, str]] = frozenset({
+    (ENABLED_PENDING_MERGE, ACTUALLY_MERGED),
+    (ENABLED_PENDING_MERGE, DISABLED_EXTERNALLY),
+})
+
+
+def is_terminal(state: str) -> bool:
+    """터미널 state 인지 확인 (더 이상 전이 불가능).
+    Whether a state is terminal (no further transitions allowed).
+    """
+    return state in {LEGACY, ACTUALLY_MERGED, DISABLED_EXTERNALLY, DIRECT_MERGED}

--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -1,5 +1,6 @@
 """Gate Engine — 3개 독립 옵션: Review Comment / Approve / Auto Merge."""
 import logging
+from datetime import datetime, timezone
 from html import escape
 
 import httpx
@@ -10,9 +11,13 @@ from src.gate._common import score_from_result as _score_from_result
 from src.gate.github_review import (
     post_github_review, get_pr_mergeable_state, get_pr_base_ref,
 )
+from src.gate import _merge_attempt_states as _states
 from src.gate.merge_failure_advisor import get_advice
 from src.gate.merge_reasons import UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT, DEFERRED
-from src.gate.native_automerge import enable_or_fallback as native_enable_or_fallback
+from src.gate.native_automerge import (
+    PATH_NATIVE_ENABLE,
+    enable_or_fallback_with_path as native_enable_with_path,
+)
 from src.gate.retry_policy import parse_reason_tag, should_retry
 from src.github_client.checks import get_ci_status, get_required_check_contexts
 from src.notifier.merge_failure_issue import create_merge_failure_issue
@@ -253,28 +258,44 @@ async def _run_auto_merge_retry(  # pylint: disable=too-many-arguments,too-many-
         head_sha = ""
 
     # 2. Native auto-merge enable 시도 — 실패 시 REST merge_pr 폴백 (Tier 3 PR-A)
-    # 2. Try native auto-merge enable; fall back to REST merge_pr on failure (Tier 3 PR-A)
-    ok, reason, observed_sha = await native_enable_or_fallback(
+    # Phase 3 PR-B1: enable_or_fallback_with_path 사용 — outcome.path 로 state 라벨링
+    # Phase 3 PR-B1: use enable_or_fallback_with_path so outcome.path drives state
+    outcome = await native_enable_with_path(
         github_token, repo_name, pr_number, expected_sha=head_sha or None
     )
+    ok, reason, observed_sha = outcome.ok, outcome.reason, outcome.head_sha
 
     # observed_sha (merge_pr 내부 조회) 우선 사용, 없으면 head_sha
     # Prefer observed_sha (from merge_pr's internal call), fall back to head_sha
     effective_sha = observed_sha or head_sha
 
-    # 3. 성공 — 기록 후 반환
-    # 3. Success — log and return
+    # 3. 성공 — 기록 후 반환 (Phase 3 PR-B1: path 기반 state 라벨링)
+    # 3. Success — log and return (Phase 3 PR-B1: state derived from path)
     if ok:
+        # native enable 성공 → enabled_pending_merge (GitHub 비동기 머지 대기)
+        # REST 폴백 즉시 성공 → direct_merged (이미 머지됨)
+        # native enable success → enabled_pending_merge (awaiting GitHub async merge)
+        # REST fallback immediate success → direct_merged (already merged)
+        if outcome.path == PATH_NATIVE_ENABLE:
+            new_state = _states.ENABLED_PENDING_MERGE
+            enabled_at = datetime.now(timezone.utc)
+        else:
+            new_state = _states.DIRECT_MERGED
+            enabled_at = None
+
         if analysis_id is not None and db is not None:
             try:
                 log_merge_attempt(
                     db, analysis_id=analysis_id, repo_name=repo_name,
                     pr_number=pr_number, score=score,
                     threshold=config.merge_threshold, success=True, reason=None,
+                    state=new_state, enabled_at=enabled_at,
                 )
             except Exception as log_exc:  # pylint: disable=broad-except
                 logger.warning("merge_attempt 기록 실패: %s", log_exc)
-        logger.info("PR #%d auto-merged: %s", pr_number, repo_name)
+        logger.info(
+            "PR #%d auto-merged (state=%s): %s", pr_number, new_state, repo_name,
+        )
         return
 
     # 4. 실패 분류 — 터미널이면 즉시 처리
@@ -432,10 +453,25 @@ async def _run_auto_merge_legacy(  # pylint: disable=too-many-arguments
     """
     try:
         # Tier 3 PR-A: native auto-merge 우선 시도, 실패 시 REST merge_pr 폴백
-        # Tier 3 PR-A: try native auto-merge first, fall back to REST merge_pr on failure
-        ok, reason, _head_sha = await native_enable_or_fallback(
+        # Phase 3 PR-B1: with_path 버전 사용 → outcome.path 로 state 라벨링
+        # Tier 3 PR-A: try native auto-merge first, fall back to REST merge_pr.
+        # Phase 3 PR-B1: use with_path so state can be derived from outcome.path.
+        outcome = await native_enable_with_path(
             github_token, repo_name, pr_number,
         )
+        ok, reason = outcome.ok, outcome.reason
+
+        # Phase 3 PR-B1: native enable success → enabled_pending_merge,
+        # REST 폴백 즉시 성공 → direct_merged. 실패는 state="legacy" 기본값 유지.
+        if ok and outcome.path == PATH_NATIVE_ENABLE:
+            new_state = _states.ENABLED_PENDING_MERGE
+            enabled_at = datetime.now(timezone.utc)
+        elif ok:
+            new_state = _states.DIRECT_MERGED
+            enabled_at = None
+        else:
+            new_state = _states.LEGACY  # 실패 — state 분류 의미 없음
+            enabled_at = None
 
         # Phase F.1: 모든 시도 DB 기록 — 관측 실패가 파이프라인을 중단시키지 않도록
         # Phase F.1: Record every attempt in DB — observability failures must not interrupt the pipeline.
@@ -452,6 +488,8 @@ async def _run_auto_merge_legacy(  # pylint: disable=too-many-arguments
                     threshold=config.merge_threshold,
                     success=ok,
                     reason=reason,
+                    state=new_state,
+                    enabled_at=enabled_at,
                 )
             except Exception as log_exc:  # pylint: disable=broad-except
                 logger.warning(

--- a/src/gate/native_automerge.py
+++ b/src/gate/native_automerge.py
@@ -14,16 +14,22 @@ the existing synchronous `merge_pr()`.
   - **MergeAttempt 로깅은 호출자(engine.py) 책임** — 본 모듈은 결과 튜플만 반환,
     `merge_pr()` 와 동일한 시그니처/의미. 호출자가 ok/reason 으로 분기 + 로깅.
 
-Design intent (Tier 3 PR-A):
+Phase 3 PR-B1 추가:
+  - `MergeOutcome` dataclass 신규 — path 정보 (native_enable / rest_fallback)
+    호출자(engine.py) 가 state 라벨링에 활용
+  - `enable_or_fallback_with_path()` 헬퍼 신규 — path 정보 포함 반환
+  - 기존 `enable_or_fallback()` 시그니처는 backwards compatible 유지
+
+Design intent (Tier 3 PR-A + PR-B1):
   - PR-A keeps both fallback and issue creation — backward-compatible (gentle migration).
-  - PR-B will reassess once dogfooded for a week (drop fallback + retire merge_retry_service).
-  - MergeAttempt logging is the caller's (engine.py) responsibility — this module just
-    returns the result tuple with the same signature/semantics as `merge_pr()`. The caller
-    branches on ok/reason and performs logging.
+  - PR-B1 adds `MergeOutcome` with `path` field so callers can distinguish
+    "GitHub will merge later" (enabled_pending_merge) from "we just merged"
+    (direct_merged) for accurate lifecycle state tagging.
 """
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
 import httpx
 
@@ -39,6 +45,33 @@ from src.github_client.graphql import (
     enable_pull_request_auto_merge,
     get_pr_node_id,
 )
+
+
+# Phase 3 PR-B1 — path 상수 (호출자가 lifecycle state 라벨링용)
+# Phase 3 PR-B1 — path constants (callers use these to label lifecycle state)
+PATH_NATIVE_ENABLE = "native_enable"
+PATH_REST_FALLBACK = "rest_fallback"
+PATH_NO_ATTEMPT = "no_attempt"  # 향후 확장 슬롯 (cache 사전 체크 등)
+
+
+@dataclass(frozen=True)
+class MergeOutcome:
+    """Phase 3 PR-B1 — enable_or_fallback_with_path() 의 반환 형식.
+
+    `merge_pr()` / 기존 `enable_or_fallback()` 의 (ok, reason, sha) 튜플에 더해
+    path 필드로 GitHub 비동기 머지(enabled_pending_merge) vs 즉시 REST 머지
+    (direct_merged) 를 구분한다.
+
+    Phase 3 PR-B1 — return shape of enable_or_fallback_with_path().
+    Adds a `path` field on top of the legacy (ok, reason, sha) tuple so
+    callers can distinguish "GitHub will merge later" vs "we just merged".
+    """
+
+    ok: bool
+    reason: str | None
+    head_sha: str
+    path: str  # PATH_NATIVE_ENABLE | PATH_REST_FALLBACK | PATH_NO_ATTEMPT
+
 
 logger = logging.getLogger(__name__)
 
@@ -147,3 +180,82 @@ async def enable_or_fallback(
         github_token, repo_full_name, pr_number,
         expected_sha=head_sha or None,
     )
+
+
+async def enable_or_fallback_with_path(
+    github_token: str,
+    repo_full_name: str,
+    pr_number: int,
+    *,
+    expected_sha: str | None = None,
+    merge_method: str = "SQUASH",
+) -> MergeOutcome:
+    """Phase 3 PR-B1: `enable_or_fallback()` 의 path-aware 버전.
+
+    동일한 분기 로직이지만 호출자가 lifecycle state 를 라벨링할 수 있도록
+    `MergeOutcome.path` 필드로 native_enable vs rest_fallback 구분.
+
+    Phase 3 PR-B1: path-aware version of `enable_or_fallback()`.
+    Same branching logic, but the caller learns whether GitHub will merge
+    asynchronously (PATH_NATIVE_ENABLE) or we just merged synchronously
+    (PATH_REST_FALLBACK).
+    """
+    # 1. PR head SHA — 호출자가 전달했으면 재사용, 아니면 조회
+    head_sha = expected_sha or ""
+    if not head_sha:
+        try:
+            _state, head_sha = await get_pr_mergeable_state(
+                github_token, repo_full_name, pr_number,
+            )
+        except httpx.HTTPError as exc:
+            logger.warning("get_pr_mergeable_state 실패 (pr=%d): %s", pr_number, exc)
+
+    # 2. PR node_id 조회
+    pr_node_id = await get_pr_node_id(github_token, repo_full_name, pr_number)
+    if pr_node_id is None:
+        # node_id 조회 실패 — 즉시 폴백
+        logger.warning(
+            "PR node_id 조회 실패, REST merge_pr 폴백 (repo=%s, pr=%d)",
+            repo_full_name, pr_number,
+        )
+        ok, reason, sha = await merge_pr(
+            github_token, repo_full_name, pr_number,
+            expected_sha=head_sha or None,
+        )
+        return MergeOutcome(ok=ok, reason=reason, head_sha=sha, path=PATH_REST_FALLBACK)
+
+    # 3. enablePullRequestAutoMerge 시도
+    result = await enable_pull_request_auto_merge(
+        github_token,
+        pr_node_id,
+        expected_head_oid=head_sha or None,
+        merge_method=merge_method,
+    )
+
+    # 4. 성공 — GitHub 가 머지 책임 인수
+    if result.status == ENABLE_OK:
+        logger.info(
+            "PR #%d native auto-merge enabled: %s (head=%s)",
+            pr_number, repo_full_name, head_sha[:7] if head_sha else "?",
+        )
+        return MergeOutcome(
+            ok=True, reason=None, head_sha=head_sha, path=PATH_NATIVE_ENABLE,
+        )
+
+    # 5. 폴백 부적합 — 즉시 실패
+    if result.status in _NO_FALLBACK_STATUSES:
+        reason = f"{result.status}: {result.detail or ''}".rstrip(": ")
+        return MergeOutcome(
+            ok=False, reason=reason, head_sha=head_sha, path=PATH_NO_ATTEMPT,
+        )
+
+    # 6. 폴백 시도
+    logger.info(
+        "PR #%d native enable=%s 폴백 (REST merge_pr): %s",
+        pr_number, result.status, result.detail or "-",
+    )
+    ok, reason, sha = await merge_pr(
+        github_token, repo_full_name, pr_number,
+        expected_sha=head_sha or None,
+    )
+    return MergeOutcome(ok=ok, reason=reason, head_sha=sha, path=PATH_REST_FALLBACK)

--- a/src/models/merge_attempt.py
+++ b/src/models/merge_attempt.py
@@ -46,3 +46,25 @@ class MergeAttempt(Base):
         default=lambda: datetime.now(timezone.utc),
         nullable=False,
     )
+    # Phase 3 PR-B1 — Tier 3 PR-A 후속: 머지 라이프사이클 추적
+    # state 의미:
+    #   - "legacy" — 0022 마이그레이션 이전 모든 행 (backfill 기본값)
+    #   - "enabled_pending_merge" — native enablePullRequestAutoMerge 성공,
+    #     GitHub 측 비동기 머지 대기 (실제 머지는 미발생)
+    #   - "actually_merged" — pull_request.closed merged=true webhook 수신 →
+    #     state 전이됨 (enabled_pending_merge 행만 갱신)
+    #   - "disabled_externally" — pull_request.auto_merge_disabled webhook
+    #     (force-push, check 실패, 사용자 수동 해제 등)
+    #   - "direct_merged" — REST merge_pr() 즉시 성공 (폴백 또는 legacy 경로)
+    #
+    # Phase 3 PR-B1 — Tier 3 PR-A follow-up: track auto-merge lifecycle.
+    # state semantics:
+    #   - "legacy"               — pre-0022 rows (backfill default)
+    #   - "enabled_pending_merge" — native enable success, GitHub will merge async
+    #   - "actually_merged"      — pull_request.closed merged=true webhook
+    #   - "disabled_externally"  — pull_request.auto_merge_disabled webhook
+    #   - "direct_merged"        — REST merge_pr() immediate success (fallback/legacy)
+    state = Column(String, nullable=False, server_default="legacy")
+    enabled_at = Column(DateTime, nullable=True)
+    merged_at = Column(DateTime, nullable=True)
+    disabled_at = Column(DateTime, nullable=True)

--- a/src/repositories/merge_attempt_repo.py
+++ b/src/repositories/merge_attempt_repo.py
@@ -1,15 +1,19 @@
 """merge_attempt_repo — MergeAttempt 영속화 + 집계 쿼리 단일 출처.
 
-Phase F.1 관측 기반. 3개 공개 함수만 노출:
+Phase F.1 관측 기반. Phase 3 PR-B1 에서 lifecycle 전이 함수 3개 추가:
   - create()                       — INSERT (upsert 아님, 모든 시도 보존)
   - list_by_repo()                 — 최근 시도 목록 (attempted_at DESC)
-  - count_failures_by_reason()     — 실패 사유별 카운트 집계 (대시보드/advisor 용)
+  - count_failures_by_reason()     — 실패 사유별 카운트 집계
+  - find_latest_for_pr()           — PR 최신 시도 행 (Phase 3 PR-B1)
+  - mark_actually_merged()         — enabled_pending_merge → actually_merged
+  - mark_disabled_externally()     — enabled_pending_merge → disabled_externally
 """
 from datetime import datetime
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from src.gate import _merge_attempt_states as _states
 from src.models.merge_attempt import MergeAttempt
 
 
@@ -24,8 +28,14 @@ def create(  # pylint: disable=too-many-arguments
     success: bool,
     failure_reason: str | None = None,
     detail_message: str | None = None,
+    state: str = _states.LEGACY,
+    enabled_at: datetime | None = None,
 ) -> MergeAttempt:
-    """MergeAttempt 레코드를 생성하고 반환한다 (항상 INSERT)."""
+    """MergeAttempt 레코드를 생성하고 반환한다 (항상 INSERT).
+
+    Phase 3 PR-B1: state + enabled_at 파라미터 추가. 기본값 'legacy' 유지로
+    backwards compatible — 기존 호출처는 변경 불필요.
+    """
     record = MergeAttempt(
         analysis_id=analysis_id,
         repo_name=repo_name,
@@ -35,6 +45,8 @@ def create(  # pylint: disable=too-many-arguments
         success=success,
         failure_reason=failure_reason,
         detail_message=detail_message,
+        state=state,
+        enabled_at=enabled_at,
     )
     db.add(record)
     db.commit()
@@ -76,3 +88,91 @@ def count_failures_by_reason(
         query = query.filter(MergeAttempt.attempted_at >= since)
     query = query.group_by(MergeAttempt.failure_reason)
     return dict(query.all())
+
+
+def find_latest_for_pr(
+    db: Session,
+    repo_name: str,
+    pr_number: int,
+) -> MergeAttempt | None:
+    """해당 PR 의 최신 MergeAttempt 행 반환 (없으면 None).
+
+    Phase 3 PR-B1: webhook 핸들러가 `pull_request.closed merged=true` 또는
+    `auto_merge_disabled` 수신 시 state 전이 대상 행 식별용.
+
+    Find the latest MergeAttempt row for a PR (Phase 3 PR-B1) — used by the
+    webhook lifecycle handlers to locate the row to transition.
+    """
+    return (
+        db.query(MergeAttempt)
+        .filter(
+            MergeAttempt.repo_name == repo_name,
+            MergeAttempt.pr_number == pr_number,
+        )
+        .order_by(MergeAttempt.attempted_at.desc())
+        .first()
+    )
+
+
+def mark_actually_merged(
+    db: Session,
+    *,
+    attempt_id: int,
+    merged_at: datetime,
+) -> bool:
+    """state='enabled_pending_merge' 행만 'actually_merged' 로 전이 (멱등).
+    Idempotent transition — only updates rows currently in 'enabled_pending_merge'.
+
+    Returns True if a row was updated, False if no-op (이미 전이됐거나 다른 state).
+    Returns True if a row was updated, False otherwise (already transitioned or
+    different state — webhook 중복 전송 시 안전).
+    """
+    rows_updated = (
+        db.query(MergeAttempt)
+        .filter(
+            MergeAttempt.id == attempt_id,
+            MergeAttempt.state == _states.ENABLED_PENDING_MERGE,
+        )
+        .update(
+            {
+                MergeAttempt.state: _states.ACTUALLY_MERGED,
+                MergeAttempt.merged_at: merged_at,
+            },
+            synchronize_session=False,
+        )
+    )
+    db.commit()
+    return rows_updated > 0
+
+
+def mark_disabled_externally(
+    db: Session,
+    *,
+    attempt_id: int,
+    disabled_at: datetime,
+    reason: str | None = None,
+) -> bool:
+    """state='enabled_pending_merge' 행만 'disabled_externally' 로 전이 (멱등).
+    Idempotent transition — only updates rows currently in 'enabled_pending_merge'.
+
+    Args:
+        reason: 추론된 비활성 사유 (예: "user_disabled", "external_event").
+                기존 failure_reason 컬럼에 기록.
+                Inferred disable reason — written to the existing failure_reason column.
+    """
+    update_values: dict = {
+        MergeAttempt.state: _states.DISABLED_EXTERNALLY,
+        MergeAttempt.disabled_at: disabled_at,
+    }
+    if reason is not None:
+        update_values[MergeAttempt.failure_reason] = reason
+    rows_updated = (
+        db.query(MergeAttempt)
+        .filter(
+            MergeAttempt.id == attempt_id,
+            MergeAttempt.state == _states.ENABLED_PENDING_MERGE,
+        )
+        .update(update_values, synchronize_session=False)
+    )
+    db.commit()
+    return rows_updated > 0

--- a/src/shared/merge_metrics.py
+++ b/src/shared/merge_metrics.py
@@ -11,11 +11,16 @@ emit. Phase F.3 의 merge_failure_advisor, Phase F.4 의 대시보드가 이 데
 DB 오류 내성: `log_merge_attempt` 는 어떤 예외도 파이프라인 밖으로 전파하지
 않는다 — WARNING 로그만 남기고 None 반환. auto-merge 파이프라인이 관측 실패로
 중단되는 것을 방지.
+
+Phase 3 PR-B1: state/enabled_at 파라미터 추가 — native auto-merge lifecycle
+추적용 (enable success → enabled_pending_merge → actually_merged 전이).
 """
 import logging
+from datetime import datetime
 
 from sqlalchemy.orm import Session
 
+from src.gate import _merge_attempt_states as _states
 from src.models.merge_attempt import MergeAttempt
 from src.repositories import merge_attempt_repo
 
@@ -35,7 +40,7 @@ def parse_reason_tag(reason: str | None) -> str | None:
     return head or None
 
 
-def log_merge_attempt(
+def log_merge_attempt(  # pylint: disable=too-many-arguments
     db: Session,
     *,
     analysis_id: int,
@@ -45,12 +50,19 @@ def log_merge_attempt(
     threshold: int,
     success: bool,
     reason: str | None = None,
+    state: str = _states.LEGACY,
+    enabled_at: datetime | None = None,
 ) -> MergeAttempt | None:
     """MergeAttempt 를 DB 에 기록하고 구조화된 INFO 로그를 낸다.
 
     - success=True 면 failure_reason/detail_message 는 None 으로 저장
     - success=False 면 reason 을 파싱해 태그만 failure_reason 에, 전체를 detail_message 에
     - DB 오류 시 WARNING 로그만 남기고 None 반환 (파이프라인 중단 금지)
+
+    Phase 3 PR-B1 신규 파라미터:
+    - state: 머지 라이프사이클 상태 (legacy/enabled_pending_merge/direct_merged 등)
+    - enabled_at: native enable 시점 (state=enabled_pending_merge 일 때만 유효)
+    Both default to legacy/None for backwards compatibility with existing callers.
     """
     failure_reason: str | None = None
     detail_message: str | None = None
@@ -70,6 +82,8 @@ def log_merge_attempt(
             success=success,
             failure_reason=failure_reason,
             detail_message=detail_message,
+            state=state,
+            enabled_at=enabled_at,
         )
     except Exception as exc:  # pylint: disable=broad-except
         # SQLAlchemy 는 commit 실패 후 세션을 invalid 로 표시 — rollback 하지 않으면
@@ -96,10 +110,11 @@ def log_merge_attempt(
         "repo_name": repo_name,
         "pr_number": pr_number,
         "analysis_id": analysis_id,
+        "state": state,
     }
     logger.info(
-        "merge_attempt repo=%s pr=%d result=%s reason=%s score=%d threshold=%d",
-        repo_name, pr_number, merge_result, failure_reason or "-", score, threshold,
+        "merge_attempt repo=%s pr=%d result=%s state=%s reason=%s score=%d threshold=%d",
+        repo_name, pr_number, merge_result, state, failure_reason or "-", score, threshold,
         extra=extra,
     )
     return record

--- a/src/webhook/providers/github.py
+++ b/src/webhook/providers/github.py
@@ -177,6 +177,10 @@ async def _handle_auto_merge_disabled_event(data: dict) -> dict:
     pr_number = pr.get("number")
     if not repo_name or pr_number is None:
         return {"status": "ignored"}
+    try:
+        pr_number_int = int(pr_number)
+    except (TypeError, ValueError):
+        return {"status": "ignored"}
 
     # GitHub payload 에 명시적 reason 필드 없음 — sender 기반 추론
     # GitHub payload has no explicit reason — infer from sender.
@@ -191,11 +195,11 @@ async def _handle_auto_merge_disabled_event(data: dict) -> dict:
 
     try:
         with SessionLocal() as db:
-            latest = merge_attempt_repo.find_latest_for_pr(db, repo_name, int(pr_number))
+            latest = merge_attempt_repo.find_latest_for_pr(db, repo_name, pr_number_int)
             if latest is None:
                 logger.info(
                     "auto_merge_disabled: no MergeAttempt row for %s pr=%d (skipped)",
-                    sanitize_for_log(repo_name), pr_number,
+                    sanitize_for_log(repo_name), pr_number_int,
                 )
                 return {"status": "ignored"}
             updated = merge_attempt_repo.mark_disabled_externally(
@@ -207,12 +211,12 @@ async def _handle_auto_merge_disabled_event(data: dict) -> dict:
                 logger.warning(
                     "merge_attempt %d: enabled_pending_merge → disabled_externally "
                     "(repo=%s, pr=%d, reason=%s)",
-                    latest.id, sanitize_for_log(repo_name), pr_number, inferred_reason,
+                    latest.id, sanitize_for_log(repo_name), pr_number_int, inferred_reason,
                 )
     except (SQLAlchemyError, KeyError, AttributeError) as exc:
         logger.warning(
             "auto_merge_disabled 전이 실패 (repo=%s, pr=%d): %s",
-            sanitize_for_log(repo_name), pr_number, type(exc).__name__,
+            sanitize_for_log(repo_name), pr_number_int, type(exc).__name__,
         )
         return {"status": "ignored"}
 

--- a/src/webhook/providers/github.py
+++ b/src/webhook/providers/github.py
@@ -9,6 +9,7 @@ import json
 import logging
 import re
 import time
+from datetime import datetime, timezone
 from typing import Annotated
 
 import httpx
@@ -21,7 +22,7 @@ from src.constants import HANDLED_EVENTS, PR_HANDLED_ACTIONS
 from src.database import SessionLocal
 from src.github_client.issues import close_issue
 from src.notifier.n8n import notify_n8n_issue
-from src.repositories import merge_retry_repo, repository_repo
+from src.repositories import merge_attempt_repo, merge_retry_repo, repository_repo
 from src.services.merge_retry_service import process_pending_retries
 from src.shared.log_safety import sanitize_for_log
 from src.webhook._helpers import get_webhook_secret
@@ -68,19 +69,33 @@ def _extract_closing_issue_numbers(body: str | None) -> list[int]:
 
 
 async def _handle_merged_pr_event(data: dict) -> dict:
-    """pull_request.closed + merged=true 시 PR body 의 Closes #N 키워드로 Issue 를 close."""
+    """pull_request.closed + merged=true 시 두 작업 수행:
+    1) PR body 의 Closes #N 키워드로 Issue 를 close (기존 동작).
+    2) Phase 3 PR-B1: MergeAttempt 의 state 를 enabled_pending_merge → actually_merged 로 전이.
+
+    Phase 3 PR-B1: When a PR closes with merged=true:
+      1) Auto-close referenced issues (existing behavior).
+      2) Transition MergeAttempt state from enabled_pending_merge → actually_merged
+         so dashboards/stats reflect the actual merge completion.
+    """
     pr = data.get("pull_request") or {}
     if not pr.get("merged"):
-        return {"status": "ignored"}
-
-    body = pr.get("body") or ""
-    numbers = _extract_closing_issue_numbers(body)
-    if not numbers:
         return {"status": "ignored"}
 
     repo_name = data.get("repository", {}).get("full_name", "")
     if not repo_name:
         return {"status": "ignored"}
+
+    pr_number = pr.get("number")
+    # Phase 3 PR-B1: MergeAttempt lifecycle 전이 (Issue close 와 독립적으로 시도)
+    # Phase 3 PR-B1: MergeAttempt lifecycle transition (independent of issue close).
+    if pr_number is not None:
+        await _record_actual_merge(repo_name, int(pr_number))
+
+    body = pr.get("body") or ""
+    numbers = _extract_closing_issue_numbers(body)
+    if not numbers:
+        return {"status": "accepted"}
 
     token = ""
     try:
@@ -94,7 +109,7 @@ async def _handle_merged_pr_event(data: dict) -> dict:
     token = token or settings.github_token
     if not token:
         logger.info("merged-pr issue close: no token available for %s — skipped", repo_name)
-        return {"status": "ignored"}
+        return {"status": "accepted"}
 
     for issue_number in numbers:
         try:
@@ -111,6 +126,95 @@ async def _handle_merged_pr_event(data: dict) -> dict:
                 "Auto-close failed (repo=%s, issue=%d): %s",
                 repo_name, issue_number, type(exc).__name__,
             )
+
+    return {"status": "accepted"}
+
+
+async def _record_actual_merge(repo_name: str, pr_number: int) -> None:
+    """Phase 3 PR-B1: MergeAttempt state 를 actually_merged 로 전이.
+    Phase 3 PR-B1: transition MergeAttempt state to actually_merged.
+
+    enabled_pending_merge 행만 갱신 (mark_actually_merged 의 WHERE 절 가드).
+    legacy / direct_merged / 기존 actually_merged 행은 idempotent no-op.
+    Only updates rows currently in enabled_pending_merge (idempotent).
+    """
+    try:
+        with SessionLocal() as db:
+            latest = merge_attempt_repo.find_latest_for_pr(db, repo_name, pr_number)
+            if latest is None:
+                return
+            updated = merge_attempt_repo.mark_actually_merged(
+                db, attempt_id=latest.id,
+                merged_at=datetime.now(timezone.utc),
+            )
+            if updated:
+                logger.info(
+                    "merge_attempt %d: enabled_pending_merge → actually_merged (repo=%s, pr=%d)",
+                    latest.id, repo_name, pr_number,
+                )
+    except (SQLAlchemyError, KeyError, AttributeError) as exc:
+        # 관측 실패가 webhook 응답을 막지 않도록 격리 — Phase 3 PR-B1
+        # Isolated so observability failure doesn't block the webhook response
+        logger.warning(
+            "actually_merged 전이 실패 (repo=%s, pr=%d): %s",
+            sanitize_for_log(repo_name), pr_number, type(exc).__name__,
+        )
+
+
+async def _handle_auto_merge_disabled_event(data: dict) -> dict:
+    """Phase 3 PR-B1: pull_request.auto_merge_disabled webhook 핸들러.
+
+    GitHub 이 force-push, required check 실패, 사용자 수동 해제 등으로
+    auto-merge 를 자동 비활성화할 때 발사. MergeAttempt state 를
+    enabled_pending_merge → disabled_externally 로 전이.
+
+    Phase 3 PR-B1: handler for pull_request.auto_merge_disabled webhook.
+    GitHub fires this on force-push, required check failure, or manual disable;
+    we transition MergeAttempt state from enabled_pending_merge → disabled_externally.
+    """
+    repo_name = data.get("repository", {}).get("full_name", "")
+    pr = data.get("pull_request") or {}
+    pr_number = pr.get("number")
+    if not repo_name or pr_number is None:
+        return {"status": "ignored"}
+
+    # GitHub payload 에 명시적 reason 필드 없음 — sender 기반 추론
+    # GitHub payload has no explicit reason — infer from sender.
+    sender_login = (data.get("sender") or {}).get("login")
+    sender_type = (data.get("sender") or {}).get("type")
+    if sender_type == "Bot":
+        inferred_reason = "auto_merge_disabled_by_check_or_force_push"
+    elif sender_login:
+        inferred_reason = "auto_merge_disabled_by_user"
+    else:
+        inferred_reason = "auto_merge_disabled_external"
+
+    try:
+        with SessionLocal() as db:
+            latest = merge_attempt_repo.find_latest_for_pr(db, repo_name, int(pr_number))
+            if latest is None:
+                logger.info(
+                    "auto_merge_disabled: no MergeAttempt row for %s pr=%d (skipped)",
+                    sanitize_for_log(repo_name), pr_number,
+                )
+                return {"status": "ignored"}
+            updated = merge_attempt_repo.mark_disabled_externally(
+                db, attempt_id=latest.id,
+                disabled_at=datetime.now(timezone.utc),
+                reason=inferred_reason,
+            )
+            if updated:
+                logger.warning(
+                    "merge_attempt %d: enabled_pending_merge → disabled_externally "
+                    "(repo=%s, pr=%d, reason=%s)",
+                    latest.id, sanitize_for_log(repo_name), pr_number, inferred_reason,
+                )
+    except (SQLAlchemyError, KeyError, AttributeError) as exc:
+        logger.warning(
+            "auto_merge_disabled 전이 실패 (repo=%s, pr=%d): %s",
+            sanitize_for_log(repo_name), pr_number, type(exc).__name__,
+        )
+        return {"status": "ignored"}
 
     return {"status": "accepted"}
 
@@ -234,6 +338,12 @@ async def _preprocess_pull_request(data: dict) -> dict | None:
         return {"status": "ignored"}
     if action == "closed":
         return await _handle_merged_pr_event(data)
+    # Phase 3 PR-B1 — Tier 3 native auto-merge lifecycle 추적
+    # GitHub 가 auto-merge 를 자동 비활성화 시 MergeAttempt state 전이
+    # Phase 3 PR-B1 — track Tier 3 native auto-merge lifecycle.
+    # When GitHub auto-disables auto-merge, transition MergeAttempt state.
+    if action == "auto_merge_disabled":
+        return await _handle_auto_merge_disabled_event(data)
     # force-push 감지: synchronize 시 이전 SHA pending 행 포기 처리
     # Force-push guard: abandon stale pending rows on synchronize
     if action == "synchronize":

--- a/src/webhook/providers/github.py
+++ b/src/webhook/providers/github.py
@@ -150,7 +150,7 @@ async def _record_actual_merge(repo_name: str, pr_number: int) -> None:
             if updated:
                 logger.info(
                     "merge_attempt %d: enabled_pending_merge → actually_merged (repo=%s, pr=%d)",
-                    latest.id, repo_name, pr_number,
+                    latest.id, sanitize_for_log(repo_name), pr_number,
                 )
     except (SQLAlchemyError, KeyError, AttributeError) as exc:
         # 관측 실패가 webhook 응답을 막지 않도록 격리 — Phase 3 PR-B1

--- a/tests/unit/gate/test_auto_merge_enqueue.py
+++ b/tests/unit/gate/test_auto_merge_enqueue.py
@@ -10,6 +10,7 @@ os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
 os.environ.setdefault("ANTHROPIC_API_KEY", "")
 
 from unittest.mock import AsyncMock, MagicMock, patch
+from src.gate.native_automerge import MergeOutcome, PATH_REST_FALLBACK
 
 from src.gate.engine import _run_auto_merge
 from src.config_manager.manager import RepoConfigData
@@ -60,7 +61,7 @@ async def test_run_auto_merge_enqueues_when_ci_running():
     enqueue_result = _make_enqueue_result(is_first_deferral=True)
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -75,7 +76,7 @@ async def test_run_auto_merge_enqueues_when_ci_running():
         mock_settings.merge_retry_initial_backoff_seconds = 60
         mock_settings.telegram_chat_id = "-100123"
         mock_state.return_value = ("unknown", "sha123")
-        mock_merge.return_value = (False, "unstable_ci: state=unstable", "sha123")
+        mock_merge.return_value = MergeOutcome(ok=False, reason="unstable_ci: state=unstable", head_sha="sha123", path=PATH_REST_FALLBACK)
         mock_required.return_value = {"ci/test"}
         mock_ci.return_value = "running"
         mock_repo.enqueue_or_bump.return_value = enqueue_result
@@ -112,7 +113,7 @@ async def test_run_auto_merge_terminal_when_ci_failed():
     config = _config()
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -128,7 +129,7 @@ async def test_run_auto_merge_terminal_when_ci_failed():
         mock_settings.telegram_chat_id = "-100123"
         mock_settings.telegram_bot_token = "123:ABC"
         mock_state.return_value = ("unknown", "sha123")
-        mock_merge.return_value = (False, "unstable_ci: state=unstable", "sha123")
+        mock_merge.return_value = MergeOutcome(ok=False, reason="unstable_ci: state=unstable", head_sha="sha123", path=PATH_REST_FALLBACK)
         mock_required.return_value = {"ci/test"}
         mock_ci.return_value = "failed"
 
@@ -160,7 +161,7 @@ async def test_run_auto_merge_success_no_enqueue():
     config = _config()
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -173,7 +174,7 @@ async def test_run_auto_merge_success_no_enqueue():
         mock_settings.merge_retry_enabled = True
         mock_settings.telegram_chat_id = "-100123"
         mock_state.return_value = ("clean", "sha123")
-        mock_merge.return_value = (True, None, "sha123")
+        mock_merge.return_value = MergeOutcome(ok=True, reason=None, head_sha="sha123", path=PATH_REST_FALLBACK)
 
         await _run_auto_merge(
             config, "ghp_token", "owner/repo", 42, 80,
@@ -199,7 +200,7 @@ async def test_run_auto_merge_terminal_on_dirty_conflict():
     config = _config()
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo, \
@@ -214,7 +215,7 @@ async def test_run_auto_merge_terminal_on_dirty_conflict():
         mock_state.return_value = ("dirty", "sha123")
         # dirty_conflict 는 merge_pr 사전 차단 경로에서 직접 반환됨
         # dirty_conflict is returned directly from the merge_pr pre-check path
-        mock_merge.return_value = (False, "dirty_conflict: 머지 조건 미충족 (state=dirty)", "sha123")
+        mock_merge.return_value = MergeOutcome(ok=False, reason="dirty_conflict: 머지 조건 미충족 (state=dirty)", head_sha="sha123", path=PATH_REST_FALLBACK)
 
         await _run_auto_merge(
             config, "ghp_token", "owner/repo", 42, 80,
@@ -241,7 +242,7 @@ async def test_run_auto_merge_deferred_no_notify_on_bump():
     enqueue_result = _make_enqueue_result(is_first_deferral=False)
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -256,7 +257,7 @@ async def test_run_auto_merge_deferred_no_notify_on_bump():
         mock_settings.merge_retry_initial_backoff_seconds = 60
         mock_settings.telegram_chat_id = "-100123"
         mock_state.return_value = ("unknown", "sha123")
-        mock_merge.return_value = (False, "unstable_ci: state=unstable", "sha123")
+        mock_merge.return_value = MergeOutcome(ok=False, reason="unstable_ci: state=unstable", head_sha="sha123", path=PATH_REST_FALLBACK)
         mock_required.return_value = {"ci/test"}
         mock_ci.return_value = "running"
         mock_repo.enqueue_or_bump.return_value = enqueue_result  # is_first_deferral=False
@@ -285,7 +286,7 @@ async def test_run_auto_merge_skips_when_score_below_threshold():
     config = _config(auto_merge=True, merge_threshold=75)
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo:
 
         mock_settings.merge_retry_enabled = True
@@ -312,7 +313,7 @@ async def test_run_auto_merge_skips_when_auto_merge_disabled():
     config = _config(auto_merge=False, merge_threshold=75)
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.merge_retry_repo") as mock_repo:
 
         mock_settings.merge_retry_enabled = True
@@ -371,7 +372,7 @@ async def test_run_auto_merge_terminal_when_ci_status_unknown():
     config = _config()
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -385,7 +386,7 @@ async def test_run_auto_merge_terminal_when_ci_status_unknown():
         mock_settings.telegram_chat_id = "-100123"
         mock_settings.telegram_bot_token = "123:ABC"
         mock_state.return_value = ("unknown", "sha123")
-        mock_merge.return_value = (False, "unstable_ci: state=unstable", "sha123")
+        mock_merge.return_value = MergeOutcome(ok=False, reason="unstable_ci: state=unstable", head_sha="sha123", path=PATH_REST_FALLBACK)
         mock_required.return_value = {"ci/test"}
         # CI 상태를 알 수 없음 → should_retry(unstable_ci, "unknown") = False
         # CI status unknown → should_retry(unstable_ci, "unknown") = False
@@ -414,7 +415,7 @@ async def test_run_auto_merge_no_analysis_id_skips_enqueue():
     config = _config()
 
     with patch("src.gate.engine.settings") as mock_settings, \
-         patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge, \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge, \
          patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
          patch("src.gate.engine.get_pr_base_ref", new_callable=AsyncMock, return_value="main") as mock_base_ref, \
          patch("src.gate.engine.get_required_check_contexts", new_callable=AsyncMock) as mock_required, \
@@ -425,7 +426,7 @@ async def test_run_auto_merge_no_analysis_id_skips_enqueue():
 
         mock_settings.merge_retry_enabled = True
         mock_state.return_value = ("unknown", "sha123")
-        mock_merge.return_value = (False, "unstable_ci: CI 진행 중", "sha123")
+        mock_merge.return_value = MergeOutcome(ok=False, reason="unstable_ci: CI 진행 중", head_sha="sha123", path=PATH_REST_FALLBACK)
         mock_required.return_value = {"ci/test"}
         mock_ci.return_value = "running"
 

--- a/tests/unit/gate/test_engine.py
+++ b/tests/unit/gate/test_engine.py
@@ -1195,3 +1195,147 @@ async def test_get_ci_status_safe_default_base_ref_is_main():
     args = mock_required.call_args
     branch_arg = args.args[2] if len(args.args) >= 3 else args.kwargs.get("branch")
     assert branch_arg == "main"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 PR-B1 — engine.py state 라벨링 분기
+# Phase 3 PR-B1 — engine.py state labeling branches
+# ---------------------------------------------------------------------------
+
+
+async def test_run_auto_merge_retry_native_enable_records_pending_state():
+    """Phase 3 PR-B1: outcome.path=PATH_NATIVE_ENABLE → state=enabled_pending_merge."""
+    from src.gate import _merge_attempt_states as _states
+    from src.gate.native_automerge import (
+        MergeOutcome, PATH_NATIVE_ENABLE,
+    )
+
+    mock_db = MagicMock()
+    config = _config(
+        approve_mode="disabled", auto_merge=True, merge_threshold=75,
+        pr_review_comment=False, notify_chat_id="-100123",
+    )
+    with patch("src.gate.engine.get_repo_config", return_value=config), \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_native, \
+         patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
+         patch("src.gate.engine.log_merge_attempt") as mock_log, \
+         patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock), \
+         patch("src.gate.engine.save_gate_decision"):
+        mock_state.return_value = ("clean", "abc123")
+        mock_native.return_value = MergeOutcome(
+            ok=True, reason=None, head_sha="abc123", path=PATH_NATIVE_ENABLE,
+        )
+        await run_gate_check(
+            repo_name="owner/repo", pr_number=3, analysis_id=10,
+            result={"score": 80, "grade": "B"},
+            github_token="tok", db=mock_db,
+        )
+    # log_merge_attempt 가 enabled_pending_merge state + enabled_at 으로 호출됨
+    mock_log.assert_called_once()
+    call_kwargs = mock_log.call_args.kwargs
+    assert call_kwargs["state"] == _states.ENABLED_PENDING_MERGE
+    assert call_kwargs["enabled_at"] is not None
+    assert call_kwargs["success"] is True
+
+
+async def test_run_auto_merge_retry_rest_fallback_records_direct_merged_state():
+    """Phase 3 PR-B1: outcome.path=PATH_REST_FALLBACK → state=direct_merged."""
+    from src.gate import _merge_attempt_states as _states
+    from src.gate.native_automerge import (
+        MergeOutcome, PATH_REST_FALLBACK,
+    )
+
+    mock_db = MagicMock()
+    config = _config(
+        approve_mode="disabled", auto_merge=True, merge_threshold=75,
+        pr_review_comment=False, notify_chat_id="-100123",
+    )
+    with patch("src.gate.engine.get_repo_config", return_value=config), \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_native, \
+         patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
+         patch("src.gate.engine.log_merge_attempt") as mock_log, \
+         patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock), \
+         patch("src.gate.engine.save_gate_decision"):
+        mock_state.return_value = ("clean", "abc123")
+        mock_native.return_value = MergeOutcome(
+            ok=True, reason=None, head_sha="abc123", path=PATH_REST_FALLBACK,
+        )
+        await run_gate_check(
+            repo_name="owner/repo", pr_number=3, analysis_id=10,
+            result={"score": 80, "grade": "B"},
+            github_token="tok", db=mock_db,
+        )
+    call_kwargs = mock_log.call_args.kwargs
+    assert call_kwargs["state"] == _states.DIRECT_MERGED
+    assert call_kwargs["enabled_at"] is None  # direct_merged 는 enabled_at 없음
+
+
+async def test_run_auto_merge_legacy_native_enable_records_pending_state():
+    """Phase 3 PR-B1: legacy 경로에서도 native enable → enabled_pending_merge."""
+    from src.gate import _merge_attempt_states as _states
+    from src.gate.native_automerge import (
+        MergeOutcome, PATH_NATIVE_ENABLE,
+    )
+
+    mock_db = MagicMock()
+    config = _config(
+        approve_mode="disabled", auto_merge=True, merge_threshold=75,
+        pr_review_comment=False, notify_chat_id="-100123",
+    )
+    with patch("src.gate.engine.get_repo_config", return_value=config), \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_native, \
+         patch("src.gate.engine.log_merge_attempt") as mock_log, \
+         patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock), \
+         patch("src.gate.engine.save_gate_decision"), \
+         patch("src.gate.engine.settings") as mock_settings:
+        mock_settings.merge_retry_enabled = False  # legacy 경로 강제
+        mock_settings.telegram_bot_token = ""
+        mock_settings.telegram_chat_id = ""
+        mock_native.return_value = MergeOutcome(
+            ok=True, reason=None, head_sha="abc123", path=PATH_NATIVE_ENABLE,
+        )
+        await run_gate_check(
+            repo_name="owner/repo", pr_number=3, analysis_id=10,
+            result={"score": 80, "grade": "B"},
+            github_token="tok", db=mock_db,
+        )
+    call_kwargs = mock_log.call_args.kwargs
+    assert call_kwargs["state"] == _states.ENABLED_PENDING_MERGE
+    assert call_kwargs["enabled_at"] is not None
+
+
+async def test_run_auto_merge_legacy_failure_records_legacy_state():
+    """Phase 3 PR-B1: legacy 경로 실패 시 state=legacy (실패는 분류 의미 없음)."""
+    from src.gate import _merge_attempt_states as _states
+    from src.gate.native_automerge import (
+        MergeOutcome, PATH_REST_FALLBACK,
+    )
+
+    mock_db = MagicMock()
+    config = _config(
+        approve_mode="disabled", auto_merge=True, merge_threshold=75,
+        pr_review_comment=False, notify_chat_id=None,
+    )
+    with patch("src.gate.engine.get_repo_config", return_value=config), \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_native, \
+         patch("src.gate.engine.log_merge_attempt") as mock_log, \
+         patch("src.gate.engine.create_merge_failure_issue", new_callable=AsyncMock), \
+         patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock), \
+         patch("src.gate.engine.save_gate_decision"), \
+         patch("src.gate.engine.settings") as mock_settings:
+        mock_settings.merge_retry_enabled = False
+        mock_settings.telegram_bot_token = ""
+        mock_settings.telegram_chat_id = ""
+        mock_native.return_value = MergeOutcome(
+            ok=False, reason="forbidden: no perms",
+            head_sha="abc123", path=PATH_REST_FALLBACK,
+        )
+        await run_gate_check(
+            repo_name="owner/repo", pr_number=3, analysis_id=10,
+            result={"score": 80, "grade": "B"},
+            github_token="tok", db=mock_db,
+        )
+    call_kwargs = mock_log.call_args.kwargs
+    assert call_kwargs["state"] == _states.LEGACY
+    assert call_kwargs["enabled_at"] is None
+    assert call_kwargs["success"] is False

--- a/tests/unit/gate/test_engine.py
+++ b/tests/unit/gate/test_engine.py
@@ -10,6 +10,7 @@ import logging
 import pytest
 import httpx
 from unittest.mock import AsyncMock, MagicMock, patch
+from src.gate.native_automerge import MergeOutcome, PATH_REST_FALLBACK
 from src.gate.engine import run_gate_check, _run_auto_merge, _notify_merge_failure
 from src.scorer.calculator import ScoreResult
 from src.config_manager.manager import RepoConfigData
@@ -60,7 +61,7 @@ async def test_review_comment_on_calls_post_pr_comment():
     with patch("src.gate.engine.get_repo_config", return_value=config):
         with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock) as mock_comment:
             with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
-                with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                     with patch("src.gate.engine.send_gate_request", new_callable=AsyncMock):
                         with patch("src.gate.engine.save_gate_decision"):
                             await run_gate_check(
@@ -104,7 +105,7 @@ async def test_auto_approve_high_score():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
             with patch("src.gate.engine.save_gate_decision"):
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -128,7 +129,7 @@ async def test_auto_reject_low_score():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
             with patch("src.gate.engine.save_gate_decision"):
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -151,7 +152,7 @@ async def test_auto_skip_middle_score():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
             with patch("src.gate.engine.save_gate_decision"):
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -228,12 +229,12 @@ async def test_auto_merge_independent_of_approve_mode():
         pr_review_comment=False,
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                     with patch("src.gate.engine.save_gate_decision"):
                         mock_state.return_value = ("clean", "abc123")
-                        mock_merge.return_value = (True, None, "abc123")
+                        mock_merge.return_value = MergeOutcome(ok=True, reason=None, head_sha="abc123", path=PATH_REST_FALLBACK)
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=3,
@@ -257,12 +258,12 @@ async def test_auto_merge_with_auto_approve():
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
-            with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+            with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
                 with patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state:
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                         with patch("src.gate.engine.save_gate_decision"):
                             mock_state.return_value = ("clean", "abc123")
-                            mock_merge.return_value = (True, None, "abc123")
+                            mock_merge.return_value = MergeOutcome(ok=True, reason=None, head_sha="abc123", path=PATH_REST_FALLBACK)
                             await run_gate_check(
                                 repo_name="owner/repo",
                                 pr_number=5,
@@ -285,7 +286,7 @@ async def test_auto_merge_below_threshold():
         pr_review_comment=False,
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                 with patch("src.gate.engine.save_gate_decision"):
                     await run_gate_check(
@@ -311,7 +312,7 @@ async def test_auto_merge_false_no_merge():
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
-            with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+            with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                     with patch("src.gate.engine.save_gate_decision"):
                         await run_gate_check(
@@ -343,7 +344,7 @@ async def test_push_event_no_gate_actions():
     with patch("src.gate.engine.get_repo_config", return_value=config):
         with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock) as mock_comment:
             with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
-                with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+                with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
                     with patch("src.gate.engine.send_gate_request", new_callable=AsyncMock) as mock_send:
                         with patch("src.gate.engine.save_gate_decision"):
                             await run_gate_check(
@@ -373,7 +374,7 @@ async def testsave_gate_decision_called_on_approve():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
             with patch("src.gate.engine.save_gate_decision") as mock_save:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -393,7 +394,7 @@ async def testsave_gate_decision_called_on_reject():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
             with patch("src.gate.engine.save_gate_decision") as mock_save:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -413,7 +414,7 @@ async def testsave_gate_decision_skip_on_middle_score():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
             with patch("src.gate.engine.save_gate_decision") as mock_save:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=1,
@@ -439,9 +440,9 @@ async def test_merge_pr_failure_does_not_raise():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock):
             with patch("src.gate.engine.save_gate_decision") as mock_save:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
                         with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock):
-                            mock_merge.return_value = (False, "forbidden: no permission", "abc123")
+                            mock_merge.return_value = MergeOutcome(ok=False, reason="forbidden: no permission", head_sha="abc123", path=PATH_REST_FALLBACK)
                             # 예외 없이 완료되어야 한다
                             # Must complete without raising an exception.
                             await run_gate_check(
@@ -469,7 +470,7 @@ async def test_post_pr_comment_exception_does_not_abort_gate():
         with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock, side_effect=httpx.ConnectError("comment failed")):
             with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
                 with patch("src.gate.engine.save_gate_decision"):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
                             result={"score": 80, "grade": "B"}, github_token="tok", db=mock_db,
@@ -485,7 +486,7 @@ async def test_post_github_review_exception_does_not_crash():
     with patch("src.gate.engine.get_repo_config", return_value=config):
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock, side_effect=httpx.ConnectError("GitHub API error")):
             with patch("src.gate.engine.save_gate_decision"):
-                with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                         # 예외 없이 완료되어야 한다
                         # Must complete without raising an exception.
@@ -500,7 +501,7 @@ async def test_merge_pr_exception_does_not_crash():
     mock_db = MagicMock()
     config = _config(approve_mode="disabled", auto_merge=True, merge_threshold=75, pr_review_comment=False)
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock, side_effect=httpx.ConnectError("merge error")):
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock, side_effect=httpx.ConnectError("merge error")):
             with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                 with patch("src.gate.engine.save_gate_decision"):
                     await run_gate_check(
@@ -623,7 +624,7 @@ async def test_approve_at_exact_threshold():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
             with patch("src.gate.engine.save_gate_decision"):
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
                             result={"score": 75}, github_token="tok", db=mock_db,
@@ -641,7 +642,7 @@ async def test_reject_threshold_boundary_is_excluded():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
             with patch("src.gate.engine.save_gate_decision") as mock_save:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
                             result={"score": 50}, github_token="tok", db=mock_db,
@@ -655,12 +656,12 @@ async def test_merge_at_exact_threshold():
     mock_db = MagicMock()
     config = _config(approve_mode="disabled", auto_merge=True, merge_threshold=75, pr_review_comment=False)
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                     with patch("src.gate.engine.save_gate_decision"):
                         mock_state.return_value = ("clean", "abc123")
-                        mock_merge.return_value = (True, None, "abc123")
+                        mock_merge.return_value = MergeOutcome(ok=True, reason=None, head_sha="abc123", path=PATH_REST_FALLBACK)
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
                             result={"score": 75}, github_token="tok", db=mock_db,
@@ -681,7 +682,7 @@ async def test_post_pr_comment_keyerror_does_not_abort_gate():
                    side_effect=KeyError("missing_field")):
             with patch("src.gate.engine.post_github_review", new_callable=AsyncMock) as mock_review:
                 with patch("src.gate.engine.save_gate_decision"):
-                    with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                    with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
                             result={"score": 80}, github_token="tok", db=mock_db,
@@ -697,7 +698,7 @@ async def test_post_github_review_keyerror_does_not_crash():
         with patch("src.gate.engine.post_github_review", new_callable=AsyncMock,
                    side_effect=KeyError("pr_number")):
             with patch("src.gate.engine.save_gate_decision"):
-                with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock):
+                with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock):
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                         await run_gate_check(
                             repo_name="owner/repo", pr_number=1, analysis_id=1,
@@ -720,12 +721,12 @@ async def test_auto_merge_success_no_telegram():
         notify_chat_id="-100123",
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock) as mock_tg:
                 with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                     with patch("src.gate.engine.save_gate_decision"):
                         # merge 성공 → (True, None)
-                        mock_merge.return_value = (True, None, "abc123")
+                        mock_merge.return_value = MergeOutcome(ok=True, reason=None, head_sha="abc123", path=PATH_REST_FALLBACK)
                         await run_gate_check(
                             repo_name="owner/repo",
                             pr_number=3,
@@ -749,7 +750,7 @@ async def test_auto_merge_failure_sends_telegram():
         notify_chat_id="-100123",
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock) as mock_tg:
                 with patch("src.gate.engine.settings") as mock_settings:
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
@@ -760,7 +761,7 @@ async def test_auto_merge_failure_sends_telegram():
                             # Use legacy path — get_pr_mergeable_state not needed
                             mock_settings.merge_retry_enabled = False
                             # merge 실패 → (False, "forbidden: Resource not accessible")
-                            mock_merge.return_value = (False, "forbidden: Resource not accessible", "abc123")
+                            mock_merge.return_value = MergeOutcome(ok=False, reason="forbidden: Resource not accessible", head_sha="abc123", path=PATH_REST_FALLBACK)
                             await run_gate_check(
                                 repo_name="owner/repo",
                                 pr_number=3,
@@ -792,14 +793,14 @@ async def test_auto_merge_failure_no_chat_id_only_logs():
         notify_chat_id=None,  # repo 전용 chat_id 없음
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock) as mock_tg:
                 with patch("src.gate.engine.settings") as mock_settings:
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                         with patch("src.gate.engine.save_gate_decision"):
                             mock_settings.telegram_bot_token = "123:ABC"
                             mock_settings.telegram_chat_id = ""  # global chat_id도 없음
-                            mock_merge.return_value = (False, "forbidden: no permission", "abc123")
+                            mock_merge.return_value = MergeOutcome(ok=False, reason="forbidden: no permission", head_sha="abc123", path=PATH_REST_FALLBACK)
                             await run_gate_check(
                                 repo_name="owner/repo",
                                 pr_number=3,
@@ -823,7 +824,7 @@ async def test_auto_merge_failure_global_fallback_chat_id():
         notify_chat_id=None,  # repo 전용 chat_id 없음
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock) as mock_tg:
                 with patch("src.gate.engine.settings") as mock_settings:
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
@@ -833,7 +834,7 @@ async def test_auto_merge_failure_global_fallback_chat_id():
                             # 레거시 경로 사용 — get_pr_mergeable_state 불필요
                             # Use legacy path — get_pr_mergeable_state not needed
                             mock_settings.merge_retry_enabled = False
-                            mock_merge.return_value = (False, "forbidden: no permission", "abc123")
+                            mock_merge.return_value = MergeOutcome(ok=False, reason="forbidden: no permission", head_sha="abc123", path=PATH_REST_FALLBACK)
                             await run_gate_check(
                                 repo_name="owner/repo",
                                 pr_number=3,
@@ -937,13 +938,13 @@ async def test_run_auto_merge_records_successful_merge_attempt():
         notify_chat_id="-100123",
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state:
                 with patch("src.gate.engine.log_merge_attempt") as mock_log:
                     with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                         with patch("src.gate.engine.save_gate_decision"):
                             mock_state.return_value = ("clean", "abc123")
-                            mock_merge.return_value = (True, None, "abc123")
+                            mock_merge.return_value = MergeOutcome(ok=True, reason=None, head_sha="abc123", path=PATH_REST_FALLBACK)
                             await run_gate_check(
                                 repo_name="owner/repo",
                                 pr_number=3,
@@ -978,14 +979,17 @@ async def test_run_auto_merge_records_failed_merge_attempt_with_reason_tag():
     )
     full_reason = "branch_protection_blocked: 머지 조건 미충족 (state=blocked)"
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state:
                 with patch("src.gate.engine.log_merge_attempt") as mock_log:
                     with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock):
                         with patch("src.gate.engine.post_pr_comment", new_callable=AsyncMock):
                             with patch("src.gate.engine.save_gate_decision"):
                                 mock_state.return_value = ("clean", "abc123")
-                                mock_merge.return_value = (False, full_reason, "abc123")
+                                mock_merge.return_value = MergeOutcome(
+                                    ok=False, reason=full_reason,
+                                    head_sha="abc123", path=PATH_REST_FALLBACK,
+                                )
                                 await run_gate_check(
                                     repo_name="owner/repo",
                                     pr_number=3,
@@ -1013,7 +1017,7 @@ async def test_run_auto_merge_log_merge_attempt_db_failure_does_not_block_notifi
         notify_chat_id="-100123",
     )
     with patch("src.gate.engine.get_repo_config", return_value=config):
-        with patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge:
+        with patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge:
             with patch("src.gate.engine.log_merge_attempt", side_effect=RuntimeError("DB down")):
                 with patch("src.gate.engine.telegram_post_message", new_callable=AsyncMock) as mock_tg:
                     with patch("src.gate.engine.settings") as mock_settings:
@@ -1024,7 +1028,7 @@ async def test_run_auto_merge_log_merge_attempt_db_failure_does_not_block_notifi
                                 # 레거시 경로 사용 — get_pr_mergeable_state 불필요
                                 # Use legacy path — get_pr_mergeable_state not needed
                                 mock_settings.merge_retry_enabled = False
-                                mock_merge.return_value = (False, "forbidden: no permission", "abc123")
+                                mock_merge.return_value = MergeOutcome(ok=False, reason="forbidden: no permission", head_sha="abc123", path=PATH_REST_FALLBACK)
                                 # log_merge_attempt 가 RuntimeError 를 던져도 전체는 중단 없이 완료
                                 await run_gate_check(
                                     repo_name="owner/repo",
@@ -1053,14 +1057,14 @@ async def test_run_auto_merge_creates_issue_when_enabled():
         notify_chat_id=None,
     )
     with (
-        patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge,
+        patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge,
         patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state,
         patch("src.gate.engine.create_merge_failure_issue", new_callable=AsyncMock) as mock_issue,
         patch("src.gate.engine.log_merge_attempt"),
         patch("src.gate.engine._notify_merge_failure", new_callable=AsyncMock),
     ):
         mock_state.return_value = ("clean", "abc123")
-        mock_merge.return_value = (False, "branch_protection_blocked: blocked", "abc123")
+        mock_merge.return_value = MergeOutcome(ok=False, reason="branch_protection_blocked: blocked", head_sha="abc123", path=PATH_REST_FALLBACK)
         mock_issue.return_value = 42
         await _run_auto_merge(
             config, "tok", "owner/repo", 1, 80, analysis_id=1, db=MagicMock()
@@ -1077,12 +1081,12 @@ async def test_run_auto_merge_skips_issue_when_disabled():
         notify_chat_id=None,
     )
     with (
-        patch("src.gate.engine.native_enable_or_fallback", new_callable=AsyncMock) as mock_merge,
+        patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_merge,
         patch("src.gate.engine.create_merge_failure_issue", new_callable=AsyncMock) as mock_issue,
         patch("src.gate.engine.log_merge_attempt"),
         patch("src.gate.engine._notify_merge_failure", new_callable=AsyncMock),
     ):
-        mock_merge.return_value = (False, "branch_protection_blocked: blocked", "abc123")
+        mock_merge.return_value = MergeOutcome(ok=False, reason="branch_protection_blocked: blocked", head_sha="abc123", path=PATH_REST_FALLBACK)
         await _run_auto_merge(
             config, "tok", "owner/repo", 1, 80, analysis_id=1, db=MagicMock()
         )

--- a/tests/unit/gate/test_native_automerge.py
+++ b/tests/unit/gate/test_native_automerge.py
@@ -273,3 +273,147 @@ async def test_fallback_failure_returns_rest_reason():
     assert result == rest_failure
     assert result[0] is False
     assert result[1] == "branch_protection_blocked: required check missing"
+
+
+# ── Phase 3 PR-B1: enable_or_fallback_with_path() — path-aware version ────
+
+
+async def test_enable_with_path_native_success_returns_native_enable_path():
+    """Phase 3 PR-B1: enable 성공 → MergeOutcome(path=PATH_NATIVE_ENABLE)."""
+    from src.gate.native_automerge import (
+        PATH_NATIVE_ENABLE, MergeOutcome, enable_or_fallback_with_path,
+    )
+
+    p_enable, p_merge, p_node, p_state, _, _, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_OK),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        outcome = await enable_or_fallback_with_path(
+            TOKEN, REPO, PR, expected_sha=HEAD_SHA,
+        )
+
+    assert isinstance(outcome, MergeOutcome)
+    assert outcome.ok is True
+    assert outcome.reason is None
+    assert outcome.head_sha == HEAD_SHA
+    assert outcome.path == PATH_NATIVE_ENABLE
+
+
+async def test_enable_with_path_disabled_in_repo_falls_back_returns_rest_path():
+    """Phase 3 PR-B1: ENABLE_DISABLED_IN_REPO → 폴백 → path=PATH_REST_FALLBACK."""
+    from src.gate.native_automerge import (
+        PATH_REST_FALLBACK, enable_or_fallback_with_path,
+    )
+
+    p_enable, p_merge, p_node, p_state, _, mock_merge, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_DISABLED_IN_REPO, "off"),
+        merge_result=(True, None, HEAD_SHA),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        outcome = await enable_or_fallback_with_path(
+            TOKEN, REPO, PR, expected_sha=HEAD_SHA,
+        )
+
+    assert outcome.ok is True
+    assert outcome.path == PATH_REST_FALLBACK
+    mock_merge.assert_awaited_once()
+
+
+async def test_enable_with_path_force_pushed_returns_no_attempt_path():
+    """Phase 3 PR-B1: ENABLE_FORCE_PUSHED → 폴백 미시도 → path=PATH_NO_ATTEMPT."""
+    from src.gate.native_automerge import (
+        PATH_NO_ATTEMPT, enable_or_fallback_with_path,
+    )
+
+    p_enable, p_merge, p_node, p_state, _, mock_merge, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_FORCE_PUSHED, "head sha mismatch"),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        outcome = await enable_or_fallback_with_path(
+            TOKEN, REPO, PR, expected_sha=HEAD_SHA,
+        )
+
+    assert outcome.ok is False
+    assert outcome.path == PATH_NO_ATTEMPT
+    assert "force_pushed" in (outcome.reason or "")
+    mock_merge.assert_not_called()
+
+
+async def test_enable_with_path_node_id_failure_falls_back():
+    """Phase 3 PR-B1: get_pr_node_id=None → 즉시 폴백 → path=PATH_REST_FALLBACK."""
+    from src.gate.native_automerge import (
+        PATH_REST_FALLBACK, enable_or_fallback_with_path,
+    )
+
+    p_enable, p_merge, p_node, p_state, mock_enable, _, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_OK),  # 호출 안 됨
+        node_id=None,  # 조회 실패
+        merge_result=(True, None, HEAD_SHA),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        outcome = await enable_or_fallback_with_path(
+            TOKEN, REPO, PR, expected_sha=HEAD_SHA,
+        )
+
+    assert outcome.ok is True
+    assert outcome.path == PATH_REST_FALLBACK
+    # node_id None 이므로 enable 자체 호출 안 됨
+    mock_enable.assert_not_called()
+
+
+async def test_enable_with_path_unclassified_status_falls_back():
+    """Phase 3 PR-B1: ENABLE_API_ERROR (분류 외) → 폴백 → path=PATH_REST_FALLBACK."""
+    from src.gate.native_automerge import (
+        PATH_REST_FALLBACK, enable_or_fallback_with_path,
+    )
+
+    p_enable, p_merge, p_node, p_state, _, _, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_API_ERROR, "weird"),
+        merge_result=(True, None, HEAD_SHA),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        outcome = await enable_or_fallback_with_path(
+            TOKEN, REPO, PR, expected_sha=HEAD_SHA,
+        )
+
+    assert outcome.ok is True
+    assert outcome.path == PATH_REST_FALLBACK
+
+
+async def test_enable_with_path_fallback_failure_propagates_reason():
+    """Phase 3 PR-B1: 폴백 머지 실패 시 reason 그대로 + path=PATH_REST_FALLBACK."""
+    from src.gate.native_automerge import (
+        PATH_REST_FALLBACK, enable_or_fallback_with_path,
+    )
+
+    p_enable, p_merge, p_node, p_state, _, _, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_PERMISSION_DENIED, "no perms"),
+        merge_result=(False, "branch_protection_blocked: ...", HEAD_SHA),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        outcome = await enable_or_fallback_with_path(
+            TOKEN, REPO, PR, expected_sha=HEAD_SHA,
+        )
+
+    assert outcome.ok is False
+    assert outcome.reason == "branch_protection_blocked: ..."
+    assert outcome.path == PATH_REST_FALLBACK
+
+
+async def test_enable_with_path_handles_get_pr_state_failure():
+    """Phase 3 PR-B1: get_pr_mergeable_state 실패 → head_sha="" 로 진행."""
+    from src.gate.native_automerge import (
+        PATH_NATIVE_ENABLE, enable_or_fallback_with_path,
+    )
+
+    p_enable, p_merge, p_node, p_state, _, _, _, _ = _patch_native(
+        enable_result=EnableAutoMergeResult(ENABLE_OK),
+        state_result=httpx.HTTPError("network down"),
+    )
+    with p_enable, p_merge, p_node, p_state:
+        # expected_sha 미전달 → 자체 조회 → HTTPError → head_sha="" 로 진행
+        outcome = await enable_or_fallback_with_path(TOKEN, REPO, PR)
+
+    assert outcome.ok is True
+    assert outcome.path == PATH_NATIVE_ENABLE
+    assert outcome.head_sha == ""

--- a/tests/unit/repositories/test_merge_attempt_repo_lifecycle.py
+++ b/tests/unit/repositories/test_merge_attempt_repo_lifecycle.py
@@ -1,0 +1,193 @@
+"""Phase 3 PR-B1 — MergeAttempt lifecycle 함수 단위 테스트.
+
+find_latest_for_pr / mark_actually_merged / mark_disabled_externally 의
+멱등 전이 가드를 검증한다 (in-memory SQLite).
+"""
+# pylint: disable=redefined-outer-name
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from src.database import Base
+import src.models  # noqa: F401 — 모든 모델 등록
+from src.gate import _merge_attempt_states as _states
+from src.models.analysis import Analysis
+from src.models.merge_attempt import MergeAttempt
+from src.models.repository import Repository
+from src.repositories import merge_attempt_repo
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine)
+    sess = Session()
+    yield sess
+    sess.close()
+    engine.dispose()
+
+
+def _seed_analysis(db, repo_name="o/r", commit_sha="abc123"):
+    repo = Repository(full_name=repo_name)
+    db.add(repo)
+    db.commit()
+    analysis = Analysis(repo_id=repo.id, commit_sha=commit_sha)
+    db.add(analysis)
+    db.commit()
+    return analysis
+
+
+def test_find_latest_for_pr_returns_none_when_no_rows(db_session):
+    """PR 에 MergeAttempt 없으면 None 반환."""
+    assert merge_attempt_repo.find_latest_for_pr(db_session, "o/r", 7) is None
+
+
+def test_find_latest_for_pr_returns_most_recent(db_session):
+    """동일 PR 의 여러 시도 중 attempted_at 가장 최근 행 반환."""
+    analysis = _seed_analysis(db_session)
+    older = MergeAttempt(
+        analysis_id=analysis.id, repo_name="o/r", pr_number=7,
+        score=80, threshold=75, success=True,
+        attempted_at=datetime(2026, 4, 1, tzinfo=timezone.utc),
+    )
+    newer = MergeAttempt(
+        analysis_id=analysis.id, repo_name="o/r", pr_number=7,
+        score=82, threshold=75, success=True,
+        attempted_at=datetime(2026, 4, 29, tzinfo=timezone.utc),
+    )
+    db_session.add_all([older, newer])
+    db_session.commit()
+
+    found = merge_attempt_repo.find_latest_for_pr(db_session, "o/r", 7)
+    assert found is not None
+    assert found.score == 82  # 최신 행
+
+
+def test_mark_actually_merged_transitions_pending_row(db_session):
+    """state='enabled_pending_merge' 행을 'actually_merged' 로 전이."""
+    analysis = _seed_analysis(db_session)
+    row = MergeAttempt(
+        analysis_id=analysis.id, repo_name="o/r", pr_number=7,
+        score=80, threshold=75, success=True,
+        state=_states.ENABLED_PENDING_MERGE,
+    )
+    db_session.add(row)
+    db_session.commit()
+
+    merged_at = datetime.now(timezone.utc)
+    updated = merge_attempt_repo.mark_actually_merged(
+        db_session, attempt_id=row.id, merged_at=merged_at,
+    )
+    assert updated is True
+    db_session.refresh(row)
+    assert row.state == _states.ACTUALLY_MERGED
+    assert row.merged_at is not None
+
+
+def test_mark_actually_merged_idempotent_on_already_merged(db_session):
+    """이미 actually_merged 인 행 재호출 시 no-op (False 반환)."""
+    analysis = _seed_analysis(db_session)
+    row = MergeAttempt(
+        analysis_id=analysis.id, repo_name="o/r", pr_number=7,
+        score=80, threshold=75, success=True,
+        state=_states.ACTUALLY_MERGED,
+    )
+    db_session.add(row)
+    db_session.commit()
+
+    updated = merge_attempt_repo.mark_actually_merged(
+        db_session, attempt_id=row.id, merged_at=datetime.now(timezone.utc),
+    )
+    assert updated is False  # WHERE 절 가드로 갱신 안 됨
+
+
+def test_mark_actually_merged_skips_legacy_rows(db_session):
+    """state='legacy' 행은 갱신 금지 (전이 무관)."""
+    analysis = _seed_analysis(db_session)
+    row = MergeAttempt(
+        analysis_id=analysis.id, repo_name="o/r", pr_number=7,
+        score=80, threshold=75, success=True,
+        state=_states.LEGACY,
+    )
+    db_session.add(row)
+    db_session.commit()
+
+    updated = merge_attempt_repo.mark_actually_merged(
+        db_session, attempt_id=row.id, merged_at=datetime.now(timezone.utc),
+    )
+    assert updated is False
+    db_session.refresh(row)
+    assert row.state == _states.LEGACY  # 변경 없음
+
+
+def test_mark_disabled_externally_transitions_pending_row(db_session):
+    """state='enabled_pending_merge' 행을 'disabled_externally' 로 전이 + reason 기록."""
+    analysis = _seed_analysis(db_session)
+    row = MergeAttempt(
+        analysis_id=analysis.id, repo_name="o/r", pr_number=7,
+        score=80, threshold=75, success=True,
+        state=_states.ENABLED_PENDING_MERGE,
+    )
+    db_session.add(row)
+    db_session.commit()
+
+    updated = merge_attempt_repo.mark_disabled_externally(
+        db_session, attempt_id=row.id,
+        disabled_at=datetime.now(timezone.utc),
+        reason="auto_merge_disabled_by_user",
+    )
+    assert updated is True
+    db_session.refresh(row)
+    assert row.state == _states.DISABLED_EXTERNALLY
+    assert row.disabled_at is not None
+    assert row.failure_reason == "auto_merge_disabled_by_user"
+
+
+def test_mark_disabled_externally_idempotent(db_session):
+    """이미 disabled_externally 인 행은 no-op."""
+    analysis = _seed_analysis(db_session)
+    row = MergeAttempt(
+        analysis_id=analysis.id, repo_name="o/r", pr_number=7,
+        score=80, threshold=75, success=True,
+        state=_states.DISABLED_EXTERNALLY,
+    )
+    db_session.add(row)
+    db_session.commit()
+
+    updated = merge_attempt_repo.mark_disabled_externally(
+        db_session, attempt_id=row.id,
+        disabled_at=datetime.now(timezone.utc),
+    )
+    assert updated is False
+
+
+def test_create_with_state_and_enabled_at(db_session):
+    """create() 의 신규 state/enabled_at 파라미터 round-trip."""
+    analysis = _seed_analysis(db_session)
+    enabled_at = datetime(2026, 4, 29, 12, tzinfo=timezone.utc)
+    record = merge_attempt_repo.create(
+        db_session,
+        analysis_id=analysis.id, repo_name="o/r", pr_number=7,
+        score=80, threshold=75, success=True,
+        state=_states.ENABLED_PENDING_MERGE, enabled_at=enabled_at,
+    )
+    assert record.state == _states.ENABLED_PENDING_MERGE
+    # SQLite 는 timezone naive 로 저장 — replace(tzinfo=None) 으로 비교
+    # SQLite stores datetimes as naive — strip tzinfo before comparing
+    assert record.enabled_at.replace(tzinfo=None) == enabled_at.replace(tzinfo=None)
+    assert record.merged_at is None
+    assert record.disabled_at is None
+
+
+def test_create_default_state_is_legacy(db_session):
+    """기존 호출처 호환 — state 미지정 시 'legacy' 기본값."""
+    analysis = _seed_analysis(db_session)
+    record = merge_attempt_repo.create(
+        db_session,
+        analysis_id=analysis.id, repo_name="o/r", pr_number=7,
+        score=80, threshold=75, success=True,
+    )
+    assert record.state == _states.LEGACY

--- a/tests/unit/repositories/test_merge_attempt_repo_lifecycle.py
+++ b/tests/unit/repositories/test_merge_attempt_repo_lifecycle.py
@@ -11,7 +11,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from src.database import Base
-import src.models  # noqa: F401 — 모든 모델 등록
 from src.gate import _merge_attempt_states as _states
 from src.models.analysis import Analysis
 from src.models.merge_attempt import MergeAttempt

--- a/tests/unit/webhook/providers/test_auto_merge_lifecycle.py
+++ b/tests/unit/webhook/providers/test_auto_merge_lifecycle.py
@@ -1,0 +1,238 @@
+"""Phase 3 PR-B1 — pull_request.closed/auto_merge_disabled 라이프사이클 핸들러 테스트.
+
+webhook → state 전이 (mark_actually_merged / mark_disabled_externally) 검증.
+"""
+# pylint: disable=redefined-outer-name,import-outside-toplevel
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# src 임포트 전 환경변수 주입
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "")
+
+
+# ────────────────── pull_request.closed merged=true ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_merged_pr_event_transitions_state_to_actually_merged():
+    """pull_request.closed merged=true → mark_actually_merged 호출."""
+    from src.webhook.providers.github import _handle_merged_pr_event
+
+    data = {
+        "pull_request": {"merged": True, "number": 7, "body": ""},
+        "repository": {"full_name": "o/r"},
+    }
+
+    # find_latest_for_pr 가 enabled_pending_merge 행 반환
+    fake_attempt = MagicMock()
+    fake_attempt.id = 99
+    with patch("src.webhook.providers.github.SessionLocal") as mock_session_cls, \
+         patch(
+             "src.webhook.providers.github.merge_attempt_repo.find_latest_for_pr",
+             return_value=fake_attempt,
+         ), \
+         patch(
+             "src.webhook.providers.github.merge_attempt_repo.mark_actually_merged",
+             return_value=True,
+         ) as mock_mark:
+        # SessionLocal 컨텍스트 매니저 mock
+        mock_session_cls.return_value.__enter__.return_value = MagicMock()
+        mock_session_cls.return_value.__exit__.return_value = None
+
+        result = await _handle_merged_pr_event(data)
+
+    assert result["status"] == "accepted"
+    mock_mark.assert_called_once()
+    assert mock_mark.call_args.kwargs["attempt_id"] == 99
+
+
+@pytest.mark.asyncio
+async def test_handle_merged_pr_event_no_op_when_no_merge_attempt():
+    """find_latest_for_pr 가 None 반환 시 mark_actually_merged 미호출."""
+    from src.webhook.providers.github import _handle_merged_pr_event
+
+    data = {
+        "pull_request": {"merged": True, "number": 7, "body": ""},
+        "repository": {"full_name": "o/r"},
+    }
+
+    with patch("src.webhook.providers.github.SessionLocal") as mock_session_cls, \
+         patch(
+             "src.webhook.providers.github.merge_attempt_repo.find_latest_for_pr",
+             return_value=None,
+         ), \
+         patch(
+             "src.webhook.providers.github.merge_attempt_repo.mark_actually_merged",
+         ) as mock_mark:
+        mock_session_cls.return_value.__enter__.return_value = MagicMock()
+        mock_session_cls.return_value.__exit__.return_value = None
+
+        result = await _handle_merged_pr_event(data)
+
+    assert result["status"] == "accepted"
+    mock_mark.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_merged_pr_event_isolates_db_failure():
+    """DB 오류로 state 전이 실패해도 webhook 응답은 정상 (관측 격리)."""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from src.webhook.providers.github import _handle_merged_pr_event
+
+    data = {
+        "pull_request": {"merged": True, "number": 7, "body": ""},
+        "repository": {"full_name": "o/r"},
+    }
+
+    with patch(
+        "src.webhook.providers.github.SessionLocal",
+        side_effect=SQLAlchemyError("connection lost"),
+    ):
+        # SQLAlchemyError 가 _record_actual_merge 안 try/except 에서 격리됨
+        result = await _handle_merged_pr_event(data)
+
+    # body 없어 close_issue 단계도 ignored — but record_actual_merge 격리 검증
+    assert result["status"] in {"accepted", "ignored"}
+
+
+# ────────────────── pull_request.auto_merge_disabled ──────────────────
+
+
+@pytest.mark.asyncio
+async def test_handle_auto_merge_disabled_user_inferred_reason():
+    """sender.type=User 면 inferred_reason='auto_merge_disabled_by_user'."""
+    from src.webhook.providers.github import _handle_auto_merge_disabled_event
+
+    data = {
+        "repository": {"full_name": "o/r"},
+        "pull_request": {"number": 7},
+        "sender": {"login": "xzawed", "type": "User"},
+    }
+
+    fake_attempt = MagicMock()
+    fake_attempt.id = 42
+    with patch("src.webhook.providers.github.SessionLocal") as mock_session_cls, \
+         patch(
+             "src.webhook.providers.github.merge_attempt_repo.find_latest_for_pr",
+             return_value=fake_attempt,
+         ), \
+         patch(
+             "src.webhook.providers.github.merge_attempt_repo.mark_disabled_externally",
+             return_value=True,
+         ) as mock_mark:
+        mock_session_cls.return_value.__enter__.return_value = MagicMock()
+        mock_session_cls.return_value.__exit__.return_value = None
+
+        result = await _handle_auto_merge_disabled_event(data)
+
+    assert result["status"] == "accepted"
+    mock_mark.assert_called_once()
+    assert mock_mark.call_args.kwargs["reason"] == "auto_merge_disabled_by_user"
+
+
+@pytest.mark.asyncio
+async def test_handle_auto_merge_disabled_bot_inferred_reason():
+    """sender.type=Bot 면 inferred_reason='auto_merge_disabled_by_check_or_force_push'."""
+    from src.webhook.providers.github import _handle_auto_merge_disabled_event
+
+    data = {
+        "repository": {"full_name": "o/r"},
+        "pull_request": {"number": 7},
+        "sender": {"login": "github-actions[bot]", "type": "Bot"},
+    }
+
+    fake_attempt = MagicMock()
+    fake_attempt.id = 42
+    with patch("src.webhook.providers.github.SessionLocal") as mock_session_cls, \
+         patch(
+             "src.webhook.providers.github.merge_attempt_repo.find_latest_for_pr",
+             return_value=fake_attempt,
+         ), \
+         patch(
+             "src.webhook.providers.github.merge_attempt_repo.mark_disabled_externally",
+             return_value=True,
+         ) as mock_mark:
+        mock_session_cls.return_value.__enter__.return_value = MagicMock()
+        mock_session_cls.return_value.__exit__.return_value = None
+
+        await _handle_auto_merge_disabled_event(data)
+
+    assert mock_mark.call_args.kwargs["reason"] == "auto_merge_disabled_by_check_or_force_push"
+
+
+@pytest.mark.asyncio
+async def test_handle_auto_merge_disabled_returns_ignored_when_no_attempt():
+    """find_latest_for_pr 가 None 면 ignored 반환."""
+    from src.webhook.providers.github import _handle_auto_merge_disabled_event
+
+    data = {
+        "repository": {"full_name": "o/r"},
+        "pull_request": {"number": 7},
+        "sender": {"login": "xzawed", "type": "User"},
+    }
+
+    with patch("src.webhook.providers.github.SessionLocal") as mock_session_cls, \
+         patch(
+             "src.webhook.providers.github.merge_attempt_repo.find_latest_for_pr",
+             return_value=None,
+         ), \
+         patch(
+             "src.webhook.providers.github.merge_attempt_repo.mark_disabled_externally",
+         ) as mock_mark:
+        mock_session_cls.return_value.__enter__.return_value = MagicMock()
+        mock_session_cls.return_value.__exit__.return_value = None
+
+        result = await _handle_auto_merge_disabled_event(data)
+
+    assert result["status"] == "ignored"
+    mock_mark.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_auto_merge_disabled_missing_repo_or_pr_returns_ignored():
+    """repo_name 또는 pr_number 없으면 ignored."""
+    from src.webhook.providers.github import _handle_auto_merge_disabled_event
+
+    # repo 누락
+    result1 = await _handle_auto_merge_disabled_event({
+        "pull_request": {"number": 7}, "sender": {"login": "x", "type": "User"},
+    })
+    assert result1["status"] == "ignored"
+
+    # pr_number 누락
+    result2 = await _handle_auto_merge_disabled_event({
+        "repository": {"full_name": "o/r"},
+        "pull_request": {},
+        "sender": {"login": "x", "type": "User"},
+    })
+    assert result2["status"] == "ignored"
+
+
+@pytest.mark.asyncio
+async def test_handle_auto_merge_disabled_isolates_db_failure():
+    """DB 오류로 mark_disabled_externally 실패해도 webhook 응답은 ignored (격리)."""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from src.webhook.providers.github import _handle_auto_merge_disabled_event
+
+    data = {
+        "repository": {"full_name": "o/r"},
+        "pull_request": {"number": 7},
+        "sender": {"login": "xzawed", "type": "User"},
+    }
+
+    with patch(
+        "src.webhook.providers.github.SessionLocal",
+        side_effect=SQLAlchemyError("connection lost"),
+    ):
+        result = await _handle_auto_merge_disabled_event(data)
+
+    assert result["status"] == "ignored"


### PR DESCRIPTION
## Summary

Tier 3 PR-A 의 가장 큰 관측 갭 (P1) 해소 — native enable 성공 시 즉시 success=True 로 기록되던 구조를 lifecycle state 추적으로 전환.

## 핵심
1. `MergeAttempt` 에 `state`/`enabled_at`/`merged_at`/`disabled_at` 4 컬럼 추가 (Alembic 0022)
2. `MergeOutcome` dataclass + `enable_or_fallback_with_path()` 헬퍼
3. `engine.py` 양쪽 경로에서 path 기반 state 라벨링
4. webhook `pull_request.closed merged=true` → mark_actually_merged 전이
5. webhook `pull_request.auto_merge_disabled` 신규 핸들러 → mark_disabled_externally

## state 의미
- `legacy` — 0022 이전 모든 행
- `enabled_pending_merge` — native enable 성공, GitHub 비동기 머지 대기
- `actually_merged` — 실제 머지 commit 발생 (closed webhook)
- `disabled_externally` — force-push/check 실패/수동 해제 (auto_merge_disabled webhook)
- `direct_merged` — REST merge_pr() 즉시 성공

## 회귀
- 단위 테스트: 1729 → **1746** (+17 신규)
- pylint 10.00, bandit 0 HIGH

## Migration 안전성
- 0022 다운타임 ~0초 (PG metadata-only)
- server_default 로 backfill 자동

## Test plan
- [ ] CI 통과
- [ ] 머지 후 자기 PR 1건에서 state 전이 검증 (enabled_pending_merge → actually_merged)
- [ ] 1주 dogfooding 후 PR-B3 (`merge_retry_service` 폐기) 평가

관련: PR #102 (설계서), PR #103 (Tier 3 PR-A)