### PR TITLE
fix(db): Phase H — gate_decisions ON DELETE CASCADE 추가 (Critical C7)

### DIFF
--- a/alembic/versions/0024_gate_decisions_cascade.py
+++ b/alembic/versions/0024_gate_decisions_cascade.py
@@ -1,0 +1,62 @@
+"""add ON DELETE CASCADE to gate_decisions.analysis_id (Phase H Critical C7)
+
+12-에이전트 감사 (2026-04-30) Critical C7 — 0002 의 `gate_decisions.analysis_id`
+FK 가 ondelete 미설정. Repository → Analysis 삭제 시 GateDecision 행이 고아
+또는 FK violation. 다른 모델 (MergeAttempt/MergeRetryQueue/AnalysisFeedback) 은
+이미 CASCADE — 일관성 확보.
+
+PostgreSQL: DROP CONSTRAINT + CREATE CONSTRAINT (online, lock 최소화).
+SQLite: FK enforcement 가 PRAGMA foreign_keys 의존이라 마이그레이션 무의미 —
+운영 DB 는 Postgres 기준이므로 SQLite 분기에서 skip.
+
+Revision ID: 0024gatedecisionscascade
+Revises: 0023compositeindexes
+Create Date: 2026-05-01
+"""
+from alembic import op
+
+
+revision = '0024gatedecisionscascade'
+down_revision = '0023compositeindexes'
+branch_labels = None
+depends_on = None
+
+# 0002 가 명시한 FK 이름 — Postgres 의 기본 명명 규칙 (table_column_fkey)
+# Default Postgres FK name from 0002 (table_column_fkey convention)
+_FK_NAME = 'gate_decisions_analysis_id_fkey'
+
+
+def upgrade() -> None:
+    # SQLite 는 ALTER TABLE 로 FK 변경 불가 + foreign_keys PRAGMA off 시 검증 안 함.
+    # 운영 DB (Postgres) 만 처리. 단위 테스트는 ORM Base.metadata.create_all 로
+    # 신규 ondelete='CASCADE' 가 자동 적용됨.
+    # SQLite cannot ALTER FKs and skips enforcement by default — production
+    # is Postgres so we only act there. Tests get the new ondelete via ORM.
+    bind = op.get_bind()
+    if bind.dialect.name != 'postgresql':
+        return
+
+    op.drop_constraint(_FK_NAME, 'gate_decisions', type_='foreignkey')
+    op.create_foreign_key(
+        _FK_NAME,
+        'gate_decisions',
+        'analyses',
+        ['analysis_id'],
+        ['id'],
+        ondelete='CASCADE',
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if bind.dialect.name != 'postgresql':
+        return
+
+    op.drop_constraint(_FK_NAME, 'gate_decisions', type_='foreignkey')
+    op.create_foreign_key(
+        _FK_NAME,
+        'gate_decisions',
+        'analyses',
+        ['analysis_id'],
+        ['id'],
+    )

--- a/src/models/gate_decision.py
+++ b/src/models/gate_decision.py
@@ -10,7 +10,19 @@ class GateDecision(Base):
 
     __tablename__ = "gate_decisions"
     id = Column(Integer, primary_key=True, index=True)
-    analysis_id = Column(Integer, ForeignKey("analyses.id"), nullable=False, index=True)
+    # Phase H — Critical C7: ondelete=CASCADE 추가. Repository → Analysis →
+    # GateDecision 삭제 사슬 일관성 보장. 미설정 시 Analysis 삭제 → FK violation.
+    # `delete_repo_cascade` (ui/_helpers.py) 가 application-level 보완 중이지만,
+    # 다른 경로 (admin script, future API) 에서 Analysis 삭제 시 안전망 필요.
+    # MergeAttempt/MergeRetryQueue/AnalysisFeedback 은 이미 CASCADE — 일관성 확보.
+    # Phase H — Critical C7: add ondelete=CASCADE so direct Analysis deletion
+    # propagates here too (mirrors MergeAttempt/MergeRetryQueue/AnalysisFeedback).
+    analysis_id = Column(
+        Integer,
+        ForeignKey("analyses.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
     decision = Column(String, nullable=False)   # "approve" | "reject" | "skip"
     mode = Column(String, nullable=False)        # "auto" | "manual"
     decided_by = Column(String, nullable=True)

--- a/tests/unit/migrations/test_0024_gate_decisions_cascade.py
+++ b/tests/unit/migrations/test_0024_gate_decisions_cascade.py
@@ -1,0 +1,32 @@
+"""Phase H — gate_decisions.analysis_id ON DELETE CASCADE 회귀 가드 (Critical C7).
+
+12-에이전트 감사 (2026-04-30) Critical C7 — `gate_decisions.analysis_id` FK 가
+ondelete 미설정 → Repository/Analysis 삭제 시 FK violation 잠재.
+
+본 테스트는 ORM 정의 측 `ondelete="CASCADE"` 가 유지되는지 검증.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+# pylint: disable=wrong-import-position
+from src.models.gate_decision import GateDecision
+
+
+def test_gate_decision_analysis_id_fk_has_cascade_delete():
+    """GateDecision.analysis_id FK 의 ondelete 가 CASCADE 인지 검증.
+
+    Repository → Analysis CASCADE 사슬과 일관성 유지. 미설정 시 Analysis
+    삭제 → FK violation → 운영 사고 가능.
+    """
+    fk_columns = list(GateDecision.__table__.c.analysis_id.foreign_keys)
+    assert len(fk_columns) == 1, "analysis_id 에 FK 가 정확히 1개 있어야 함"
+    fk = fk_columns[0]
+    assert fk.ondelete == "CASCADE", (
+        f"gate_decisions.analysis_id FK ondelete='{fk.ondelete}' — "
+        "'CASCADE' 이어야 함 (Critical C7 회귀)"
+    )


### PR DESCRIPTION
12-에이전트 감사 (2026-04-30) Critical C7 — `gate_decisions.analysis_id` FK 가 ondelete 미설정 (0002 마이그레이션). 다른 모델 (MergeAttempt/MergeRetryQueue/ AnalysisFeedback) 은 모두 CASCADE 인데 GateDecision 만 누락 — 일관성 깨짐.

**문제 시나리오**:
  - admin script 또는 미래 API 가 Analysis 직접 삭제 → FK violation
  - `delete_repo_cascade` (ui/_helpers.py) 가 application-level 보완 중이지만 경유하지 않는 삭제 경로에서는 무방비

수정 내용:
  - src/models/gate_decision.py — `ForeignKey("analyses.id", ondelete="CASCADE")`
    + 한·영 주석으로 의도 명시 (다른 모델과 일관성 + 안전망 사유)
  - alembic/versions/0024_gate_decisions_cascade.py — 신규 마이그레이션
    * PostgreSQL: DROP CONSTRAINT + CREATE CONSTRAINT (online, 락 최소)
    * SQLite: dialect 분기로 skip (FK enforcement 가 PRAGMA 의존, 운영 DB 는 PG 기준이므로 무의미)
    * downgrade: ondelete 제거 후 재생성 (역방향 호환)

회귀 방지 테스트 1건 추가:
  - tests/unit/migrations/test_0024_gate_decisions_cascade.py test_gate_decision_analysis_id_fk_has_cascade_delete — ORM 측 ondelete 값 검증 (`fk.ondelete == 'CASCADE'`)

검증:
  - tests/unit/migrations/test_0024_gate_decisions_cascade.py 1 passed
  - tests/unit/ 1955 passed (사전 12 failures 변동 없음, +1 신규 통과)
  - pylint src/ 전체 10.00/10 유지
  - batch_alter_table 미사용 (CLAUDE.md 0007+ 규약 준수)

운영 안전성:
  - Postgres `DROP/CREATE CONSTRAINT` 짧은 ACCESS EXCLUSIVE lock — 데이터 스캔 없음 (메타데이터 변경) → 다운타임 ~ms
  - 기존 FK violation 가능성 0 (CASCADE 추가는 더 관대한 정책)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
