### PR TITLE
fix(ui): Step B — 모바일 전용 결함 (iOS 줌인 + insights/insights_me 분기 + 테이블)

### DIFF
--- a/src/templates/add_repo.html
+++ b/src/templates/add_repo.html
@@ -31,6 +31,8 @@
     text-transform: uppercase;
     letter-spacing: .05em;
   }
+  /* Step B (B1): font-size 16px — iOS Safari 자동 줌인 방지 (16px 미만 input focus 시 zoom)
+     Step B (B1): 16px to prevent iOS Safari zoom on focus (any <16px triggers it) */
   .form-select {
     width: 100%;
     padding: .625rem 1rem;
@@ -38,10 +40,16 @@
     border: 1px solid var(--border);
     border-radius: var(--radius-btn);
     color: var(--text-primary);
-    font-size: 14px;
+    font-size: 16px;
     transition: border-color var(--transition), background var(--transition);
     appearance: none;
     cursor: pointer;
+    /* B1 보조: chevron SVG 추가 — appearance:none 으로 기본 화살표 사라진 것 보강
+       B1 supplement: chevron SVG since appearance:none removed the native arrow */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='none' stroke='%2373737c' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M1 1l5 5 5-5'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 14px center;
+    padding-right: 36px;
   }
   .form-select:focus {
     outline: none;

--- a/src/templates/insights.html
+++ b/src/templates/insights.html
@@ -72,6 +72,24 @@
 
   /* ─── 정보 알림 / Info notice ─── */
   .lb-notice { font-size:.82rem; color:var(--text-muted); margin-bottom:1rem; }
+
+  /* Step B (B2): 모바일 분기 신규 — 이전엔 미디어쿼리 0개 / Mobile breakpoint added (was missing) */
+  @media (max-width: 768px) {
+    /* B1: iOS Safari 자동 줌인 방지 / iOS focus zoom prevention */
+    .days-select { font-size: 16px; min-height: 40px; padding: .45rem .7rem; }
+    .compare-btn { font-size: 14px; min-height: 40px; padding: .55rem 1rem; }
+    /* WCAG 2.5.5 — 칩 클릭 영역 ≥40px / Chip touch target */
+    .chip-label { padding: .55rem .9rem; font-size: 13px; min-height: 40px; }
+    /* 탭 클릭 영역 + flex-wrap 시 "내 추세 →" 우측 정렬 reset (margin-left:auto 제거) */
+    .ins-tabs { flex-wrap: wrap; }
+    .ins-tab { padding: .65rem 1rem; min-height: 44px; }
+    .ins-tabs > a[style*="margin-left:auto"] { margin-left: 0 !important; min-height: 40px; padding: .55rem .85rem; display: inline-flex; align-items: center; }
+    /* B2: 테이블 가로 스크롤 처리 / Table horizontal overflow */
+    .cmp-table, .lb-table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    .cmp-table th, .cmp-table td,
+    .lb-table th, .lb-table td { white-space: nowrap; }
+    .score-bar-track { max-width: 100px; }
+  }
 </style>
 
 <!-- 탭 헤더 / Tab header -->

--- a/src/templates/insights_me.html
+++ b/src/templates/insights_me.html
@@ -59,10 +59,30 @@
   .section-divider { height:1px; background:var(--border); margin:1.5rem 0; }
 
   /* ─── 백링크 / Back link ─── */
-  .back-row { display:flex; align-items:center; gap:1rem; margin-bottom:1.25rem; }
+  .back-row { display:flex; align-items:center; gap:1rem; margin-bottom:1.25rem; flex-wrap:wrap; }
   .back-row a { font-size:.86rem; color:var(--text-muted); text-decoration:none; }
   .back-row a:hover { color:var(--accent); }
   .page-title { font-size:1.15rem; font-weight:700; }
+
+  /* Step B (B3): 모바일 분기 신규 — 이전엔 미디어쿼리 0개 / Mobile breakpoint added */
+  @media (max-width: 768px) {
+    /* KPI 카드 — 4×1 stack 회피 (auto-fit minmax 140 → 160 으로 2×2 권장)
+       Avoid 4×1 stack by raising minmax to 160px → forces 2×2 on narrow viewports */
+    .kpi-grid { grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); }
+    /* WCAG 2.5.5 — day-selector 클릭 영역 + Settings P2-7 같은 안내 hint 정렬 */
+    .day-selector a { padding: .55rem 1rem; font-size: 14px; min-height: 40px; display: inline-flex; align-items: center; }
+    /* B3: 추세 테이블 가로 스크롤 + 셀 nowrap */
+    .trend-table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    .trend-table th, .trend-table td { white-space: nowrap; }
+    .trend-table th { font-size: 12px; }
+    /* 차트 모바일 높이 축소 (240 → clamp) — viewport 33% 차지 회피 */
+    .chart-wrap { height: clamp(180px, 40vh, 240px); }
+    /* 백링크 row — 좁은 화면에서 page-title wrap 시각 안정화 */
+    .back-row { gap: .5rem; }
+    /* B1: KPI/이슈 글자 가독성 */
+    .kpi-value { font-size: 1.4rem; }
+    .issue-msg { word-break: break-word; overflow-wrap: anywhere; }
+  }
 </style>
 
 <div class="back-row">

--- a/src/templates/overview.html
+++ b/src/templates/overview.html
@@ -49,6 +49,8 @@
   .score-cell.score-mid  { color: var(--grade-c); }
   .score-cell.score-low  { color: var(--grade-f); }
   .analysis-count { font-size: var(--fs-xs); color: var(--text-muted); }
