### PR TITLE
docs: Phase H PR-5B — /health active_db 약속 문서 정정 (Critical C9)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ Railway 대시보드 설정:
 - **Variables** 탭에서 나머지 환경변수 설정 (`${{Postgres.DATABASE_URL}}`)
 - `APP_BASE_URL` 반드시 설정 — OAuth redirect_uri HTTPS 보장
 
-헬스체크: `GET /health` → `{"status":"ok","active_db":"primary"|"fallback"}` (timeout: 60초)
+헬스체크: `GET /health` → `{"status":"ok"}` (timeout: 60초). **`active_db` 등 내부 상태는 의도적으로 미노출** — 정보 노출 방지 (`tests/unit/test_main.py::test_health_returns_status_ok` 가 회귀 보장). DB failover 모니터링이 필요하면 별도 인증 엔드포인트 (`INTERNAL_CRON_API_KEY` 또는 admin key 기반) 신설 권장.
 
 ### NIXPACKS 빌드 설정 우선순위
 

--- a/docs/guides/github-integration-guide.md
+++ b/docs/guides/github-integration-guide.md
@@ -348,7 +348,7 @@ curl https://your-domain/api/hook/verify?repo=owner/repo&token=TOKEN
 □ 3. 웹 UI에서 GitHub 로그인
 □ 4. 리포지토리 추가 → Webhook 자동 생성 확인
 □ 5. 테스트 Push → Telegram 알림 + 대시보드 확인
-□ 6. GET /health → {"status":"ok","active_db":"primary"} 확인
+□ 6. GET /health → {"status":"ok"} 확인 (active_db 등 내부 상태는 의도적 미노출 — 보안)
 □ 7. (선택) 로컬 클론에서 bash .scamanager/install-hook.sh 실행
 □ 8. (선택) 설정 탭에서 PR 리뷰 댓글 · Gate 모드 · Auto Merge 설정
 □ 9. (기존 리포) Webhook 재등록 → check_suite 이벤트 구독 확인 (Phase 12 check_suite 섹션 참조)

--- a/docs/guides/onpremise-migration-guide.md
+++ b/docs/guides/onpremise-migration-guide.md
@@ -325,8 +325,8 @@ Primary 장애 감지 (OperationalError)
   → Fallback DB(Supabase)로 자동 전환
   → probe thread가 30초마다 Primary 복구 확인
   → Primary 복구 감지 시 자동 복귀
-  → /health → {"status":"ok","active_db":"fallback"} (장애 중)
-              {"status":"ok","active_db":"primary"}  (정상)
+  → /health → {"status":"ok"} (active 분기 무관 — 보안상 내부 DB 상태 미노출)
+  → 실제 failover 발생/복구는 logger.warning 로그로 추적 (Sentry/Railway logs)
 ```
 
 `DATABASE_URL_FALLBACK`이 비어 있으면 Failover 비활성 — 단일 엔진 모드로 동작합니다.
@@ -356,11 +356,20 @@ DATABASE_URL="postgresql://...supabase.co/postgres?sslmode=require" make migrate
 
 ```bash
 curl http://localhost:8000/health
-# 정상: {"status":"ok","active_db":"primary"}
-# 장애: {"status":"ok","active_db":"fallback"}
+# 정상/장애 무관: {"status":"ok"}
 ```
 
-`active_db`가 `"fallback"`이면 Primary DB 장애 상태입니다. 모니터링 도구(Uptime Kuma, Prometheus 등)에서 이 필드를 감시해 경보를 설정하세요.
+`/health` 는 liveness probe 전용 — DB failover 등 내부 상태는 보안상 노출하지
+않습니다 (정보 노출 방지). DB failover 발생/복구는 다음 경로로 추적합니다:
+
+1. **로그 모니터링** (권장) — `src/database.py::_probe_primary_loop` 가
+   `logger.warning("DB failover: primary → fallback")` / `logger.info(
+   "DB failover: fallback → primary recovered")` 로 기록.
+   Sentry / Railway / Loki 등 로그 수집기에서 위 패턴을 알림 규칙으로 설정.
+2. **Sentry 메트릭** — `init_sentry()` 가 동일 로그 메시지를 자동 캡처.
+
+> 인증된 운영자 대시보드에서 active_db 상태가 필요하면 별도 엔드포인트
+> 신설 권장 — `INTERNAL_CRON_API_KEY` 또는 admin key 기반.
 
 ### 동작 방식 상세
 
@@ -378,7 +387,7 @@ curl http://localhost:8000/health
 
 ```
 □ curl https://your-domain/health
-      → {"status":"ok","active_db":"primary"} 응답 확인
+      → {"status":"ok"} 응답 확인 (active_db 등 내부 상태는 의도적 미노출)
 
 □ GitHub OAuth 로그인
       → https://your-domain/login → GitHub으로 로그인
