### PR TITLE
fix(security): Phase H PR-5C — Telegram gate 콜백 HMAC 발신/수신 PARITY (Cr…

### DIFF
--- a/src/webhook/providers/telegram.py
+++ b/src/webhook/providers/telegram.py
@@ -49,13 +49,17 @@ def _parse_gate_callback(data: str) -> "tuple[str, int, str] | None":
         analysis_id = int(analysis_id_str)
     except ValueError:
         return None
-    # 32자 hex (128-bit) — telegram_gate.py 의 발신 토큰과 동일 절단 길이 유지
-    # 32 hex chars (128-bit) — matches the truncation length in telegram_gate._gate_callback_token.
-    # Telegram callback_data 64-byte 한도로 인해 [:32] 절단이 필수 (NIST SP 800-107 충족).
-    # [:32] truncation is required by Telegram's 64-byte callback_data limit (meets NIST SP 800-107).
+    # Phase H PR-5C — 발신측 (telegram_gate._make_callback_token) 과 동일한
+    # HMAC msg 형식 사용 — `f"gate:{analysis_id}"`. 이전 구현은 `str(analysis_id)`
+    # 만 HMAC 해 발신 토큰과 불일치 → 모든 semi-auto 콜백이 401 거부되던
+    # functional bug. 12-에이전트 감사 Critical C10 직접 수정.
+    # cmd 도메인 (cmd:N) 과의 격리도 본 변경으로 보장 — cross-replay 차단.
+    # Phase H PR-5C: align HMAC msg with sender (`f"gate:{id}"` not `str(id)`) —
+    # mismatch had caused all semi-auto callbacks to fail with 401. Also restores
+    # cmd-domain isolation (Critical C10 from 2026-04-30 audit).
     expected = hmac.new(
         settings.telegram_bot_token.encode(),
-        str(analysis_id).encode(),
+        f"gate:{analysis_id}".encode(),
         digestmod=hashlib.sha256,
     ).hexdigest()[:32]
     if not hmac.compare_digest(expected, callback_token):

--- a/tests/unit/webhook/test_telegram_provider.py
+++ b/tests/unit/webhook/test_telegram_provider.py
@@ -16,8 +16,9 @@ client = TestClient(app)
 
 # HMAC-SHA256[:32] token for analysis_id=42, bot_token="123:ABC" — 32자 hex (128-bit)
 # Telegram callback_data 64-byte 한도로 인해 32자 절단 유지 (NIST SP 800-107 충족).
-# 32-char truncation is required by Telegram's 64-byte callback_data limit (meets NIST SP 800-107).
-_TOKEN_42 = "d9939856ed07d33d8689614fcb1a7dff"
+# Phase H PR-5C — HMAC msg = `f"gate:{analysis_id}"` (발신측과 동일 — scope 격리)
+# Computed: hmac("123:ABC", "gate:42", sha256).hexdigest()[:32]
+_TOKEN_42 = "2e3450af594e60ff0c34543790c58342"
 APPROVE = {"update_id": 1, "callback_query": {"id": "c1", "from": {"id": 1, "username": "john"},
             "data": f"gate:approve:42:{_TOKEN_42}", "message": {"message_id": 1, "chat": {"id": -1}}}}
 REJECT = {"update_id": 2, "callback_query": {"id": "c2", "from": {"id": 1, "username": "john"},
@@ -445,3 +446,67 @@ def test_unknown_payload_returns_ok():
     r = client.post("/api/webhook/telegram", json={"update_id": 1, "unknown_key": "value"})
     assert r.status_code == 200
     assert r.json() == {"status": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# Phase H PR-5C — sender ↔ receiver HMAC PARITY 회귀 가드
+# 12-에이전트 감사 Critical C10 — 이전에는 발신측 (gate.telegram_gate) 의
+# `f"gate:{id}"` 와 수신측의 `str(id)` 가 달라 모든 semi-auto 콜백이 401.
+# 본 테스트는 두 토큰이 정확히 동일함을 영구 가드.
+# ---------------------------------------------------------------------------
+
+
+def test_sender_receiver_hmac_token_parity():
+    """발신측 _gate_callback_token() 이 만든 토큰을 수신측이 검증 통과해야 한다."""
+    from src.gate.telegram_gate import _gate_callback_token  # pylint: disable=import-outside-toplevel
+    from src.webhook.providers.telegram import _parse_gate_callback  # pylint: disable=import-outside-toplevel
+
+    bot_token = "123:ABC"  # conftest 환경변수와 일치
+    analysis_id = 99
+    sender_token = _gate_callback_token(bot_token, analysis_id)
+
+    # 수신측은 settings.telegram_bot_token 사용 — patch 로 주입
+    with patch("src.webhook.providers.telegram.settings") as mock_settings:
+        mock_settings.telegram_bot_token = bot_token
+        callback_data = f"gate:approve:{analysis_id}:{sender_token}"
+        parsed = _parse_gate_callback(callback_data)
+
+    assert parsed is not None, (
+        "PARITY 위반: 발신측 토큰이 수신측 검증을 통과해야 함 — "
+        "HMAC msg 형식이 양쪽 동일해야 한다"
+    )
+    decision, parsed_id, parsed_token = parsed
+    assert decision == "approve"
+    assert parsed_id == analysis_id
+    assert parsed_token == sender_token
+
+
+def test_receiver_rejects_legacy_str_id_token():
+    """레거시 패턴 (HMAC msg = str(id)) 토큰은 수신 거부 — 보안 가드."""
+    import hashlib  # pylint: disable=import-outside-toplevel
+    import hmac as _hmac  # pylint: disable=import-outside-toplevel
+    bot_token = "123:ABC"
+    legacy_token = _hmac.new(
+        bot_token.encode(), b"42", digestmod=hashlib.sha256,
+    ).hexdigest()[:32]
+
+    with patch("src.webhook.providers.telegram.settings") as mock_settings:
+        mock_settings.telegram_bot_token = bot_token
+        from src.webhook.providers.telegram import _parse_gate_callback  # pylint: disable=import-outside-toplevel
+        parsed = _parse_gate_callback(f"gate:approve:42:{legacy_token}")
+
+    assert parsed is None, "구 패턴 토큰은 거부되어야 함 (Critical C10 가드)"
+
+
+def test_cmd_scope_token_does_not_validate_as_gate():
+    """cmd 도메인 토큰을 gate 콜백에 재사용 시도 → 거부 (cross-replay 차단)."""
+    from src.gate.telegram_gate import _make_callback_token  # pylint: disable=import-outside-toplevel
+    bot_token = "123:ABC"
+    cmd_token = _make_callback_token(bot_token, "cmd", 42)
+
+    with patch("src.webhook.providers.telegram.settings") as mock_settings:
+        mock_settings.telegram_bot_token = bot_token
+        from src.webhook.providers.telegram import _parse_gate_callback  # pylint: disable=import-outside-toplevel
+        parsed = _parse_gate_callback(f"gate:approve:42:{cmd_token}")
+
+    assert parsed is None, "cmd 도메인 토큰을 gate 로 재사용 시도 차단 필요"


### PR DESCRIPTION
…itical C10)

12-에이전트 감사 (2026-04-30) Critical C10 — `_parse_gate_callback` 의 HMAC 계산이 발신측 `_make_callback_token` 과 다른 메시지 형식 사용:
  - 발신: `hmac(bot, f"gate:{id}", sha256)[:32]` (scope 격리)
  - 수신: `hmac(bot, str(id), sha256)[:32]` (scope 미적용)

**확정된 영향**:
  - 운영 배포된 semi-auto 콜백은 모두 401 거부 — Telegram 인라인 키보드 승인/반려 버튼이 동작하지 않는 functional bug
  - cmd 도메인 (`scope="cmd"`) 토큰을 gate 콜백으로 cross-replay 가능 (둘 다 검증 통과해서는 안 되는데 수신측이 `str(id)` 만 비교)
  - 기존 단위 테스트가 통과한 이유: `_TOKEN_42` 가 receiver pattern 으로 하드코딩 — 발신측 코드 경로 미검증 (발신 mock 처리)

수정 내용:
  - src/webhook/providers/telegram.py:_parse_gate_callback HMAC msg `str(analysis_id)` → `f"gate:{analysis_id}"` (발신측과 통일)
    + 한·영 주석으로 PARITY 의도 명시

테스트 갱신 + 회귀 가드 3건 추가:
  - 기존 _TOKEN_42 하드코딩 갱신 (receiver pattern → sender pattern) `d9939856...` → `2e3450af...` (실측 hmac("123:ABC", "gate:42"))
  - test_sender_receiver_hmac_token_parity — 발신/수신 PARITY 영구 가드
  - test_receiver_rejects_legacy_str_id_token — 구 패턴 토큰 거부 검증
  - test_cmd_scope_token_does_not_validate_as_gate — cross-replay 차단 검증

검증:
  - tests/unit/webhook/test_telegram_provider.py 23 passed
  - tests/unit/ 1949 passed (사전 12 failures 변동 없음)
  - pylint src/ 전체 10.00/10 유지

운영 영향:
  - **Telegram semi-auto 콜백이 본 fix 머지 후 처음으로 정상 동작** (이전에는 401 거부됐으나 사용자 보고 부재 — semi-auto 모드 미사용 또는 무음 실패).
  - cmd 도메인 격리 복원 — 보안 표면 정상화.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