+  /* Step B (B4): settings-link nowrap + 모바일에서 클릭 영역 ≥40px (WCAG 2.5.5)
+     Step B (B4): settings-link nowrap + ≥40px touch on mobile (WCAG 2.5.5) */
   .settings-link {
     display: inline-flex;
     align-items: center;
@@ -60,6 +62,7 @@
     border-radius: var(--radius-sm);
     border: 1px solid var(--border);
     transition: all var(--transition);
+    white-space: nowrap;
   }
   .settings-link:hover { color: var(--accent); border-color: var(--accent); text-decoration: none; }
   .empty-state {
@@ -70,6 +73,13 @@
   .empty-state p { color: var(--text-muted); margin: 0; font-size: var(--fs-sm); line-height: 1.7; }
   @media (max-width: 768px) {
     .overview-header { flex-direction: column; align-items: flex-start; margin-bottom: var(--space-5); }
+    /* B4: 테이블 헤더/셀 세로 wrap ("평/균/점/수") 방지 + 가로 스크롤
+       B4: prevent vertical wrap on narrow th/td + horizontal scroll */
+    .table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    .table-wrap th, .table-wrap td { white-space: nowrap; }
+    .repo-link { white-space: nowrap; }
+    /* B4: 설정 링크 클릭 영역 강화 (모바일 손가락 권장 ≥40px) */
+    .settings-link { padding: 8px 12px; min-height: 40px; box-sizing: border-box; }
   }
 </style>
 

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -183,6 +183,15 @@
     .filter-divider { display: none; }
     .custom-date-wrap { flex-wrap: wrap; }
     .date-input { width: 110px; }
+    /* Step B (B1): iOS Safari 자동 줌인 방지 — focus 시 16px 미만이면 zoom
+       Step B (B1): prevent iOS Safari focus zoom (any input <16px triggers it) */
+    .filter-search { font-size: 16px; }
+    .date-input { font-size: 16px; }
+    /* Step B (B1): filter-btn / page-btn 클릭 영역 보강 (WCAG 2.5.5) — Step A 의 .btn 분기 보완 */
+    .filter-btn { min-height: 40px; padding: .55rem .85rem; font-size: 13px; }
+    .page-btn { min-width: 44px; min-height: 44px; }
+    /* Step B (B1): 슬라이더 thumb 모바일 24px (settings P2-6 패턴 재적용) */
+    .dual-slider-track input[type=range]::-webkit-slider-thumb { width: 24px; height: 24px; }
   }
   @media (max-width: 480px) {
     .commit-msg-preview { display: none; }


### PR DESCRIPTION
7-페이지 4-에이전트 감사 잔여 결함 중 Step A 의 root cause fix 후
페이지별 모바일 전용 polish 4건을 일괄 적용.

== B1: iOS Safari 자동 줌인 방지 (font-size ≥16px) ==
iOS Safari 는 input/select 의 font-size < 16px 일 때 focus 시 자동 zoom-in → UX 깨짐. 다음 input 들 16px 강제:
- add_repo.html .form-select (14 → 16px) + chevron SVG 추가 (appearance:none 으로 사라진 기본 화살표 보강)
- repo_detail.html .filter-search / .date-input (모바일 분기)
- insights.html .days-select (모바일 분기)

== B2: insights.html 모바일 분기 신규 추가 (이전 0개) ==
@media (max-width: 768px) 신규:
- 칩 (.chip-label) 클릭 영역 ≥40px (WCAG 2.5.5)
- 탭 (.ins-tab) 클릭 영역 ≥44px + flex-wrap
- "내 추세 →" 링크 margin-left:auto reset (wrap 시 첫 행 점유 회피 — settings mode-toggle 와 동일 패턴)
- .cmp-table / .lb-table 가로 스크롤 + 셀 nowrap
- .compare-btn / .days-select 클릭 영역

== B3: insights_me.html 모바일 분기 신규 추가 (이전 0개) ==
@media (max-width: 768px) 신규:
- KPI grid auto-fit minmax 140 → 160 (4×1 stack 회피, 2×2 권장)
- .day-selector a 클릭 영역 ≥40px + 14px (B1 규약)
- .trend-table 가로 스크롤 + 셀 nowrap (이전 잘림)
- .chart-wrap 240 → clamp(180px, 40vh, 240px) (모바일 viewport 33% 차지 회피)
- .back-row flex-wrap (page-title wrap 시 안정화)
- .issue-msg word-break: break-all → break-word (한글/영문 혼용 안전)

== B4: overview.html 테이블 헤더 세로 wrap 방지 ==
모바일에서 "분석 / 평균 점수 / 등급 / 설정" 헤더가 한 글자씩 wrap
("평/균/점/수") 되어 가독성 심각. 동시에 ⚙️ 설정 링크도 세로 wrap.

@media (max-width: 768px) 추가:
- .table-wrap { overflow-x: auto } + th/td white-space: nowrap
- .repo-link nowrap
- .settings-link 클릭 영역 ≥40px + nowrap (전역)

== repo_detail.html 추가 polish (B1 묶음) ==
- 모바일 분기 .filter-search / .date-input 16px (iOS 줌인)
- .filter-btn 클릭 영역 ≥40px / .page-btn ≥44px (WCAG)
- 슬라이더 thumb 모바일 24px (settings P2-6 패턴 재적용)

== 5-way sync 보존 ==
- form 필드명 + JS 헬퍼 시그니처 + 백엔드 핸들러 모두 불변
- 변경 영향: 5 templates CSS 만 (HTML/JS 변경 0)

== 검증 ==
- tests/unit/ui/ 106 PASS (회귀 0건)
- pylint src/ 10.00/10 유지 (template-only)

== 잔여 (Step C/D/E) ==
- Step C: Chart.js vendoring + claude-dark 차트 등급 색 호환
- Step D: 색 의미 통일 (#10b981/#ef4444 → --success/--danger 토큰화)
- Step E: 페이지별 P1/P2 polish

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
