### PR TITLE
fix(pipeline): Phase H PR-2A — race-recovery 시 notify 단계 명시 skip (Cri…

### DIFF
--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -412,6 +412,26 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
                 with SessionLocal() as db:
                     repo_config, analysis_id, result_dict = await _save_and_gate(db, save_params)
 
+            # Phase H PR-2A: race-recovery 또는 repo 누락 시 notify skip
+            # `_save_and_gate` 가 result_dict=None 을 반환하면 두 가지 경우다:
+            #   (1) repo 가 두 번째 세션에서 사라짐 — 알림 의미 없음
+            #   (2) 동시 webhook race 로 기존 Analysis 가 이미 알림을 발송함 —
+            #       중복 알림 방지 + result_dict=None 으로 인한 silent KeyError 차단
+            # `analysis_id` 는 실 운영에서 항상 int 이지만 단위 테스트의 mock db
+            # 에서는 refresh() 가 동작하지 않아 None 일 수 있음 — race-recovery
+            # 시그널은 두 값 동시 None 인 `result_dict is None` 으로 판정.
+            # Phase H PR-2A: skip notify on race-recovery or missing repo.
+            # `result_dict is None` is the canonical race-recovery signal — only
+            # set when `_save_and_gate` early-returned without building the dict.
+            # `analysis_id is None` cannot be used alone because mock-DB tests
+            # leave it None (refresh() no-op) even on the normal path.
+            if result_dict is None:
+                logger.info(
+                    "Race-recovery or repo missing for %s @ %s — skipping notify stage",
+                    repo_log, commit_sha,
+                )
+                return
+
             with stage_timer("notify", repo=repo_log) as ctx:
                 notify_tasks, task_names = build_notification_tasks(
                     repo_config=repo_config,

--- a/tests/unit/worker/test_pipeline_save_and_gate.py
+++ b/tests/unit/worker/test_pipeline_save_and_gate.py
@@ -324,3 +324,45 @@ async def test_regate_pr_if_needed_logs_exception_with_traceback(caplog):
         r for r in error_records if "Re-gate check failed" in r.message
     )
     assert re_gate_record.exc_info is not None
+
+
+# ---------------------------------------------------------------------------
+# Phase H PR-2A — race-recovery 시 run_analysis_pipeline 의 notify 단계 skip
+# 12-에이전트 감사 Critical C2 — race-recovery 가 (cfg, None, None) 반환 시
+# build_notification_tasks 가 result_dict=None 으로 호출돼 silent KeyError 위험.
+# 호출자 측에서 analysis_id is None 을 race-recovery 시그널로 인식하고 notify skip.
+# ---------------------------------------------------------------------------
+
+
+async def test_pipeline_skips_notify_when_save_returns_no_analysis_id(caplog):
+    """_save_and_gate 가 (cfg, None, None) 반환 시 run_analysis_pipeline 은
+    notify 단계를 건너뛴다 — 원본 webhook 이 이미 알림을 발송했음을 가정.
+    """
+    push_data = {
+        "repository": {"full_name": "owner/repo"},
+        "after": "racesha000000",
+        "head_commit": {"id": "racesha000000", "message": "feat: race"},
+        "commits": [{"id": "racesha000000", "message": "feat: race"}],
+        "sender": {"login": "alice", "type": "User"},
+    }
+    repo_config = MagicMock()
+
+    # _save_and_gate 가 race-recovery 반환 (cfg, None, None) 시뮬레이션
+    save_mock = AsyncMock(return_value=(repo_config, None, None))
+
+    with patch.object(pipeline_mod, "_extract_event_metadata",
+                      return_value=("owner/repo", "racesha000000", "feat: race", None)), \
+         patch.object(pipeline_mod, "_ensure_repo", return_value=(MagicMock(), "ghp_test")), \
+         patch.object(pipeline_mod, "_collect_files",
+                      return_value=[MagicMock(filename="a.py", patch="+x=1")]), \
+         patch.object(pipeline_mod, "_run_static_analysis",
+                      new=AsyncMock(return_value=[])), \
+         patch.object(pipeline_mod, "review_code", new=AsyncMock()), \
+         patch.object(pipeline_mod, "calculate_score", return_value=MagicMock(total=80, grade="B")), \
+         patch.object(pipeline_mod, "_save_and_gate", new=save_mock), \
+         patch.object(pipeline_mod, "build_notification_tasks") as mock_notify_build, \
+         caplog.at_level(logging.INFO, logger="src.worker.pipeline"):
+        await pipeline_mod.run_analysis_pipeline("push", push_data)
+
+    # 핵심 검증: race-recovery 시 build_notification_tasks 는 호출되지 않아야 함
+    mock_notify_build.assert_not_called()


### PR DESCRIPTION
…tical C2)

12-에이전트 감사 (2026-04-30) Critical C2 — `_save_and_gate` 가 race-recovery 경로에서 (cfg, None, None) 을 반환할 때 호출자(`run_analysis_pipeline`)가 그대로 notify 단계로 진행 → `result_dict=None` 으로 `build_notification_tasks` 호출 → notifier 가 result_dict 참조 시 silent KeyError → `asyncio.gather(return_exceptions=True)` 가 흡수해 사용자 알림 무음 누락.

수정 내용:
  - src/worker/pipeline.py — `_save_and_gate` 결과를 받은 직후 명시적 가드: `if result_dict is None: skip notify + INFO log`
  - 시그널은 `result_dict is None` 사용 (race-recovery + repo-missing 모두 catch). `analysis_id is None` 은 mock-DB 단위 테스트에서 refresh() 가 동작 안 해 정상 경로에서도 None — race-recovery 시그널로 부적합.

Race-recovery 흐름 (PR #105 silent skip 사고 + 본 fix):
  1. push 이벤트 → Analysis(pr_number=None) 저장 + 알림 발송 (정상)
  2. 동시 PR 이벤트 → 1차 dedup 통과 → 분석 → 2차 dedup 에서 race detect
  3. _save_and_gate race-recovery 분기: pr_number 부여 + gate 재실행 (PR comment 등)
  4. 본 fix: notify skip — push 이벤트가 이미 알림 발송했으므로 중복 방지

회귀 방지 테스트 1건 추가:
  - tests/unit/worker/test_pipeline_save_and_gate.py test_pipeline_skips_notify_when_save_returns_no_analysis_id — `_save_and_gate` 가 (cfg, None, None) 반환 시 build_notification_tasks 미호출 검증.

검증:
  - TDD: Red 확인 후 Green
  - tests/unit/worker/ 73 passed (사전 1 failure 는 main 동일, 무관)
  - pylint src/ 전체 10.00/10 유지
  - src/ 변경 ~15줄 (대부분 한·영 주석)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
