### PR TITLE
fix(ui): Step A — 디자인 시스템 root cause fix (환각 토큰 + safe-area + WCAG)

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -77,6 +77,15 @@
       --claude-font-body:    'Inter', system-ui, -apple-system, sans-serif;
       --claude-font-mono:    'JetBrains Mono', Menlo, Consolas, monospace;
       --claude-line-height:  1.65;
+
+      /* Step A (UI 감사): 환각(phantom) 토큰 alias — 4-테마 자동 적용
+       * Step A: phantom-token aliases — auto-resolved per active theme via CSS lazy var()
+       * 7 페이지에서 var(--bg-hover) / var(--card-bg) / var(--text) 참조하지만 base.html
+       * 미정의 → 다크 테마에서 시각 깨짐. 사용처 그대로 두고 alias 만 추가해 회귀 0.
+       * Phantom-token alias: keeps consumers untouched; 0-regression compatibility shim. */
+      --bg-hover: var(--table-row-hover);
+      --card-bg:  var(--bg-card);
+      --text:     var(--text-primary);
     }
 
     /* ── Phase 1A: Claude 톤 다크 모드 토큰 (warm black) ──────────────────
@@ -273,10 +282,12 @@
     }
 
     /* ── 네비게이션 ───────────────────────────── */
+    /* Step A (S4): nav 좌우 padding 에 safe-area-inset 적용 — iOS notch landscape 호환
+       Step A (S4): safe-area-inset on nav left/right padding for iOS notch landscape */
     nav {
       background: var(--bg-nav);
       color: var(--text-nav);
-      padding: 0 1.5rem;
+      padding: 0 max(1.5rem, env(safe-area-inset-left)) 0 max(1.5rem, env(safe-area-inset-right));
       display: flex;
       align-items: center;
       gap: var(--space-2);
@@ -425,10 +436,12 @@
     .theme-option.active::after { content: '✓'; margin-left: auto; font-size: 11px; }
 
     /* ── 레이아웃 ──────────────────────────────── */
+    /* Step A (S4): container 좌우 padding 에 safe-area-inset 적용
+       Step A (S4): safe-area-inset on container horizontal padding */
     .container {
       max-width: var(--container-lg);
       margin: 0 auto;
-      padding: var(--space-7) var(--space-6);
+      padding: var(--space-7) max(var(--space-6), env(safe-area-inset-right)) var(--space-7) max(var(--space-6), env(safe-area-inset-left));
     }
 
     /* ── 레거시 카드 (기존 페이지 호환) ─────── */
@@ -639,7 +652,9 @@
 
     /* ── 반응형 (태블릿) ───────────────────────── */
     @media (max-width: 768px) {
-      nav { padding: 0 1rem; gap: var(--space-1); }
+      /* Step A (S4): 모바일 nav 좌우 padding safe-area-inset
+         Step A (S4): mobile nav horizontal padding with safe-area-inset */
+      nav { padding: 0 max(1rem, env(safe-area-inset-left)) 0 max(1rem, env(safe-area-inset-right)); gap: var(--space-1); }
       .nav-links { display: none; }
       .nav-links.open {
         display: flex;
@@ -650,24 +665,29 @@
         left: 0;
         right: 0;
         background: var(--bg-nav);
-        padding: var(--space-3) var(--space-4) var(--space-4);
+        /* Step A (S4): 모바일 메뉴 하단 padding 에 safe-area-inset-bottom */
+        padding: var(--space-3) var(--space-4) calc(var(--space-4) + env(safe-area-inset-bottom, 0px));
         border-bottom: 1px solid rgba(255,255,255,.08);
         gap: 2px;
         z-index: 99;
         box-shadow: var(--shadow-md);
       }
-      .nav-links.open a.nav-link { width: 100%; padding: 8px 10px; }
-      .nav-hamburger { display: flex; }
-      .container { padding: var(--space-5) var(--space-3); }
+      .nav-links.open a.nav-link { width: 100%; padding: 8px 10px; min-height: 44px; box-sizing: border-box; display: flex; align-items: center; }
+      .nav-hamburger { display: flex; min-width: 44px; min-height: 44px; }
+      /* Step A (S4): container 모바일 패딩에도 safe-area-inset 적용 */
+      .container { padding: var(--space-5) max(var(--space-3), env(safe-area-inset-right)) var(--space-5) max(var(--space-3), env(safe-area-inset-left)); }
       .card { padding: 1rem; border-radius: var(--radius-sm); }
       .s-card-body { padding: var(--space-4); }
       th { padding: .5rem .75rem; font-size: 11px; }
       td { padding: .625rem .75rem; font-size: var(--fs-xs); }
       .page-header { flex-wrap: wrap; gap: .75rem; margin-bottom: var(--space-5); }
       .page-header h2, .page-header h1 { font-size: 1.15rem; }
-      .btn { padding: 6px 12px; font-size: var(--fs-xs); }
+      /* Step A (S3): WCAG 2.5.5 Target Size — .btn 모바일 ≥44px
+         Step A (S3): WCAG 2.5.5 Target Size — .btn ≥44px on mobile */
+      .btn { padding: 10px 14px; font-size: var(--fs-sm); min-height: 44px; box-sizing: border-box; }
+      .btn--sm { padding: 8px 12px; min-height: 40px; box-sizing: border-box; }
       .nav-user-name { max-width: 80px; }
-      .nav-logout-btn { padding: 4px 9px; }
+      .nav-logout-btn { padding: 8px 12px; min-height: 40px; box-sizing: border-box; }
     }
 
     /* ── 반응형 (소형) ─────────────────────────── */
@@ -675,8 +695,10 @@
       nav { gap: var(--space-1); }
       .nav-logo strong { display: none; }
       .nav-user-name { display: none; }
-      .theme-btn, .nav-logout-btn { padding: 4px 8px; font-size: 11px; }
-      .container { padding: var(--space-4) var(--space-2); }
+      /* Step A (S3): theme/logout 버튼 클릭 영역 보강 (이전 11px → 안 변경하고 padding 만 확장) */
+      .theme-btn, .nav-logout-btn { padding: 8px 10px; font-size: 11px; min-height: 40px; box-sizing: border-box; }
+      /* Step A (S4): 480px 분기 container 도 safe-area-inset */
+      .container { padding: var(--space-4) max(var(--space-2), env(safe-area-inset-right)) var(--space-4) max(var(--space-2), env(safe-area-inset-left)); }
     }
 
     /* ── 모션 감소 ─────────────────────────────── */

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -4,11 +4,13 @@
 
 {% block content %}
 <style>
