### PR TITLE
fix(notifier): Phase H PR-2B — Telegram 429 retry-after 단일 재시도 (Criti…

### DIFF
--- a/src/notifier/telegram.py
+++ b/src/notifier/telegram.py
@@ -1,4 +1,6 @@
 """Telegram notifier — sends HTML-formatted analysis results via Bot API."""
+import asyncio
+import logging
 from html import escape
 
 from src.constants import GRADE_EMOJI, TELEGRAM_MAX_MESSAGE_LENGTH, NOTIFIER_MAX_ISSUES_SHORT
@@ -8,9 +10,21 @@ from src.analyzer.io.static import StaticAnalysisResult
 from src.analyzer.io.ai_review import AiReviewResult
 from src.notifier._common import format_ref, get_all_issues, truncate_message, truncate_issue_msg
 
+logger = logging.getLogger(__name__)
+
+# Phase H PR-2B — Telegram 429 재시도 정책
+# 12-에이전트 감사 Critical C4 — Bot API 429 응답의 retry_after 미처리 시
+# 봇 그룹 차단(spam) → cron 누적 시 운영 중단. 단일 재시도 + cap 으로 보호.
+# Phase H PR-2B — Telegram 429 retry policy: respect retry_after with cap,
+# single retry only to avoid infinite loop. Critical C4 from 2026-04-30 audit.
+TELEGRAM_RETRY_AFTER_MAX_SECONDS = 30
+
 
 async def telegram_post_message(bot_token: str, chat_id: str, payload: dict) -> None:
     """Telegram Bot API sendMessage 엔드포인트에 JSON 페이로드를 POST한다.
+
+    429 Too Many Requests 응답 시 `parameters.retry_after` 만큼 sleep 후 1회 재시도.
+    cap 30s — 악의적 응답으로 인한 무기한 sleep 방지.
 
     Args:
         bot_token: Telegram Bot API 토큰
@@ -19,8 +33,29 @@ async def telegram_post_message(bot_token: str, chat_id: str, payload: dict) -> 
     """
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
     client = get_http_client()  # 싱글톤
-    r = await client.post(url, json={"chat_id": chat_id, **payload})
+    body = {"chat_id": chat_id, **payload}
+    r = await client.post(url, json=body)
+
+    # 429 처리 — retry_after 파싱 후 1회 재시도
+    # Handle 429 — parse retry_after and retry once
+    if r.status_code == 429:
+        retry_after = _parse_retry_after(r)
+        logger.warning(
+            "Telegram 429 received, sleeping %ds before single retry", retry_after,
+        )
+        await asyncio.sleep(retry_after)
+        r = await client.post(url, json=body)
+
     r.raise_for_status()
+
+
+def _parse_retry_after(response) -> int:
+    """429 응답에서 retry_after 추출 — cap 적용. 파싱 실패 시 1초 fallback."""
+    try:
+        retry_after = int(response.json().get("parameters", {}).get("retry_after", 1))
+    except (ValueError, KeyError, AttributeError):
+        retry_after = 1
+    return min(max(retry_after, 1), TELEGRAM_RETRY_AFTER_MAX_SECONDS)
 
 
 def _build_message(  # pylint: disable=too-many-positional-arguments

--- a/tests/unit/notifier/test_telegram.py
+++ b/tests/unit/notifier/test_telegram.py
@@ -189,3 +189,91 @@ async def test_telegram_post_message_sends_correct_chat_id():
         call_json = mock_client.post.call_args.kwargs.get("json") or {}
         assert call_json["chat_id"] == "-999888"
         assert call_json["text"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Phase H PR-2B — Telegram 429 (Too Many Requests) retry_after 처리
+# 12-에이전트 감사 Critical C4 — 429 미처리 시 raise_for_status 가
+# HTTPStatusError 전파 → cron 누적 시 봇 그룹 차단(spam) → 운영 중단.
+# 단일 재시도: parameters.retry_after 만큼 sleep (cap 30s) 후 1회 재시도.
+# ---------------------------------------------------------------------------
+
+
+def _make_429_response(retry_after: int) -> MagicMock:
+    """429 응답 mock — parameters.retry_after 포함."""
+    resp = MagicMock()
+    resp.status_code = 429
+    resp.json = MagicMock(return_value={
+        "ok": False, "error_code": 429,
+        "description": f"Too Many Requests: retry after {retry_after}",
+        "parameters": {"retry_after": retry_after},
+    })
+    resp.raise_for_status = MagicMock()  # 호출되어도 무시 (재시도 후 200 가정)
+    return resp
+
+
+def _make_200_response() -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json = MagicMock(return_value={"ok": True, "result": {}})
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+async def test_telegram_post_message_retries_on_429_then_succeeds():
+    """첫 응답 429 + retry_after=2 → asyncio.sleep 호출 후 재시도 → 200."""
+    with patch("src.notifier.telegram.get_http_client") as mock_get, \
+         patch("src.notifier.telegram.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        mock_client = AsyncMock()
+        mock_get.return_value = mock_client
+        # 첫 호출 429 → 두 번째 호출 200
+        mock_client.post = AsyncMock(side_effect=[_make_429_response(2), _make_200_response()])
+
+        await telegram_post_message(
+            bot_token="123:ABC", chat_id="-100", payload={"text": "x"},
+        )
+
+    # 두 번 호출됨 — 429 후 retry
+    assert mock_client.post.call_count == 2
+    # asyncio.sleep 가 retry_after 만큼 호출됨
+    mock_sleep.assert_awaited_once()
+    sleep_arg = mock_sleep.await_args.args[0]
+    assert sleep_arg == 2  # retry_after 그대로
+
+
+async def test_telegram_post_message_caps_retry_after_at_max():
+    """retry_after=999 (Telegram 악의적 응답 가정) → cap 적용 (≤ 30s)."""
+    with patch("src.notifier.telegram.get_http_client") as mock_get, \
+         patch("src.notifier.telegram.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        mock_client = AsyncMock()
+        mock_get.return_value = mock_client
+        mock_client.post = AsyncMock(side_effect=[_make_429_response(999), _make_200_response()])
+
+        await telegram_post_message(
+            bot_token="123:ABC", chat_id="-100", payload={"text": "x"},
+        )
+
+    sleep_arg = mock_sleep.await_args.args[0]
+    assert sleep_arg <= 30  # cap 적용 — 무한 sleep 차단
+
+
+async def test_telegram_post_message_raises_on_second_429():
+    """재시도 후에도 429 → HTTPStatusError 전파 (무한 루프 방지)."""
+    second_429 = _make_429_response(1)
+    second_429.raise_for_status = MagicMock(side_effect=httpx.HTTPStatusError(
+        "429 Too Many Requests", request=MagicMock(), response=second_429,
+    ))
+
+    with patch("src.notifier.telegram.get_http_client") as mock_get, \
+         patch("src.notifier.telegram.asyncio.sleep", new_callable=AsyncMock):
+        mock_client = AsyncMock()
+        mock_get.return_value = mock_client
+        mock_client.post = AsyncMock(side_effect=[_make_429_response(1), second_429])
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await telegram_post_message(
+                bot_token="123:ABC", chat_id="-100", payload={"text": "x"},
+            )
+
+    # 정확히 2회 시도 후 포기
+    assert mock_client.post.call_count == 2


### PR DESCRIPTION
…cal C4)

12-에이전트 감사 (2026-04-30) Critical C4 — `telegram_post_message` 가 Bot API 의 429 Too Many Requests 응답을 처리하지 않고 raise_for_status 가 그대로 HTTPStatusError 전파. cron 주간 보고/연속 분석 시 누적되어 봇 그룹 차단(spam) → 운영 중단 위험.

수정 내용:
  - src/notifier/telegram.py
    * 429 응답 시 `parameters.retry_after` 파싱 후 asyncio.sleep + 단일 재시도
    * cap 30s — 악의적 응답으로 인한 무기한 sleep 방지
    * 재시도 후에도 429 면 raise_for_status 가 HTTPStatusError 전파 (무한 루프 차단)
    * `_parse_retry_after` 헬퍼 — ValueError/KeyError/AttributeError graceful

  - 신규 상수 `TELEGRAM_RETRY_AFTER_MAX_SECONDS = 30` (모듈 레벨)
  - logger.warning 로 sleep 발생 추적 가능 (운영 가시성)

회귀 방지 테스트 3건 추가:
  - test_telegram_post_message_retries_on_429_then_succeeds — 429 후 200
  - test_telegram_post_message_caps_retry_after_at_max — retry_after=999 → cap
  - test_telegram_post_message_raises_on_second_429 — 무한 루프 방지

검증:
  - TDD: Red (2 fail) → Green (12 telegram 테스트 모두 통과)
  - tests/unit/notifier/ + 관련 영역 194 passed (사전 3 failures 무관)
  - pylint src/ 전체 10.00/10 유지

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
