### PR TITLE
fix(ui): Settings 화면 P1·P2 시각 polish 12건 (Step 2 — form/토큰 변경 제외)

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -2,7 +2,9 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- viewport-fit=cover: iOS notch 디바이스의 safe-area-inset env() 활성화
+       viewport-fit=cover: enables safe-area-inset env() on iOS notch devices -->
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
   <title>{% block title %}SCAManager{% endblock %}</title>
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pretendard@1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" crossorigin="anonymous">

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -2,9 +2,10 @@
 {% block title %}설정 — {{ repo_name }}{% endblock %}
 {% block content %}
 <style>
-  /* P0-3: padding-bottom 6rem 으로 sticky save-bar 가 form 마지막 카드를 가리지 않게
-     P0-3: 6rem bottom padding so sticky save-bar never overlaps the last card */
-  .settings-wrap { max-width: 860px; margin: 0 auto; padding: 1.5rem 1rem 6rem; }
+  /* P0-3 + P2-5: padding-bottom 6rem + iOS safe-area-inset 추가 (notch 디바이스 호환)
+     P0-3 + P2-5: 6rem bottom padding + iOS safe-area-inset (notch device support) */
+  .settings-wrap { max-width: 860px; margin: 0 auto;
+                   padding: 1.5rem 1rem calc(6rem + env(safe-area-inset-bottom, 0px)); }
 
   /* 페이지 헤더 */
   .settings-header { display:flex; align-items:center; gap:.75rem; margin-bottom:1.75rem; }
@@ -102,7 +103,8 @@
     text-align:center;
   }
 
-  /* Gate 모드 버튼 */
+  /* Gate 모드 버튼 — P1-3: 모바일 클릭 영역 ≥48px (WCAG 2.5.5)
+     Gate mode buttons — P1-3: ≥48px touch target on mobile (WCAG 2.5.5) */
   .gate-btns { display:grid; grid-template-columns:repeat(3,1fr); gap:.4rem; margin-bottom:1rem; }
   .gate-mode-btn {
     padding:.5rem .25rem; border-radius:8px; border:1.5px solid var(--border);
@@ -110,12 +112,16 @@
     font-size:12px; font-weight:600; text-align:center; cursor:pointer;
     transition:all var(--transition);
     display:flex; flex-direction:column; align-items:center; gap:.15rem;
+    min-height:44px;
   }
   .gate-mode-btn .gm-icon { font-size:15px; }
   .gate-mode-btn.active {
     background:var(--btn-gate-active-bg);
     border-color:var(--btn-gate-active-bd);
     color:var(--btn-gate-active-tx);
+  }
+  @media (max-width: 480px) {
+    .gate-mode-btn { padding:.65rem .35rem; min-height:48px; }
   }
 
   /* 슬라이더 + 숫자 인라인 */
