### PR TITLE
fix(scripts): translate_comments.py SyntaxError 수정 — SYSTEM_PROMPT 안 …

### DIFF
--- a/scripts/i18n_comments/translate_comments.py
+++ b/scripts/i18n_comments/translate_comments.py
@@ -103,7 +103,7 @@ Given a JSON list of Korean comment or docstring lines (with line numbers), retu
 mapping each line number to its English translation.
 
 STRICT RULES:
-1. Translate ONLY the Korean text. Keep code, symbols (#, """, ''', variable names) unchanged.
+1. Translate ONLY the Korean text. Keep code, symbols (#, \"\"\", ''', variable names) unchanged.
 2. Use the domain glossary below — do NOT substitute synonyms.
 3. Match the tone: concise technical English (not verbose, no "This function...").
 4. For inline comments with "# 한글", output only the translated text (no leading #).


### PR DESCRIPTION
…triple-quote escape

== 증상 ==
python -m py_compile scripts/i18n_comments/translate_comments.py → SyntaxError: unterminated string literal (detected at line 190)

== 원인 ==
SYSTEM_PROMPT 가 line 98 에서 triple-double-quote (\"\"\")로 시작하는데, line 106 의 글로사리 안내 텍스트에 그대로 \"\"\" 가 포함되어 있어 line 106 이 SYSTEM_PROMPT 종료로 해석됨. Parser 가 그 후의 코드를 string literal 로 보고 실제로는 line 137 에서 이미 종료된 SYSTEM_PROMPT 의 \"\"\" 를 새 string 시작으로 해석. 결국 line 190 의 따옴표 매칭이 깨져 unterminated 로 보고됨.

== 수정 ==
line 106 의 노출된 \"\"\" 를 \\\"\\\"\\\" (escape) 로 변경. Python lexer 는 backslash escape 를 인식하므로 string literal 로 해석되어 종료 매칭 회피. LLM 입장에서는 unescape 되어 \"\"\" 로 전달되므로 의미 보존.

Before: 1. ... symbols (#, \"\"\", ''', variable names) ...
After:  1. ... symbols (#, \\\"\\\"\\\", ''', variable names) ...

== 검증 ==
- python -m py_compile ... → OK
- python tokenize.tokenize → no error
- 줄 길이 97자 (PEP 8 100자 한계 내)

이 도구는 CI/SonarCloud 가 분석하는 파일이지만 src/ 가 아니라 단위 테스트 영향 없음. import anthropic 의존성으로 module exec 자체는 ANTHROPIC_API_KEY 환경에서만 실행 가능.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
