### PR TITLE
feat(ui): Settings 화면 일괄 재설계 — Progressive Mode + W2 + 사용자 신호 진입

### DIFF
--- a/e2e/test_settings.py
+++ b/e2e/test_settings.py
@@ -5,35 +5,21 @@ SETTINGS_URL = "/repos/owner%2Ftestrepo/settings"
 
 
 def _expand_advanced(page):
-    """고급 설정 아코디언이 접혀 있으면 펼친다 (멱등).
+    """단순 모드를 강제로 'advanced' 로 전환한다 (멱등).
 
-    UI 리디자인(a1aedd1 + PR #89)으로 Gate 모드 버튼·임계값 슬라이더가
-    <details class="advanced-details"> 안으로 이동해 기본 상태에서 invisible.
-    또한 Settings UI/UX 리디자인 후 'simple/advanced' 모드 토글이 추가되어
-    기본값이 'simple' 일 때 advanced-details 가 CSS `display:none !important` —
-    Playwright actionability check 에서 30s timeout 발생.
+    Phase 2A Progressive 재설계 후 advanced-details <details> 아코디언은 제거되고,
+    카드 평탄화 + .adv-only 클래스로 단순/고급 분리. 따라서 advanced 필드(approve_mode 3-way,
+    threshold 슬라이더, Discord/Slack 등) 에 도달하려면 data-settings-mode='advanced' 만
+    설정하면 된다 (별도 <details> 펼침 불필요).
 
-    헬퍼는 두 단계 보정:
-      1) data-settings-mode 를 'advanced' 로 설정 + localStorage 영속화
-      2) <details> 가 닫혀있으면 summary 클릭으로 펼침
+    Phase 2A: advanced-details accordion removed; cards flattened with .adv-only.
+    To reach advanced fields, only data-settings-mode='advanced' is needed.
     """
-    # 1단계 — Simple/Advanced 모드 토글: Simple 이 기본이면 advanced-details 가
-    # display:none 이라 클릭 자체 불가능. 직접 attribute 설정으로 강제 advanced.
-    # Step 1 — Force advanced mode so .advanced-details becomes visible
     page.evaluate(
         "document.body.setAttribute('data-settings-mode','advanced'); "
-        "(document.querySelector('main')||{}).setAttribute"
-        "&&document.querySelector('main').setAttribute('data-settings-mode','advanced'); "
-        "try{localStorage.setItem('sca-settings-mode','advanced')}catch(e){}"
+        "try{localStorage.setItem('scamanager_settings_mode','advanced')}catch(e){}"
     )
-    # 2단계 — <details> 펼침
-    # Step 2 — Open the <details> if collapsed
-    is_open = page.evaluate(
-        "document.querySelector('.advanced-details')?.open ?? false"
-    )
-    if not is_open:
-        page.locator(".advanced-details > summary").click()
-        page.wait_for_timeout(200)
+    page.wait_for_timeout(100)
 
 
 def test_settings_page_loads(seeded_page, base_url):
@@ -328,7 +314,8 @@ def test_gate_mode_persists_after_save(seeded_page, base_url):
     seeded_page.click('[data-mode="auto"]')
     seeded_page.locator('button[type="submit"].btn-save-new').click()
     seeded_page.wait_for_load_state("networkidle", timeout=5000)
-    # 리로드 후에도 advanced-details 펼쳐야 버튼 class 를 읽을 수 있음
+    # 리로드 후 advanced 모드로 전환해야 approve_mode 버튼이 보임
+    # After reload, switch to advanced mode so approve_mode button is visible
     _expand_advanced(seeded_page)
     cls = seeded_page.get_attribute('[data-mode="auto"]', "class") or ""
     assert "active" in cls
@@ -381,12 +368,18 @@ def test_six_card_titles_present(seeded_page, base_url):
     body = seeded_page.content()
     # ① 빠른 설정 제목은 기존 유지 — 개별 프리셋 카드로 대체
     # ① Quick settings heading is preserved — replaced by individual preset cards.
-    # PR #89 카드명 변경 — 의도 기반 명칭으로 갱신
-    # PR #89 renamed cards to intent-based labels
-    assert "분석 동작 규칙" in body, "카드 ② 분석 동작 규칙 누락"
-    assert "Push / 배포 이벤트" in body, "카드 ③ Push / 배포 이벤트 누락"
-    assert "통합 &amp; 연결" in body or "통합 & 연결" in body, "카드 ⑤ 통합 & 연결 누락"
-    assert "위험 구역" in body, "카드 ⑥ 위험 구역 누락"
+    # Phase 2A Progressive 재설계 — 카드 평탄화 + W2 수신/발신 분리 + 의도 기반 명명
+    # Phase 2A Progressive redesign — cards flattened + W2 inbound/outbound split + intent-based names
+    assert "PR 동작 규칙" in body, "카드 'PR 동작 규칙' 누락"
+    assert "알림 채널 (발신)" in body, "카드 '알림 채널 (발신)' 누락"
+    assert "이벤트 후 자동화" in body, "카드 '이벤트 후 자동화' 누락"
+    assert "통합 &amp; 인증 (수신)" in body or "통합 & 인증 (수신)" in body, "카드 '통합 & 인증 (수신)' 누락"
+    assert "위험 구역" in body, "카드 '위험 구역' 누락"
+    # 구 카드명 잔존 부재 가드 / Old card names must not linger
+    assert "분석 동작 규칙" not in body, "구 카드명 '분석 동작 규칙' 잔존"
+    assert "Push / 배포 이벤트" not in body, "구 카드명 'Push / 배포 이벤트' 잔존"
+    assert "알림 발신 채널" not in body, "구 카드명 '알림 발신 채널' 잔존"
+    assert "통합 &amp; 연결" not in body, "구 카드명 '통합 & 연결' 잔존"
 
 
 def test_preset_diff_preview_has_nine_rows(seeded_page, base_url):
@@ -482,34 +475,42 @@ def test_railway_api_token_in_main_form(seeded_page, base_url):
     assert form_attr == "settingsForm", f"railway_api_token form 속성이 'settingsForm' 이어야 하는데 {form_attr!r}"
 
 
-def test_save_error_opens_advanced_accordion(seeded_page, base_url):
-    """?save_error=1 쿼리로 접근 시 고급설정 아코디언이 자동 펼쳐져야 한다."""
+def test_save_error_forces_advanced_mode(seeded_page, base_url):
+    """?save_error=1 쿼리로 접근 시 자동으로 advanced 모드로 전환되어야 한다.
+
+    Phase 2A Progressive 재설계: advanced-details 제거, save_error → data-settings-mode='advanced' 강제.
+    Phase 2A Progressive: advanced-details removed; save_error forces data-settings-mode='advanced'.
+    """
     seeded_page.goto(f"{base_url}{SETTINGS_URL}?save_error=1")
     seeded_page.wait_for_timeout(300)
-    is_open = seeded_page.evaluate(
-        "document.querySelector('.advanced-details')?.open"
+    mode = seeded_page.evaluate(
+        "document.body.getAttribute('data-settings-mode')"
     )
-    assert is_open is True, "save_error=1 쿼리 시 .advanced-details 가 펼쳐져야 함"
+    assert mode == "advanced", f"save_error=1 시 data-settings-mode='advanced' 기대, 실제 {mode!r}"
 
 
-def test_save_success_keeps_advanced_accordion_closed(seeded_page, base_url):
-    """?saved=1 (성공) 쿼리로 접근 시 고급설정 아코디언은 펼쳐지지 않아야 한다."""
+def test_save_success_keeps_simple_mode(seeded_page, base_url):
+    """?saved=1 (성공) 쿼리로 접근 시 모드는 유지 (강제 전환 없음).
+
+    Phase 2A: localStorage 또는 서버 신호 또는 simple default — saved 는 강제 전환 사유 아님.
+    """
     seeded_page.goto(f"{base_url}{SETTINGS_URL}?saved=1")
     seeded_page.wait_for_timeout(300)
-    is_open = seeded_page.evaluate(
-        "document.querySelector('.advanced-details')?.open"
+    mode = seeded_page.evaluate(
+        "document.body.getAttribute('data-settings-mode')"
     )
-    assert not is_open, "saved=1 쿼리 시 .advanced-details 는 기본 접힘 유지"
+    # 기본값은 simple (localStorage 비어있고 서버 신호 없음 — 시드 리포는 기본 설정)
+    # Default is simple when localStorage empty and server signals no advanced fields.
+    assert mode == "simple", f"saved=1 시 simple 모드 유지 기대, 실제 {mode!r}"
 
 
-def test_auto_merge_in_pr_card_not_push_card(seeded_page, base_url):
-    """auto_merge 체크박스가 PR 카드('분석 동작 규칙') 안에 있어야 한다 (Push 카드 아님).
+def test_auto_merge_in_pr_card(seeded_page, base_url):
+    """auto_merge 체크박스가 PR 동작 규칙 카드 안에 있어야 한다 (이벤트 후 자동화 카드 아님).
 
-    PR #89 Settings UI/UX 리디자인으로 카드명이 의도 기반('분석 동작 규칙') 으로 갱신됨.
-    PR #89 renamed the card to intent-based '분석 동작 규칙'.
+    Phase 2A Progressive 재설계: 카드명이 'PR 동작 규칙' 으로 갱신.
+    Phase 2A: card renamed to 'PR 동작 규칙'.
     """
     seeded_page.goto(f"{base_url}{SETTINGS_URL}")
