### PR TITLE
feat(ui): Phase 2A Step A — Settings 6 → 5 카드 (③+④ → '알림 & 배포')

### DIFF
--- a/e2e/test_settings.py
+++ b/e2e/test_settings.py
@@ -376,17 +376,25 @@ def test_two_column_layout_on_desktop(seeded_page, base_url):
 # ── Settings 재설계 E2E 테스트 (2026-04-21) ──────────────────────────
 
 def test_six_card_titles_present(seeded_page, base_url):
-    """6 카드 의도 기반 제목이 모두 렌더링되어야 한다."""
+    """카드 의도 기반 제목이 모두 렌더링되어야 한다.
+
+    Phase 2A Step A: 카드 ③ Push/배포 + ④ 알림 채널 → '알림 & 배포' 단일 카드 통합.
+    Phase 2A Step A: cards ③ Push/Deploy + ④ Notify channels merged into a single 'Notify & Deploy' card.
+    """
     seeded_page.goto(f"{base_url}{SETTINGS_URL}")
     body = seeded_page.content()
     # ① 빠른 설정 제목은 기존 유지 — 개별 프리셋 카드로 대체
     # ① Quick settings heading is preserved — replaced by individual preset cards.
-    # PR #89 카드명 변경 — 의도 기반 명칭으로 갱신
-    # PR #89 renamed cards to intent-based labels
     assert "분석 동작 규칙" in body, "카드 ② 분석 동작 규칙 누락"
-    assert "Push / 배포 이벤트" in body, "카드 ③ Push / 배포 이벤트 누락"
+    assert "알림 &amp; 배포" in body or "알림 & 배포" in body, (
+        "통합 카드 '알림 & 배포' 누락 (Phase 2A Step A)"
+    )
     assert "통합 &amp; 연결" in body or "통합 & 연결" in body, "카드 ⑤ 통합 & 연결 누락"
     assert "위험 구역" in body, "카드 ⑥ 위험 구역 누락"
+    # 구 카드 제목은 더 이상 존재하지 않아야 함
+    # Old card titles must no longer exist
+    assert "Push / 배포 이벤트" not in body, "구 카드 'Push / 배포 이벤트' 잔존"
+    assert "알림 발신 채널" not in body, "구 카드 '알림 발신 채널' 잔존"
 
 
 def test_preset_diff_preview_has_nine_rows(seeded_page, base_url):

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -377,7 +377,7 @@
         <p style="font-size:13px;color:var(--text-muted);margin:0 0 .75rem;">분석 결과를 받으려면 아래 단계를 완료하세요.</p>
         <div style="display:flex;flex-direction:column;gap:.45rem;font-size:13px;">
           <a href="#notifyCard" style="color:var(--accent);font-weight:600;">
-            ① 알림 채널 설정 → 아래 <strong>알림 발신 채널</strong>에서 Telegram 또는 다른 채널을 연결하세요
+            ① 알림 채널 설정 → 아래 <strong>알림 &amp; 배포</strong> 카드에서 Telegram 또는 다른 채널을 연결하세요
           </a>
           <span style="color:var(--text-muted);">
             ② 리뷰 수준 결정 → 위 <strong>빠른 설정</strong>에서 프리셋을 선택하세요 (선택 사항)
@@ -613,10 +613,10 @@
             </div>
           </div>
 
-          <!-- semi-auto 안내 힌트 (Telegram Chat ID는 ④ 알림 채널에서 설정) / semi-auto hint (Telegram Chat ID configured in ④ notification channels) -->
+          <!-- semi-auto 안내 힌트 (Telegram Chat ID는 알림 & 배포 카드에서 설정) / semi-auto hint (Telegram Chat ID configured in Notify & Deploy card) -->
           <div id="semiAutoHint" class="{% if config.approve_mode != 'semi-auto' %}is-hidden{% endif %}"
                style="margin-top:.75rem;padding:.5rem .75rem;background:var(--hint-bg);border:1px solid var(--hint-border);border-radius:7px;font-size:11px;color:var(--text-muted);line-height:1.6;">
