### PR TITLE
perf(db): Phase H PR-4A — 복합 인덱스 3종 (analyses + merge_attempts)

### DIFF
--- a/alembic/versions/0023_add_composite_indexes.py
+++ b/alembic/versions/0023_add_composite_indexes.py
@@ -1,0 +1,57 @@
+"""add composite indexes for repo-scoped queries (Phase H PR-4A)
+
+12-에이전트 감사 (2026-04-30) High 성능 — `analytics_service` / leaderboard /
+author_trend / Phase F.4 dashboard 쿼리가 복합 인덱스 부재로 1만 row 시점부터
+풀스캔. 신규 인덱스 3종 추가:
+
+  - ix_analyses_repo_id_created_at — `WHERE repo_id=X ORDER BY created_at DESC`
+    (analytics_service.weekly_summary / moving_average / repo_detail 차트)
+  - ix_analyses_repo_id_author_login — leaderboard / author_trend
+  - ix_merge_attempts_attempted_at — Phase F.4 dashboard 시계열
+
+PostgreSQL `CREATE INDEX` 는 기본 online (테이블 락 없음) — 다운타임 ~0.
+Single-column 인덱스(0021 created_at 등) 는 보존 — 전역 추세 쿼리에 여전히 사용.
+
+Revision ID: 0023compositeindexes
+Revises: 0022mergeattemptlifecycle
+Create Date: 2026-05-01
+"""
+from alembic import op
+
+
+revision = '0023compositeindexes'
+down_revision = '0022mergeattemptlifecycle'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. analyses (repo_id, created_at) — repo-scoped 시간 순 쿼리 hot path
+    # 1. analyses (repo_id, created_at) — hot path for repo-scoped time-ordered queries
+    op.create_index(
+        'ix_analyses_repo_id_created_at',
+        'analyses',
+        ['repo_id', 'created_at'],
+    )
+
+    # 2. analyses (repo_id, author_login) — leaderboard / author_trend
+    # 2. analyses (repo_id, author_login) — leaderboard / author_trend aggregations
+    op.create_index(
+        'ix_analyses_repo_id_author_login',
+        'analyses',
+        ['repo_id', 'author_login'],
+    )
+
+    # 3. merge_attempts (attempted_at) — Phase F.4 dashboard 시계열
+    # 3. merge_attempts (attempted_at) — Phase F.4 dashboard time-series filter
+    op.create_index(
+        'ix_merge_attempts_attempted_at',
+        'merge_attempts',
+        ['attempted_at'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_merge_attempts_attempted_at', table_name='merge_attempts')
+    op.drop_index('ix_analyses_repo_id_author_login', table_name='analyses')
+    op.drop_index('ix_analyses_repo_id_created_at', table_name='analyses')

--- a/src/models/analysis.py
+++ b/src/models/analysis.py
@@ -1,6 +1,8 @@
 """Analysis ORM 모델 — 분석 이력(정적 분석 + AI 리뷰 점수) 저장."""
 from datetime import datetime, timezone
-from sqlalchemy import Column, Integer, String, JSON, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy import (
+    Column, Integer, String, JSON, DateTime, ForeignKey, UniqueConstraint, Index,
+)
 from sqlalchemy.orm import relationship
 from src.database import Base
 
@@ -10,7 +12,17 @@ class Analysis(Base):
     """Push/PR 분석 이력 테이블 — commit_sha별 점수·등급·AI 리뷰 결과 저장."""
 
     __tablename__ = "analyses"
-    __table_args__ = (UniqueConstraint("repo_id", "commit_sha", name="uq_analyses_repo_sha"),)
+    # Phase H PR-4A — 복합 인덱스 2종:
+    #   (repo_id, created_at) — `WHERE repo_id=X ORDER BY created_at DESC LIMIT N`
+    #     analytics_service.weekly_summary / moving_average / repo_detail 차트
+    #   (repo_id, author_login) — leaderboard / author_trend 집계
+    # 단일 컬럼 created_at/author_login 인덱스는 다른 쿼리(전역 추세 등) 용으로 유지.
+    # Phase H PR-4A — composite indexes for repo-scoped sort/group queries.
+    __table_args__ = (
+        UniqueConstraint("repo_id", "commit_sha", name="uq_analyses_repo_sha"),
+        Index("ix_analyses_repo_id_created_at", "repo_id", "created_at"),
+        Index("ix_analyses_repo_id_author_login", "repo_id", "author_login"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     repo_id = Column(Integer, ForeignKey("repositories.id"), nullable=False)

--- a/src/models/merge_attempt.py
+++ b/src/models/merge_attempt.py
@@ -16,7 +16,7 @@ upsert 가 아닌 순수 append-only 이력.
 """
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, Integer, String
 
 from src.database import Base
 
@@ -26,6 +26,12 @@ class MergeAttempt(Base):
     """auto-merge 시도 1회 기록 — 성공·실패 모두 저장."""
 
     __tablename__ = "merge_attempts"
+    # Phase H PR-4A — Phase F.4 dashboard 시계열 쿼리용 단일 인덱스
+    # `WHERE attempted_at >= NOW() - INTERVAL '7 days'` 풀스캔 → 인덱스 스캔.
+    # Phase H PR-4A — single index for Phase F.4 dashboard time-series queries.
+    __table_args__ = (
+        Index("ix_merge_attempts_attempted_at", "attempted_at"),
+    )
 
     id = Column(Integer, primary_key=True, index=True)
     analysis_id = Column(

--- a/tests/unit/migrations/test_0023_composite_indexes.py
+++ b/tests/unit/migrations/test_0023_composite_indexes.py
@@ -1,0 +1,81 @@
+"""Phase H PR-4A — 복합 인덱스 3종 회귀 가드.
+
+12-에이전트 감사 (2026-04-30) High 성능 — analytics/leaderboard/dashboard 쿼리가
+복합 인덱스 부재로 1만 row 시점부터 풀스캔 회귀.
+
+신규 인덱스:
+  - ix_analyses_repo_id_created_at — `WHERE repo_id=X ORDER BY created_at DESC LIMIT N`
+  - ix_analyses_repo_id_author_login — leaderboard / author_trend
+  - ix_merge_attempts_attempted_at — Phase F.4 dashboard 시계열
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+# pylint: disable=wrong-import-position
+import pytest
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import sessionmaker
+
+from src.database import Base
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(eng)
+    yield eng
+    eng.dispose()
+
+
+def _index_columns(engine_, table: str, index_name: str) -> list[str] | None:
+    """SQLAlchemy Inspector 로 인덱스의 컬럼 목록 조회. 미존재 시 None."""
+    inspector = inspect(engine_)
+    for idx in inspector.get_indexes(table):
+        if idx["name"] == index_name:
+            return idx["column_names"]
+    return None
+
+
+def test_analyses_has_composite_repo_id_created_at_index(engine):
+    """ix_analyses_repo_id_created_at 인덱스 존재 + 컬럼 순서."""
+    cols = _index_columns(engine, "analyses", "ix_analyses_repo_id_created_at")
+    assert cols is not None, "복합 인덱스 ix_analyses_repo_id_created_at 미존재"
+    assert cols == ["repo_id", "created_at"], (
+        f"인덱스 컬럼 순서 불일치: {cols}"
+    )
+
+
+def test_analyses_has_composite_repo_id_author_login_index(engine):
+    """ix_analyses_repo_id_author_login 인덱스 존재 + 컬럼 순서."""
+    cols = _index_columns(engine, "analyses", "ix_analyses_repo_id_author_login")
+    assert cols is not None, "복합 인덱스 ix_analyses_repo_id_author_login 미존재"
+    assert cols == ["repo_id", "author_login"], (
+        f"인덱스 컬럼 순서 불일치: {cols}"
+    )
+
+
+def test_merge_attempts_has_attempted_at_index(engine):
+    """ix_merge_attempts_attempted_at 인덱스 존재 (시계열 쿼리용)."""
+    cols = _index_columns(engine, "merge_attempts", "ix_merge_attempts_attempted_at")
+    assert cols is not None, "ix_merge_attempts_attempted_at 미존재"
+    assert cols == ["attempted_at"]
+
+
+def test_existing_orm_indexes_preserved(engine):
+    """기존 ORM 인덱스 회귀 가드 — Phase 2 추가 단일 인덱스 보존.
+
+    Note: 일부 인덱스(예: ix_merge_attempts_state_repo from 0022)는 마이그레이션
+    전용이라 ORM `Base.metadata.create_all` 에서 생성되지 않음. 본 테스트는
+    ORM 측 인덱스만 검증.
+    """
+    # 0021 — analyses.created_at 단일 인덱스 (ORM index=True 명시)
+    assert _index_columns(engine, "analyses", "ix_analyses_created_at") == ["created_at"]
+    # author_login 단일 인덱스 (ORM index=True 명시)
+    assert _index_columns(engine, "analyses", "ix_analyses_author_login") == ["author_login"]
+    # commit_sha 단일 인덱스
+    assert _index_columns(engine, "analyses", "ix_analyses_commit_sha") == ["commit_sha"]

--- a/tests/unit/migrations/test_0023_composite_indexes.py
+++ b/tests/unit/migrations/test_0023_composite_indexes.py
@@ -19,7 +19,6 @@ os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
 # pylint: disable=wrong-import-position
 import pytest
 from sqlalchemy import create_engine, inspect
-from sqlalchemy.orm import sessionmaker
 
 from src.database import Base
 


### PR DESCRIPTION
12-에이전트 감사 (2026-04-30) High 성능 H1/H2/H3 — analytics_service / leaderboard / Phase F.4 dashboard 쿼리가 복합 인덱스 부재로 1만 row 시점부터 풀스캔 회귀 (P95 ~180ms 까지 악화). 본 PR 로 즉시 차단.

신규 인덱스 3종 (모두 CREATE INDEX — DROP/ALTER 없음):
  1. ix_analyses_repo_id_created_at — `WHERE repo_id=X ORDER BY created_at DESC LIMIT N` (analytics_service.weekly_summary / moving_average / repo_detail 차트). 가장 hot 한 path — repo_detail 페이지 첫 로드.
  2. ix_analyses_repo_id_author_login — leaderboard / author_trend 집계 (`GROUP BY author_login WHERE repo_id=X`)
  3. ix_merge_attempts_attempted_at — Phase F.4 dashboard 시계열 필터 (`WHERE attempted_at >= NOW() - INTERVAL '7 days'`)

수정 내용:
  - src/models/analysis.py — `__table_args__` 에 Index 2종 추가
  - src/models/merge_attempt.py — `__table_args__` 에 Index 1종 추가
  - alembic/versions/0023_add_composite_indexes.py — 신규 마이그레이션 (upgrade: 3 op.create_index, downgrade: 3 op.drop_index — 역방향 호환)

운영 안전성:
  - PostgreSQL `CREATE INDEX` 기본 online (테이블 락 없음) — 다운타임 ~0
  - 단일 컬럼 인덱스 (0021 created_at, author_login 등) 보존 — 전역 추세 쿼리에 여전히 사용
  - batch_alter_table 미사용 (CLAUDE.md 0007+ 규약 준수)

회귀 방지 테스트 4건 추가:
  - tests/unit/migrations/test_0023_composite_indexes.py
    * test_analyses_has_composite_repo_id_created_at_index
    * test_analyses_has_composite_repo_id_author_login_index
    * test_merge_attempts_has_attempted_at_index
    * test_existing_orm_indexes_preserved (회귀 가드)

검증:
  - tests/unit/ 1946 passed (사전 12 failures 무관, +4 신규 통과)
  - pylint src/ 전체 10.00/10 유지
  - SQLite + PostgreSQL 모두 호환 (Index() ORM 정의 + 표준 op.create_index)

예상 효과 (감사 보고서):
  - repo_detail 차트 P95 latency: ~180ms → <50ms (10K rows 기준)
  - leaderboard 쿼리: ~70% 메모리 절감 + ~50% latency 감소
  - merge_attempts 시계열: 풀스캔 → 인덱스 스캔 전환

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
