### PR TITLE
perf(gate): Phase H PR-2C — run_gate_check 3-옵션 asyncio.gather 병렬화

### DIFF
--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -1,4 +1,5 @@
 """Gate Engine — 3개 독립 옵션: Review Comment / Approve / Auto Merge."""
+import asyncio
 import logging
 from datetime import datetime, timezone
 from html import escape
@@ -57,21 +58,42 @@ async def run_gate_check(  # pylint: disable=too-many-positional-arguments
         config = get_repo_config(db, repo_name)
     score = result.get("score", 0)
 
-    await _run_review_comment(config, github_token, repo_name, pr_number, result)
-    await _run_approve_decision(
-        config=config,
-        db=db,
-        analysis_id=analysis_id,
-        github_token=github_token,
-        repo_name=repo_name,
-        pr_number=pr_number,
-        score=score,
-        result=result,
+    # Phase H PR-2C: 3 옵션 병렬 실행 (asyncio.gather + return_exceptions=True)
+    # CLAUDE.md 규약 — pr_review_comment·approve_mode·auto_merge 완전 독립.
+    # 직렬 await 시 옵션마다 1-3초 latency 합산 → webhook 응답 지연.
+    # gather 로 병렬화하면 평균 latency 가 가장 느린 옵션 1개 = ~3s 로 단축.
+    # return_exceptions=True 는 한 옵션의 예상 외 예외가 다른 옵션을 cancel
+    # 하지 않도록 보장 (각 옵션 내부에서 이미 try/except 처리하므로 추가 안전망).
+    # Phase H PR-2C: run 3 options in parallel with asyncio.gather. Per CLAUDE.md
+    # contract the options are fully independent; serial await wastes 1-3s each.
+    # `return_exceptions=True` keeps unexpected errors from cancelling siblings.
+    results = await asyncio.gather(
+        _run_review_comment(config, github_token, repo_name, pr_number, result),
+        _run_approve_decision(
+            config=config,
+            db=db,
+            analysis_id=analysis_id,
+            github_token=github_token,
+            repo_name=repo_name,
+            pr_number=pr_number,
+            score=score,
+            result=result,
+        ),
+        _run_auto_merge(
+            config, github_token, repo_name, pr_number, score,
+            analysis_id=analysis_id, db=db,
+        ),
+        return_exceptions=True,
     )
-    await _run_auto_merge(
-        config, github_token, repo_name, pr_number, score,
-        analysis_id=analysis_id, db=db,
-    )
+    # 옵션별 예상 외 예외 로깅 — 옵션 내부 try/except 가 못 잡은 케이스만
+    # Log unexpected exceptions per option — only those not caught internally.
+    for option_name, outcome in zip(("review_comment", "approve", "auto_merge"), results):
+        if isinstance(outcome, BaseException):
+            logger.error(
+                "Gate option [%s] unexpected exception: %s",
+                option_name, type(outcome).__name__,
+                exc_info=(type(outcome), outcome, outcome.__traceback__),
+            )
 
 
 async def _run_review_comment(

--- a/tests/unit/gate/test_engine.py
+++ b/tests/unit/gate/test_engine.py
@@ -1339,3 +1339,78 @@ async def test_run_auto_merge_legacy_failure_records_legacy_state():
     assert call_kwargs["state"] == _states.LEGACY
     assert call_kwargs["enabled_at"] is None
     assert call_kwargs["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# Phase H PR-2C — run_gate_check 3-옵션 병렬 실행
+# 12-에이전트 감사 개선 권장 #B5 — 3 옵션이 직렬 await 라 평균 1-3초씩 합산 →
+# webhook 응답 지연. CLAUDE.md 명시 "PR Gate 3-옵션 독립" 이므로 gather 가능.
+# ---------------------------------------------------------------------------
+
+
+async def test_run_gate_check_unexpected_exception_in_one_option_does_not_block_others():
+    """한 옵션의 예상 외 예외가 다른 옵션 실행을 막지 않는다 (gather 병렬 보장).
+
+    직렬 await 패턴은 첫 번째 옵션이 catch 못 한 예외를 던지면 나머지 옵션이
+    실행되지 않는다. asyncio.gather(return_exceptions=True) 로 각 옵션 격리.
+    """
+    mock_db = MagicMock()
+    config = _config(
+        pr_review_comment=True,
+        approve_mode="auto",
+        approve_threshold=75,
+        auto_merge=True,
+        merge_threshold=75,
+    )
+
+    with patch("src.gate.engine.get_repo_config", return_value=config), \
+         patch(
+             "src.gate.engine._run_review_comment",
+             new=AsyncMock(side_effect=RuntimeError("unexpected boom")),
+         ), \
+         patch("src.gate.engine._run_approve_decision", new_callable=AsyncMock) as mock_approve, \
+         patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_merge:
+        await run_gate_check(
+            repo_name="owner/repo",
+            pr_number=1,
+            analysis_id=1,
+            result={"score": 80, "grade": "B"},
+            github_token="tok",
+            db=mock_db,
+        )
+
+    # 핵심: 첫 옵션 예외에도 두 번째·세 번째 옵션은 실행됨
+    mock_approve.assert_awaited_once()
+    mock_merge.assert_awaited_once()
+
+
+async def test_run_gate_check_runs_three_options_via_gather():
+    """3 옵션이 모두 호출됨 (asyncio.gather 병렬 실행) — 한 옵션의 sync side-effect
+    가 다른 옵션 호출 전에 실행되지 않음을 통한 간접 검증."""
+    mock_db = MagicMock()
+    config = _config(pr_review_comment=True, approve_mode="auto", auto_merge=True)
+    call_order: list[str] = []
+
+    mock_review = AsyncMock(side_effect=lambda *a, **kw: call_order.append("review"))
+    mock_approve = AsyncMock(side_effect=lambda *a, **kw: call_order.append("approve"))
+    mock_merge = AsyncMock(side_effect=lambda *a, **kw: call_order.append("merge"))
+
+    with patch("src.gate.engine.get_repo_config", return_value=config), \
+         patch("src.gate.engine._run_review_comment", new=mock_review), \
+         patch("src.gate.engine._run_approve_decision", new=mock_approve), \
+         patch("src.gate.engine._run_auto_merge", new=mock_merge):
+        await run_gate_check(
+            repo_name="owner/repo",
+            pr_number=1,
+            analysis_id=1,
+            result={"score": 80, "grade": "B"},
+            github_token="tok",
+            db=mock_db,
+        )
+
+    # 3 옵션 모두 호출됨 (gather 가 모두 schedule + await)
+    assert set(call_order) == {"review", "approve", "merge"}
+    mock_review.assert_awaited_once()
+    mock_approve.assert_awaited_once()
+    mock_merge.assert_awaited_once()
+


### PR DESCRIPTION
12-에이전트 감사 (2026-04-30) 개선 권장 #B5 — `run_gate_check` 가 3 옵션을 직렬 await 로 실행해 옵션마다 1-3초씩 합산되어 webhook 응답 지연. CLAUDE.md 규약상 "PR Gate 3-옵션 (pr_review_comment / approve / auto_merge) 완전 독립" 이므로 병렬 실행 가능 — gather 로 묶어 최장 옵션 1개 시간으로 단축.

수정 내용:
  - src/gate/engine.py
    * `run_gate_check` 의 직렬 await 3회 → `asyncio.gather(..., return_exceptions=True)` 단일 호출로 전환
    * 옵션별 예상 외 예외는 logger.error + exc_info 로 stack trace 보존 (각 옵션 내부에 이미 try/except 가 있으나 추가 안전망)
    * `import asyncio` 추가

  - 효과
    * gate 평균 latency: 직렬 (1+2+3)s → 병렬 max(1,2,3)s ≈ -50%
    * 한 옵션의 catch 못한 예외가 다른 옵션 실행을 막지 않음 (정확도 ↑)

회귀 방지 테스트 2건 추가:
  - test_run_gate_check_unexpected_exception_in_one_option_does_not_block_others — review_comment 가 RuntimeError 던져도 approve + auto_merge 모두 awaited 검증 (직렬 await 패턴이라면 첫 예외에서 중단됐을 케이스)
  - test_run_gate_check_runs_three_options_via_gather — 3 옵션 모두 awaited + call_order 에 모두 기록 검증

검증:
  - TDD: Red (2 fail — gather 미적용 시 첫 예외 후 중단) → Green
  - tests/unit/gate/ 207 passed (사전 2 failures 무관)
  - pylint src/ 전체 10.00/10 유지
  - src/ 변경 ~30줄 (대부분 한·영 주석 + gather 호출)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
