### PR TITLE
fix(ui): Settings P1 위험 2건 마무리 (Step 3) — 색 의미 분리 + 카드 동작 안내

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -120,7 +120,10 @@
       --code-bg:        #0f0f15;
       /* 설정 페이지 호환 */
       --grad-gate:           linear-gradient(135deg, #5e6ad2, #4a57c4);
-      --grad-merge:          linear-gradient(135deg, #4ade80, #22c55e);
+      /* P1-5: --grad-merge 녹색 → cyan/teal 로 변경 — --success (녹색 토글/conn-dot) 와
+         색 의미 분리 ("이벤트 후 자동화" 카드 헤더가 "성공 상태"로 오인되던 문제 해소)
+         P1-5: change green → cyan/teal to disambiguate from --success (toggle/conn-dot) */
+      --grad-merge:          linear-gradient(135deg, #06b6d4, #0891b2);
       --grad-notify:         linear-gradient(135deg, #fbbf24, #f59e0b);
       --grad-hook:           linear-gradient(135deg, #a78bfa, #8b5cf6);
       --title-gradient:      linear-gradient(135deg, #8d95e0, #c084fc);
@@ -160,7 +163,8 @@
       --code-bg:        #f5f5f7;
       /* 설정 페이지 호환 */
       --grad-gate:           linear-gradient(135deg, #8d95e0, #5e6ad2);
-      --grad-merge:          linear-gradient(135deg, #4ade80, #16a34a);
+      /* P1-5: cyan/teal — --success 와 분리 / disambiguate from --success */
+      --grad-merge:          linear-gradient(135deg, #22d3ee, #0891b2);
       --grad-notify:         linear-gradient(135deg, #fcd34d, #f59e0b);
       --grad-hook:           linear-gradient(135deg, #c4b5fd, #8b5cf6);
       --title-gradient:      linear-gradient(135deg, #4a57c4, #7c3aed);
@@ -200,7 +204,8 @@
       --code-bg:        rgba(0,0,0,0.3);
       /* 설정 페이지 호환 */
       --grad-gate:           linear-gradient(135deg, rgba(141,149,224,.9), rgba(94,106,210,.9));
-      --grad-merge:          linear-gradient(135deg, rgba(74,222,128,.9), rgba(34,197,94,.9));
+      /* P1-5: cyan/teal — --success 와 분리 / disambiguate from --success */
+      --grad-merge:          linear-gradient(135deg, rgba(6,182,212,.9), rgba(8,145,178,.9));
       --grad-notify:         linear-gradient(135deg, rgba(251,191,36,.9), rgba(245,158,11,.9));
       --grad-hook:           linear-gradient(135deg, rgba(196,181,253,.9), rgba(139,92,246,.9));
       --title-gradient:      linear-gradient(135deg, #c084fc, #f472b6);

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -1011,9 +1011,18 @@
     <div class="s-card-hdr hdr-hook">
       <span class="hdr-icon">📥</span>
       <span class="hdr-title">통합 &amp; 인증 (수신)</span>
-      <span class="hdr-badge">외부 → SCAManager</span>
+      <span class="hdr-badge">⚡ + 💾 혼합</span>
     </div>
     <div class="s-card-body">
+
+      <!-- P1-2: 카드 동작 안내 — 사용자 인식 격차 해소 (form 구조 변경 없이 라벨만 추가)
+           P1-2: Card behaviour notice — closes the perception gap without changing form structure -->
+      <p style="font-size:12px;color:var(--text-muted);margin:0 0 1rem;padding:.5rem .75rem;
+                background:var(--hint-bg);border-left:3px solid var(--accent);border-radius:6px;line-height:1.55;">
+        💡 <strong>각 항목 동작 방식이 다릅니다</strong> —
+        🔗 GitHub Webhook 재등록 / 🔄 CLI Hook 재커밋 버튼은 <strong>클릭 시 즉시 실행</strong>됩니다.
+        Railway API 토큰만 페이지 하단의 <strong>💾 설정 저장</strong> 버튼으로 적용됩니다.
+      </p>
 
       <div class="s-section-label">GitHub 수신 Webhook</div>
       <div class="hook-btns" style="margin-bottom:.5rem;">
@@ -1080,8 +1089,15 @@
     <div class="s-card-hdr" style="background:linear-gradient(135deg,#991b1b,#dc2626)">
       <span class="hdr-icon">⚠️</span>
       <span class="hdr-title">위험 구역</span>
+      <span class="hdr-badge">⚡ 즉시 실행</span>
     </div>
     <div class="s-card-body">
+      <!-- P1-2: 카드 동작 안내 — 삭제는 저장 버튼과 무관하게 즉시 실행됨을 명시
+           P1-2: Behaviour notice — delete is independent of the save button -->
+      <p style="font-size:12px;color:var(--text-muted);margin:0 0 1rem;padding:.5rem .75rem;
+                background:rgba(220,38,38,.08);border-left:3px solid var(--danger);border-radius:6px;line-height:1.55;">
+        💡 이 카드의 작업은 <strong>버튼 클릭 시 즉시 실행</strong>됩니다 (저장 불필요).
+      </p>
       <details class="danger-summary-wrap">
         <summary class="danger-summary">⚠️ 위험한 작업 펼치기</summary>
         <div style="margin-top:.75rem;">


### PR DESCRIPTION
Step 1·2 (P0 + P1 안전 + P2/P3) 머지 후 Step 3 으로 form 구조 변경 위험을 회피한 안전한 방식으로 잔여 P1 2건 처리.

== P1-5: --grad-merge (녹색) ↔ --success (녹색) 색 의미 충돌 해소 == "이벤트 후 자동화" 카드 헤더가 녹색이라 토글 ON / conn-dot 활성 (둘 다 녹색) 과 의미 충돌, 사용자가 카드 헤더를 "성공 상태" 로 오인.

src/templates/base.html — --grad-merge 토큰 3-테마 모두 cyan/teal 로 변경:
- 다크:  #4ade80→#22c55e  → #06b6d4→#0891b2 (cyan-500/600)
- 라이트: #4ade80→#16a34a  → #22d3ee→#0891b2 (cyan-400/600)
- 글래스: rgba(74,222,128,.9)→rgba(34,197,94,.9) → rgba(6,182,212,.9)→rgba(8,145,178,.9)
- claude-dark: 다크 상속 (자동 적용)

영향 범위: settings.html 의 .hdr-merge (이벤트 후 자동화 카드 헤더) 1곳만 사용. 다른 페이지 (overview, repo_detail, analysis_detail) 영향 0 — grep 으로 검증 완료.

== P1-2: ⑥ 통합 & 인증 / ⑦ 위험 구역 카드 form 분리 인식 격차 해소 == form 구조 변경 (모든 input 에 form="settingsForm" 명시 등) 은 5-way sync 와 backend 핸들러에 영향이 클 수 있으므로 회피. 대신 카드별 "동작 방식 안내 박스" 를 추가하여 사용자 인식 격차만 해소.

src/templates/settings.html
- ⑥ 카드 헤더 hdr-badge: "외부 → SCAManager" → "⚡ + 💾 혼합"
- ⑥ 카드 본문 상단에 안내 박스: 🔗 GitHub Webhook 재등록 / 🔄 CLI Hook 재커밋 버튼은 클릭 시 즉시 실행 / Railway API 토큰만 💾 저장 버튼으로 적용 명시
- ⑦ 위험 구역 헤더 hdr-badge: "⚡ 즉시 실행" 추가
- ⑦ 카드 본문 상단에 안내 박스: "버튼 클릭 시 즉시 실행" 명시

== 5-way sync 보존 ==
- form 필드명 14종 + PRESETS 9 + JS 헬퍼 12종 시그니처 모두 불변
- 백엔드 핸들러 시그니처 불변
- 변경 영향: src/templates/base.html (3-테마 토큰 1줄씩) + src/templates/settings.html (카드 헤더 2 + 안내 박스 2)

== 검증 ==
- tests/unit/ui/ 106 PASS (회귀 0건)
- pylint src/ 10.00/10 유지

== 마무리 ==
4-에이전트 감사 P0 5 + P1 8 + P2/P3 7 = 총 20건 결함을 3 PR (#156 P0, #158 P1+P2 안전, 본 PR P1 위험) 시리즈로 모두 처리 완료.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