+  /* Step A (S2/L3): 100dvh 사용 — iOS Safari 동적 툴바 점프 회피
+     Step A (S2/L3): use 100dvh to avoid iOS Safari URL-bar bounce */
   .login-wrap {
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: calc(100vh - 52px);
+    min-height: calc(100dvh - 52px);
     padding: var(--space-6);
   }
   .login-card {
@@ -17,6 +19,12 @@
     text-align: center;
     padding: 3rem 2.5rem;
     border-radius: 14px;
+  }
+  /* Step A (S2): 모바일 분기 — wrap 좌우 0 (이중 패딩 해소) + card padding 축소
+     Step A (S2): mobile breakpoint — wrap zero horizontal, card padding shrunk */
+  @media (max-width: 480px) {
+    .login-wrap { padding: var(--space-4) 0; }
+    .login-card { padding: 2rem 1.5rem; max-width: 100%; }
   }
   .login-logo {
     width: 60px;


### PR DESCRIPTION
7-페이지 4-에이전트 감사 결과 root cause 4건을 base.html 한 곳에서 일괄 해소. Step A 적용으로 7 페이지의 약 60% 결함이 자동 해소됨 (consumer 코드 변경 0).

== S1: 환각(phantom) 토큰 alias 3종 추가 ==
overview / repo_detail / analysis_detail / settings 가 var(--bg-hover) / var(--card-bg) / var(--text) 를 참조하지만 base.html 미정의 → 다크 테마에서 시각 깨짐 (피드백 버튼 hover 안 보임, 이전/다음 분석 nav 버튼 안 보임,
filter-bar 배경 투명 등).

src/templates/base.html :root 에 alias 3개 추가:
  --bg-hover: var(--table-row-hover);
  --card-bg:  var(--bg-card);
  --text:     var(--text-primary);

CSS 변수 lazy resolution 으로 4-테마 (dark/light/glass/claude-dark) 자동 적용. consumer 코드 (7곳) 변경 없음 = 회귀 위험 0.

== S2: login.html 모바일 분기 + iOS Safari 동적 툴바 호환 ==
- min-height: calc(100vh - 52px) → calc(100dvh - 52px) iOS URL bar 표시/숨김 시 카드 점프 회피
- @media (max-width: 480px): .login-wrap { padding: var(--space-4) 0 }  (이중 패딩 해소) .login-card { padding: 2rem 1.5rem; max-width: 100% }

== S3: WCAG 2.5.5 Target Size — 모바일 클릭 영역 ≥44px == 모든 페이지의 .btn, .btn--sm, .nav-link, .nav-hamburger, .nav-logout-btn, .theme-btn 모바일 분기에 min-height 44px (또는 40px for sm) + box-sizing.

@media (max-width: 768px):
  .btn         { padding: 10px 14px; min-height: 44px }
  .btn--sm     { padding: 8px 12px;  min-height: 40px }
  .nav-link    { min-height: 44px }
  .nav-hamburger { min-width: 44px; min-height: 44px }
  .nav-logout-btn { padding: 8px 12px; min-height: 40px }
@media (max-width: 480px):
  .theme-btn, .nav-logout-btn { padding: 8px 10px; min-height: 40px }

이전: 모바일 .btn 26~28px 높이 (WCAG 미달)

== S4: iOS safe-area-inset (notch + home indicator) 적용 ==
- nav 좌우 padding: max(1.5rem|1rem, env(safe-area-inset-left|right)) iPhone 14 Pro landscape 시 노치 영역에 로고/햄버거 가려짐 회피
- .container 좌우 padding: 모든 분기 (data + 768/480)
- .nav-links.open (모바일 메뉴) padding-bottom: env(safe-area-inset-bottom) iOS home indicator 와 메뉴 마지막 항목 겹침 회피

viewport meta 의 viewport-fit=cover 는 settings P2-5 (PR #159) 에서 이미 적용됨 — 본 PR 은 nav/container 가 그 env() 값을 활용하도록 확장.

== 5-way sync 보존 ==
- form 필드명 14종 + PRESETS 9 + JS 헬퍼 12종 시그니처 모두 불변
- 백엔드 핸들러 시그니처 불변
- 변경 영향: src/templates/base.html (CSS) + src/templates/login.html (CSS)

== 검증 ==
- tests/unit/ui/ 106 PASS (회귀 0건)
- pylint src/ 10.00/10 유지

== 잔여 (Step B/C/D/E) ==
- Step B: 모바일 전용 결함 (iOS <select> 16px, 테이블 모바일, insights/insights_me 미디어쿼리 신규)
- Step C: Chart.js vendoring + claude-dark 차트 등급 색 호환
- Step D: 색 의미 통일 (#10b981/#ef4444 → --success/--danger 토큰화)
- Step E: 페이지별 P1/P2 polish

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