-    # auto_merge input 의 가장 가까운 s-card 헤더 타이틀 확인
     card_title = seeded_page.evaluate(
         """() => {
             const input = document.querySelector('input[name="auto_merge"]');
@@ -520,8 +521,8 @@ def test_auto_merge_in_pr_card_not_push_card(seeded_page, base_url):
             return title ? title.textContent.trim() : null;
         }"""
     )
-    assert card_title == "분석 동작 규칙", (
-        f"auto_merge 의 상위 카드 타이틀이 '분석 동작 규칙' 여야 하는데 '{card_title}' 임"
+    assert card_title == "PR 동작 규칙", (
+        f"auto_merge 의 상위 카드 타이틀이 'PR 동작 규칙' 여야 하는데 '{card_title}' 임"
     )
 
 

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -245,35 +245,8 @@
   @keyframes toastIn  { from { opacity:0; transform:translateX(-50%) translateY(-10px); } to { opacity:1; transform:translateX(-50%) translateY(0); } }
   @keyframes toastOut { from { opacity:1; } to { opacity:0; pointer-events:none; } }
 
-  /* 고급 설정 아코디언 */
-  .advanced-details {
-    margin-bottom:1rem;
-    border:1.5px solid var(--border); border-radius:var(--radius-card);
-    background:var(--bg-card); box-shadow:var(--shadow-card); overflow:hidden;
-    transition:border-color var(--transition), box-shadow var(--transition);
-  }
-  .advanced-details[open] {
-    border-color:var(--accent);
-    box-shadow:0 0 0 3px rgba(99,102,241,.1), var(--shadow-card);
-  }
-  body[data-theme="glass"] .advanced-details { backdrop-filter:blur(16px); -webkit-backdrop-filter:blur(16px); }
-  .advanced-summary {
-    list-style:none; cursor:pointer; user-select:none;
-    padding:.8rem 1.1rem; display:flex; align-items:center; gap:.55rem;
-    font-size:13px; font-weight:700; color:var(--text-primary);
-    transition:background var(--transition);
-  }
-  .advanced-summary::-webkit-details-marker { display:none; }
-  .advanced-summary .adv-icon { font-size:16px; }
-  .advanced-summary .adv-hint { font-size:11px; font-weight:500; color:var(--text-muted); margin-left:.5rem; }
-  .advanced-summary::after {
-    content:'▼'; font-size:10px; color:var(--text-muted);
-    margin-left:auto; transition:transform var(--transition);
-  }
-  .advanced-details[open] .advanced-summary::after { transform:rotate(180deg); }
-  .advanced-summary:hover { background:rgba(99,102,241,.05); }
-  .advanced-body { padding:1rem; border-top:1px solid var(--border); }
-  .advanced-body .settings-grid { margin-bottom:0; }
+  /* (Phase 2A Progressive 재설계: 별도 아코디언 제거 — .adv-only 클래스로 단순/고급 분리)
+     Phase 2A Progressive: dedicated accordion removed — replaced by .adv-only class-based split */
 
   /* 마스킹 필드 */
   .masked-field { position:relative; display:flex; align-items:center; }
@@ -330,35 +303,61 @@
     <div class="repo-badge">{{ repo_name }}</div>
   </div>
 
-  <!-- Phase E.4 — Simple/Advanced 모드 토글 / Simple/Advanced mode toggle -->
-  <div class="mode-toggle-bar" id="modeToggleBar">
-    <span class="mode-toggle-label">보기 모드:</span>
-    <button type="button" class="mode-toggle-btn active" data-settings-mode-btn="simple">
-      ✨ Simple <span class="mode-toggle-hint">(필수 항목만)</span>
-    </button>
-    <button type="button" class="mode-toggle-btn" data-settings-mode-btn="advanced">
-      ⚙️ Advanced <span class="mode-toggle-hint">(전체 설정)</span>
-    </button>
+  <!-- Simple/Advanced 모드 토글 — 시각 강화 (Progressive Mode 재설계) -->
+  <!-- Simple/Advanced mode toggle — visually strengthened segmented control (Progressive Mode redesign) -->
+  <div class="mode-toggle-bar" id="modeToggleBar"
+       data-initial-mode="{{ initial_mode or 'simple' }}">
+    <span class="mode-toggle-label">보기 모드</span>
+    <div class="mode-toggle-segment">
+      <button type="button" class="mode-toggle-btn active" data-settings-mode-btn="simple">
+        ✨ Simple <span class="mode-toggle-hint">필수 항목만</span>
+      </button>
+      <button type="button" class="mode-toggle-btn" data-settings-mode-btn="advanced">
+        ⚙️ Advanced <span class="mode-toggle-hint">전체 설정</span>
+      </button>
+    </div>
+    <span class="mode-toggle-counter" id="modeToggleCounter"></span>
   </div>
   <style>
-    .mode-toggle-bar { display: flex; align-items: center; gap: 0.6rem;
-                       margin: 0 0 1rem; padding: 0.6rem 0.9rem;
-                       background: var(--bg-card); border-radius: 8px;
-                       border: 1px solid var(--border); flex-wrap: wrap; }
-    .mode-toggle-label { font-size: 13px; color: var(--text-muted); font-weight: 600; }
-    .mode-toggle-btn { padding: 0.4rem 0.9rem; border-radius: 6px;
-                       border: 1px solid var(--border); background: transparent;
+    /* 강화된 segmented control — 시각 무게 ↑, 경계 명확 / Strengthened segmented control */
+    .mode-toggle-bar { display: flex; align-items: center; gap: 0.75rem;
+                       margin: 0 0 1.25rem; padding: 0.55rem 0.85rem;
+                       background: var(--bg-card); border-radius: 10px;
+                       border: 2px solid var(--border); flex-wrap: wrap;
+                       transition: border-color 0.2s ease; }
+    .mode-toggle-bar:hover { border-color: var(--accent); }
+    .mode-toggle-label { font-size: 12px; color: var(--text-muted);
+                         font-weight: 700; text-transform: uppercase;
+                         letter-spacing: 0.05em; }
+    .mode-toggle-segment { display: inline-flex; gap: 2px; padding: 3px;
+                           background: var(--bg-input); border-radius: 8px; }
+    .mode-toggle-btn { padding: 0.4rem 0.95rem; border-radius: 6px;
+                       border: 1px solid transparent; background: transparent;
                        cursor: pointer; font-size: 13px; color: var(--text-primary);
-                       transition: all 0.15s ease; }
-    .mode-toggle-btn:hover { background: var(--bg-hover); }
+                       font-weight: 500; transition: all 0.15s ease;
+                       display: inline-flex; align-items: center; gap: 0.35rem; }
+    .mode-toggle-btn:hover:not(.active) { background: var(--bg-hover); }
     .mode-toggle-btn.active { background: var(--accent); color: white;
-                              border-color: var(--accent); }
-    .mode-toggle-hint { font-size: 11px; opacity: 0.7; margin-left: 0.2rem; }
-    /* Simple 모드: adv-only 섹션 자체와 advanced-details 숨김 */
+                              border-color: var(--accent); font-weight: 600;
+                              transform: scale(1.02);
+                              box-shadow: 0 2px 8px rgba(99,102,241,0.25); }
+    .mode-toggle-hint { font-size: 11px; opacity: 0.85; margin-left: 0.15rem; }
+    .mode-toggle-counter { margin-left: auto; font-size: 11px; color: var(--text-muted);
+                           font-weight: 600; }
+
+    /* Simple 모드: .adv-only 숨김 / Simple mode hides .adv-only */
     body[data-settings-mode="simple"] .adv-only,
     main[data-settings-mode="simple"] .adv-only { display: none !important; }
