### PR TITLE
fix(webhook): loop_guard head_commit/pull_request=None NPE 방어

### DIFF
--- a/src/webhook/providers/github.py
+++ b/src/webhook/providers/github.py
@@ -275,9 +275,15 @@ def _loop_guard_check(data: dict) -> dict | None:
         return {"status": "skipped", "reason": "self_analysis_disabled"}
 
     full_name = data.get("repository", {}).get("full_name", "")
+    # GitHub 페이로드의 head_commit / pull_request 키가 존재하면서 값이 None 일 수
+    # 있다 (예: 브랜치 삭제 push). 이때 .get(default) 는 None 을 반환하므로 후행
+    # .get(...) 체이닝이 NPE — `or {}` 로 None 을 빈 dict 로 정규화.
+    # GitHub may send head_commit / pull_request as None (e.g. branch-delete push).
+    # `.get(default)` returns None in that case, so `.get(...)` chaining NPEs.
+    # Normalize None to an empty dict via `or {}`.
     commit_msg = (
-        data.get("head_commit", {}).get("message", "")
-        or data.get("pull_request", {}).get("title", "")
+        (data.get("head_commit") or {}).get("message", "")
+        or (data.get("pull_request") or {}).get("title", "")
         or ""
     )
 

--- a/tests/unit/webhook/test_router.py
+++ b/tests/unit/webhook/test_router.py
@@ -270,3 +270,43 @@ def test_self_analysis_disabled_skips_all():
     assert resp.json()["status"] == "skipped"
     assert resp.json()["reason"] == "self_analysis_disabled"
     mock_pipeline.assert_not_called()
+
+
+def test_loop_guard_handles_head_commit_none_without_npe():
+    """Phase 4 회고 — head_commit=None 페이로드 시 _loop_guard_check 가
+    AttributeError 던지지 않고 graceful 진행 (회귀 방지).
+
+    GitHub 의 일부 push 이벤트(브랜치 삭제 등)에서 head_commit 키 값이 None 으로
+    내려오는 사례가 있었으며, 기존 `data.get("head_commit", {}).get(...)` 체이닝은
+    값이 None 이면 NPE. pull_request 키도 동일 패턴 보호 필요.
+    """
+    data = {
+        "repository": {"full_name": "owner/repo"},
+        "sender": {"type": "User", "login": "developer"},
+        "after": "abc123",
+        "head_commit": None,         # NPE 트리거 (회고 §발견된 잔여 결함)
+        "pull_request": None,         # 두 번째 분기 동일 보호 검증
+    }
+    payload = json.dumps(data).encode()
+    with patch("src.webhook.providers.github.settings") as mock_settings, \
+         patch("src.webhook._helpers.settings") as mock_helpers_settings:
+        mock_helpers_settings.github_webhook_secret = SECRET
+        mock_settings.github_webhook_secret = SECRET
+        mock_settings.scamanager_self_analysis_disabled = False
+        with patch("src.webhook.providers.github.run_analysis_pipeline") as mock_pipeline:
+            resp = client.post(
+                "/webhooks/github",
+                content=payload,
+                headers={
+                    "X-Hub-Signature-256": _sign(payload),
+                    "X-GitHub-Event": "push",
+                },
+            )
+    # NPE 가 났다면 500 응답 — 200/202 범위면 graceful 진행
+    # 정확한 status 는 후속 분기에 따라 다르나 5xx 는 회귀 신호
+    assert resp.status_code < 500, (
+        f"head_commit=None NPE 회귀 — got {resp.status_code}: {resp.text}"
+    )
+    # 정상 흐름이면 파이프라인이 등록되어야 함 (skip 마커 없음)
+    if resp.status_code == 202 and resp.json().get("status") == "accepted":
+        mock_pipeline.assert_called_once()


### PR DESCRIPTION
Phase 4 회고 §발견된 잔여 결함 — `_loop_guard_check` 의 commit_msg 추출 시 `data.get("head_commit", {}).get("message", "")` 패턴이 head_commit 키 값이 None 일 때 AttributeError 를 던진다. GitHub 의 일부 push 이벤트(브랜치 삭제 등)는 head_commit=None 을 내려 보내며, 동일 위험이 pull_request 키에도 존재.

  # 수정 전 (취약)
  data.get("head_commit", {}).get("message", "")

  # 수정 후 (None 정규화)
  (data.get("head_commit") or {}).get("message", "")

`_extract_commit_message` (worker/pipeline.py) 는 이미 `if head:` 체크로 안전 — 두 위치의 패턴 일관성 확보.

검증:
  - tests/unit/webhook/test_router.py::test_loop_guard_handles_head_commit_none_without_npe 회귀 방지 테스트 신규 추가 — head_commit=None + pull_request=None 페이로드로 NPE 회귀 검출. fix 전 AttributeError 확인 후 fix 후 통과.
  - pylint 10.00/10 유지

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