-            💡 반자동 Approve는 <strong>④ 알림 채널의 Telegram Chat ID</strong>로 전송됩니다.
+            💡 반자동 Approve는 <a href="#notifyCard" style="color:var(--accent);font-weight:600;">알림 &amp; 배포 카드의 Telegram Chat ID</a>로 전송됩니다.
           </div>
 
           <div class="s-divider"></div>
@@ -672,12 +672,18 @@
         </div>
       </div>
 
-      <!-- Push / 배포 이벤트 & 팀 설정 카드 / Push/deploy events & team settings card -->
-      <div class="s-card">
-        <div class="s-card-hdr hdr-merge">
-          <span class="hdr-icon">🚀</span>
-          <span class="hdr-title">Push / 배포 이벤트</span>
-          <span class="hdr-badge">Push · Railway</span>
+        </div><!-- /.settings-grid -->
+      </div><!-- /.advanced-body -->
+    </details><!-- /.advanced-details -->
+
+    <!-- ③ 알림 & 배포 (Push/배포 토글 + 팀 설정 + 알림 채널 통합 — Phase 2A Step A) -->
+    <!-- ③ Notify & Deploy (push/deploy toggles + team settings + notification channels merged — Phase 2A Step A) -->
+    <div class="settings-grid">
+      <div class="s-card notify-full" id="notifyCard">
+        <div class="s-card-hdr hdr-notify">
+          <span class="hdr-icon">🔔</span>
+          <span class="hdr-title">알림 &amp; 배포</span>
+          <span class="hdr-badge">이벤트 · 채널</span>
         </div>
         <div class="s-card-body">
 
@@ -708,6 +714,7 @@
           </div>
 
           <div class="s-divider"></div>
+          <div class="s-section-label">Railway 배포</div>
           <div class="toggle-row">
             <div class="toggle-info">
               <div class="t-title">Railway 빌드 실패 알림</div>
@@ -737,22 +744,7 @@
             </label>
           </div>
 
-        </div>
-      </div>
-
-        </div><!-- /.settings-grid -->
-      </div><!-- /.advanced-body -->
-    </details><!-- /.advanced-details -->
-
-    <!-- ④ 알림 채널 (항상 표시 — 고급 설정 아코디언 밖) / Notification channels (always visible — outside advanced settings accordion) -->
-    <div class="settings-grid">
-      <div class="s-card notify-full" id="notifyCard">
-        <div class="s-card-hdr hdr-notify">
-          <span class="hdr-icon">🔔</span>
-          <span class="hdr-title">알림 발신 채널</span>
-          <span class="hdr-badge">SCAManager → 외부</span>
-        </div>
-        <div class="s-card-body">
+          <div class="s-divider"></div>
           <div class="s-section-label">메신저 / 이메일</div>
           <div class="channel-grid">
             <div class="field-row">
@@ -790,8 +782,8 @@
                   </p>
                 </div>
                 <script>
