### PR TITLE
chore(skills): PR-γ — 슬래시 명령 정의 stale 정정 3건 (G1-G3, Phase H+I 무관 부수)

### DIFF
--- a/.claude/skills/lint.md
+++ b/.claude/skills/lint.md
@@ -27,9 +27,12 @@ bandit -r src/ -ll
 | flake8 | X개 경고 | ... |
 | bandit | HIGH:X, MED:X | ... |
 
-SCAManager 자체 점수 체계 기준으로 환산:
-- pylint: 8.0+ → 30점 만점, 7.0~8.0 → 20점, 6.0~7.0 → 10점
-- bandit HIGH 0개 → 보안 20점 만점
+SCAManager 자체 점수 체계 기준으로 환산 (Phase E 이후 — `src/constants.py` 단일 출처):
+- pylint + flake8 (code_quality) → 25점 만점 (`CODE_QUALITY_MAX`). error -3, warning -1 (cap `CQ_WARNING_CAP=25`)
+- bandit + semgrep(security) → 20점 만점 (`SECURITY_MAX`). HIGH -7, LOW/MED -2
+- 합산 정적분석 만점: 45점 (총점 100 중)
+- AI 항목: 커밋 15 + 방향 25 + 테스트 15 = 55점 (Claude API)
+- 등급: A (≥90) / B (≥75) / C (≥60) / D (≥45) / F (<45) — `GRADE_THRESHOLDS`
 
 ## 인자
 

--- a/.claude/skills/test.md
+++ b/.claude/skills/test.md
@@ -2,35 +2,57 @@
 description: SCAManager 테스트 실행 — 전체 또는 특정 모듈
 ---
 
-프로젝트 루트에서 pytest를 실행한다.
+프로젝트 루트(`pwd`) 에서 pytest 를 실행한다. **Linux/devcontainer/Windows 환경 모두 호환** — `cd` 절대경로 하드코딩 금지.
 
 ## 인자 없이 호출 (`/test`)
 
-전체 테스트 스위트 실행:
+환경변수 격리 + 전체 테스트 스위트 실행 (권장):
 
 ```bash
-cd D:/Source/SCAManager && pytest -v
+make test-isolated
+```
+
+`.env` 파일이 stash 되어 단위 테스트가 깨끗한 환경변수로 실행. CLAUDE.md 메모리 규약 — 로컬 devcontainer 에서 `make test` 직접 실행 시 7건 false failure 가능.
+
+빠른 단위 테스트만 (통합 제외):
+
+```bash
+make test-fast
+```
+
+또는 직접 pytest 호출:
+
+```bash
+python -m pytest tests/ -q
 ```
 
 결과 요약을 출력하고, 실패한 테스트가 있으면 오류 내용과 수정 방향을 제시한다.
 
 ## 인자와 함께 호출 (`/test pipeline`, `/test webhook` 등)
 
-인자를 모듈명으로 해석하여 해당 테스트 파일만 실행:
+Phase 4 이후 테스트 파일은 `tests/unit/<영역>/test_<모듈>.py` 계층 구조. 인자 해석:
 
 ```bash
-cd D:/Source/SCAManager && pytest tests/test_<인자>.py -v
+# 영역 단위 — 모든 단위 테스트 실행
+python -m pytest tests/unit/<영역>/ -q
+
+# 특정 모듈 — 단일 파일 실행
+python -m pytest tests/unit/<영역>/test_<모듈>.py -q
 ```
 
-예: `/test pipeline` → `pytest tests/test_pipeline.py -v`
+예:
+- `/test pipeline` → `pytest tests/unit/worker/ -q`
+- `/test webhook` → `pytest tests/unit/webhook/ -q`
+- `/test gate` → `pytest tests/unit/gate/ -q`
+- `/test integration` → `pytest tests/integration/ -q` (slow tests, `make test-slow` 와 동일)
 
 ## 커버리지 포함 (`/test coverage`)
 
 ```bash
-cd D:/Source/SCAManager && pytest --cov=src --cov-report=term-missing
+make test-cov
 ```
 
 ## 테스트 실행 후
 
-- 통과: "✅ X/X 테스트 통과" 요약
+- 통과: "✅ X/X 테스트 통과" 요약 + 사전 실패 (현재 12건) 와 신규 실패 명확히 분리
 - 실패: 실패한 테스트명, 오류 메시지, 원인 분석, 수정 제안 제공

