### PR TITLE
refactor(logging): Phase H PR-6A — logger.error → logger.exception 7곳 일괄

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -94,8 +94,10 @@ async def lifespan(_app: FastAPI):
         logger.info("DB migration completed")
     except asyncio.TimeoutError:
         logger.error("DB migration timed out after 30s — starting app anyway")
-    except Exception as exc:  # pylint: disable=broad-exception-caught
-        logger.error("DB migration failed: %s", exc)
+    except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        # Phase H PR-6A: logger.exception 으로 stack trace 보존
+        # Sentry/Railway 로그에서 마이그레이션 실패 원인 추적 가능
+        logger.exception("DB migration failed")
     await init_http_client()
 
     # Phase 2 — GitHub API warm-up ping. PR #105 silent skip 사고 분석에서 cold

--- a/src/notifier/merge_failure_issue.py
+++ b/src/notifier/merge_failure_issue.py
@@ -90,6 +90,9 @@ async def create_merge_failure_issue(  # pylint: disable=too-many-locals
         number = create_resp.json().get("number")
         logger.info("Auto-merge failure Issue 생성 완료 #%s (pr=%d)", number, pr_number)
         return number
-    except httpx.HTTPError as exc:
-        logger.error("create_merge_failure_issue 실패 (%s, pr=%d): %s", repo_name, pr_number, exc)
+    except httpx.HTTPError:
+        # Phase H PR-6A: logger.exception 으로 stack trace 보존
+        logger.exception(
+            "create_merge_failure_issue 실패 (%s, pr=%d)", repo_name, pr_number,
+        )
         return None

--- a/src/notifier/railway_issue.py
+++ b/src/notifier/railway_issue.py
@@ -87,6 +87,7 @@ async def create_deploy_failure_issue(
         number = create_resp.json().get("number")
         logger.info("Railway Issue 생성 완료 #%s (%s)", number, repo_full_name)
         return number
-    except httpx.HTTPError as exc:
-        logger.error("create_deploy_failure_issue 실패 (%s): %s", repo_full_name, exc)
+    except httpx.HTTPError:
+        # Phase H PR-6A: logger.exception 으로 stack trace 보존
+        logger.exception("create_deploy_failure_issue 실패 (%s)", repo_full_name)
         return None

--- a/src/webhook/providers/telegram.py
+++ b/src/webhook/providers/telegram.py
@@ -119,8 +119,9 @@ async def handle_gate_callback(
                         "PR #%d manual-approved but auto-merge 실패: %s",
                         analysis.pr_number, reason,
                     )
-        except (httpx.HTTPError, KeyError, ValueError, SQLAlchemyError) as exc:
-            logger.error("Gate callback failed: %s", exc)
+        except (httpx.HTTPError, KeyError, ValueError, SQLAlchemyError):
+            # Phase H PR-6A: logger.exception 으로 stack trace 보존
+            logger.exception("Gate callback failed")
 
 
 def _handle_message(

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -190,8 +190,11 @@ async def _regate_pr_if_needed(
     try:
         existing.pr_number = pr_number
         db.commit()
-    except SQLAlchemyError as exc:
-        logger.error("pr_number update failed (sha=%s, pr=#%d): %s", commit_sha, pr_number, exc)
+    except SQLAlchemyError:
+        # Phase H PR-6A: logger.exception 으로 stack trace 보존
+        logger.exception(
+            "pr_number update failed (sha=%s, pr=#%d)", commit_sha, pr_number,
+        )
         db.rollback()
         return
     owner_token: str = settings.github_token
@@ -267,10 +270,11 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
                     "Race-recovered: PR #%d re-gated on concurrent existing Analysis %d (sha=%s)",
                     params.pr_number, existing.id, params.commit_sha[:8],
                 )
-            except SQLAlchemyError as exc:
-                logger.error(
-                    "Race-recovery pr_number commit failed (sha=%s, pr=#%d): %s",
-                    params.commit_sha, params.pr_number, exc,
+            except SQLAlchemyError:
+                # Phase H PR-6A: logger.exception 으로 stack trace 보존
+                logger.exception(
+                    "Race-recovery pr_number commit failed (sha=%s, pr=#%d)",
+                    params.commit_sha, params.pr_number,
                 )
                 db.rollback()
             except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
@@ -312,8 +316,9 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
                 db=db,
                 config=repo_config,
             )
-        except (httpx.HTTPError, SQLAlchemyError, KeyError, ValueError, OSError) as exc:
-            logger.error("Gate check failed: %s", exc)
+        except (httpx.HTTPError, SQLAlchemyError, KeyError, ValueError, OSError):
+            # Phase H PR-6A: logger.exception 으로 stack trace 보존
+            logger.exception("Gate check failed")
         except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             logger.error("Gate check unexpected error: %s", exc, exc_info=True)
     return repo_config, analysis_id, result_dict


### PR DESCRIPTION
12-에이전트 감사 (2026-04-30) 개선 권장 #D1 — `logger.error("...%s", exc)` 패턴 이 stack trace 를 손실해 Sentry/Railway 로그에서 디버깅 어려움. 8건 식별 중 exc 를 직접 포맷하는 7건 변환. 나머지 (`type(exc).__name__` 만 출력 — 의도적 보안 패턴, 또는 이미 `exc_info=...` 적용) 는 그대로 유지.

수정 내용 (모두 동일 패턴 — `logger.error("...%s", exc)` → `logger.exception("...")`):
  - src/main.py:98 — DB migration failed
  - src/notifier/merge_failure_issue.py:94 — create_merge_failure_issue 실패
  - src/notifier/railway_issue.py:91 — create_deploy_failure_issue 실패
  - src/webhook/providers/telegram.py:123 — Gate callback failed
  - src/worker/pipeline.py:194 — pr_number update failed
  - src/worker/pipeline.py:271-274 — Race-recovery pr_number commit failed
  - src/worker/pipeline.py:316 — Gate check failed

각 변환 시 한·영 PR 표지 주석 추가.

**유지 (의도적 type-name 만 출력)**:
  - src/gate/engine.py:119,179,205 — `type(exc).__name__` 만 (HTTP 응답 바디 노출 위험 차단 — 보안 결정)
  - src/gate/engine.py:248,565 — 동일 의도
  - src/gate/engine.py:92-96 — 이미 `exc_info=...` 적용 (PR-2C)
  - src/main.py:83-86 — config warning (no exc)
  - src/main.py:96 — timeout warning (no exc)
  - src/github_client/checks.py:224-228 — status code only (no exc)
  - src/worker/pipeline.py:341 — 이미 `exc_info=(type, exc, tb)` 적용

검증:
  - tests/unit/ 1942 passed (사전 12 failures 무관, 변동 0)
  - pylint src/ 전체 10.00/10 유지
  - src/ 동작 변경 0 (logger 출력 형식만 향상)

효과:
  - Sentry 자동 그룹화 정확도 ↑ — stack trace 가 같은 스택 위치 자동 묶음
  - 디버깅 시간 단축 — exc 메시지만 보고 추측하던 케이스가 실제 trace 로 즉시 식별
  - SonarCloud `pythonsecurity` 룰 false-positive 감소

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