@@ -131,6 +137,12 @@
   }
   .threshold-ctrl input[type=range]::-webkit-slider-thumb {
     -webkit-appearance:none; width:18px; height:18px; border-radius:50%; cursor:pointer;
+  }
+  /* P2-6: 모바일 thumb 24px — 손가락 터치 권장 크기 / Larger thumb for mobile touch */
+  @media (max-width: 480px) {
+    .threshold-ctrl input[type=range]::-webkit-slider-thumb {
+      width:24px; height:24px;
+    }
   }
   .approve-range::-webkit-slider-thumb { background:linear-gradient(135deg,#10b981,#34d399); box-shadow:0 2px 6px rgba(16,185,129,.4); }
   .reject-range::-webkit-slider-thumb  { background:linear-gradient(135deg,#ef4444,#f87171); box-shadow:0 2px 6px rgba(239,68,68,.4); }
@@ -149,7 +161,10 @@
   .range-hint strong { color:var(--text-primary); }
 
   /* 토글 스위치 */
-  .toggle-row { display:flex; align-items:center; justify-content:space-between; gap:1rem; }
+  /* P1-7: 다중 줄 t-desc 와 1줄 토글의 baseline 어긋남 보정 — flex-start + 토글 자체 중앙 정렬
+     P1-7: align-items:flex-start to fix multi-line desc vs single-line toggle baseline */
+  .toggle-row { display:flex; align-items:flex-start; justify-content:space-between; gap:1rem; }
+  .toggle-row .toggle-switch { align-self:center; flex-shrink:0; }
   .toggle-row + .toggle-row { margin-top:.85rem; }
   .toggle-info .t-title { font-size:13px; font-weight:600; margin-bottom:.2rem; }
   .toggle-info .t-desc  { font-size:11px; color:var(--text-muted); line-height:1.4; }
@@ -219,10 +234,11 @@
   details[open] .danger-summary::before { transform:rotate(90deg); }
 
   /* 저장 버튼 — P0-3: 단색 배경 + box-shadow 로 본문과 명확히 분리
-     Save bar — P0-3: solid bg + box-shadow so the bar is clearly above content */
+     P2-5: iOS safe-area-inset 추가 (홈 인디케이터 회피)
+     Save bar — P0-3 solid bg + shadow; P2-5 iOS safe-area-inset for home indicator */
   .save-bar {
     position:sticky; bottom:0;
-    padding:.75rem 0 .85rem;
+    padding:.75rem 0 calc(.85rem + env(safe-area-inset-bottom, 0px));
     background: var(--bg-page);
     border-top: 1px solid var(--border);
     box-shadow: 0 -8px 16px -8px rgba(0,0,0,.18);
@@ -278,18 +294,24 @@
   /* 반응형 — 640px 이상에서 2컬럼 전환 / Responsive: 2-col at ≥640px */
   @media(max-width:639px) {
     .repo-badge { display:none; }
-    /* P0-5: .container 가 좌우 패딩 담당 → settings-wrap 좌우 0 (이중 패딩 해소)
-       P0-5: .container handles horizontal padding → settings-wrap is 0 (avoid double-pad) */
-    .settings-wrap { padding:1rem 0 6rem; }
+    /* P0-5 + P2-5: 모바일 좌우 0 (이중 패딩 해소) + iOS safe-area-inset
+       P0-5 + P2-5: zero horizontal pad on mobile + iOS safe-area-inset */
+    .settings-wrap { padding:1rem 0 calc(6rem + env(safe-area-inset-bottom, 0px)); }
   }
   @media(min-width:640px) {
     .settings-grid { grid-template-columns:1fr 1fr; }
-    .channel-grid  { grid-template-columns:1fr 1fr; }
-    .preset-cards  { display:grid; grid-template-columns:repeat(3,1fr); gap:.6rem; }
+    /* P2-4: align-items:start — 한 카드 펼침 시 인접 카드가 빈 영역으로 늘어나지 않게
+       P2-4: align-items:start so adjacent cards stay short when one is expanded */
+    .preset-cards  { display:grid; grid-template-columns:repeat(3,1fr); gap:.6rem; align-items:start; }
     .notify-full   { grid-column:1/-1; }
     /* P0-1: 자식 카드가 1개뿐인 settings-grid 는 자동 1컬럼 (우측 빈공간 해소)
        P0-1: settings-grid with a single child card auto-collapses to 1 col */
     .settings-grid:has(> .s-card:only-child) { grid-template-columns: 1fr; }
+  }
+  /* P1-4: channel-grid 2-col 은 충분한 폭 (≥1024px) 에서만 활성화 — 좁은 데스크탑·태블릿에서
+     placeholder URL 잘림 회피 / Activate 2-col channel grid only ≥1024px */
+  @media(min-width:1024px) {
+    .channel-grid  { grid-template-columns:1fr 1fr; }
   }
   /* P0-2: 데스크탑 ≥1024px 에서 페이지 폭 확장 (양옆 빈여백 해소)
      P0-2: Widen page at ≥1024px to remove desktop dead space */
@@ -333,19 +355,35 @@
     </div>
     <span class="mode-toggle-counter" id="modeToggleCounter"></span>
   </div>
+
+  <!-- P2-7: 단순 모드 안내 — mode toggle 바로 아래로 이동 (저장 버튼 보조설명 오해 회피)
+       P2-7: Hint moved right under the mode toggle (avoid being misread as save-bar caption) -->
+  <p class="simple-only-hint" style="font-size:12px;color:var(--text-muted);
+            margin: -.6rem 0 1.25rem; padding: .5rem .85rem; line-height:1.55;
+            background: var(--hint-bg, rgba(99,102,241,.06));
+            border-left: 3px solid var(--accent); border-radius: 6px;">
+    ⚙️ 더 정밀한 제어 (Approve 임계값 · Discord/Slack/Email · CLI Hook · 리포 삭제 등) 가 필요하면
+    상단의 <strong>Advanced</strong> 토글을 눌러주세요.
+  </p>
   <style>
-    /* 강화된 segmented control — 시각 무게 ↑, 경계 명확 / Strengthened segmented control */
+    /* P1-6: mode-toggle-bar 시각 무게를 카드(1px)와 동일화 + 강조는 box-shadow ring 으로 분리
+       P1-6: align toggle bar weight with card (1px) + accent ring instead of thicker border */
     .mode-toggle-bar { display: flex; align-items: center; gap: 0.75rem;
                        margin: 0 0 1.25rem; padding: 0.55rem 0.85rem;
                        background: var(--bg-card); border-radius: 10px;
-                       border: 2px solid var(--border); flex-wrap: wrap;
-                       transition: border-color 0.2s ease; }
-    .mode-toggle-bar:hover { border-color: var(--accent); }
+                       border: 1px solid var(--border); flex-wrap: wrap;
+                       box-shadow: var(--shadow-card);
+                       transition: border-color 0.2s ease, box-shadow 0.2s ease; }
+    .mode-toggle-bar:hover { border-color: var(--accent);
+                             box-shadow: 0 0 0 3px rgba(99,102,241,0.10), var(--shadow-card); }
     .mode-toggle-label { font-size: 12px; color: var(--text-muted);
                          font-weight: 700; text-transform: uppercase;
                          letter-spacing: 0.05em; }
+    /* P1-1 보완: segment 컨테이너는 모바일에서 풀폭 stretch 가능하도록 / Segment can stretch on mobile */
     .mode-toggle-segment { display: inline-flex; gap: 2px; padding: 3px;
                            background: var(--bg-input); border-radius: 8px; }
+    /* P1-6: scale(1.02) 제거 (segment 패딩 3px 초과해 튀어나오는 문제) — font-weight 강조로 대체
+       P1-6: drop scale(1.02) which overflowed segment 3px padding; rely on font-weight emphasis */
     .mode-toggle-btn { padding: 0.4rem 0.95rem; border-radius: 6px;
                        border: 1px solid transparent; background: transparent;
                        cursor: pointer; font-size: 13px; color: var(--text-primary);
@@ -353,12 +391,23 @@
                        display: inline-flex; align-items: center; gap: 0.35rem; }
     .mode-toggle-btn:hover:not(.active) { background: var(--bg-hover); }
     .mode-toggle-btn.active { background: var(--accent); color: white;
-                              border-color: var(--accent); font-weight: 600;
-                              transform: scale(1.02);
+                              border-color: var(--accent); font-weight: 700;
                               box-shadow: 0 2px 8px rgba(99,102,241,0.25); }
     .mode-toggle-hint { font-size: 11px; opacity: 0.85; margin-left: 0.15rem; }
     .mode-toggle-counter { margin-left: auto; font-size: 11px; color: var(--text-muted);
                            font-weight: 600; }
+    /* 빈 카운터 숨김 — JS 미주입 시 죽은 마크업 회피 / Hide empty counter to avoid dead markup */
+    .mode-toggle-counter:empty { display: none; }
+
+    /* P1-1: 모바일(≤480px)에서 토글 바 세로 stack + segment 풀폭 + hint 숨김
+       P1-1: ≤480px → column stack, segment full width, hint hidden */
+    @media (max-width: 480px) {
+      .mode-toggle-bar { flex-direction: column; align-items: stretch; gap: 0.5rem; }
+      .mode-toggle-segment { width: 100%; }
+      .mode-toggle-btn { flex: 1; justify-content: center; }
+      .mode-toggle-hint { display: none; }
+      .mode-toggle-counter { margin-left: 0; text-align: center; }
+    }
 
     /* Simple 모드: .adv-only 숨김 / Simple mode hides .adv-only */
     body[data-settings-mode="simple"] .adv-only,
@@ -366,13 +415,50 @@
     /* Simple 모드 전용 안내 — 고급 모드에선 숨김 / Simple-only hint hidden in advanced mode */
     body[data-settings-mode="advanced"] .simple-only-hint { display: none !important; }
 
-    /* ●○ 연결 상태 점 / Connection status dot */
+    /* ●○ 연결 상태 점 / Connection status dot
+       P2-1: ring 색을 var(--bg-card) 로 변경 → 라이트/다크/claude-dark 모든 테마에서 일관 ("뚫린" 효과)
+       P2-1: ring uses var(--bg-card) — works across all 3 themes (light/dark/claude-dark) */
     .conn-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%;
                 vertical-align: middle; margin-right: 6px;
-                box-shadow: 0 0 0 1.5px rgba(255,255,255,0.6); }
+                box-shadow: 0 0 0 1.5px var(--bg-card); }
     .conn-dot.is-on  { background: var(--success, #10b981); }
     .conn-dot.is-off { background: var(--text-muted, #9ca3af); opacity: 0.55; }
     .conn-status-text { font-size: 11px; color: var(--text-muted); font-weight: 500; }
+
+    /* P2-2: s-section-label (uppercase 11px) 안 conn-dot 의 baseline 보정
+       P2-2: vertical-align fix for conn-dot inside uppercase section labels */
+    .s-section-label .conn-dot { vertical-align: -1px; }
+
+    /* P1-8: webhook stale 배너용 Bootstrap 호환 클래스 정의 (프로젝트는 Bootstrap 미로드)
+       P1-8: Bootstrap-compatible classes for webhook stale banner (project does not load Bootstrap) */
+    .alert {
+      display: flex; align-items: center; gap: .5rem; flex-wrap: wrap;
+      padding: .85rem 1.1rem; margin-bottom: 1rem;
+      border-radius: 8px; border: 1px solid transparent;
+      font-size: 13px; line-height: 1.5;
+    }
+    .alert-warning {
+      background: rgba(245, 158, 11, .12);
+      border-color: rgba(245, 158, 11, .35);
+      color: var(--text-primary);
+    }
+    .alert .me-2 { margin-right: .5rem; }
+    .alert .ms-auto { margin-left: auto; }
+    .alert.mb-4 { margin-bottom: 1rem; }
+    .alert .text-muted { color: var(--text-muted); }
+    .btn.btn-sm {
+      padding: .35rem .85rem; font-size: 12px; font-weight: 600;
+      border-radius: 6px; border: 1px solid transparent; cursor: pointer;
+      transition: opacity .15s ease, transform .1s ease;
+    }
+    .btn.btn-warning {
+      background: #f59e0b; color: #fff; border-color: #d97706;
+    }
+    .btn.btn-warning:hover { opacity: .9; }
+    @media (max-width: 480px) {
+      .alert .ms-auto { margin-left: 0; width: 100%; }
+      .alert .btn { width: 100%; }
+    }
   </style>
 
   <form id="settingsForm" method="post" action="/repos/{{ repo_name }}/settings">
@@ -912,12 +998,6 @@
       </div>
 
     </div><!-- /settings-grid -->
-
-    <!-- 단순 모드 안내 — 고급 모드에선 숨김 (modal-toggle CSS) / Simple-mode hint (hidden in advanced mode) -->
-    <p class="simple-only-hint" style="text-align:center;font-size:12px;color:var(--text-muted);margin:.5rem 0 1rem;line-height:1.6;">
-      ⚙️ 더 정밀한 제어 (Approve 임계값 · Discord/Slack/Email · CLI Hook · 리포 삭제 등) 가 필요하면
-      상단의 <strong>Advanced</strong> 토글을 눌러주세요.
-    </p>
 
     <div class="save-bar">
       <button type="submit" class="btn-save-new">💾 설정 저장</button>


### PR DESCRIPTION
P0 핫픽스 (PR #156) 머지 후 4-에이전트 감사 잔여 결함 중
형 안전한 P1 6건 + P2/P3 6건을 한 PR 로 일괄 처리.
form 구조 변경 + --grad-merge 토큰 변경은 다른 페이지 영향 가능성으로
Step 3 사용자 확인 후 별도 PR.

== P1 (안전, 6건) ==
- P1-1 모바일 mode-toggle-bar wrap 깨짐 → @media(≤480px) column stack + segment 풀폭 + hint 숨김 + counter 중앙 정렬
- P1-3 gate-btns 모바일 클릭 영역 ~40px → min-height 44px 기본 + ≤480px 에서 48px (WCAG 2.5.5)
- P1-4 channel-grid 데스탁탑 placeholder 잘림 → 2-col 활성화 폭을 640px → 1024px 로 상향 (좁은 데스크탑·태블릿에서 1-col)
- P1-6 mode-toggle-bar 시각 무게 카드보다 무거움 → border 2px → 1px + box-shadow card + hover 시 accent ring (페이지 위계 정상화)
  + .active 의 transform: scale(1.02) 제거 (segment 패딩 초과 튀어나옴 해소)
- P1-7 toggle-row baseline 어긋남 → align-items: flex-start + .toggle-switch align-self: center
- P1-8 Bootstrap 클래스 미정의 → .alert / .alert-warning / .me-2 / .ms-auto / .mb-4 / .btn.btn-sm / .btn-warning 정의 추가 (webhook stale 배너 정상 표시)

== P2/P3 (마감, 6건) ==
- P2-1 conn-dot ring 다크/라이트 비대칭 → rgba(255,255,255,.6) → var(--bg-card) (3-테마 일관)
- P2-2 conn-dot in section-label baseline 어긋남 → vertical-align: -1px
- P2-4 preset-cards 데스탁탑 한 카드 펼침 시 인접 빈영역 → align-items: start
- P2-5 iOS notch safe-area-inset 미고려 → base.html viewport meta 에 viewport-fit=cover 추가 + .settings-wrap / .save-bar 의 padding-bottom 에 env(safe-area-inset-bottom)
- P2-6 range thumb 18px (모바일 권장 24~28px 미달) → @media(≤480px) thumb 24px
- P2-7 simple-only-hint 위치 어색 (form 끝, save-bar 직전 → 저장 버튼 보조설명처럼 오해) → mode toggle 바로 아래로 이동 + accent border-left + hint-bg 배경 (info card 패턴)

== 5-way sync 보존 ==
- form 필드명 14종 + PRESETS 9 + JS 헬퍼 12종 시그니처 모두 불변
- 백엔드 핸들러 시그니처 불변
- 변경 영향: src/templates/settings.html (CSS + 1 hint 위치 이동) + src/templates/base.html (viewport meta 1줄)

== 검증 ==
- tests/unit/ui/ 106 PASS (회귀 0건)
- pylint src/ 10.00/10 유지

== 잔여 (Step 3, 사용자 확인 필요) ==
- P1-2 ⑥/⑦ 카드 form 통합 (현재 메인 form 외부 → 모든 input 에 form="settingsForm" 명시 또는 카드 위치 form 내부 이동)
- P1-5 --grad-merge (녹색) ↔ --success (녹색) 색 의미 충돌 → base.html 디자인 토큰 변경 (다른 페이지 overview/repo_detail/ analysis_detail 에 영향 가능)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
