### PR TITLE
fix(ui): Step D — 색 의미(semantic) 토큰 통일 + --warning 토큰 신규

### DIFF
--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -129,8 +129,10 @@
     border-radius: 4px;
     flex-shrink: 0;
   }
-  .ad-issue-tool.error { background: rgba(239,68,68,0.15); color: #ef4444; }
-  .ad-issue-tool.warning { background: rgba(245,158,11,0.15); color: #f59e0b; }
+  /* Step D: 시맨틱 토큰화 — #ef4444/#f59e0b → var(--danger)/var(--warning)
+     Step D: semantic tokenization — claude-dark 테마 sage/sand/muted-red 자동 적용 */
+  .ad-issue-tool.error { background: rgba(239,68,68,0.15); color: var(--danger); }
+  .ad-issue-tool.warning { background: rgba(245,158,11,0.15); color: var(--warning); }
   .ad-issue-line {
     font-size: 12px;
     color: var(--text-muted);
@@ -313,12 +315,15 @@
             background: var(--bg-card); cursor: pointer; font-size: 14px;
             transition: all 0.15s ease; display: inline-flex; align-items: center; gap: 0.3rem; }
   .fb-btn:hover { background: var(--bg-hover); transform: translateY(-1px); }
-  .fb-btn.active.fb-up   { background: #10b98122; border-color: #10b981; color: #10b981; }
-  .fb-btn.active.fb-down { background: #ef444422; border-color: #ef4444; color: #ef4444; }
+  /* Step D: 피드백 버튼 시맨틱 토큰화 (3-테마 + claude-dark 자동 적용)
+     Step D: feedback button semantic tokens — auto across 4 themes */
+  .fb-btn.active.fb-up   { background: rgba(74,222,128,.13); border-color: var(--success); color: var(--success); }
+  .fb-btn.active.fb-down { background: rgba(248,113,113,.13); border-color: var(--danger); color: var(--danger); }
   .fb-btn:disabled { opacity: 0.5; cursor: not-allowed; }
   .fb-status { font-size: 12px; color: var(--text-muted); margin-left: 0.5rem; }
-  .fb-status.ok    { color: #10b981; }
-  .fb-status.error { color: #ef4444; }
+  /* Step D: 피드백 상태 토큰화 / Feedback status semantic tokens */
+  .fb-status.ok    { color: var(--success); }
+  .fb-status.error { color: var(--danger); }
 </style>
 <script>
 (function() {
@@ -378,11 +383,12 @@
 <!-- AI 기본값 적용 경고 배너 / AI defaults applied warning banner -->
 {% set ai_status = r.get('ai_review_status', 'success') if r else 'success' %}
 {% if ai_status != 'success' %}
-<div class="card ad-section" style="border-left:4px solid #f59e0b;background:rgba(245,158,11,0.06)">
+<!-- Step D: AI 기본값 안내 배너 시맨틱 토큰화 / AI defaults notice — semantic warning tokens -->
+<div class="card ad-section" style="border-left:4px solid var(--warning);background:rgba(245,158,11,0.08)">
   <div style="display:flex;align-items:center;gap:.6rem">
     <span style="font-size:1.1rem">⚠️</span>
     <div>
-      <div style="font-size:13px;font-weight:700;color:#f59e0b;margin-bottom:2px">AI 리뷰 기본값 적용</div>
+      <div style="font-size:13px;font-weight:700;color:var(--warning);margin-bottom:2px">AI 리뷰 기본값 적용</div>
       <div style="font-size:13px;color:var(--text-primary)">
         {% if ai_status == 'no_api_key' %}ANTHROPIC_API_KEY가 설정되지 않아 AI 점수에 중립적 기본값이 적용되었습니다.
         {% elif ai_status == 'api_error' %}AI API 호출에 실패하여 기본값이 적용되었습니다. 서버 로그를 확인하세요.
@@ -554,8 +560,11 @@
   var accent = s.getPropertyValue('--accent').trim() || '#6366f1';
   var muted  = s.getPropertyValue('--text-muted').trim() || '#64748b';
   var border = s.getPropertyValue('--border').trim() || '#2d3748';
+  /* Step D: 현재 분석 강조 색을 var(--danger) 에서 읽기 (3-테마 + claude-dark 호환)
+     Step D: read current-point highlight from var(--danger) for theme harmony */
+  var dangerColor = s.getPropertyValue('--danger').trim() || '#ef4444';
 
-  var pointColors  = TREND.map(function(t) { return t.id === CURRENT_ID ? '#ef4444' : accent; });
+  var pointColors  = TREND.map(function(t) { return t.id === CURRENT_ID ? dangerColor : accent; });
   var pointRadii   = TREND.map(function(t) { return t.id === CURRENT_ID ? 7 : 3; });
   var pointBorders = TREND.map(function(t) { return t.id === CURRENT_ID ? '#fff' : accent; });
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -122,6 +122,9 @@
       --accent-grad:    linear-gradient(135deg, #5e6ad2, #8d95e0);
       --success:        #4ade80;
       --danger:         #f87171;
+      /* Step D: --warning 토큰 신규 — 이전엔 페이지마다 #f59e0b/#fbbf24 하드코딩
+         Step D: new --warning token — was hardcoded as #f59e0b in 5+ places */
+      --warning:        #f59e0b;
       --shadow:         0 4px 24px rgba(0,0,0,.5);
       --shadow-card:    0 1px 3px rgba(0,0,0,.25), 0 0 0 1px rgba(255,255,255,.04);
       --table-head:     #1a1a21;
@@ -165,6 +168,8 @@
       --accent-grad:    linear-gradient(135deg, #5e6ad2, #4a57c4);
       --success:        #16a34a;
       --danger:         #dc2626;
+      /* Step D: --warning 라이트 테마 — Tailwind amber-600 */
+      --warning:        #d97706;
       --shadow:         0 2px 8px rgba(0,0,0,.07), 0 0 0 1px rgba(0,0,0,.04);
       --shadow-card:    0 1px 3px rgba(0,0,0,.05), 0 0 0 1px rgba(0,0,0,.05);
       --table-head:     #f9f9fb;
@@ -206,6 +211,8 @@
       --accent-grad:    linear-gradient(135deg, #5e6ad2, #ec4899);
       --success:        #4ade80;
       --danger:         #f87171;
+      /* Step D: --warning 글래스 테마 — 다크와 동일 hex */
+      --warning:        #f59e0b;
       --shadow:         0 8px 32px rgba(0,0,0,.5);
       --shadow-card:    0 4px 20px rgba(0,0,0,.4), 0 0 0 1px rgba(255,255,255,.06);
       --table-head:     rgba(255,255,255,0.04);
@@ -279,6 +286,10 @@
       --grade-c: var(--claude-grade-c);  /* sand #D4A574 */
       --grade-d: var(--claude-grade-d);  /* terracotta #C8895E */
       --grade-f: var(--claude-grade-f);  /* muted red #C84E3F */
+      /* Step D: claude-dark 의 --warning 도 sand 톤으로 alias */
+      --warning: var(--claude-warning);  /* sand #DDB585 */
+      --success: var(--claude-success);  /* sage #A8BA94 */
+      --danger:  var(--claude-danger);   /* muted red #D45F50 */
     }
 
     /* ── 네비게이션 ───────────────────────────── */

--- a/src/templates/overview.html
+++ b/src/templates/overview.html
@@ -267,7 +267,10 @@
   .calibration-table th { font-size: 12px; color: var(--text-muted); font-weight: 600; }
   .cal-bar { width: 160px; height: 8px; background: var(--bg-hover); border-radius: 4px;
              overflow: hidden; }
-  .cal-bar-fill { height: 100%; background: linear-gradient(90deg, #10b981, #34d399);
+  /* Step D: cal-bar-fill 시맨틱 토큰화 — claude-dark 에서 sage 톤 자동 적용
+     Step D: semantic tokenization — auto sage in claude-dark theme */
+  .cal-bar-fill { height: 100%; background: linear-gradient(90deg, var(--success), var(--success));
+                  opacity: .85;
                   transition: width 0.3s ease; }
 </style>
 {% endif %}

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -467,8 +467,10 @@ document.getElementById('scoreMax').addEventListener('input', function() {
 });
 
 // ── 렌더 테이블 ──────────────────────────────────────
+// Step D: 소스 배지 시맨틱 토큰화 — push=success / cli=warning / pr=accent (모두 var)
+// Step D: source badge semantic tokens — auto across 4 themes
 function renderSourceBadge(src) {
-  const m = { pr: ['PR','#3b82f6'], push: ['Push','var(--success)'], cli: ['CLI','#f59e0b'] };
+  const m = { pr: ['PR','var(--accent)'], push: ['Push','var(--success)'], cli: ['CLI','var(--warning)'] };
   const [label, color] = m[src] || [src || '—', 'var(--text-muted)'];
   return '<span style="font-size:11px;font-weight:600;color:' + color + '">' + label + '</span>';
 }


### PR DESCRIPTION
7-페이지 4-에이전트 감사 잔여 결함 중 색상 일관성 root cause 처리.
페이지마다 #10b981/#ef4444/#f59e0b 하드코딩 → 4-테마(특히 claude-dark)에서 sage/sand/muted-red 톤으로 자동 분기 안 되던 문제 해소.

== D1: --warning 토큰 신규 정의 (이전엔 없었음) ==
base.html 4-테마 모두에 --warning 추가:
- dark:        #f59e0b (Tailwind amber-500)
- light:       #d97706 (Tailwind amber-600 — 라이트 가독성)
- glass:       #f59e0b
- claude-dark: var(--claude-warning) (sand #DDB585)

이전엔 --success / --danger 만 있었고 #f59e0b 가 5+ 곳에 하드코딩. 또한 claude-dark 테마에서 --success / --danger 도 명시적으로
var(--claude-success/danger) 로 alias (이전엔 다크 테마 #4ade80/#f87171 상속 → claude 톤 sage/muted-red 와 갈림).

== D2: analysis_detail.html 7곳 토큰화 ==
- .ad-issue-tool.error  : color #ef4444 → var(--danger)
- .ad-issue-tool.warning: color #f59e0b → var(--warning)
- .fb-btn.active.fb-up  : 3종 #10b981 → var(--success)
- .fb-btn.active.fb-down: 3종 #ef4444 → var(--danger)
- .fb-status.ok         : color #10b981 → var(--success)
- .fb-status.error      : color #ef4444 → var(--danger)
- AI 기본값 안내 배너   : border + color #f59e0b → var(--warning)
- trendChart pointColors: '#ef4444' → var(--danger) 동적 읽기 (3-테마 호환)

== D3: overview.html .cal-bar-fill 토큰화 ==
정합도 막대 그라디언트 #10b981 → #34d399 → var(--success) 단색 + opacity .85 (claude-dark sage 톤 자동 적용)

== D4: repo_detail.html JS 소스 배지 토큰화 ==
const m = { pr: '#3b82f6', push: 'var(--success)', cli: '#f59e0b' }
       → { pr: 'var(--accent)', push: 'var(--success)', cli: 'var(--warning)' }
inline style 안 var() 는 브라우저가 element scope 에서 평가 → 정상 동작.

== 5-way sync 보존 ==
- form 필드명 + JS 헬퍼 시그니처 + 백엔드 핸들러 모두 불변
- 변경 영향: 4 templates CSS + 1 JS source badge map

== 검증 ==
- tests/unit/ui/ 106 PASS (회귀 0건)
- 색상 단순 hex → var(--token) 치환만이라 시각 결과 변화 없음 단, claude-dark 테마 시 새로 sage/sand/muted-red 톤 자동 적용

== 잔여 (Step E) ==
- Step E: 페이지별 P1/P2 polish — preset 카드 width/높이, 인라인 그라디언트 토큰화 (위험구역/preset/온보딩 — 일부는 P0-4 에서 처리), navigation 비로그인 가드, file 아이콘 fallback 등

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
