### PR TITLE
fix(api): Phase H PR-1A — Anthropic + aiosmtplib timeout 명시 전달

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -64,7 +64,11 @@ async def review_code(
     if not diff_text.strip():
         return _default_result("empty_diff")
 
-    client = anthropic.AsyncAnthropic(api_key=api_key)
+    # Anthropic SDK 기본 timeout=600s 는 BackgroundTask 슬롯을 10분 점유 위험.
+    # HTTP_CLIENT_TIMEOUT 보다 여유 두고 60s 로 설정 — 평균 응답 5-15s 대비 충분.
+    # Default SDK timeout (600s) can occupy a BackgroundTask slot for 10 min.
+    # Set 60s — well above the typical 5-15s response, far below SDK default.
+    client = anthropic.AsyncAnthropic(api_key=api_key, timeout=60.0)
     model = settings.claude_review_model
     system_text = get_system_prompt()
     start = time.perf_counter()

--- a/src/notifier/email.py
+++ b/src/notifier/email.py
@@ -9,7 +9,7 @@ import aiosmtplib
 from src.scorer.calculator import ScoreResult
 from src.analyzer.io.static import StaticAnalysisResult
 from src.analyzer.io.ai_review import AiReviewResult
-from src.constants import GRADE_COLOR_HTML, NOTIFIER_MAX_ISSUES_LONG
+from src.constants import GRADE_COLOR_HTML, HTTP_CLIENT_TIMEOUT, NOTIFIER_MAX_ISSUES_LONG
 from src.notifier._common import format_ref, get_all_issues, truncate_issue_msg
 
 logger = logging.getLogger(__name__)
@@ -96,6 +96,10 @@ async def send_email_notification(  # pylint: disable=too-many-arguments
     msg["To"] = recipients
     msg.attach(MIMEText(html, "html"))
 
+    # SMTP hang 방어: aiosmtplib 기본 timeout=60s 가 길어 운영 hang 시
+    # BackgroundTask 슬롯 점유 위험. HTTP_CLIENT_TIMEOUT(=10s) 과 동일 정책.
+    # SMTP hang guard: aiosmtplib's default 60s timeout is too long; align to
+    # HTTP_CLIENT_TIMEOUT to avoid BackgroundTask slot exhaustion.
     await aiosmtplib.send(
         msg,
         hostname=smtp_host,
@@ -103,6 +107,7 @@ async def send_email_notification(  # pylint: disable=too-many-arguments
         username=smtp_user,
         password=smtp_pass,
         use_tls=True,
+        timeout=HTTP_CLIENT_TIMEOUT,
     )
 
 

--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -279,3 +279,36 @@ def test_default_result_neutral_scores():
         assert result.ai_score == 17
         assert result.test_score == 7
         assert result.summary  # 비어있지 않음
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 회귀 방지 — Phase H PR-1A: anthropic.AsyncAnthropic timeout 명시 전달
+# Regression guard — Phase H PR-1A: AsyncAnthropic timeout kwarg passed
+# ──────────────────────────────────────────────────────────────────────────
+
+
+async def test_review_code_passes_explicit_timeout_to_anthropic_client():
+    """Anthropic SDK hang 방어 — AsyncAnthropic 인스턴스화 시 timeout 명시.
+
+    SDK 기본 timeout=600초 — Claude API hang 시 BackgroundTask 슬롯 10분
+    점유 → 다른 webhook 분석 큐잉 정체. 명시적 timeout 으로 차단.
+    """
+    response_obj = MagicMock()
+    response_obj.content = [MagicMock(text='{"summary": "ok"}')]
+    response_obj.usage = MagicMock(input_tokens=10, output_tokens=20)
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=response_obj)
+
+    captured_kwargs = {}
+
+    def _capture_init(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return fake_client
+
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", side_effect=_capture_init):
+        await review_code("sk-test", "feat: x", [("a.py", "+ x = 1")])
+
+    assert "timeout" in captured_kwargs, "AsyncAnthropic 인스턴스화에 timeout 인자 필수"
+    timeout_val = captured_kwargs["timeout"]
+    assert isinstance(timeout_val, (int, float))
+    assert 0 < timeout_val <= 120  # SDK 600초 default 보다 훨씬 짧아야 함

--- a/tests/unit/notifier/test_email.py
+++ b/tests/unit/notifier/test_email.py
@@ -216,3 +216,37 @@ def test_build_html_escapes_xss_in_ai_summary():
     assert "<img" not in html
     assert "&lt;img" in html
     assert "&amp;" in html
+
+
+# ---------------------------------------------------------------------------
+# 회귀 방지 — Phase H PR-1A: aiosmtplib timeout 인자 전달 검증
+# Regression guard — Phase H PR-1A: aiosmtplib timeout kwarg passed
+# ---------------------------------------------------------------------------
+
+
+async def test_send_email_passes_explicit_timeout_to_aiosmtplib():
+    """SMTP hang 방어 — aiosmtplib.send 호출 시 timeout 인자가 명시적으로 전달.
+
+    aiosmtplib 기본 timeout 은 60초로 길어 운영 hang 시 BackgroundTask 슬롯
+    점유 위험. HTTP_CLIENT_TIMEOUT 과 동일 값으로 통일.
+    """
+    with patch("src.notifier.email.aiosmtplib") as mock_smtp:
+        mock_smtp.send = AsyncMock()
+
+        await send_email_notification(
+            recipients="a@test.com",
+            repo_name="owner/repo",
+            commit_sha="abc1234",
+            score_result=_make_score(),
+            analysis_results=_make_analysis(),
+            smtp_host="smtp.test.com",
+            smtp_port=587,
+            smtp_user="user",
+            smtp_pass="pass",
+        )
+
+    mock_smtp.send.assert_called_once()
+    call_kwargs = mock_smtp.send.call_args.kwargs
+    assert "timeout" in call_kwargs, "aiosmtplib.send 호출에 timeout 인자 필수"
+    assert isinstance(call_kwargs["timeout"], (int, float))
+    assert 0 < call_kwargs["timeout"] <= 30  # 보수적 상한


### PR DESCRIPTION
12-에이전트 감사 (2026-04-30) Critical C1 + 외부 API 통합 검토 항목 — 외부 SDK 의 기본 timeout 이 너무 길어 운영 hang 시 BackgroundTask 슬롯을 점유해 다른 webhook 분석을 큐잉 정체시키는 위험을 즉시 차단.

수정 내용:
  1. src/analyzer/io/ai_review.py:67 anthropic.AsyncAnthropic(api_key=..., timeout=60.0) — SDK 기본 600s → 60s. 평균 응답 5-15s 대비 충분히 여유 두면서 BackgroundTask 점유 한계 명확화.
  2. src/notifier/email.py:99-110 aiosmtplib.send(..., timeout=HTTP_CLIENT_TIMEOUT) — 기본 60s → 10s. HTTP_CLIENT_TIMEOUT 단일 출처로 정책 통일.

회귀 방지 테스트 2건 추가:
  - tests/unit/analyzer/io/test_ai_review_errors.py test_review_code_passes_explicit_timeout_to_anthropic_client — AsyncAnthropic 인스턴스화 kwargs 에 timeout 전달 검증, 0 < timeout ≤ 120 범위 가드.
  - tests/unit/notifier/test_email.py test_send_email_passes_explicit_timeout_to_aiosmtplib — aiosmtplib.send 호출 kwargs 에 timeout 검증, 0 < timeout ≤ 30 범위 가드.

검증:
  - TDD: Red (timeout 인자 없음 검출) → Green (수정 후 2건 모두 통과) 사이클
  - tests/unit/notifier/ + tests/unit/analyzer/io/ 전체 62 passed (1.21s)
  - pylint src/ 전체 10.00/10 유지
  - src/ 변경 ~6줄 (주석 포함), 회귀 위험 최소

Phase H PR-1B (tenacity 5xx 재시도 도입) 후속 진행 예정.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
