### PR TITLE
refactor(security): Phase H PR-6B — sanitize_for_log 16곳 일괄 적용 (로그 인젝…

### DIFF
--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -27,6 +27,7 @@ from src.notifier.github_comment import post_pr_comment_from_result as post_pr_c
 from src.notifier.telegram import telegram_post_message
 from src.models.gate_decision import GateDecision
 from src.repositories import gate_decision_repo, merge_retry_repo
+from src.shared.log_safety import sanitize_for_log
 from src.shared.merge_metrics import log_merge_attempt
 
 logger = logging.getLogger(__name__)
@@ -189,7 +190,9 @@ async def _run_semi_auto_approve(
 ) -> None:
     """Semi-auto Approve 분기 — Telegram 인라인 키보드 발송."""
     if not config.notify_chat_id:
-        logger.warning("semi-auto 모드이나 notify_chat_id 미설정: %s", repo_name)
+        logger.warning(
+            "semi-auto 모드이나 notify_chat_id 미설정: %s", sanitize_for_log(repo_name),
+        )
         return
     try:
         score_result = _score_from_result(result)
@@ -527,7 +530,7 @@ async def _run_auto_merge_legacy(  # pylint: disable=too-many-arguments
                 )
 
         if ok:
-            logger.info("PR #%d auto-merged: %s", pr_number, repo_name)
+            logger.info("PR #%d auto-merged: %s", pr_number, sanitize_for_log(repo_name))
             return
 
         advice = get_advice(reason)
@@ -599,7 +602,10 @@ async def _handle_terminal_merge_failure(  # pylint: disable=too-many-arguments
             logger.warning("merge_attempt 기록 실패: %s", log_exc)
 
     advice = get_advice(reason_tag)
-    logger.warning("PR #%d auto-merge 실패 (repo=%s): %s", pr_number, repo_name, reason)
+    logger.warning(
+        "PR #%d auto-merge 실패 (repo=%s): %s",
+        pr_number, sanitize_for_log(repo_name), sanitize_for_log(reason),
+    )
     await _notify_merge_failure(
         repo_name=repo_name,
         pr_number=pr_number,

--- a/src/gate/github_review.py
+++ b/src/gate/github_review.py
@@ -8,6 +8,7 @@ from src.config import settings
 from src.gate import merge_reasons
 from src.github_client.helpers import github_api_headers
 from src.shared.http_client import get_http_client
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -172,5 +173,8 @@ async def merge_pr(  # pylint: disable=too-many-locals
         return (False, reason, head_sha)
     except httpx.HTTPError as exc:
         reason = f"{merge_reasons.NETWORK_ERROR}: {exc}"
-        logger.warning("PR Merge 실패 (repo=%s, pr=%d): %s", repo_full_name, pr_number, reason)
+        logger.warning(
+            "PR Merge 실패 (repo=%s, pr=%d): %s",
+            sanitize_for_log(repo_full_name), pr_number, sanitize_for_log(reason),
+        )
         return (False, reason, head_sha)

--- a/src/github_client/repos.py
+++ b/src/github_client/repos.py
@@ -8,6 +8,7 @@ import httpx
 
 from src.constants import GITHUB_API
 from src.shared.http_client import get_http_client
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -265,5 +266,8 @@ async def commit_scamanager_files(
 
         return True
     except httpx.HTTPError as exc:
-        logger.warning("commit_scamanager_files 실패 (%s): %s", repo_full_name, exc)
+        logger.warning(
+            "commit_scamanager_files 실패 (%s): %s",
+            sanitize_for_log(repo_full_name), exc,
+        )
         return False

--- a/src/notifier/github_commit_comment.py
+++ b/src/notifier/github_commit_comment.py
@@ -7,6 +7,7 @@ from src.constants import GITHUB_API
 from src.github_client.helpers import github_api_headers
 from src.notifier.github_comment import _build_comment_from_result
 from src.shared.http_client import get_http_client
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,10 @@ async def post_commit_comment(
         )
         resp.raise_for_status()
     except httpx.HTTPError as exc:
-        logger.warning("post_commit_comment 실패 (%s@%s): %s", repo_name, commit_sha, exc)
+        logger.warning(
+            "post_commit_comment 실패 (%s@%s): %s",
+            sanitize_for_log(repo_name), sanitize_for_log(commit_sha), exc,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/notifier/github_issue.py
+++ b/src/notifier/github_issue.py
@@ -7,6 +7,7 @@ from src.config import settings
 from src.constants import GITHUB_API
 from src.github_client.helpers import github_api_headers
 from src.shared.http_client import get_http_client
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +95,10 @@ async def create_low_score_issue(
         resp.raise_for_status()
         return resp.json().get("number")
     except httpx.HTTPError as exc:
-        logger.warning("create_low_score_issue 실패 (%s@%s): %s", repo_name, commit_sha, exc)
+        logger.warning(
+            "create_low_score_issue 실패 (%s@%s): %s",
+            sanitize_for_log(repo_name), sanitize_for_log(commit_sha), exc,
+        )
         return None
 
 

--- a/src/notifier/railway_issue.py
+++ b/src/notifier/railway_issue.py
@@ -5,6 +5,7 @@ from src.constants import GITHUB_API
 from src.github_client.helpers import github_api_headers
 from src.railway_client.models import RailwayDeployEvent
 from src.shared.http_client import get_http_client
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -85,9 +86,9 @@ async def create_deploy_failure_issue(
         )
         create_resp.raise_for_status()
         number = create_resp.json().get("number")
-        logger.info("Railway Issue 생성 완료 #%s (%s)", number, repo_full_name)
+        logger.info("Railway Issue 생성 완료 #%s (%s)", number, sanitize_for_log(repo_full_name))
         return number
     except httpx.HTTPError:
         # Phase H PR-6A: logger.exception 으로 stack trace 보존
-        logger.exception("create_deploy_failure_issue 실패 (%s)", repo_full_name)
+        logger.exception("create_deploy_failure_issue 실패 (%s)", sanitize_for_log(repo_full_name))
         return None

--- a/src/webhook/providers/github.py
+++ b/src/webhook/providers/github.py
@@ -104,11 +104,17 @@ async def _handle_merged_pr_event(data: dict) -> dict:
             if repo and repo.owner:
                 token = repo.owner.plaintext_token or ""
     except (SQLAlchemyError, KeyError, AttributeError) as exc:
-        logger.warning("merged-pr issue close: repo lookup failed for %s: %s", repo_name, exc)
+        logger.warning(
+            "merged-pr issue close: repo lookup failed for %s: %s",
+            sanitize_for_log(repo_name), exc,
+        )
 
     token = token or settings.github_token
     if not token:
-        logger.info("merged-pr issue close: no token available for %s — skipped", repo_name)
+        logger.info(
+            "merged-pr issue close: no token available for %s — skipped",
+            sanitize_for_log(repo_name),
+        )
         return {"status": "accepted"}
 
     for issue_number in numbers:
@@ -118,7 +124,10 @@ async def _handle_merged_pr_event(data: dict) -> dict:
                 repo_full_name=repo_name,
                 issue_number=issue_number,
             )
-            logger.info("Auto-closed issue #%d on %s (PR merge)", issue_number, repo_name)
+            logger.info(
+                "Auto-closed issue #%d on %s (PR merge)",
+                issue_number, sanitize_for_log(repo_name),
+            )
         except httpx.HTTPError as exc:
             # exc 본문에 GitHub API 응답 세부사항이 포함될 수 있으므로 타입명만 기록
             # Log only the exception type — exc body may contain GitHub API response details.
@@ -239,7 +248,10 @@ async def _handle_issues_event(data: dict, background_tasks: BackgroundTasks) ->
             if repo and repo.owner:
                 repo_token = repo.owner.plaintext_token or ""
     except (SQLAlchemyError, KeyError, AttributeError) as exc:
-        logger.warning("issues relay: repo config lookup failed for %s: %s", repo_name, exc)
+        logger.warning(
+            "issues relay: repo config lookup failed for %s: %s",
+            sanitize_for_log(repo_name), exc,
+        )
 
     if not n8n_url:
         return {"status": "ignored"}

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -232,7 +232,10 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
     """
     repo = repository_repo.find_by_full_name(db, params.repo_name)
     if repo is None:
-        logger.warning("Repository not found in second session: %s", params.repo_name)
+        logger.warning(
+            "Repository not found in second session: %s",
+            sanitize_for_log(params.repo_name),
+        )
         return None, None, None
     # 멱등성 재확인 — 동시 Webhook 전달로 인한 중복 Analysis 삽입 방지 (TOCTOU 완화)
     # Idempotency re-check — defends against concurrent webhooks racing past the first dedup.
@@ -303,7 +306,10 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
     try:
         repo_config = get_repo_config(db, params.repo_name)
     except (SQLAlchemyError, KeyError):
-        logger.warning("Failed to load repo config for %s, using defaults", params.repo_name)
+        logger.warning(
+            "Failed to load repo config for %s, using defaults",
+            sanitize_for_log(params.repo_name),
+        )
         repo_config = None
     if params.pr_number is not None:
         try:


### PR DESCRIPTION
…션 방어)

12-에이전트 감사 (2026-04-30) Medium 보안 — `repo_name` / `repo_full_name` 등 user-controlled 값을 logger 에 직접 전달하는 16곳 식별. SonarCloud `pythonsecurity:S5145` taint analysis 가 잡지 못하는 잠재 로그 인젝션 표면. 모두 `sanitize_for_log()` 경유로 정규화.

수정 영역 (8개 파일, 16 callsite):
  - src/gate/engine.py (3) — semi-auto 경고 / auto-merged info / 실패 warning
  - src/gate/github_review.py (1) — PR Merge 실패
  - src/github_client/repos.py (1) — commit_scamanager_files 실패
  - src/notifier/github_issue.py (1) — create_low_score_issue 실패
  - src/notifier/github_commit_comment.py (1) — post_commit_comment 실패
  - src/notifier/railway_issue.py (2) — Issue 생성 완료/실패
  - src/webhook/providers/github.py (4) — merged-pr lookup/no-token/auto-close/ issues relay
  - src/worker/pipeline.py (2) — Repository not found / repo config load failed

각 파일 import 누락 시 `from src.shared.log_safety import sanitize_for_log` 1줄 추가. 중복 인자 (예: `repo_name` + `commit_sha` 함께) 는 양쪽 sanitize.

검증:
  - tests/unit/ 1942 passed (사전 12 failures 동일, 변동 0)
  - pylint src/ 전체 10.00/10 유지
  - src/ 동작 변경 0 (logger 출력 시 CR/LF/NUL 등 정제만 추가)

효과:
  - 로그 인젝션 방어 표면 +16곳
  - SonarCloud taint warnings 감소 예상 (~18 → ~2)
  - 미래 쟝애 발생 시 안전한 로그 — fake newline 으로 가짜 로그 라인 위조 차단

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
