### PR TITLE
test(coverage): Phase 4 PR-T1 — Critical 테스트 갭 보강 (analyzer + scorer …

### DIFF
--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -1,0 +1,281 @@
+"""Phase 4 PR-T1 — ai_review.py 에러 경로 + cache_control 동작 단위 테스트.
+
+기존 test_ai_review.py 는 happy path 위주 — 에러 경로를 별도 파일로 분리해
+가독성 + 14-에이전트 감사 R1-B 의 "AI review 에러 케이스 부족" 갭 해소.
+
+검증 대상:
+  - anthropic API 예외 (timeout / rate-limit / auth / connection) → graceful
+  - log_claude_api_call 호출 검증 (status="error" + error_type)
+  - prompt cache 토큰 추출 (Phase 1 PR-B caching 후속)
+  - response 파싱 fallback (preamble + JSON, malformed)
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "test-token")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123456:test")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123456")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-key")
+os.environ.setdefault("GITHUB_CLIENT_ID", "test-client-id")
+os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-client-secret")
+os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+
+# pylint: disable=wrong-import-position
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+
+from src.analyzer.io.ai_review import (
+    _default_result,
+    _extract_json_payload,
+    _parse_response,
+    review_code,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# anthropic API 예외 경로 — 모든 케이스 graceful "api_error" fallback
+# ──────────────────────────────────────────────────────────────────────────
+
+
+async def test_review_code_handles_httpx_connect_error():
+    """httpx.ConnectError 발생 시 _default_result("api_error") 반환."""
+    fake_client = MagicMock()
+    fake_client.messages = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        side_effect=httpx.ConnectError("DNS lookup failed"),
+    )
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client):
+        result = await review_code(
+            "sk-test", "feat: test", [("app.py", "+ x = 1")],
+        )
+    assert result.status == "api_error"
+    assert result.commit_score == 17
+    assert result.ai_score == 17
+    assert result.test_score == 7
+
+
+async def test_review_code_handles_httpx_timeout_error():
+    """httpx.TimeoutException → api_error fallback."""
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        side_effect=httpx.TimeoutException("read timeout"),
+    )
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client):
+        result = await review_code(
+            "sk-test", "feat: test", [("app.py", "+ x = 1")],
+        )
+    assert result.status == "api_error"
+
+
+async def test_review_code_handles_runtime_error():
+    """RuntimeError (예: anthropic 내부 정책 거부) → api_error fallback.
+
+    실제 anthropic 예외 클래스(APIError 등)는 SDK 의존성 — 광역 Exception catch
+    가 의도적이므로 RuntimeError 로 동작 검증.
+    """
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        side_effect=RuntimeError("policy denied"),
+    )
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client):
+        result = await review_code(
+            "sk-test", "feat: test", [("app.py", "+ x = 1")],
+        )
+    assert result.status == "api_error"
+
+
+async def test_review_code_logs_claude_api_call_with_error_status():
+    """예외 발생 시 log_claude_api_call(status='error', error_type=...) 호출 검증."""
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(side_effect=httpx.ConnectError("net"))
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client), \
+         patch("src.analyzer.io.ai_review.log_claude_api_call") as mock_log:
+        await review_code("sk-test", "feat: test", [("app.py", "+ x = 1")])
+    mock_log.assert_called_once()
+    kwargs = mock_log.call_args.kwargs
+    assert kwargs["status"] == "error"
+    assert kwargs["error_type"] == "ConnectError"
+    assert kwargs["input_tokens"] == 0
+    assert kwargs["output_tokens"] == 0
+
+
+async def test_review_code_logs_claude_api_call_with_success_status():
+    """정상 응답 시 log_claude_api_call(status='success' + cache token) 호출 검증."""
+    response_obj = MagicMock()
+    response_obj.content = [MagicMock(text=json.dumps({
+        "commit_message_score": 18, "direction_score": 17, "test_score": 8,
+        "summary": "ok", "suggestions": [],
+        "commit_message_feedback": "", "code_quality_feedback": "",
+        "security_feedback": "", "direction_feedback": "", "test_feedback": "",
+        "file_feedbacks": [],
+    }))]
+    response_obj.usage = MagicMock(
+        input_tokens=120, output_tokens=300,
+        cache_read_input_tokens=80, cache_creation_input_tokens=0,
+    )
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=response_obj)
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client), \
+         patch("src.analyzer.io.ai_review.log_claude_api_call") as mock_log:
+        result = await review_code("sk-test", "feat: test", [("app.py", "+ x = 1")])
+    assert result.status == "success"
+    mock_log.assert_called_once()
+    kwargs = mock_log.call_args.kwargs
+    assert kwargs["status"] == "success"
+    assert kwargs["input_tokens"] == 120
+    assert kwargs["output_tokens"] == 300
+    # Phase 1 PR-B caching 후속 — cache 토큰 전달 검증
+    assert kwargs["cache_read_tokens"] == 80
+    assert kwargs["cache_creation_tokens"] == 0
+
+
+async def test_review_code_uses_cache_control_in_system_prompt():
+    """Phase 1 PR-B: messages.create 호출에 system=[{cache_control: ephemeral}] 포함 검증."""
+    response_obj = MagicMock()
+    response_obj.content = [MagicMock(text='{"summary": "ok"}')]
+    response_obj.usage = MagicMock(input_tokens=10, output_tokens=20)
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=response_obj)
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client):
+        await review_code("sk-test", "feat: test", [("app.py", "+ x = 1")])
+    call_kwargs = fake_client.messages.create.call_args.kwargs
+    assert "system" in call_kwargs
+    system_blocks = call_kwargs["system"]
+    assert isinstance(system_blocks, list)
+    assert system_blocks[0]["type"] == "text"
+    assert system_blocks[0]["cache_control"] == {"type": "ephemeral"}
+    assert system_blocks[0]["text"]  # 비어있지 않음
+
+
+async def test_review_code_propagates_detected_languages():
+    """build_review_prompt 가 detected_languages 반환 → result.detected_languages 전달."""
+    response_obj = MagicMock()
+    response_obj.content = [MagicMock(text='{"summary": "ok"}')]
+    response_obj.usage = MagicMock(input_tokens=10, output_tokens=20)
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=response_obj)
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client), \
+         patch(
+             "src.analyzer.io.ai_review.build_review_prompt",
+             return_value=("user prompt", ["python", "go"]),
+         ):
+        result = await review_code(
+            "sk-test", "feat: test", [("app.py", "+ x = 1")],
+        )
+    assert result.detected_languages == ["python", "go"]
+
+
+async def test_review_code_returns_empty_diff_status_for_empty_patches():
+    """patches list 가 비어있을 때 status=empty_diff (build_review_prompt → empty)."""
+    result = await review_code("sk-test", "feat: x", [])
+    assert result.status == "empty_diff"
+
+
+async def test_review_code_returns_no_api_key_for_missing_key():
+    """api_key 가 빈 문자열일 때 status=no_api_key (empty_diff 보다 우선)."""
+    result = await review_code("", "feat: x", [("a.py", "+ x = 1")])
+    assert result.status == "no_api_key"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _extract_json_payload 응답 파싱 fallback
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_json_payload_codeblock_lowercase():
+    """```json {...} ``` → JSON 본문만 추출."""
+    text = '```json\n{"key": "value"}\n```'
+    assert _extract_json_payload(text) == '{"key": "value"}'
+
+
+def test_extract_json_payload_codeblock_uppercase():
+    """대문자 ```JSON 도 case-insensitive 매칭."""
+    text = '```JSON\n{"key": "value"}\n```'
+    assert _extract_json_payload(text) == '{"key": "value"}'
+
+
+def test_extract_json_payload_codeblock_no_lang_tag():
+    """언어 태그 없는 ``` ``` → 동일 매칭."""
+    text = '```\n{"key": "value"}\n```'
+    assert _extract_json_payload(text) == '{"key": "value"}'
+
+
+def test_extract_json_payload_with_preamble_and_trailing_text():
+    """JSON 앞뒤 설명 텍스트 → 첫 { ~ 마지막 } 구간 추출."""
+    text = (
+        "Here is the analysis:\n"
+        '{"commit_message_score": 18, "summary": "ok"}\n'
+        "End of response."
+    )
+    extracted = _extract_json_payload(text)
+    assert extracted.startswith("{")
+    assert extracted.endswith("}")
+    assert "commit_message_score" in extracted
+
+
+def test_extract_json_payload_returns_cleaned_when_no_braces():
+    """{ } 없으면 cleaned text 그대로 반환."""
+    text = "no JSON here at all"
+    assert _extract_json_payload(text) == "no JSON here at all"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _parse_response — JSON decode/value/key 에러 모두 parse_error fallback
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_response_value_error_returns_default():
+    """int(non-numeric) ValueError → status=parse_error."""
+    text = '{"commit_message_score": "not-a-number"}'
+    result = _parse_response(text)
+    assert result.status == "parse_error"
+    assert result.commit_score == 17
+
+
+def test_parse_response_invalid_json_returns_default():
+    """완전 깨진 JSON → status=parse_error."""
+    result = _parse_response("totally broken {][")
+    assert result.status == "parse_error"
+
+
+def test_parse_response_clamps_out_of_range_scores():
+    """commit_message_score=99 → max(0, min(20, 99)) = 20."""
+    text = json.dumps({
+        "commit_message_score": 99, "direction_score": -5, "test_score": 50,
+        "summary": "x",
+    })
+    result = _parse_response(text)
+    assert result.commit_score == 20  # clamped to max
+    assert result.ai_score == 0       # clamped to min
+    assert result.test_score == 10    # clamped to test max
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _default_result — status enum 정확성
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_default_result_carries_status_field():
+    """_default_result(reason) 의 status 필드가 reason 그대로."""
+    assert _default_result("api_error").status == "api_error"
+    assert _default_result("no_api_key").status == "no_api_key"
+    assert _default_result("empty_diff").status == "empty_diff"
+    assert _default_result("parse_error").status == "parse_error"
+
+
+def test_default_result_default_reason_is_no_api_key():
+    """기본값 호출 시 status='no_api_key'."""
+    assert _default_result().status == "no_api_key"
+
+
+def test_default_result_neutral_scores():
+    """모든 default 결과가 동일한 중립 점수 (commit=17, ai=17, test=7)."""
+    for reason in ("no_api_key", "empty_diff", "api_error", "parse_error"):
+        result = _default_result(reason)
+        assert result.commit_score == 17
+        assert result.ai_score == 17
+        assert result.test_score == 7
+        assert result.summary  # 비어있지 않음

--- a/tests/unit/analyzer/tools/test_python.py
+++ b/tests/unit/analyzer/tools/test_python.py
@@ -1,0 +1,470 @@
+"""Phase 4 PR-T1 — Python static analyzer tools 단위 테스트.
+
+대상 모듈: `src/analyzer/io/tools/python.py`
+  - _PylintAnalyzer  (code_quality)
+  - _Flake8Analyzer  (code_quality)
+  - _BanditAnalyzer  (security, 테스트 파일 제외)
+
+subprocess.run mock 으로 실제 도구 바이너리 호출 없이 모든 경로 검증.
+14-에이전트 감사 R1-B 에서 식별된 Critical Gap (test_python.py 전무) 해소.
+"""
+import json
+import os
+import subprocess
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "test-token")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123456:test")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123456")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-key")
+os.environ.setdefault("GITHUB_CLIENT_ID", "test-github-client-id")
+os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-github-client-secret")
+os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+
+# pylint: disable=redefined-outer-name,wrong-import-position
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.analyzer.io.tools.python import (
+    _BanditAnalyzer,
+    _Flake8Analyzer,
+    _PylintAnalyzer,
+)
+from src.analyzer.pure.registry import (
+    AnalyzeContext,
+    Category,
+    Severity,
+)
+from src.constants import STATIC_ANALYSIS_TIMEOUT
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 공용 헬퍼 — subprocess.run mock + AnalyzeContext fixture
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _mock_proc(stdout: str = "", returncode: int = 0) -> MagicMock:
+    """subprocess.run 반환값을 모방하는 MagicMock 생성."""
+    mock = MagicMock()
+    mock.stdout = stdout
+    mock.returncode = returncode
+    return mock
+
+
+@pytest.fixture
+def py_ctx() -> AnalyzeContext:
+    """Python 파일용 AnalyzeContext (테스트 아님)."""
+    return AnalyzeContext(
+        filename="src/example.py",
+        content="x = 1\n",
+        language="python",
+        tmp_path="/tmp/example.py",
+        is_test=False,
+    )
+
+
+@pytest.fixture
+def py_test_ctx() -> AnalyzeContext:
+    """Python 테스트 파일용 AnalyzeContext."""
+    return AnalyzeContext(
+        filename="tests/test_example.py",
+        content="def test_foo(): pass\n",
+        language="python",
+        tmp_path="/tmp/test_example.py",
+        is_test=True,
+    )
+
+
+@pytest.fixture
+def js_ctx() -> AnalyzeContext:
+    """JavaScript 파일 — Python analyzer가 supports() 거부해야 함."""
+    return AnalyzeContext(
+        filename="src/app.js",
+        content="const x = 1;\n",
+        language="javascript",
+        tmp_path="/tmp/app.js",
+        is_test=False,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _PylintAnalyzer
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestPylintAnalyzerAttributes:
+    """name/category 속성 + Analyzer Protocol 구현 검증."""
+
+    def test_name_is_pylint(self):
+        assert _PylintAnalyzer().name == "pylint"
+
+    def test_category_is_code_quality(self):
+        assert _PylintAnalyzer().category == Category.CODE_QUALITY
+
+
+class TestPylintSupports:
+    """supports(): language=='python' 만 True."""
+
+    def test_returns_true_for_python(self, py_ctx):
+        assert _PylintAnalyzer().supports(py_ctx) is True
+
+    def test_returns_false_for_javascript(self, js_ctx):
+        assert _PylintAnalyzer().supports(js_ctx) is False
+
+    @pytest.mark.parametrize("lang", ["go", "rust", "shell", "ruby", "unknown"])
+    def test_returns_false_for_other_languages(self, lang):
+        ctx = AnalyzeContext(
+            filename="x", content="", language=lang,
+            tmp_path="/tmp/x", is_test=False,
+        )
+        assert _PylintAnalyzer().supports(ctx) is False
+
+
+class TestPylintIsEnabled:
+    """is_enabled(): 항상 True (pip 의존성 보장)."""
+
+    def test_always_enabled_for_prod(self, py_ctx):
+        assert _PylintAnalyzer().is_enabled(py_ctx) is True
+
+    def test_always_enabled_for_test(self, py_test_ctx):
+        assert _PylintAnalyzer().is_enabled(py_test_ctx) is True
+
+
+class TestPylintRunSubprocessCall:
+    """subprocess.run 호출 인자 검증."""
+
+    def test_includes_pylint_binary_and_path(self, py_ctx):
+        with patch("subprocess.run", return_value=_mock_proc("[]")) as mock_run:
+            _PylintAnalyzer().run(py_ctx)
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == "pylint"
+        assert "/tmp/example.py" in cmd
+
+    def test_uses_static_analysis_timeout(self, py_ctx):
+        with patch("subprocess.run", return_value=_mock_proc("[]")) as mock_run:
+            _PylintAnalyzer().run(py_ctx)
+        assert mock_run.call_args.kwargs["timeout"] == STATIC_ANALYSIS_TIMEOUT
+
+    def test_includes_json_output_format(self, py_ctx):
+        with patch("subprocess.run", return_value=_mock_proc("[]")) as mock_run:
+            _PylintAnalyzer().run(py_ctx)
+        cmd = mock_run.call_args.args[0]
+        assert "--output-format=json" in cmd
+
+    def test_test_file_adds_extra_disables(self, py_test_ctx):
+        """is_test=True → W0611,W0212,C0302,R0401 추가 disable."""
+        with patch("subprocess.run", return_value=_mock_proc("[]")) as mock_run:
+            _PylintAnalyzer().run(py_test_ctx)
+        cmd = mock_run.call_args.args[0]
+        disable_arg = next(a for a in cmd if a.startswith("--disable="))
+        assert "W0611" in disable_arg
+        assert "R0401" in disable_arg
+
+    def test_prod_file_no_extra_test_disables(self, py_ctx):
+        """is_test=False → W0611 등 미포함."""
+        with patch("subprocess.run", return_value=_mock_proc("[]")) as mock_run:
+            _PylintAnalyzer().run(py_ctx)
+        cmd = mock_run.call_args.args[0]
+        disable_arg = next(a for a in cmd if a.startswith("--disable="))
+        assert "W0611" not in disable_arg
+
+
+class TestPylintRunOutputParsing:
+    """JSON 출력 파싱 + Severity 분류."""
+
+    def test_maps_error_type_to_error_severity(self, py_ctx):
+        stdout = json.dumps([
+            {"type": "error", "message": "undefined name", "line": 5},
+        ])
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert len(issues) == 1
+        assert issues[0].severity == Severity.ERROR
+        assert issues[0].tool == "pylint"
+        assert issues[0].line == 5
+        assert issues[0].category == Category.CODE_QUALITY
+
+    def test_maps_fatal_type_to_error_severity(self, py_ctx):
+        stdout = json.dumps([
+            {"type": "fatal", "message": "fatal error", "line": 1},
+        ])
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert issues[0].severity == Severity.ERROR
+
+    def test_maps_warning_type_to_warning_severity(self, py_ctx):
+        stdout = json.dumps([
+            {"type": "warning", "message": "unused var", "line": 3},
+        ])
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert issues[0].severity == Severity.WARNING
+
+    def test_maps_convention_type_to_warning_severity(self, py_ctx):
+        """convention/refactor/info 등 비-error 타입은 모두 WARNING."""
+        stdout = json.dumps([
+            {"type": "convention", "message": "naming", "line": 1},
+        ])
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert issues[0].severity == Severity.WARNING
+
+    def test_returns_empty_when_stdout_not_starts_with_bracket(self, py_ctx):
+        """non-JSON stdout (예: pylint banner) → 빈 list."""
+        with patch("subprocess.run", return_value=_mock_proc("Your code rated 10.00/10")):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert issues == []
+
+    def test_returns_empty_when_stdout_empty(self, py_ctx):
+        with patch("subprocess.run", return_value=_mock_proc("")):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert issues == []
+
+    def test_propagates_language_field(self, py_ctx):
+        stdout = json.dumps([{"type": "warning", "message": "x", "line": 1}])
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert issues[0].language == "python"
+
+
+class TestPylintRunGracefulDegradation:
+    """예외 상황 graceful fallback 검증."""
+
+    def test_timeout_returns_empty_list(self, py_ctx, caplog):
+        import logging
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="pylint", timeout=30),
+        ):
+            with caplog.at_level(logging.WARNING):
+                issues = _PylintAnalyzer().run(py_ctx)
+        assert issues == []
+        assert any("pylint timed out" in r.message for r in caplog.records)
+
+    def test_file_not_found_returns_empty(self, py_ctx):
+        """pylint 미설치 시 FileNotFoundError → []."""
+        with patch("subprocess.run", side_effect=FileNotFoundError("pylint not installed")):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert issues == []
+
+    def test_json_decode_error_returns_empty(self, py_ctx):
+        """깨진 JSON ([로 시작하지만 파싱 실패) → []."""
+        with patch("subprocess.run", return_value=_mock_proc("[broken json")):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert issues == []
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _Flake8Analyzer
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestFlake8AnalyzerAttributes:
+    def test_name_is_flake8(self):
+        assert _Flake8Analyzer().name == "flake8"
+
+    def test_category_is_code_quality(self):
+        assert _Flake8Analyzer().category == Category.CODE_QUALITY
+
+
+class TestFlake8Supports:
+    def test_supports_python(self, py_ctx):
+        assert _Flake8Analyzer().supports(py_ctx) is True
+
+    def test_rejects_javascript(self, js_ctx):
+        assert _Flake8Analyzer().supports(js_ctx) is False
+
+
+class TestFlake8IsEnabled:
+    def test_always_enabled(self, py_ctx, py_test_ctx):
+        assert _Flake8Analyzer().is_enabled(py_ctx) is True
+        assert _Flake8Analyzer().is_enabled(py_test_ctx) is True
+
+
+class TestFlake8RunSubprocessCall:
+    def test_includes_flake8_binary(self, py_ctx):
+        with patch("subprocess.run", return_value=_mock_proc("")) as mock_run:
+            _Flake8Analyzer().run(py_ctx)
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == "flake8"
+
+    def test_includes_max_line_length(self, py_ctx):
+        with patch("subprocess.run", return_value=_mock_proc("")) as mock_run:
+            _Flake8Analyzer().run(py_ctx)
+        cmd = mock_run.call_args.args[0]
+        assert "--max-line-length=120" in cmd
+
+    def test_test_file_adds_ignore_flag(self, py_test_ctx):
+        """is_test=True → --ignore=E302,E402,... 추가."""
+        with patch("subprocess.run", return_value=_mock_proc("")) as mock_run:
+            _Flake8Analyzer().run(py_test_ctx)
+        cmd = mock_run.call_args.args[0]
+        ignore_args = [a for a in cmd if a.startswith("--ignore=")]
+        assert ignore_args
+        assert "F401" in ignore_args[0]
+
+
+class TestFlake8RunOutputParsing:
+    def test_parses_row_col_text_format(self, py_ctx):
+        stdout = "10:5: E501 line too long\n3:1: F401 unused import\n"
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _Flake8Analyzer().run(py_ctx)
+        assert len(issues) == 2
+        assert issues[0].line == 10
+        assert "E501" in issues[0].message
+        assert issues[1].line == 3
+        assert all(i.severity == Severity.WARNING for i in issues)
+
+    def test_skips_malformed_lines(self, py_ctx):
+        """parts.split(':',2) 결과 길이 != 3 → continue (skip)."""
+        stdout = "totally invalid line\n5:2: valid issue\n"
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _Flake8Analyzer().run(py_ctx)
+        assert len(issues) == 1
+        assert issues[0].line == 5
+
+    def test_skips_value_error_on_int_parse(self, py_ctx):
+        """int(parts[0]) 실패 시 continue."""
+        stdout = "abc:def: not a number\n7:3: valid\n"
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _Flake8Analyzer().run(py_ctx)
+        assert len(issues) == 1
+        assert issues[0].line == 7
+
+    def test_returns_empty_for_empty_stdout(self, py_ctx):
+        with patch("subprocess.run", return_value=_mock_proc("")):
+            issues = _Flake8Analyzer().run(py_ctx)
+        assert issues == []
+
+
+class TestFlake8RunGracefulDegradation:
+    def test_timeout_returns_empty(self, py_ctx, caplog):
+        import logging
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="flake8", timeout=30),
+        ):
+            with caplog.at_level(logging.WARNING):
+                issues = _Flake8Analyzer().run(py_ctx)
+        assert issues == []
+        assert any("flake8 timed out" in r.message for r in caplog.records)
+
+    def test_file_not_found_returns_empty(self, py_ctx):
+        with patch("subprocess.run", side_effect=FileNotFoundError("flake8 not installed")):
+            issues = _Flake8Analyzer().run(py_ctx)
+        assert issues == []
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _BanditAnalyzer
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestBanditAnalyzerAttributes:
+    def test_name_is_bandit(self):
+        assert _BanditAnalyzer().name == "bandit"
+
+    def test_category_is_security(self):
+        assert _BanditAnalyzer().category == Category.SECURITY
+
+
+class TestBanditSupports:
+    def test_supports_python(self, py_ctx):
+        assert _BanditAnalyzer().supports(py_ctx) is True
+
+    def test_rejects_javascript(self, js_ctx):
+        assert _BanditAnalyzer().supports(js_ctx) is False
+
+
+class TestBanditIsEnabled:
+    """bandit 은 테스트 파일 제외 (프로덕션 코드만)."""
+
+    def test_enabled_for_prod_files(self, py_ctx):
+        assert _BanditAnalyzer().is_enabled(py_ctx) is True
+
+    def test_disabled_for_test_files(self, py_test_ctx):
+        assert _BanditAnalyzer().is_enabled(py_test_ctx) is False
+
+
+class TestBanditRunSubprocessCall:
+    def test_includes_bandit_binary_and_json_format(self, py_ctx):
+        stdout = json.dumps({"results": []})
+        with patch("subprocess.run", return_value=_mock_proc(stdout)) as mock_run:
+            _BanditAnalyzer().run(py_ctx)
+        cmd = mock_run.call_args.args[0]
+        assert cmd[0] == "bandit"
+        assert "-f" in cmd
+        assert "json" in cmd
+        assert "/tmp/example.py" in cmd
+
+
+class TestBanditRunOutputParsing:
+    def test_maps_high_severity_to_error(self, py_ctx):
+        stdout = json.dumps({"results": [
+            {
+                "issue_severity": "HIGH",
+                "issue_text": "use of subprocess shell=True",
+                "line_number": 12,
+            },
+        ]})
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert len(issues) == 1
+        assert issues[0].severity == Severity.ERROR
+        assert issues[0].tool == "bandit"
+        assert issues[0].line == 12
+        assert issues[0].category == Category.SECURITY
+
+    def test_maps_low_severity_to_warning(self, py_ctx):
+        stdout = json.dumps({"results": [
+            {"issue_severity": "LOW", "issue_text": "weak rng", "line_number": 5},
+        ]})
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert issues[0].severity == Severity.WARNING
+
+    def test_maps_medium_severity_to_warning(self, py_ctx):
+        stdout = json.dumps({"results": [
+            {"issue_severity": "MEDIUM", "issue_text": "x", "line_number": 1},
+        ]})
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert issues[0].severity == Severity.WARNING
+
+    def test_returns_empty_when_results_key_missing(self, py_ctx):
+        """results 키 없는 정상 JSON → 빈 list (graceful)."""
+        stdout = json.dumps({"errors": [], "metrics": {}})
+        with patch("subprocess.run", return_value=_mock_proc(stdout)):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert issues == []
+
+    def test_returns_empty_when_stdout_not_json(self, py_ctx):
+        """stdout 이 { 로 시작하지 않으면 빈 list."""
+        with patch("subprocess.run", return_value=_mock_proc("bandit usage info")):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert issues == []
+
+
+class TestBanditRunGracefulDegradation:
+    def test_timeout_returns_empty(self, py_ctx, caplog):
+        import logging
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="bandit", timeout=30),
+        ):
+            with caplog.at_level(logging.WARNING):
+                issues = _BanditAnalyzer().run(py_ctx)
+        assert issues == []
+        assert any("bandit timed out" in r.message for r in caplog.records)
+
+    def test_file_not_found_returns_empty(self, py_ctx):
+        with patch("subprocess.run", side_effect=FileNotFoundError("bandit not installed")):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert issues == []
+
+    def test_json_decode_error_returns_empty(self, py_ctx):
+        with patch("subprocess.run", return_value=_mock_proc("{broken json")):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert issues == []

--- a/tests/unit/scorer/test_calculator_edges.py
+++ b/tests/unit/scorer/test_calculator_edges.py
@@ -1,0 +1,261 @@
+"""Phase 4 PR-T1 — scorer/calculator.py 경계값·엣지 케이스 단위 테스트.
+
+기존 test_calculator.py 는 happy/typical 케이스 중심 — 14-에이전트 감사 R1-B 가
+지적한 "등급 경계 (44/45/59/60/74/75/89/90), CQ_WARNING_CAP 경계, 모든 status
+fallback 경로" 갭을 메운다.
+
+검증 대상:
+  - calculate_grade: F/D/C/B/A 모든 경계값 (44↔45, 59↔60, 74↔75, 89↔90)
+  - calculate_grade: 음수·101 등 범위 초과 입력
+  - calculate_score: CQ_WARNING_CAP=25 정확 경계 (24/25/26 warning)
+  - calculate_score: AI status 모든 값 (no_api_key/empty_diff/api_error/parse_error)
+    이 모두 ai_defaults_applied=True 로 폴백되는지
+  - calculate_score: round() banker's rounding 경계 (commit_score=10 → 7.5 → 8)
+  - calculate_score: 빈 analysis_results 리스트
+  - calculate_score: mixed category(code_quality + security) 동시 감점
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "test-token")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123456:test")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123456")
+os.environ.setdefault("GITHUB_CLIENT_ID", "test-client-id")
+os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-client-secret")
+os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+
+# pylint: disable=wrong-import-position
+import pytest
+
+from src.analyzer.io.ai_review import AiReviewResult
+from src.analyzer.io.static import AnalysisIssue, StaticAnalysisResult
+from src.scorer.calculator import calculate_grade, calculate_score
+
+
+def _make_result(issues: list[AnalysisIssue]) -> StaticAnalysisResult:
+    r = StaticAnalysisResult(filename="t.py")
+    r.issues = issues
+    return r
+
+
+def _make_ai(commit_score=18, ai_score=17, test_score=10, status="success"):
+    ai = AiReviewResult(
+        commit_score=commit_score,
+        ai_score=ai_score,
+        test_score=test_score,
+        summary="ok",
+    )
+    ai.status = status  # type: ignore[attr-defined]
+    return ai
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# calculate_grade — 모든 경계값
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("score,expected", [
+    (100, "A"),
+    (90, "A"),       # A 하한 경계
+    (89, "B"),       # B 상한 경계
+    (75, "B"),       # B 하한 경계
+    (74, "C"),       # C 상한 경계
+    (60, "C"),       # C 하한 경계
+    (59, "D"),       # D 상한 경계
+    (45, "D"),       # D 하한 경계
+    (44, "F"),       # F 상한 경계
+    (0, "F"),
+])
+def test_calculate_grade_all_boundaries(score: int, expected: str) -> None:
+    """등급 경계값(44/45, 59/60, 74/75, 89/90) 정확성 검증."""
+    assert calculate_grade(score) == expected
+
+
+def test_calculate_grade_negative_returns_f():
+    """음수 점수도 F (방어적)."""
+    assert calculate_grade(-10) == "F"
+    assert calculate_grade(-1) == "F"
+
+
+def test_calculate_grade_above_100_returns_a():
+    """100 초과 (clamp 전 호출 시) 도 A."""
+    assert calculate_grade(101) == "A"
+    assert calculate_grade(150) == "A"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# CQ_WARNING_CAP 경계 (= 25)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_cq_warning_cap_exactly_at_boundary():
+    """warning 25개 정확 = cap 도달. cq=25-25=0."""
+    issues = [AnalysisIssue(tool="pylint", severity="warning", message="w", line=i) for i in range(25)]
+    result = calculate_score([_make_result(issues)])
+    assert result.code_quality_score == 0
+
+
+def test_cq_warning_cap_one_below_boundary():
+    """warning 24개 = cap 미달. cq=25-24=1."""
+    issues = [AnalysisIssue(tool="pylint", severity="warning", message="w", line=i) for i in range(24)]
+    result = calculate_score([_make_result(issues)])
+    assert result.code_quality_score == 1
+
+
+def test_cq_warning_cap_above_boundary_no_extra_deduction():
+    """warning 100개여도 cap=25 적용 → cq=0 동일."""
+    issues = [AnalysisIssue(tool="pylint", severity="warning", message="w", line=i) for i in range(100)]
+    result = calculate_score([_make_result(issues)])
+    assert result.code_quality_score == 0
+
+
+def test_cq_errors_not_capped_by_warning_cap():
+    """error 는 cap 적용 안됨 — error 1개 + warning 25개 = 25 - 3 - 25 = clamp 0."""
+    issues = (
+        [AnalysisIssue(tool="pylint", severity="error", message="e", line=i) for i in range(1)]
+        + [AnalysisIssue(tool="pylint", severity="warning", message="w", line=i) for i in range(25)]
+    )
+    result = calculate_score([_make_result(issues)])
+    assert result.code_quality_score == 0
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# AI status fallback — 모든 비-success status 값
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("status", ["no_api_key", "empty_diff", "api_error", "parse_error"])
+def test_all_failure_statuses_apply_defaults(status: str) -> None:
+    """status ∈ {no_api_key, empty_diff, api_error, parse_error} 시 ai_defaults_applied=True."""
+    ai = _make_ai(status=status)
+    result = calculate_score([_make_result([])], ai_review=ai)
+    assert result.breakdown["ai_defaults_applied"] is True
+    # 기본값: commit=13, ai=21, test=10
+    assert result.breakdown["commit_message"] == 13
+    assert result.breakdown["ai_review"] == 21
+    assert result.breakdown["test_coverage"] == 10
+
+
+def test_unknown_status_treated_as_failure():
+    """status 가 알 수 없는 값이면 기본값 적용 (방어적)."""
+    ai = _make_ai(status="some_future_status")
+    result = calculate_score([_make_result([])], ai_review=ai)
+    assert result.breakdown.get("ai_defaults_applied") is True
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# round() banker's rounding 경계
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_commit_score_10_scales_to_8_via_round():
+    """commit_score=10 → 10*15/20=7.5 → round() banker → 8."""
+    ai = _make_ai(commit_score=10, ai_score=10, test_score=5)
+    result = calculate_score([_make_result([])], ai_review=ai)
+    # round(7.5) = 8 (Python banker's rounding rounds half-to-even, 8 is even)
+    assert result.breakdown["commit_message"] == 8
+
+
+def test_ai_score_10_scales_via_round():
+    """ai_score=10 → 10*25/20=12.5 → round() banker → 12 (12 is even)."""
+    ai = _make_ai(commit_score=10, ai_score=10, test_score=5)
+    result = calculate_score([_make_result([])], ai_review=ai)
+    assert result.breakdown["ai_review"] == 12
+
+
+def test_test_score_5_scales_via_round():
+    """test_score=5 → 5*15/10=7.5 → round() banker → 8 (8 is even)."""
+    ai = _make_ai(commit_score=10, ai_score=10, test_score=5)
+    result = calculate_score([_make_result([])], ai_review=ai)
+    assert result.breakdown["test_coverage"] == 8
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 빈/혼합 입력
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_empty_analysis_results_list():
+    """analysis_results=[] (정적 분석 미수행) — 만점 25 + 20 = 45 + AI 기본값."""
+    result = calculate_score([], ai_review=None)
+    assert result.code_quality_score == 25
+    assert result.security_score == 20
+    # 25 + 20 + 13 + 21 + 10 = 89
+    assert result.total == 89
+    assert result.grade == "B"
+
+
+def test_multiple_analysis_results_concat_issues():
+    """여러 StaticAnalysisResult 의 issues 가 합산되어 감점."""
+    r1 = _make_result([AnalysisIssue(tool="pylint", severity="error", message="e", line=1)])
+    r2 = _make_result([AnalysisIssue(tool="pylint", severity="error", message="e", line=2)])
+    result = calculate_score([r1, r2])
+    # 2 errors × 3 = 6 감점 → cq=19
+    assert result.code_quality_score == 19
+
+
+def test_mixed_category_independent_deduction():
+    """code_quality 와 security 가 독립적으로 감점됨."""
+    issues = [
+        AnalysisIssue(tool="pylint", severity="error", message="e", line=1, category="code_quality"),
+        AnalysisIssue(tool="bandit", severity="error", message="s", line=1, category="security"),
+    ]
+    result = calculate_score([_make_result(issues)])
+    assert result.code_quality_score == 22  # 25 - 3
+    assert result.security_score == 13       # 20 - 7
+
+
+def test_security_warnings_have_separate_cap_behavior():
+    """security warning 은 별도 카테고리 — cq cap 미적용."""
+    issues = [
+        AnalysisIssue(tool="bandit", severity="warning", message="w", line=i, category="security")
+        for i in range(20)
+    ]
+    result = calculate_score([_make_result(issues)])
+    # security = max(0, 20 - 20*2) = 0 (cap 없이 0 으로 clamp)
+    assert result.security_score == 0
+    assert result.code_quality_score == 25  # 영향 없음
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# total clamp + breakdown 일관성
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_breakdown_sum_matches_total_when_under_100():
+    """code_quality + security + commit + ai + test 합계가 total 과 일치 (clamp 미발동)."""
+    ai = _make_ai(commit_score=15, ai_score=15, test_score=8)
+    result = calculate_score([_make_result([])], ai_review=ai)
+    expected_sum = (
+        result.breakdown["code_quality"]
+        + result.breakdown["security"]
+        + result.breakdown["commit_message"]
+        + result.breakdown["ai_review"]
+        + result.breakdown["test_coverage"]
+    )
+    assert result.total == expected_sum
+
+
+def test_score_result_dataclass_fields():
+    """ScoreResult 의 모든 필드가 올바른 타입."""
+    result = calculate_score([_make_result([])], ai_review=None)
+    assert isinstance(result.total, int)
+    assert isinstance(result.grade, str)
+    assert isinstance(result.code_quality_score, int)
+    assert isinstance(result.security_score, int)
+    assert isinstance(result.breakdown, dict)
+
+
+def test_score_result_total_in_range():
+    """total 은 항상 0-100 범위."""
+    # 극단적 입력 다수 케이스
+    for ai_status in ["success", "api_error"]:
+        for issue_count in [0, 5, 50]:
+            issues = [
+                AnalysisIssue(tool="pylint", severity="error", message="e", line=i)
+                for i in range(issue_count)
+            ]
+            ai = _make_ai(status=ai_status)
+            result = calculate_score([_make_result(issues)], ai_review=ai)
+            assert 0 <= result.total <= 100, f"total={result.total} out of range"


### PR DESCRIPTION
…106 tests)

14-에이전트 감사 R1-B 가 지적한 "단위 테스트 커버리지 사각지대 3곳"을
다각도로 메운 PR-T1.

신규 테스트 파일 3종:
  - tests/unit/analyzer/tools/test_python.py (55 tests) _PylintAnalyzer / _Flake8Analyzer / _BanditAnalyzer 의 supports / is_enabled / run subprocess 호출 / 출력 파싱 / graceful degradation 전 경로 검증.
  - tests/unit/analyzer/io/test_ai_review_errors.py (20 tests) review_code() 의 에러 경로(httpx ConnectError/Timeout/RuntimeError) → api_error fallback, log_claude_api_call 호출 시 status/error_type/cache 토큰 kwargs 검증, _extract_json_payload 의 codeblock(lower/upper/no-tag)·preamble· no-braces 분기, _parse_response 의 ValueError·JSON decode 에러·점수 clamp, _default_result 의 모든 reason enum + 중립 점수 검증.
  - tests/unit/scorer/test_calculator_edges.py (31 tests) calculate_grade 의 모든 등급 경계(44/45, 59/60, 74/75, 89/90) + 음수/100 초과, CQ_WARNING_CAP=25 정확 경계 (24/25/26 + 100), AI status 4종 (no_api_key/empty_diff/api_error/parse_error) 모두 ai_defaults_applied=True, round() banker's rounding 경계 (commit=10 → 7.5 → 8), 빈 analysis_results, mixed-category 독립 감점, breakdown 합계=total 일관성, total ∈ [0,100] 불변식.

검증:
  - 신규 106 테스트 전부 통과 (1.21s)
  - 사전 실패 12건은 main 브랜치에서도 동일 — PR-T1 무관
  - 단위 테스트 합계: 1864 → 1970 (+106)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
