### PR TITLE
perf(pipeline): Phase H PR-3A — PyGithub blocking I/O 를 asyncio.to_th…

### DIFF
--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -379,7 +379,16 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
                 _, owner_token = ensure_result
 
             with stage_timer("collect_files", repo=repo_log) as ctx:
-                files = _collect_files(event, owner_token, repo_name, commit_sha, pr_number)
+                # Phase H PR-3A: PyGithub 동기 I/O 를 별도 스레드로 격리
+                # _collect_files 내부의 PyGithub 호출은 sync HTTP I/O — async
+                # 컨텍스트에서 직접 실행 시 이벤트 루프 블록 (20파일 PR 시 5-15s).
+                # asyncio.to_thread 로 wrap 해 다른 BackgroundTask 처리를 막지 않음.
+                # Phase H PR-3A: offload PyGithub sync I/O to a worker thread.
+                # Direct calls block the event loop (~5-15s on 20-file PRs);
+                # asyncio.to_thread keeps other BackgroundTasks responsive.
+                files = await asyncio.to_thread(
+                    _collect_files, event, owner_token, repo_name, commit_sha, pr_number,
+                )
                 ctx["file_count"] = len(files)
 
             if not files:

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -945,3 +945,37 @@ async def test_create_issue_not_called_when_disabled(mock_deps):
                 await run_analysis_pipeline("push", PUSH_DATA)
 
     mock_issue.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Phase H PR-3A — PyGithub blocking I/O 가 asyncio.to_thread 로 wrap 됨
+# 12-에이전트 감사 Critical C3 — sync PyGithub 가 async 컨텍스트에서 직접
+# 호출되어 이벤트 루프 블록. _collect_files 호출 시 asyncio.to_thread 로 wrap.
+# ---------------------------------------------------------------------------
+
+
+async def test_collect_files_wrapped_in_asyncio_to_thread(mock_deps):
+    """_collect_files (PyGithub sync I/O) 가 asyncio.to_thread 경유로 호출된다.
+
+    sync 호출이 이벤트 루프를 블록하면 같은 BackgroundTask 슬롯에서 다른
+    webhook 처리가 정체. asyncio.to_thread 로 별도 스레드에서 실행해야 안전.
+    """
+    from src.worker.pipeline import run_analysis_pipeline
+    from unittest.mock import AsyncMock, patch
+
+    # asyncio.to_thread 호출 횟수 추적
+    real_to_thread = __import__("asyncio").to_thread
+    to_thread_calls = []
+
+    async def _spy_to_thread(fn, *args, **kwargs):
+        to_thread_calls.append(getattr(fn, "__name__", str(fn)))
+        return await real_to_thread(fn, *args, **kwargs)
+
+    with patch("src.worker.pipeline.asyncio.to_thread", side_effect=_spy_to_thread), \
+         patch("src.worker.pipeline.run_gate_check", new_callable=AsyncMock):
+        await run_analysis_pipeline("push", PUSH_DATA)
+
+    # _collect_files 가 to_thread 경유 호출됨
+    assert "_collect_files" in to_thread_calls, (
+        f"_collect_files 미호출 — to_thread 호출 목록: {to_thread_calls}"
+    )


### PR DESCRIPTION
…read 로 격리 (Critical C3)

12-에이전트 감사 (2026-04-30) Critical C3 — `_collect_files` 가 sync PyGithub 호출 (`get_pr_files` / `get_push_files`) 을 async 컨텍스트(`run_analysis_pipeline`) 에서 직접 실행 → 이벤트 루프 블록. 20파일 PR 시 GitHub API 21회 직렬 호출로 5-15초 동안 다른 BackgroundTask (다른 webhook 분석/알림) 정체.

수정 내용:
  - src/worker/pipeline.py
    * `_collect_files` 호출을 `await asyncio.to_thread(_collect_files, ...)` 로 wrap
    * stage_timer("collect_files") 컨텍스트 내부 위치 유지
    * `_collect_files` 자체 시그니처는 sync 유지 (PyGithub 라이브러리 변경 없음)

  - 효과
    * 이벤트 루프 블록 0 — 다른 webhook 처리 latency 영향 차단
    * 20파일 PR 처리 중에도 health check / 다른 분석 동시 진행 가능
    * Sentry "GitHub sync hang" 월 5-10건 → 0 예상

회귀 방지 테스트 1건 추가:
  - test_collect_files_wrapped_in_asyncio_to_thread — `asyncio.to_thread` 호출 spy 로 `_collect_files` 가 thread pool 경유 호출됨 검증.

검증:
  - TDD: Red (직접 호출 시 to_thread 미호출) → Green
  - tests/unit/worker/ 74 passed (사전 1 failure 무관)
  - pylint src/ 전체 10.00/10 유지
  - src/ 변경 ~10줄 (대부분 한·영 주석)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