--- a/.claude/skills/webhook-test.md
+++ b/.claude/skills/webhook-test.md
@@ -43,9 +43,47 @@ curl -X POST http://localhost:8000/webhooks/github \
   -d "$PAYLOAD"
 ```
 
+## check_suite 이벤트 테스트 (Phase 12 — CI-aware Auto Merge 재시도)
+
+CI 완료 시 GitHub 가 발송하는 `check_suite.completed` 이벤트로 `merge_retry_queue` 즉각 처리 트리거.
+
+```bash
+PAYLOAD='{"action":"completed","check_suite":{"head_sha":"def456","conclusion":"success"},"repository":{"full_name":"owner/repo"}}'
+SECRET="your-webhook-secret"
+SIG=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.* /sha256=/')
+
+curl -X POST http://localhost:8000/webhooks/github \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: check_suite" \
+  -H "X-Hub-Signature-256: $SIG" \
+  -d "$PAYLOAD"
+```
+
+응답:
+- `{"status":"accepted"}` — 해당 SHA 의 pending retry 행 BackgroundTask 트리거
+- `{"status":"debounced"}` — 30초 내 동일 (repo, sha) 재요청 (monorepo 폭주 방어)
+- `{"status":"ignored"}` — `action != "completed"` 또는 head_sha/repo 누락
+- `{"status":"disabled"}` — `merge_retry_check_suite_webhook_enabled=false` 설정 시
+
+## auto_merge_disabled 이벤트 테스트 (Phase 3 PR-B1 — MergeAttempt lifecycle)
+
+GitHub 가 force-push / 사용자 수동 해제 등으로 auto-merge 를 자동 비활성화 시 발송. MergeAttempt state 전이 (`enabled_pending_merge` → `disabled_externally`).
+
+```bash
+PAYLOAD='{"action":"auto_merge_disabled","number":1,"pull_request":{"head":{"sha":"def456"}},"sender":{"login":"someuser"},"repository":{"full_name":"owner/repo"}}'
+SECRET="your-webhook-secret"
+SIG=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.* /sha256=/')
+
+curl -X POST http://localhost:8000/webhooks/github \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: pull_request" \
+  -H "X-Hub-Signature-256: $SIG" \
+  -d "$PAYLOAD"
+```
+
 ## 응답
 
 - `202 Accepted` — 정상 처리 (비동기 분석 시작)
 - `400 Bad Request` — 페이로드 형식 오류
-- `403 Forbidden` — 서명 검증 실패
-- `422 Ignored` — 처리 불필요한 이벤트 (지원하지 않는 액션 등)
+- `401 Unauthorized` — 서명 검증 실패 (Phase G P1-4: 200 OK 반환 금지 — 공격자 응답 노출 차단)
+- `200 / "ignored"` — 처리 불필요한 이벤트 (지원하지 않는 액션, ping 등)


### PR DESCRIPTION
Phase H+I 문서 반영 사이클 4-에이전트 검증 (general-purpose) 이 식별한 부수 발견 3건 정정. Phase H+I 와 직접 무관하나 미래 Claude 의 슬래시 명령 사용 정확성을 위해 정리.

G1 — `.claude/skills/test.md` 경로 stale + Phase 4 계층 구조 반영:
  - `cd D:/Source/SCAManager && pytest` Windows 경로 하드코딩 제거 — Linux/ devcontainer (현재 환경) 에서 무의미
  - 권장 명령: `make test-isolated` (env 격리 — CLAUDE.md 메모리 규약)
  - 인자 경로: Phase 4 이후 `tests/unit/<영역>/` 계층 반영 (예: `/test pipeline` → `pytest tests/unit/worker/`)
  - 통합 테스트: `tests/integration/` (slow tests) 명시
  - 사전 12 failures 와 신규 실패 분리 가이드 추가

G2 — `.claude/skills/lint.md` 점수 환산 stale 정정:
  - 구 환산: pylint 8.0+ → 30점 / bandit HIGH 0 → 20점 (Phase E 이전)
  - 신 환산: code_quality 25 + security 20 = 45점 (Phase E 이후 — `src/constants.py` `CODE_QUALITY_MAX/SECURITY_MAX` 단일 출처). AI 항목 합산 만점 100.
  - 등급 임계값 명시 (`GRADE_THRESHOLDS` A 90 / B 75 / C 60 / D 45 / F)

G3 — `.claude/skills/webhook-test.md` Phase 12 + Phase 3 PR-B1 페이로드 추가:
  - `check_suite.completed` 페이로드 예시 (Phase 12 — merge_retry_queue 즉각 트리거). 응답 분류 4종 명시 (accepted/debounced/ignored/disabled).
  - `pull_request.auto_merge_disabled` 페이로드 예시 (Phase 3 PR-B1 — MergeAttempt state `enabled_pending_merge` → `disabled_externally` 전이).
  - 응답 코드 정정: 403 Forbidden → 401 Unauthorized (Phase G P1-4 — 200 OK 반환 금지 규약 적용 후), 422 Ignored → 200 / "ignored"

검증:
  - src/ 변경 0 (.claude/skills/ 만)
  - pylint / pytest 무관 (skill 정의는 코드가 아님)
  - 3 파일 / +76줄 / -13줄

Phase H+I 문서 반영 사이클 종결:
  - PR-α: 정합성 통합 (A1 + B1-B7) ✅
  - PR-β: 가이드 + docstring + 에이전트 + 회고 (C1-3 + D1-2 + E1-3 + F1-2) ✅
  - PR-γ: 부수 G (G1-G3) ← 본 PR
  - 잔여: PR-3B-2 (호출처 마이그레이션), PR-5A-2 (실제 dedup), PR-B3 평가 (~2026-05-06 dogfooding 결과)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
