### PR TITLE
fix(api): Phase H PR-1B-1 — Anthropic SDK max_retries 명시 (회귀 면역)

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -66,9 +66,14 @@ async def review_code(
 
     # Anthropic SDK 기본 timeout=600s 는 BackgroundTask 슬롯을 10분 점유 위험.
     # HTTP_CLIENT_TIMEOUT 보다 여유 두고 60s 로 설정 — 평균 응답 5-15s 대비 충분.
+    # max_retries=2 — SDK 기본값 명시화. 5xx / connection error / timeout 시 SDK 가
+    # exponential backoff 으로 자동 재시도. SDK 업그레이드로 기본값 변경되면
+    # 운영 영향 — 명시적 인자로 면역. tests/unit/analyzer/io/test_ai_review_errors.py
+    # ::test_review_code_passes_explicit_max_retries_to_anthropic_client 회귀 가드.
     # Default SDK timeout (600s) can occupy a BackgroundTask slot for 10 min.
-    # Set 60s — well above the typical 5-15s response, far below SDK default.
-    client = anthropic.AsyncAnthropic(api_key=api_key, timeout=60.0)
+    # Set 60s — well above typical 5-15s response, far below SDK default.
+    # max_retries=2 — explicit so SDK upgrades cannot silently change retry behavior.
+    client = anthropic.AsyncAnthropic(api_key=api_key, timeout=60.0, max_retries=2)
     model = settings.claude_review_model
     system_text = get_system_prompt()
     start = time.perf_counter()

--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -312,3 +312,30 @@ async def test_review_code_passes_explicit_timeout_to_anthropic_client():
     timeout_val = captured_kwargs["timeout"]
     assert isinstance(timeout_val, (int, float))
     assert 0 < timeout_val <= 120  # SDK 600초 default 보다 훨씬 짧아야 함
+
+
+async def test_review_code_passes_explicit_max_retries_to_anthropic_client():
+    """Anthropic SDK 5xx/timeout 재시도 정책 명시 — Phase H PR-1B-1 회귀 가드.
+
+    SDK 기본 max_retries=2 (현재 동작 중이지만 명시되지 않음). SDK 업그레이드
+    시 default 변경되면 운영 영향 — 명시적 인자로 면역 + 미래 검증 가능.
+    """
+    response_obj = MagicMock()
+    response_obj.content = [MagicMock(text='{"summary": "ok"}')]
+    response_obj.usage = MagicMock(input_tokens=10, output_tokens=20)
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=response_obj)
+
+    captured_kwargs = {}
+
+    def _capture_init(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return fake_client
+
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", side_effect=_capture_init):
+        await review_code("sk-test", "feat: x", [("a.py", "+ x = 1")])
+
+    assert "max_retries" in captured_kwargs, "AsyncAnthropic 인스턴스화에 max_retries 명시 필수"
+    retries = captured_kwargs["max_retries"]
+    assert isinstance(retries, int)
+    assert 1 <= retries <= 5  # 합리적 범위 (무한 재시도 차단)


### PR DESCRIPTION
12-에이전트 감사 (2026-04-30) High C1 (외부 API 재시도 정책 부재) 의 첫 단계. Anthropic SDK 는 이미 기본 max_retries=2 로 5xx/timeout/connection error 시 exponential backoff 로 자동 재시도 중 — 그러나 코드에 명시되지 않아 SDK 업그레이드로 기본값 변경되면 silent regression 위험.

수정 내용:
  - src/analyzer/io/ai_review.py:71 `anthropic.AsyncAnthropic(api_key=..., timeout=60.0)` 에 `max_retries=2` 명시 추가 + 한·영 주석으로 회귀 가드 의도 명시.

수정 전후 동작 동일 (SDK 기본 = 2 그대로) — runtime 영향 0, 미래 면역 ↑.

회귀 방지 테스트 1건 추가:
  - tests/unit/analyzer/io/test_ai_review_errors.py test_review_code_passes_explicit_max_retries_to_anthropic_client — AsyncAnthropic 인스턴스화 kwargs 에 max_retries 검증 + 1≤retries≤5 가드.

검증:
  - tests/unit/analyzer/io/ 47 passed
  - tests/unit/ 1950 passed (사전 12 failures 변동 없음)
  - pylint src/ 전체 10.00/10 유지

PR-1B-2/3 (예정): tenacity 도입 검토 (또는 직접 retry helper) 후 GitHub GraphQL / Discord / Slack / n8n 등 5xx 재시도 미적용 채널 점진 적용. 의존성 추가 PR 은 별도 분리 — Railway 빌드 영향 평가 필요.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