-    body[data-settings-mode="simple"] details.advanced-details,
-    main[data-settings-mode="simple"] details.advanced-details { display: none !important; }
+    /* Simple 모드 전용 안내 — 고급 모드에선 숨김 / Simple-only hint hidden in advanced mode */
+    body[data-settings-mode="advanced"] .simple-only-hint { display: none !important; }
+
+    /* ●○ 연결 상태 점 / Connection status dot */
+    .conn-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+                vertical-align: middle; margin-right: 6px;
+                box-shadow: 0 0 0 1.5px rgba(255,255,255,0.6); }
+    .conn-dot.is-on  { background: var(--success, #10b981); }
+    .conn-dot.is-off { background: var(--text-muted, #9ca3af); opacity: 0.55; }
+    .conn-status-text { font-size: 11px; color: var(--text-muted); font-weight: 500; }
   </style>
 
   <form id="settingsForm" method="post" action="/repos/{{ repo_name }}/settings">
@@ -377,7 +376,7 @@
         <p style="font-size:13px;color:var(--text-muted);margin:0 0 .75rem;">분석 결과를 받으려면 아래 단계를 완료하세요.</p>
         <div style="display:flex;flex-direction:column;gap:.45rem;font-size:13px;">
           <a href="#notifyCard" style="color:var(--accent);font-weight:600;">
-            ① 알림 채널 설정 → 아래 <strong>알림 발신 채널</strong>에서 Telegram 또는 다른 채널을 연결하세요
+            ① 알림 채널 설정 → 아래 <strong>알림 채널 (발신)</strong> 카드에서 Telegram 또는 다른 채널을 연결하세요
           </a>
           <span style="color:var(--text-muted);">
             ② 리뷰 수준 결정 → 위 <strong>빠른 설정</strong>에서 프리셋을 선택하세요 (선택 사항)
@@ -522,27 +521,18 @@
       </div>
     </div>
 
-    <!-- 고급 설정 (프리셋 외 세부 조정) / Advanced settings (fine-tuning beyond presets) -->
-    <details class="advanced-details">
-      <summary class="advanced-summary">
-        <span class="adv-icon">⚙️</span>
-        <span>고급 설정</span>
-        <span class="adv-hint">프리셋 외 세부 조정이 필요할 때만 펼치세요</span>
-      </summary>
-      <div class="advanced-body">
-        <div class="settings-grid">
-
-      <!-- ② 분석 동작 규칙 / Analysis behavior rules -->
+    <!-- ② PR 동작 규칙 — 단순 모드에선 핵심 3 필드(pr_review_comment, auto_merge, merge_threshold)만 노출 -->
+    <!-- ② PR Behavior Rules — simple mode shows only 3 core fields; rest is .adv-only -->
+    <div class="settings-grid">
       <div class="s-card">
         <div class="s-card-hdr hdr-gate">
           <span class="hdr-icon">⚡</span>
-          <span class="hdr-title">분석 동작 규칙</span>
+          <span class="hdr-title">PR 동작 규칙</span>
           <span class="hdr-badge" id="approveBadge">{{ config.approve_mode }}</span>
         </div>
         <div class="s-card-body">
 
-          <div class="s-section-label">PR 이벤트</div>
-          <!-- PR 코드리뷰 댓글 / PR code review comment -->
+          <!-- 단순 모드 노출: PR 코멘트 / Always-visible: PR comment -->
           <div class="toggle-row">
             <div class="toggle-info">
               <div class="t-title">PR 코드리뷰 댓글</div>
@@ -555,73 +545,8 @@
             </label>
           </div>
 
+          <!-- 단순 모드 노출: 자동 Merge + 임계값 / Always-visible: auto-merge + threshold -->
           <div class="s-divider"></div>
-          <div class="s-section-label">Approve 자동화</div>
-
-          <!-- Approve 3-way -->
-          <div class="gate-btns">
-            <button type="button"
-                    class="gate-mode-btn {% if config.approve_mode == 'disabled' %}active{% endif %}"
-                    data-mode="disabled" onclick="setApproveMode('disabled')">
-              <span class="gm-icon">🚫</span>비활성
-            </button>
-            <button type="button"
-                    class="gate-mode-btn {% if config.approve_mode == 'auto' %}active{% endif %}"
-                    data-mode="auto" onclick="setApproveMode('auto')">
-              <span class="gm-icon">⚡</span>자동
-            </button>
-            <button type="button"
-                    class="gate-mode-btn {% if config.approve_mode == 'semi-auto' %}active{% endif %}"
-                    data-mode="semi-auto" onclick="setApproveMode('semi-auto')">
-              <span class="gm-icon">📱</span>반자동
-            </button>
-          </div>
-
-          <!-- 기준점 슬라이더 (disabled 시 숨김) / Threshold slider (hidden when disabled) -->
-          <div id="approveThresholds" class="{% if config.approve_mode == 'disabled' %}is-hidden{% endif %}">
-            <div class="threshold-row">
-              <div class="threshold-label">
-                <span>승인 기준점</span>
-                <span style="color:var(--success);font-size:11px;font-weight:600;">이상 → 승인</span>
-              </div>
-              <div class="threshold-ctrl">
-                <input type="range" class="approve-range" name="approve_threshold"
-                       min="0" max="100" value="{{ config.approve_threshold }}"
-                       oninput="document.getElementById('approveVal').value=this.value">
-                <input type="number" id="approveVal" class="num-input"
-                       min="0" max="100" value="{{ config.approve_threshold }}"
-                       oninput="this.previousElementSibling.value=this.value">
-              </div>
-            </div>
-            <div class="threshold-row" style="margin-bottom:0">
-              <div class="threshold-label">
-                <span>반려 기준점</span>
-                <span style="color:var(--danger);font-size:11px;font-weight:600;">미만 → 반려</span>
-              </div>
-              <div class="threshold-ctrl">
-                <input type="range" class="reject-range" name="reject_threshold"
-                       min="0" max="100" value="{{ config.reject_threshold }}"
-                       oninput="document.getElementById('rejectVal').value=this.value">
-                <input type="number" id="rejectVal" class="num-input danger"
-                       min="0" max="100" value="{{ config.reject_threshold }}"
-                       oninput="this.previousElementSibling.value=this.value">
-              </div>
-            </div>
-            <div class="range-hint">
-              💡 <strong>{{ config.approve_threshold }}점 이상</strong> 자동 승인 ·
-                 <strong>{{ config.reject_threshold }}점 미만</strong> 자동 반려 · 그 사이 스킵
-            </div>
-          </div>
-
-          <!-- semi-auto 안내 힌트 (Telegram Chat ID는 ④ 알림 채널에서 설정) / semi-auto hint (Telegram Chat ID configured in ④ notification channels) -->
-          <div id="semiAutoHint" class="{% if config.approve_mode != 'semi-auto' %}is-hidden{% endif %}"
-               style="margin-top:.75rem;padding:.5rem .75rem;background:var(--hint-bg);border:1px solid var(--hint-border);border-radius:7px;font-size:11px;color:var(--text-muted);line-height:1.6;">
-            💡 반자동 Approve는 <strong>④ 알림 채널의 Telegram Chat ID</strong>로 전송됩니다.
-          </div>
-
-          <div class="s-divider"></div>
-          <div class="s-section-label">자동 Merge</div>
-
           <div class="toggle-row">
             <div class="toggle-info">
               <div class="t-title">자동 Merge</div>
@@ -636,7 +561,6 @@
             </label>
           </div>
 
-          <!-- Merge 임계값 (auto_merge OFF 시 숨김) / Merge threshold (hidden when auto_merge is OFF) -->
           <div id="mergeThresholdRow" class="{% if not config.auto_merge %}is-hidden{% endif %}" style="margin-top:.75rem;">
             <div class="threshold-row" style="margin-bottom:0">
               <div class="threshold-label">
@@ -654,30 +578,98 @@
             </div>
           </div>
 
-          <!-- Auto-merge 실패 시 Issue 생성 (auto_merge OFF 시 숨김) / Create issue on auto-merge failure (hidden when auto_merge is OFF) -->
-          <div id="mergeIssueRow" class="{% if not config.auto_merge %}is-hidden{% endif %}" style="margin-top:.75rem;">
-            <div class="toggle-row">
-              <div class="toggle-info">
-                <div class="t-title">실패 시 Issue 자동 생성</div>
-                <div class="t-desc">Auto-merge 실패 시 권장 조치를 담은<br>GitHub Issue 자동 생성</div>
-              </div>
-              <label class="toggle-switch">
-                <input type="checkbox" name="auto_merge_issue_on_failure" value="on"
-                       {% if config.auto_merge_issue_on_failure %}checked{% endif %}>
-                <span class="toggle-track"></span>
-              </label>
+          <!-- 고급 모드 전용: Approve 3-way + 기준점 슬라이더 / Advanced-only: approve 3-way + thresholds -->
+          <div class="adv-only">
+            <div class="s-divider"></div>
+            <div class="s-section-label">Approve 자동화 (고급)</div>
+
+            <div class="gate-btns">
+              <button type="button"
+                      class="gate-mode-btn {% if config.approve_mode == 'disabled' %}active{% endif %}"
+                      data-mode="disabled" onclick="setApproveMode('disabled')">
+                <span class="gm-icon">🚫</span>비활성
+              </button>
+              <button type="button"
+                      class="gate-mode-btn {% if config.approve_mode == 'auto' %}active{% endif %}"
+                      data-mode="auto" onclick="setApproveMode('auto')">
+                <span class="gm-icon">⚡</span>자동
+              </button>
+              <button type="button"
+                      class="gate-mode-btn {% if config.approve_mode == 'semi-auto' %}active{% endif %}"
+                      data-mode="semi-auto" onclick="setApproveMode('semi-auto')">
+                <span class="gm-icon">📱</span>반자동
+              </button>
             </div>
-          </div>
+
+            <div id="approveThresholds" class="{% if config.approve_mode == 'disabled' %}is-hidden{% endif %}">
+              <div class="threshold-row">
+                <div class="threshold-label">
+                  <span>승인 기준점</span>
+                  <span style="color:var(--success);font-size:11px;font-weight:600;">이상 → 승인</span>
+                </div>
+                <div class="threshold-ctrl">
+                  <input type="range" class="approve-range" name="approve_threshold"
+                         min="0" max="100" value="{{ config.approve_threshold }}"
+                         oninput="document.getElementById('approveVal').value=this.value">
+                  <input type="number" id="approveVal" class="num-input"
+                         min="0" max="100" value="{{ config.approve_threshold }}"
+                         oninput="this.previousElementSibling.value=this.value">
+                </div>
+              </div>
+              <div class="threshold-row" style="margin-bottom:0">
+                <div class="threshold-label">
+                  <span>반려 기준점</span>
+                  <span style="color:var(--danger);font-size:11px;font-weight:600;">미만 → 반려</span>
+                </div>
+                <div class="threshold-ctrl">
+                  <input type="range" class="reject-range" name="reject_threshold"
+                         min="0" max="100" value="{{ config.reject_threshold }}"
+                         oninput="document.getElementById('rejectVal').value=this.value">
+                  <input type="number" id="rejectVal" class="num-input danger"
+                         min="0" max="100" value="{{ config.reject_threshold }}"
+                         oninput="this.previousElementSibling.value=this.value">
+                </div>
+              </div>
+              <div class="range-hint">
+                💡 <strong>{{ config.approve_threshold }}점 이상</strong> 자동 승인 ·
+                   <strong>{{ config.reject_threshold }}점 미만</strong> 자동 반려 · 그 사이 스킵
+              </div>
+            </div>
+
+            <!-- semi-auto 힌트 (Telegram Chat ID는 알림 채널 카드에서 설정) / semi-auto hint -->
+            <div id="semiAutoHint" class="{% if config.approve_mode != 'semi-auto' %}is-hidden{% endif %}"
+                 style="margin-top:.75rem;padding:.5rem .75rem;background:var(--hint-bg);border:1px solid var(--hint-border);border-radius:7px;font-size:11px;color:var(--text-muted);line-height:1.6;">
+              💡 반자동 Approve는 <a href="#notifyCard" style="color:var(--accent);font-weight:600;">알림 채널 카드의 Telegram Chat ID</a>로 전송됩니다.
+            </div>
+
+            <!-- Auto-merge 실패 시 Issue 생성 (auto_merge OFF 시 숨김 — 고급 모드에서만 의미) -->
+            <div id="mergeIssueRow" class="{% if not config.auto_merge %}is-hidden{% endif %}" style="margin-top:.75rem;">
+              <div class="toggle-row">
+                <div class="toggle-info">
+                  <div class="t-title">Auto-merge 실패 시 Issue 자동 생성</div>
+                  <div class="t-desc">실패 사유 + 권장 조치를 담은<br>GitHub Issue 자동 생성</div>
+                </div>
+                <label class="toggle-switch">
+                  <input type="checkbox" name="auto_merge_issue_on_failure" value="on"
+                         {% if config.auto_merge_issue_on_failure %}checked{% endif %}>
+                  <span class="toggle-track"></span>
+                </label>
+              </div>
+            </div>
+          </div><!-- /.adv-only -->
 
         </div>
       </div>
+    </div>
 
-      <!-- Push / 배포 이벤트 & 팀 설정 카드 / Push/deploy events & team settings card -->
+    <!-- ⑤ 이벤트 후 자동화 (Push 이벤트 + Railway 배포 + 팀 리더보드) — 전체 .adv-only 카드 -->
+    <!-- ⑤ Post-event Automation (push events + Railway deploy + team leaderboard) — entire card .adv-only -->
+    <div class="settings-grid adv-only">
       <div class="s-card">
         <div class="s-card-hdr hdr-merge">
-          <span class="hdr-icon">🚀</span>
-          <span class="hdr-title">Push / 배포 이벤트</span>
-          <span class="hdr-badge">Push · Railway</span>
+          <span class="hdr-icon">🛠</span>
+          <span class="hdr-title">이벤트 후 자동화</span>
+          <span class="hdr-badge">Push · Railway · 팀</span>
         </div>
         <div class="s-card-body">
 
@@ -697,7 +689,7 @@
           <div class="s-divider"></div>
           <div class="toggle-row">
             <div class="toggle-info">
-              <div class="t-title">이슈 자동 생성</div>
+              <div class="t-title">점수 미달 시 Issue 생성</div>
               <div class="t-desc">점수 미달 또는 보안 HIGH 발견 시<br>GitHub Issue 자동 생성</div>
             </div>
             <label class="toggle-switch">
@@ -708,6 +700,7 @@
           </div>
 
           <div class="s-divider"></div>
+          <div class="s-section-label">Railway 배포</div>
           <div class="toggle-row">
             <div class="toggle-info">
               <div class="t-title">Railway 빌드 실패 알림</div>
@@ -722,7 +715,6 @@
 
           <div class="s-divider"></div>
           <div class="s-section-label">팀 설정</div>
-          <!-- 팀 인사이트 리더보드 옵트인 (기본 비활성) / Team Insights leaderboard opt-in (disabled by default) -->
           <div class="toggle-row">
             <div class="toggle-info">
               <div class="t-title">팀 리더보드 공개</div>
@@ -739,24 +731,25 @@
 
         </div>
       </div>
+    </div>
 
-        </div><!-- /.settings-grid -->
-      </div><!-- /.advanced-body -->
-    </details><!-- /.advanced-details -->
-
-    <!-- ④ 알림 채널 (항상 표시 — 고급 설정 아코디언 밖) / Notification channels (always visible — outside advanced settings accordion) -->
+    <!-- ③ 📤 알림 채널 (발신) — Telegram 항상 노출, 외부 채널은 .adv-only -->
+    <!-- ③ 📤 Outbound Channels — Telegram always visible, external channels .adv-only -->
     <div class="settings-grid">
       <div class="s-card notify-full" id="notifyCard">
         <div class="s-card-hdr hdr-notify">
-          <span class="hdr-icon">🔔</span>
-          <span class="hdr-title">알림 발신 채널</span>
-          <span class="hdr-badge">SCAManager → 외부</span>
+          <span class="hdr-icon">📤</span>
+          <span class="hdr-title">알림 채널 (발신)</span>
+          <span class="hdr-badge">→ 외부</span>
         </div>
         <div class="s-card-body">
-          <div class="s-section-label">메신저 / 이메일</div>
+          <div class="s-section-label">Telegram</div>
           <div class="channel-grid">
             <div class="field-row">
-              <label class="field-label">Telegram Chat ID</label>
+              <label class="field-label">
+                <span class="conn-dot {% if config.notify_chat_id %}is-on{% else %}is-off{% endif %}"></span>
+                Telegram Chat ID
+              </label>
               <span class="field-hint">미설정 시 전역 Chat ID 사용 · 반자동 Approve에도 사용</span>
               <div class="masked-field">
                 <input class="field-input" type="password" name="notify_chat_id"
@@ -790,8 +783,8 @@
                   </p>
                 </div>
                 <script>
-                  // Telegram OTP 발급 버튼 — 알림 발신 채널 카드로 이동 (B+A 리디자인)
-                  // Telegram OTP button — moved to notification channel card (B+A redesign)
+                  // Telegram OTP 발급 버튼 — 알림 채널 (발신) 카드 (Phase 2A Progressive 재설계)
+                  // Telegram OTP button — Outbound channel card (Phase 2A Progressive redesign)
                   (function () {
                     var btn = document.getElementById('issueTelegramOtp');
                     if (!btn) { return; }
@@ -828,7 +821,13 @@
             </div>
 
             <div class="field-row adv-only">
-              <label class="field-label">Discord Webhook</label>
+              <div class="s-section-label" style="grid-column:1/-1;margin:.6rem 0 .25rem;">메신저 / 이메일</div>
+            </div>
+            <div class="field-row adv-only">
+              <label class="field-label">
+                <span class="conn-dot {% if config.discord_webhook_url %}is-on{% else %}is-off{% endif %}"></span>
+                Discord Webhook
+              </label>
               <div class="masked-field">
                 <input class="field-input" type="password" name="discord_webhook_url"
                        value="{{ config.discord_webhook_url or '' }}"
@@ -838,7 +837,10 @@
               </div>
             </div>
             <div class="field-row adv-only">
-              <label class="field-label">Slack Webhook</label>
+              <label class="field-label">
+                <span class="conn-dot {% if config.slack_webhook_url %}is-on{% else %}is-off{% endif %}"></span>
+                Slack Webhook
+              </label>
               <div class="masked-field">
                 <input class="field-input" type="password" name="slack_webhook_url"
                        value="{{ config.slack_webhook_url or '' }}"
@@ -848,7 +850,10 @@
               </div>
             </div>
             <div class="field-row adv-only">
-              <label class="field-label">Email 수신자 <span class="field-tag">SMTP 필요</span></label>
+              <label class="field-label">
+                <span class="conn-dot {% if config.email_recipients %}is-on{% else %}is-off{% endif %}"></span>
+                Email 수신자 <span class="field-tag">SMTP 필요</span>
+              </label>
               <span class="field-hint">쉼표로 구분</span>
               <div class="masked-field">
                 <input class="field-input" type="password" name="email_recipients"
@@ -859,7 +864,10 @@
               </div>
             </div>
             <div class="field-row adv-only">
-              <label class="field-label">Custom Webhook</label>
+              <label class="field-label">
+                <span class="conn-dot {% if config.custom_webhook_url %}is-on{% else %}is-off{% endif %}"></span>
+                Custom Webhook
+              </label>
               <div class="masked-field">
                 <input class="field-input" type="password" name="custom_webhook_url"
                        value="{{ config.custom_webhook_url or '' }}"
@@ -869,10 +877,13 @@
               </div>
             </div>
             <div class="field-row adv-only">
-              <div class="s-section-label" style="grid-column:1/-1;margin-bottom:.25rem;">자동화 연동 Webhook (발신)</div>
+              <div class="s-section-label" style="grid-column:1/-1;margin:.6rem 0 .25rem;">자동화 연동 (발신)</div>
             </div>
             <div class="field-row adv-only">
-              <label class="field-label">n8n Webhook</label>
+              <label class="field-label">
+                <span class="conn-dot {% if config.n8n_webhook_url %}is-on{% else %}is-off{% endif %}"></span>
+                n8n Webhook
+              </label>
               <div class="masked-field">
                 <input class="field-input" type="password" name="n8n_webhook_url"
                        value="{{ config.n8n_webhook_url or '' }}"
@@ -887,17 +898,25 @@
 
     </div><!-- /settings-grid -->
 
+    <!-- 단순 모드 안내 — 고급 모드에선 숨김 (modal-toggle CSS) / Simple-mode hint (hidden in advanced mode) -->
+    <p class="simple-only-hint" style="text-align:center;font-size:12px;color:var(--text-muted);margin:.5rem 0 1rem;line-height:1.6;">
+      ⚙️ 더 정밀한 제어 (Approve 임계값 · Discord/Slack/Email · CLI Hook · 리포 삭제 등) 가 필요하면
+      상단의 <strong>Advanced</strong> 토글을 눌러주세요.
+    </p>
+
     <div class="save-bar">
       <button type="submit" class="btn-save-new">💾 설정 저장</button>
     </div>
 
   </form>
 
-  <!-- ⑤ 통합 & 연결 (GitHub 수신 Webhook + CLI Hook + Railway API 토큰 + 위험 구역 — 메인 form 외부) / Integration & connections (GitHub inbound webhook + CLI Hook + Railway API token + danger zone — outside main form) -->
-  <div class="s-card" style="margin-bottom:1rem;">
+  <!-- ⑥ 📥 통합 & 인증 (수신) — GitHub Webhook 재등록 + CLI Hook + Railway API 토큰 + Webhook URL — 전체 .adv-only -->
+  <!-- ⑥ 📥 Inbound Integration & Auth — entire card .adv-only -->
+  <div class="s-card adv-only" style="margin-bottom:1rem;">
     <div class="s-card-hdr hdr-hook">
-      <span class="hdr-icon">🔗</span>
-      <span class="hdr-title">통합 &amp; 연결</span>
+      <span class="hdr-icon">📥</span>
+      <span class="hdr-title">통합 &amp; 인증 (수신)</span>
+      <span class="hdr-badge">외부 → SCAManager</span>
     </div>
     <div class="s-card-body">
 
@@ -909,7 +928,7 @@
       <span class="field-hint">GitHub이 SCAManager로 push·PR·check_suite 이벤트를 전송합니다.</span>
 
       <div class="s-divider"></div>
-      <div class="s-section-label">CLI Hook</div>
+      <div class="s-section-label">CLI Hook (pre-push)</div>
       {% if hook_ok %}
       <div class="hook-alert ok">✅ <strong>.scamanager/</strong> 파일이 Repo에 커밋됐습니다.</div>
       {% endif %}
@@ -923,8 +942,10 @@
 
       <div class="s-divider"></div>
 
-      <div class="s-section-label">Railway 연동</div>
-      <div class="s-section-label" style="font-size:10px;text-transform:none;letter-spacing:0;color:var(--text-muted);margin-top:-.4rem;margin-bottom:.6rem;">API 토큰 (로그 조회용)</div>
+      <div class="s-section-label">
+        <span class="conn-dot {% if railway_api_token_set %}is-on{% else %}is-off{% endif %}"></span>
+        Railway API 토큰
+      </div>
       <div class="field-row">
         <div class="masked-field">
           <input class="field-input" type="password" name="railway_api_token"
@@ -938,8 +959,11 @@
         <span class="field-hint">Railway 대시보드 → Account Settings → Tokens 에서 발급. 변경하지 않으려면 그대로 두세요.</span>
       </div>
 
+      <div class="s-section-label" style="margin-top:.85rem">
+        <span class="conn-dot {% if railway_webhook_url %}is-on{% else %}is-off{% endif %}"></span>
+        Railway Webhook URL
+      </div>
       {% if railway_webhook_url %}
-      <div class="s-section-label" style="margin-top:.85rem">Railway Webhook URL</div>
       <div class="field-row">
         <div style="display:flex;gap:.5rem;align-items:center">
           <input type="text" readonly class="field-input" id="railway-webhook-url"
@@ -950,16 +974,14 @@
         <span class="field-hint">Railway Project Settings → Webhooks 에 위 URL 을 추가하세요.</span>
       </div>
       {% else %}
-      <div class="s-section-label" style="margin-top:.85rem">Railway Webhook URL</div>
       <span class="field-hint">설정 저장 후 Railway Webhook URL 이 자동 생성됩니다.</span>
       {% endif %}
-
 
     </div>
   </div>
 
-  <!-- ⑥ 위험 구역 (메인 form 외부, 페이지 최하단) / Danger zone (outside main form, page bottom) -->
-  <div class="s-card" style="margin-bottom:2rem;">
+  <!-- ⑦ 위험 구역 (전체 .adv-only) / Danger zone (entire card .adv-only) -->
+  <div class="s-card adv-only" style="margin-bottom:2rem;">
     <div class="s-card-hdr" style="background:linear-gradient(135deg,#991b1b,#dc2626)">
       <span class="hdr-icon">⚠️</span>
       <span class="hdr-title">위험 구역</span>
@@ -1245,16 +1267,9 @@
     toggleMergeIssueOption(checked);
   }
 
-  // 저장 오류 시 고급설정 아코디언 자동 펼침 — 문제 필드
-  // (approve_threshold / reject_threshold) 가 접힌 아코디언 안에 있어
-  // 사용자가 오류 원인을 즉시 볼 수 없던 페인 포인트 해결.
-  (function() {
-    const params = new URLSearchParams(location.search);
-    if (params.get('save_error') === '1') {
-      const adv = document.querySelector('.advanced-details');
-      if (adv) adv.open = true;
-    }
-  })();
+  // 저장 오류 시 — 모드 전환은 initSettingsMode() 가 ?save_error=1 을 감지해
+  // 자동으로 advanced 로 전환한다 (Phase 2A Progressive 재설계).
+  // Save-error advanced switch is handled by initSettingsMode() via ?save_error=1 detection.
 
   // 토스트 클릭 시 즉시 닫기 + URL 쿼리 제거
   const toast = document.getElementById('saveToast');
@@ -1269,7 +1284,8 @@
     }
   }
 
-  // Phase E.4 — Simple/Advanced 모드 토글 (localStorage 에 영속, ?mode= 쿼리 오버라이드)
+  // Simple/Advanced 모드 토글 (localStorage 에 영속, ?mode= 쿼리 오버라이드, 서버 신호 fallback)
+  // Mode toggle — localStorage persistent, ?mode= override, server signal fallback
   const SETTINGS_MODE_KEY = 'scamanager_settings_mode';
   function toggleSettingsMode(mode) {
     if (mode !== 'simple' && mode !== 'advanced') mode = 'simple';
@@ -1278,18 +1294,23 @@
     document.querySelectorAll('[data-settings-mode-btn]').forEach(btn => {
       btn.classList.toggle('active', btn.dataset.settingsModeBtn === mode);
     });
-    // Advanced 로 전환 시 고급 설정 details 자동 펼침 (UX)
-    if (mode === 'advanced') {
-      document.querySelectorAll('details.advanced-details').forEach(d => d.open = true);
-    }
   }
-  // 초기 모드 결정: ?mode= 쿼리 > localStorage > 기본값 simple
+  // 초기 모드 결정 우선순위 / Initial mode priority:
+  //   1) ?mode= URL 쿼리 (가장 명시적 / most explicit)
+  //   2) ?save_error=1 → 강제 advanced (사용자가 숨은 필드 오류를 볼 수 있어야 함)
+  //   3) localStorage (사용자의 마지막 선택)
+  //   4) data-initial-mode (서버 신호 — DB 의 비-기본값 존재 시 'advanced')
+  //   5) 'simple' (default)
   (function initSettingsMode() {
     const params = new URLSearchParams(location.search);
     const urlMode = params.get('mode');
+    const saveErr = params.get('save_error');
     let stored = null;
     try { stored = localStorage.getItem(SETTINGS_MODE_KEY); } catch (_) { /* ignore */ }
-    const initial = urlMode || stored || 'simple';
+    const bar = document.getElementById('modeToggleBar');
+    const serverHint = bar ? (bar.dataset.initialMode || '') : '';
+    const initial = urlMode || (saveErr === '1' ? 'advanced' : null)
+                            || stored || serverHint || 'simple';
     toggleSettingsMode(initial);
   })();
   // 토글 버튼 바인딩

--- a/src/ui/routes/settings.py
+++ b/src/ui/routes/settings.py
@@ -10,6 +10,8 @@ import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from dataclasses import fields as dataclass_fields
+
 from src.auth.session import CurrentUser, require_login
 from src.config_manager.manager import RepoConfigData, get_repo_config, upsert_repo_config
 from src.database import SessionLocal
@@ -119,6 +121,33 @@ async def _detect_stale_webhook(
         return False
 
 
+# 단순 모드에서 그대로 노출되는 핵심 필드 4개 (+ Telegram OTP 는 user 글로벌이라 별도)
+# 4 core fields exposed in simple mode (Telegram OTP is user-global, handled separately)
+_SIMPLE_MODE_FIELDS = frozenset({
+    "notify_chat_id", "pr_review_comment", "auto_merge", "merge_threshold",
+})
+
+
+def _detect_initial_mode(config: RepoConfigData, railway_api_token_set: bool) -> str:
+    """단순 모드 노출 5개 핵심 필드 외에 사용자가 한 번이라도 비-기본값으로 저장한 흔적이 있으면 'advanced' 반환.
+    Return 'advanced' when any non-simple-mode field carries a non-default value.
+
+    이 신호는 클라이언트의 localStorage 가 비어있을 때만 사용되는 server fallback.
+    `data-initial-mode` 속성으로 템플릿에 내려가고, JS `initSettingsMode()` 가 우선순위를
+    localStorage > data-initial-mode > 'simple' 순으로 적용한다.
+    """
+    default = RepoConfigData(repo_full_name=config.repo_full_name)
+    for field in dataclass_fields(RepoConfigData):
+        name = field.name
+        if name == "repo_full_name" or name in _SIMPLE_MODE_FIELDS:
+            continue
+        if getattr(config, name) != getattr(default, name):
+            return "advanced"
+    if railway_api_token_set:
+        return "advanced"
+    return "simple"
+
+
 @router.get("/repos/{repo_name:path}/settings", response_class=HTMLResponse)
 async def repo_settings(  # pylint: disable=too-many-positional-arguments,too-many-locals
     request: Request,
@@ -158,6 +187,10 @@ async def repo_settings(  # pylint: disable=too-many-positional-arguments,too-ma
         not current_user.is_telegram_connected
     )
 
+    # 사용자 신호 기반 초기 모드 판정 — localStorage 가 비어있을 때만 fallback 으로 사용됨
+    # User-signal initial-mode detection — used as fallback only when localStorage is empty
+    initial_mode = _detect_initial_mode(config, railway_api_token_set)
+
     return templates.TemplateResponse(request, "settings.html", {
         "repo_name": repo_name, "config": config,
         "hook_ok": bool(hook_ok), "hook_fail": bool(hook_fail),
@@ -167,6 +200,7 @@ async def repo_settings(  # pylint: disable=too-many-positional-arguments,too-ma
         "railway_api_token_set": railway_api_token_set,
         "webhook_stale": webhook_stale,
         "onboarding_needed": onboarding_needed,
+        "initial_mode": initial_mode,
     })
 
 

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -436,68 +436,91 @@ def test_mask_toggle_buttons_present():
     )
 
 
-def test_advanced_settings_accordion_exists():
-    """①·② 카드는 '고급 설정' <details>로 감싸져야 한다."""
+def test_advanced_details_removed_in_progressive_redesign():
+    """Progressive Mode 재설계 후 advanced-details <details> 아코디언은 제거되어야 한다.
+
+    Phase 2A 재설계: 카드 평탄화 + .adv-only 클래스 기반 단순/고급 분리.
+    Phase 2A redesign: cards flattened; simple/advanced split via .adv-only class.
+    """
     html = _render_settings()
-    assert "advanced-details" in html, "advanced-details 클래스가 없음"
-    assert "고급 설정" in html, "'고급 설정' summary 텍스트가 없음"
+    assert "advanced-details" not in html, (
+        "advanced-details 클래스가 잔존 — Progressive Mode 재설계 후 제거되어야 함"
+    )
+    # .adv-only 클래스 다수 존재 확인 (단순/고급 분리는 카드/필드 단위 .adv-only 로 처리)
+    # Verify .adv-only is used as the new simple/advanced split mechanism.
+    assert html.count('adv-only') >= 5, (
+        f".adv-only 클래스가 부족: {html.count('adv-only')}회 (5회 이상 기대)"
+    )
 
 
-def test_advanced_settings_default_closed():
-    """고급 설정 <details>는 기본 닫힘 상태여야 한다 (open 속성 없음)."""
+def test_pr_card_simple_fields_outside_adv_only():
+    """단순 모드 노출 핵심 필드(pr_review_comment / auto_merge / merge_threshold) 는
+    .adv-only 영역 바깥에 있어야 한다.
+
+    Phase 2A: 단순 모드 = 5개 핵심 필드만 노출 + Telegram (notify_chat_id + OTP).
+    Phase 2A: simple mode exposes only 5 core fields + Telegram.
+    """
     html = _render_settings()
-    # advanced-details 엘리먼트에 open 속성이 없어야 함
+    # PR 동작 카드(hdr-gate)는 카드 자체에 .adv-only 가 없어야 함 (단순 모드 노출)
+    # PR Behavior card (hdr-gate) must NOT have .adv-only on the card wrapper itself.
     import re
-    match = re.search(r'<details[^>]*class="[^"]*advanced-details[^"]*"[^>]*>', html)
-    assert match, "advanced-details <details> 엘리먼트를 찾지 못함"
-    assert " open" not in match.group(0), (
-        f"고급 설정이 기본 열림 상태: {match.group(0)}"
+    pr_card_match = re.search(
+        r'<div class="s-card[^"]*">\s*<div class="s-card-hdr hdr-gate">', html,
     )
+    assert pr_card_match, "PR 동작 카드(hdr-gate) 를 찾지 못함"
+    # 단순 모드 핵심 필드 3종은 카드 안에 존재
+    # 3 simple-mode core fields must exist
+    for name in ("pr_review_comment", "auto_merge", "merge_threshold"):
+        assert f'name="{name}"' in html, f"단순 모드 필드 누락: {name}"
 
 
-def test_pr_and_push_cards_inside_advanced():
-    """① PR 동작(hdr-gate) / ② Push 동작(hdr-merge) 카드는 고급 설정 <details> 안에 위치해야 한다."""
+def test_notify_card_always_visible():
+    """알림 채널 카드(hdr-notify)는 .adv-only 클래스 없이 항상 노출되어야 한다.
+
+    Phase 2A: notify_chat_id 와 Telegram OTP 는 단순 모드 핵심 필드.
+    Phase 2A: notify_chat_id and Telegram OTP are simple-mode core fields.
+    """
     html = _render_settings()
-    adv_open_idx = html.find('class="advanced-details')
-    adv_close_idx = html.find("</details>", adv_open_idx)
-    assert adv_open_idx != -1, "advanced-details 시작 태그 없음"
-    assert adv_close_idx != -1, "advanced-details 닫기 태그 없음"
-    gate_idx = html.find("s-card-hdr hdr-gate")
-    merge_idx = html.find("s-card-hdr hdr-merge")
-    assert adv_open_idx < gate_idx < adv_close_idx, (
-        "① PR 동작 카드가 고급 설정 <details> 안에 없음"
-    )
-    assert adv_open_idx < merge_idx < adv_close_idx, (
-        "② Push 동작 카드가 고급 설정 <details> 안에 없음"
-    )
-
-
-def test_notify_channel_outside_advanced():
-    """③ 알림 채널은 고급 설정 <details> 바깥에 있어야 한다 (항상 표시)."""
-    html = _render_settings()
-    adv_open_idx = html.find('class="advanced-details')
-    adv_close_idx = html.find("</details>", adv_open_idx)
     notify_idx = html.find("s-card-hdr hdr-notify")
-    assert notify_idx != -1, "③ 알림 채널 카드 없음"
-    assert notify_idx > adv_close_idx, (
-        "③ 알림 채널이 고급 설정 <details> 바깥에 없음 — 항상 표시되어야 함"
+    assert notify_idx != -1, "알림 채널 카드 없음"
+    # notifyCard 카드 자체 wrapper 에 .adv-only 가 없어야 함
+    # The notifyCard wrapper itself must NOT carry .adv-only.
+    notify_wrapper_start = html.rfind('<div class="s-card', 0, notify_idx)
+    notify_wrapper_open_tag = html[notify_wrapper_start:notify_idx]
+    assert "adv-only" not in notify_wrapper_open_tag, (
+        f"알림 채널 카드 wrapper 에 .adv-only 클래스 부착됨: {notify_wrapper_open_tag}"
     )
 
 
-def test_semi_auto_hint_in_pr_card():
-    """semi-auto 모드에서 ① PR 동작 카드에 hint 텍스트가 노출되어야 한다."""
+def test_semi_auto_hint_inside_adv_only_block():
+    """semi-auto 안내 hint 는 PR 동작 카드의 .adv-only 영역 안에 있어야 한다.
+
+    Phase 2A: approve_mode 3-way 와 threshold 슬라이더는 고급 모드 전용.
+    Phase 2A: approve_mode 3-way and threshold sliders are advanced-only.
+    """
     from src.config_manager.manager import RepoConfigData
     cfg = RepoConfigData(repo_full_name="owner/repo", approve_mode="semi-auto")
     html = _render_settings(cfg)
     assert "semiAutoHint" in html, "semiAutoHint 엘리먼트가 없음"
-    # PR 동작 카드(s-card-hdr hdr-gate div) 이후, Push 동작 카드(s-card-hdr hdr-merge) 이전에 hint가 있어야 함
     gate_card_idx = html.find('s-card-hdr hdr-gate')
-    merge_card_idx = html.find('s-card-hdr hdr-merge')
+    notify_card_idx = html.find('s-card-hdr hdr-notify')
     hint_idx = html.find("semiAutoHint")
-    assert gate_card_idx != -1, "s-card-hdr hdr-gate 카드 헤더가 없음"
-    assert merge_card_idx != -1, "s-card-hdr hdr-merge 카드 헤더가 없음"
-    assert gate_card_idx < hint_idx < merge_card_idx, (
-        "semiAutoHint가 ① PR 동작 카드 안에 없음"
+    assert gate_card_idx != -1, "s-card-hdr hdr-gate 카드 헤더 없음"
+    assert notify_card_idx != -1, "s-card-hdr hdr-notify 카드 헤더 없음"
+    assert gate_card_idx < hint_idx < notify_card_idx, (
+        "semiAutoHint 가 PR 동작 카드 안 (다음 알림 카드 이전) 에 위치해야 함"
+    )
+
+
+def test_initial_mode_data_attribute_present():
+    """모드 토글 바에 data-initial-mode 속성(서버 신호) 이 있어야 한다.
+
+    Phase 2A: localStorage 가 비어있을 때 서버 신호로 advanced 진입.
+    Phase 2A: server signal triggers advanced mode when localStorage is empty.
+    """
+    html = _render_settings()
+    assert 'data-initial-mode="' in html, (
+        "data-initial-mode 속성이 모드 토글 바에 없음 — 서버 신호 fallback 깨짐"
     )
 
 

--- a/tests/unit/ui/test_settings_webhook_banner.py
+++ b/tests/unit/ui/test_settings_webhook_banner.py
@@ -169,14 +169,23 @@ def test_settings_no_onboarding_banner_when_telegram_connected():
 def test_settings_new_card_structure_present():
     """새 카드 헤더 텍스트 확인 + 구 카드 헤더 부재 확인.
     Verify new card header text is present and old card headers are gone.
+
+    Phase 2A Progressive 재설계: 카드명 의도 기반 갱신 (W2 수신/발신 분리 명시).
+    Phase 2A Progressive redesign: card names updated (W2 inbound/outbound split).
     """
     resp = _settings_get(stale=False)
     assert resp.status_code == 200
-    # 새 카드 이름이 있어야 함
-    assert "분석 동작 규칙" in resp.text
-    assert "알림 발신 채널" in resp.text
-    assert "통합 &amp; 연결" in resp.text
-    # 구 카드 이름이 없어야 함
+    # 새 카드 이름이 있어야 함 / New card names must be present
+    assert "PR 동작 규칙" in resp.text
+    assert "알림 채널 (발신)" in resp.text
+    assert "이벤트 후 자동화" in resp.text
+    assert "통합 &amp; 인증 (수신)" in resp.text
+    assert "위험 구역" in resp.text
+    # 구 카드명은 더 이상 존재하지 않아야 함 / Old card names must be gone
+    assert "분석 동작 규칙" not in resp.text
+    assert "알림 발신 채널" not in resp.text
+    assert "통합 &amp; 연결" not in resp.text
+    assert "Push / 배포 이벤트" not in resp.text
     assert "이벤트 후 피드백" not in resp.text
     assert "시스템 &amp; 토큰" not in resp.text
 


### PR DESCRIPTION
다중 에이전트 5명 (정찰·디자인안 3·웹훅 전담) 분석 후 사용자 결정:
일괄 적용 + 안건 B (Progressive Mode 강화) + 웹훅 W2 (수신/발신 분리) + 사용자 신호 기반 첫 진입.

== 핵심 변경 ==

1) **단순 모드 노출 5개 핵심 필드만**
   - notify_chat_id (Telegram Chat ID) + Telegram OTP
   - pr_review_comment, auto_merge, merge_threshold
   - 나머지 12개 필드 + 외부 채널 5개 + Railway 토큰 = .adv-only

2) **카드 W2 분리 (수신/발신 명시)**
   - 구 ② '분석 동작 규칙' → 'PR 동작 규칙' (advanced-details 제거, 평탄화)
   - 구 ③ '알림 발신 채널' → '알림 채널 (발신)' (📤 outbound 명시)
   - 구 Push/배포 → 별도 카드 '🛠 이벤트 후 자동화' (전체 .adv-only)
   - 구 ⑤ '통합 & 연결' → '통합 & 인증 (수신)' (📥 inbound 명시, 전체 .adv-only)
   - 구 ⑥ '위험 구역' → 전체 .adv-only

3) **사용자 신호 기반 진입 모드** (settings.py)
   - 신규 함수 `_detect_initial_mode(config, railway_api_token_set)` — 단순 모드 5개 핵심 필드 외에 비-기본값 1개라도 있으면 'advanced' 반환
   - templates context 에 `initial_mode` 전달 → `data-initial-mode` 속성
   - JS `initSettingsMode()` 우선순위: ?mode= > ?save_error=1 > localStorage > data-initial-mode > 'simple'

4) **모드 토글 시각 강화**
   - segmented control 패턴 (border 2px + 활성 그림자 + scale 1.02)
   - 호버 시 border 색 강조

5) **●○ 점 상태 표시 (.conn-dot)**
   - Telegram Chat ID, Discord, Slack, Email, Custom, n8n
   - Railway API 토큰, Railway Webhook URL
   - is-on (success 색) / is-off (muted 회색)

6) **save_error 자동 advanced 전환**
   - 숨은 필드(approve_threshold/reject_threshold) 오류를 사용자가 즉시 볼 수 있음

== 5-way sync 보존 확인 ==
- 폼 필드명 14종 불변 (5-way sync 손상 0)
- PRESETS 9 필드 불변
- JS 헬퍼 12종 시그니처 불변 (toggleSettingsMode, initSettingsMode 등)
- 백엔드 핸들러 (`update_repo_settings`, `repo_settings`) 시그니처 불변

== 회귀 가드 갱신 ==
- tests/unit/ui/test_router.py:
  - test_advanced_details_removed_in_progressive_redesign — 아코디언 제거 확인 + .adv-only 5+ 사용
  - test_pr_card_simple_fields_outside_adv_only — 단순 모드 핵심 3 필드 위치
  - test_notify_card_always_visible — notifyCard wrapper 에 .adv-only 없음 가드
  - test_semi_auto_hint_inside_adv_only_block — semi-auto hint 위치
  - test_initial_mode_data_attribute_present — 서버 신호 fallback
- tests/unit/ui/test_settings_webhook_banner.py:
  - test_settings_new_card_structure_present — 새 카드명 5종 검증 + 구 카드명 6종 잔존 가드
  - test_settings_all_form_fields_present_after_restructure — 16 form field 회귀 (불변)
- e2e/test_settings.py:
  - _expand_advanced 헬퍼 — advanced-details 펼침 → data-settings-mode='advanced' 단순화
  - test_six_card_titles_present — 새 카드 5종 + 구 4종 부재 가드
  - test_save_error_forces_advanced_mode — data-settings-mode='advanced' 강제
  - test_save_success_keeps_simple_mode — 모드 유지
  - test_auto_merge_in_pr_card — 'PR 동작 규칙' 카드명

== 검증 ==
- tests/unit/ui/ 106 PASS (UI 회귀 0건)
- pylint src/ 10.00/10 유지
- 16 form field 회귀 가드 통과

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