@@ -407,5 +416,5 @@ curl http://localhost:8000/health
 | `SESSION_SECRET` 경고 | `.env`에서 세션 시크릿 미설정 또는 기본값 사용 | `python -c "import secrets; print(secrets.token_hex(32))"` 로 새 값 생성 |
 | Webhook ping 실패 | nginx `X-Forwarded-Proto` 미설정 → HTTP URL 등록 | nginx 설정에 `proxy_set_header X-Forwarded-Proto $scheme` 추가 + `APP_BASE_URL` 확인 |
 | `DB_FORCE_IPV4=true` 오류 | Railway 전용 옵션이 온프레미스에서 DNS hang 유발 | `.env`에서 `DB_FORCE_IPV4=false` 로 변경 |
-| `active_db: "fallback"` 지속 | Primary DB 연결 복구 안 됨 | `DATABASE_URL` 연결 확인 (포트 방화벽·PostgreSQL 기동 상태) |
+| 로그에 `DB failover: primary → fallback` 지속 | Primary DB 연결 복구 안 됨 | `DATABASE_URL` 연결 확인 (포트 방화벽·PostgreSQL 기동 상태). `/health` 는 상태 노출 안 함 — Sentry/Railway 로그 모니터링 |
 | Supabase Fallback 연결 실패 | SSL 설정 불일치 | `DATABASE_URL_FALLBACK`에 `?sslmode=require` 포함 확인 |

--- a/docs/reports/2026-04-30-12agent-comprehensive-audit.md
+++ b/docs/reports/2026-04-30-12agent-comprehensive-audit.md
@@ -72,7 +72,7 @@
 | **C6** | `claim_batch` SKIP LOCKED | CLAUDE.md vs 코드 불일치, 수평 확장 시 더블-클레임 |
 | **C7** | `gate_decisions.analysis_id` ON DELETE CASCADE | 누락 시 FK 위반 잠재 |
 | **C8** | `_get_ci_status_safe` 중복 | engine.py + merge_retry_service.py 한쪽 수정 시 분기 깨짐 |
-| **C9** | `/health` `active_db` 누락 | CLAUDE.md 와 불일치 → 외부 모니터링이 failover 미감지 |
+| **C9** | `/health` `active_db` 누락 | ~~CLAUDE.md 와 불일치~~ → **PR-5B 해결 (문서 정정)**: `/health` 의 `active_db` 미노출은 의도적 보안 결정 (`tests/unit/test_main.py::test_health_returns_status_ok` 가 회귀 차단). CLAUDE.md + 가이드 5곳 갱신해 코드 = 단일 진실 소스 정합성 확보. failover 모니터링은 logger 로그 (Sentry/Railway) 경로로 대체. |
 | **C10** | Telegram gate 콜백 토큰 도메인 격리 비대칭 | `_make_callback_token` vs `_parse_gate_callback` HMAC 비대칭 |
 
 ---


### PR DESCRIPTION
12-에이전트 감사 (2026-04-30) Critical C9 — `/health` 가 `active_db` 필드를 노출한다고 CLAUDE.md + 가이드 5곳에 명시됐으나, 실제 코드는 의도적 보안 결정
으로 미노출 (`tests/unit/test_main.py::test_health_returns_status_ok` 가 회귀 가드). 코드 = 단일 진실 소스 원칙으로 문서 정정.

**의도와 절충**:
  - 12-에이전트 감사는 "active_db 누락 → 외부 모니터링 미감지" 우려 제기
  - 그러나 STATE.md 그룹 (line 456) 에 이미 "active_db 필드 제거 — 내부 DB 상태 노출 차단" 이력 + 단위 테스트 명시적 회귀 가드 존재
  - 안전한 절충: 코드 (보안 결정) 보존, 문서 5곳 정정 + failover 모니터링은 logger 로그 (Sentry/Railway) 경로 안내. 인증된 운영 대시보드 필요 시 별도 엔드포인트 신설 권장 표기.

수정 내용:
  - CLAUDE.md L312 — 헬스체크 응답 정정 + 의도적 미노출 표기 + 별도 인증 엔드포인트 권장 안내
  - docs/guides/github-integration-guide.md L351 — 검증 체크리스트 갱신
  - docs/guides/onpremise-migration-guide.md (~5곳)
    * Failover 동작 흐름도 — /health 응답 형태 정정 + logger 추적 안내
    * /health 모니터링 섹션 — 보안 결정 설명 + 로그 모니터링 권장 패턴 (Sentry/Railway/Loki 알림 규칙 예시)
    * 검증 체크리스트
    * 트러블슈팅 표 — active_db 행 → 로그 모니터링 행으로 교체
  - docs/reports/2026-04-30-12agent-comprehensive-audit.md
    * C9 항목에 PR-5B 해결 표기 (취소선 + 절충안 설명)

검증:
  - tests/unit/test_main.py 19 passed (security 가드 회귀 0)
  - src/ 변경 0 (문서 + 회고만)

Phase H Critical 4건 (C1~C4) + C9 (5건) 모두 처리 완료.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
