### PR TITLE
feat(graphql): Phase 3 PR-B2 — 이중 enable 가드 (already-enabled → ENABLE_OK)

### DIFF
--- a/src/github_client/graphql.py
+++ b/src/github_client/graphql.py
@@ -154,6 +154,24 @@ def _classify_graphql_errors(errors: list[dict]) -> EnableAutoMergeResult:
     err_msg = err.get("message") or ""
     msg_lower = err_msg.lower()
 
+    # Phase 3 PR-B2 — 이중 enable 가드: 이미 enabled 인 PR 에 mutation 재호출 시
+    # GitHub 가 "already" 류 메시지로 응답. 이 경우 ENABLE_OK 로 처리해 폴백을
+    # 차단 — 폴백이 일어나면 REST PUT/merge 가 405 (Not Mergeable) 로 실패하여
+    # 잘못된 advice 와 Issue 가 사용자에게 발송됨 (14-에이전트 감사 R2-C 식별).
+    # Phase 3 PR-B2 — double-enable guard: when GitHub returns an "already enabled"
+    # message for a PR that already has auto-merge active, classify as ENABLE_OK
+    # to skip fallback. Otherwise the REST PUT/merge fallback returns 405 and we
+    # surface a misleading "Auto Merge 실패" alert (audit R2-C).
+    if "already" in msg_lower and (
+        "auto merge" in msg_lower
+        or "auto-merge" in msg_lower
+        or "merge state" in msg_lower
+    ):
+        return EnableAutoMergeResult(
+            ENABLE_OK,
+            f"idempotent: already enabled — {err_msg}",
+        )
+
     # "Auto merge is not allowed for this repository"
     if "auto merge is not allowed" in msg_lower or "auto-merge is not allowed" in msg_lower:
         return EnableAutoMergeResult(ENABLE_DISABLED_IN_REPO, err_msg)

--- a/tests/unit/github_client/test_graphql.py
+++ b/tests/unit/github_client/test_graphql.py
@@ -112,6 +112,32 @@ async def test_enable_returns_ok_on_successful_response():
     assert result.detail is None
 
 
+async def test_enable_classifies_already_enabled_as_ok():
+    """Phase 3 PR-B2 idempotency 가드 — "already in auto merge state" → ENABLE_OK.
+
+    GitHub 이 이미 enabled 된 PR 에 mutation 재호출 시 응답하는 메시지를
+    ENABLE_OK 로 처리. 폴백 차단 (REST PUT/merge → 405 거짓 실패 회피).
+    Phase 3 PR-B2 idempotency guard — when GitHub responds "already in auto
+    merge state", classify as ENABLE_OK to skip fallback (avoiding the false
+    405 failure that would surface a misleading alert).
+    """
+    test_messages = [
+        "Pull request is already in auto merge state",
+        "Auto-merge is already enabled for this PR",
+        "auto merge already requested",
+    ]
+    for msg in test_messages:
+        err_body = {"errors": [{"message": msg}]}
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=_make_response(err_body))
+        with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+            result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
+        assert result.status == "ok", (
+            f"메시지 {msg!r} 가 ENABLE_OK 로 분류되어야 함 — 실제 {result.status!r}"
+        )
+        assert "idempotent: already enabled" in (result.detail or "")
+
+
 async def test_enable_classifies_disabled_in_repo():
     """리포 settings 에 auto-merge 미활성 메시지 → ENABLE_DISABLED_IN_REPO.
     Message "Auto merge is not allowed for this repository" → ENABLE_DISABLED_IN_REPO.


### PR DESCRIPTION
## Summary

14-에이전트 감사 R2-C P1 — 이미 enabled 된 PR 에 mutation 재호출 시 405 거짓 실패로 사용자에게 잘못된 알림이 발송되는 문제 차단.

## 변경
- `_classify_graphql_errors` 에 "already" 패턴 매칭 추가 → ENABLE_OK 분류
- 5줄 코드 변경 + 1개 테스트 함수 (3 변형 동시 검증)

## 효과
- synchronize webhook 재전송 시 거짓 "Auto Merge 실패" 알림 0건
- PR-B1 의 lifecycle state 추적과 자연스럽게 연동 (멱등 enable → 기존 enabled_pending_merge 행 보존)

## 회귀
- 단위 테스트: 1726 passed / 0 failed
- pylint 10.00, bandit 0 HIGH

## 의존성
PR #114 (PR-B1) 와 독립적 — 머지 순서 무관