### PR TITLE
feat(ui): Phase 1C — claude-dark 테마에 등급 색상 alias 적용 (sage/sand/muted …

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -253,6 +253,16 @@
       --accent:         var(--claude-accent);
       --accent-hover:   #F09578;  /* claude-accent 의 라이트 변형 */
       --accent-grad:    linear-gradient(135deg, #D97757, #F09578);
+
+      /* Phase 1C (UI 개편) — claude-dark 테마에서 등급 색상 alias.
+       * 기존 토큰 (--grade-a 등) 을 claude 톤 (sage/sand/muted red) 로 재정의.
+       * .grade-a/.grade-b/... 클래스 + Chart.js 의 var(--grade-*) 참조 모두
+       * 자동 적용 (마크업 무변경). 기본 다크/라이트 테마는 영향 0. */
+      --grade-a: var(--claude-grade-a);  /* sage #9CAF88 */
+      --grade-b: var(--claude-grade-b);  /* taupe #A8A595 */
+      --grade-c: var(--claude-grade-c);  /* sand #D4A574 */
+      --grade-d: var(--claude-grade-d);  /* terracotta #C8895E */
+      --grade-f: var(--claude-grade-f);  /* muted red #C84E3F */
     }
 
     /* ── 네비게이션 ───────────────────────────── */


### PR DESCRIPTION
…red)

UI 개편 권장안 1 의 세 번째 PR. claude-dark 테마 활성 시 등급 색상이 자동으로 Claude 톤 (sage/sand/muted red) 으로 변경. 기본 다크/라이트/glass 테마는 영향 0.

수정 내용:
  - src/templates/base.html `body[data-theme="claude-dark"]` 블록에 등급 색상 alias 5종 추가:
    * --grade-a → var(--claude-grade-a)  // sage #9CAF88 (A등급)
    * --grade-b → var(--claude-grade-b)  // taupe #A8A595 (B등급)
    * --grade-c → var(--claude-grade-c)  // sand #D4A574 (C등급)
    * --grade-d → var(--claude-grade-d)  // terracotta #C8895E (D등급)
    * --grade-f → var(--claude-grade-f)  // muted red #C84E3F (F등급)

자동 적용 영역 (var(--grade-*) 참조 — 마크업 무변경):
  - .grade-a/.grade-b/... 클래스 (전 페이지)
  - repo_detail.html: .score-val.high, .filter-btn[data-source="push"]
  - analysis_detail.html: .ad-score-big.high, .ad-bar-fill.high
  - insights_me.html: .delta-pos
  - 기타 모든 var(--grade-*) 참조

별도 후속 (insights_me.html hex 하드코딩):
  - L136-139 boundary thresholds 의 #4ade80/#60a5fa/#fbbf24/#fb923c hex 4종 은 Chart.js plugin 의 정적 색상으로 themechange 자동 갱신 어려움
  - 별도 PR 에서 themechange 이벤트 + getComputedStyle 로 동적 갱신 추가

검증:
  - tests/unit/ui/ 106 passed
  - tests/unit/ 1955 passed (사전 12 failures 변동 없음)
  - 시각 변화: claude-dark 테마 명시 선택 시에만 등급 색상 변경
  - 기본 다크/라이트/glass 테마: 0 영향 (기존 hex 유지)

다음 단계 (Phase 2A):
  - Settings 6 카드 → 3 카드 통합 (HTML 재구성, 5-way sync 보존 의무)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