-                  // Telegram OTP 발급 버튼 — 알림 발신 채널 카드로 이동 (B+A 리디자인)
-                  // Telegram OTP button — moved to notification channel card (B+A redesign)
+                  // Telegram OTP 발급 버튼 — 알림 & 배포 카드 (Phase 2A Step A 통합)
+                  // Telegram OTP button — Notify & Deploy card (Phase 2A Step A merge)
                   (function () {
                     var btn = document.getElementById('issueTelegramOtp');
                     if (!btn) { return; }

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -456,47 +456,59 @@ def test_advanced_settings_default_closed():
 
 
 def test_pr_and_push_cards_inside_advanced():
-    """① PR 동작(hdr-gate) / ② Push 동작(hdr-merge) 카드는 고급 설정 <details> 안에 위치해야 한다."""
+    """① PR 동작(hdr-gate) 카드는 고급 설정 <details> 안에 위치해야 한다.
+
+    Phase 2A Step A: Push/배포 카드는 알림 카드와 통합되어 <details> 바깥으로 이동.
+    Phase 2A Step A: Push/Deploy card was merged into the notify card outside <details>.
+    """
     html = _render_settings()
     adv_open_idx = html.find('class="advanced-details')
     adv_close_idx = html.find("</details>", adv_open_idx)
     assert adv_open_idx != -1, "advanced-details 시작 태그 없음"
     assert adv_close_idx != -1, "advanced-details 닫기 태그 없음"
     gate_idx = html.find("s-card-hdr hdr-gate")
-    merge_idx = html.find("s-card-hdr hdr-merge")
     assert adv_open_idx < gate_idx < adv_close_idx, (
         "① PR 동작 카드가 고급 설정 <details> 안에 없음"
-    )
-    assert adv_open_idx < merge_idx < adv_close_idx, (
-        "② Push 동작 카드가 고급 설정 <details> 안에 없음"
     )
 
 
 def test_notify_channel_outside_advanced():
-    """③ 알림 채널은 고급 설정 <details> 바깥에 있어야 한다 (항상 표시)."""
+    """알림 & 배포 카드(hdr-notify)는 고급 설정 <details> 바깥에 있어야 한다 (항상 표시).
+
+    Phase 2A Step A: Push 토글 + 배포 알림 + 채널이 단일 '알림 & 배포' 카드로 통합됨.
+    Phase 2A Step A: push toggles + deploy alerts + channels merged into single 'Notify & Deploy'.
+    """
     html = _render_settings()
     adv_open_idx = html.find('class="advanced-details')
     adv_close_idx = html.find("</details>", adv_open_idx)
     notify_idx = html.find("s-card-hdr hdr-notify")
-    assert notify_idx != -1, "③ 알림 채널 카드 없음"
+    assert notify_idx != -1, "알림 & 배포 카드 없음"
     assert notify_idx > adv_close_idx, (
-        "③ 알림 채널이 고급 설정 <details> 바깥에 없음 — 항상 표시되어야 함"
+        "알림 & 배포 카드가 고급 설정 <details> 바깥에 없음 — 항상 표시되어야 함"
     )
+    # 통합된 토글들이 새 카드 안에 함께 존재해야 함 / Merged toggles must coexist in the new card
+    assert 'name="commit_comment"' in html
+    assert 'name="railway_deploy_alerts"' in html
+    assert 'name="notify_chat_id"' in html
 
 
 def test_semi_auto_hint_in_pr_card():
-    """semi-auto 모드에서 ① PR 동작 카드에 hint 텍스트가 노출되어야 한다."""
+    """semi-auto 모드에서 ① PR 동작 카드(hdr-gate) 안에 hint 텍스트가 노출되어야 한다.
+
+    Phase 2A Step A 이후 Push/배포 카드가 통합 카드로 흡수되었으므로,
+    힌트는 PR 동작 카드 헤더와 카드 종료(notify 카드 시작) 사이에 있어야 한다.
+    Phase 2A Step A: Push/Deploy card merged; hint must sit between hdr-gate and hdr-notify.
+    """
     from src.config_manager.manager import RepoConfigData
     cfg = RepoConfigData(repo_full_name="owner/repo", approve_mode="semi-auto")
     html = _render_settings(cfg)
     assert "semiAutoHint" in html, "semiAutoHint 엘리먼트가 없음"
-    # PR 동작 카드(s-card-hdr hdr-gate div) 이후, Push 동작 카드(s-card-hdr hdr-merge) 이전에 hint가 있어야 함
     gate_card_idx = html.find('s-card-hdr hdr-gate')
-    merge_card_idx = html.find('s-card-hdr hdr-merge')
+    notify_card_idx = html.find('s-card-hdr hdr-notify')
     hint_idx = html.find("semiAutoHint")
     assert gate_card_idx != -1, "s-card-hdr hdr-gate 카드 헤더가 없음"
-    assert merge_card_idx != -1, "s-card-hdr hdr-merge 카드 헤더가 없음"
-    assert gate_card_idx < hint_idx < merge_card_idx, (
+    assert notify_card_idx != -1, "s-card-hdr hdr-notify 카드 헤더가 없음"
+    assert gate_card_idx < hint_idx < notify_card_idx, (
         "semiAutoHint가 ① PR 동작 카드 안에 없음"
     )
 

--- a/tests/unit/ui/test_settings_webhook_banner.py
+++ b/tests/unit/ui/test_settings_webhook_banner.py
@@ -169,16 +169,22 @@ def test_settings_no_onboarding_banner_when_telegram_connected():
 def test_settings_new_card_structure_present():
     """새 카드 헤더 텍스트 확인 + 구 카드 헤더 부재 확인.
     Verify new card header text is present and old card headers are gone.
+
+    Phase 2A Step A: 카드 ③ Push/배포 + ④ 알림 채널 → '알림 & 배포' 단일 카드 통합.
+    Phase 2A Step A: cards ③ Push/Deploy + ④ Notify channels merged into 'Notify & Deploy'.
     """
     resp = _settings_get(stale=False)
     assert resp.status_code == 200
     # 새 카드 이름이 있어야 함
     assert "분석 동작 규칙" in resp.text
-    assert "알림 발신 채널" in resp.text
+    assert "알림 &amp; 배포" in resp.text
     assert "통합 &amp; 연결" in resp.text
     # 구 카드 이름이 없어야 함
     assert "이벤트 후 피드백" not in resp.text
     assert "시스템 &amp; 토큰" not in resp.text
+    # Phase 2A Step A 통합 후 사라져야 할 구 카드명 / Old card names removed by Step A merge
+    assert "알림 발신 채널" not in resp.text
+    assert "Push / 배포 이벤트" not in resp.text
 
 
 def test_settings_all_form_fields_present_after_restructure():


### PR DESCRIPTION
Push/배포 이벤트 카드(③ commit_comment, create_issue, railway_deploy_alerts, leaderboard_opt_in)를 알림 발신 채널 카드(④)로 통합하여
'알림 & 배포' 단일 카드로 묶었다.

배경 — 기존 사용자가 "리포에 결과 알리기"와 "외부 채널로 보내기"를
서로 다른 카드(③ 고급설정 안 / ④ 항상 표시)에서 찾아야 했던
인지 부담 해결 (UI 개편 기획서 권장안 1: A+D 하이브리드 — 옵션 D 시범).

변경 범위
- src/templates/settings.html
  - 카드 ③ 블록 삭제 (Push/배포 이벤트 + 팀 설정 토글 4개)
  - 카드 ④ 헤더 '알림 발신 채널' → '알림 & 배포' 변경
  - 카드 ④ body 상단에 4개 토글 + 섹션 라벨(Push/Railway/팀) 삽입
  - L619 semi-auto hint: '④ 알림 채널' → '알림 & 배포 카드' (#notifyCard 링크)
  - L380 onboarding banner: '알림 발신 채널' → '알림 & 배포' 명칭 동기화

폼 필드명 14종 + PRESETS 9 필드 모두 불변 — 5-way sync 보존
JS 헬퍼(toggleFieldMask, applyPreset 9종) 시그니처 불변 — 필드명 lookup 유지

회귀 테스트 갱신
- e2e/test_settings.py::test_six_card_titles_present 통합 카드 '알림 & 배포' 검증 + 구 카드명 잔존 부재 가드
- tests/unit/ui/test_router.py::test_pr_and_push_cards_inside_advanced Push 카드 통합으로 hdr-merge 어설션 제거, hdr-gate만 검증
- tests/unit/ui/test_router.py::test_notify_channel_outside_advanced 통합된 토글 3종(commit_comment/railway_deploy_alerts/notify_chat_id) 공존 가드
- tests/unit/ui/test_router.py::test_semi_auto_hint_in_pr_card hdr-gate ~ hdr-notify 사이 hint 위치 검증으로 갱신
- tests/unit/ui/test_settings_webhook_banner.py::test_settings_new_card_structure_present '알림 & 배포' 검증 + 구 카드명('알림 발신 채널', 'Push / 배포 이벤트') 부재 가드

검증
- tests/unit/ui/ 106 PASS (UI 회귀 0건)
- pylint src/ 10.00/10 유지
- 16개 form field 회귀 가드 통과 — 5-way sync 손상 없음

Step B(② → 'Reviews' 리네이밍 + create_issue 이동)/Step C(⑤⑥ → 'System')는 사용자 시범 운영 결과 평가 후 별도 PR 진행.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
