### PR TITLE
fix(ui): Step E — 페이지별 P1/P2 polish 5건 (UI 감사 사이클 마무리)

### DIFF
--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -181,9 +181,15 @@
   .nav-btn.disabled { opacity: 0.38; cursor: default; pointer-events: none; }
   .nav-label { font-size: 0.82rem; color: var(--text-muted); flex: 1; text-align: center; }
   /* 트렌드 차트 섹션 */
+  /* Step E (E2): 차트 컨테이너 명시 height — maintainAspectRatio:false 와 페어
+     Step E (E2): explicit height paired with maintainAspectRatio:false */
   .trend-section {
     margin-bottom: 1.25rem;
     padding: 1rem 1.25rem;
+  }
+  .trend-section .chart-wrap-inner {
+    position: relative;
+    height: 200px;
   }
   .trend-section-title {
     font-size: 13px;
@@ -372,11 +378,13 @@
 
 {% set r = analysis.result %}
 
-<!-- 점수 추이 트렌드 차트 / Score trend chart -->
+<!-- 점수 추이 트렌드 차트 / Score trend chart — Step E (E2): canvas wrap container -->
 {% if trend_data is defined and trend_data|length > 1 %}
 <div class="card trend-section">
   <div class="trend-section-title">📈 점수 추이 (최근 {{ trend_data|length }}건)</div>
-  <canvas id="trendChart" height="100"></canvas>
+  <div class="chart-wrap-inner">
+    <canvas id="trendChart"></canvas>
+  </div>
 </div>
 {% endif %}
 
@@ -625,7 +633,9 @@
         }
       },
       responsive: true,
-      maintainAspectRatio: true
+      /* Step E (E2): false — chart-wrap-inner 컨테이너 height(200px) 가
+         폭과 무관하게 보장. 모바일 압착 + canvas height attr 깜빡임 회피. */
+      maintainAspectRatio: false
     }
   });
 })();

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -564,6 +564,21 @@
       box-shadow: 0 3px 12px rgba(94,106,210,.4);
       text-decoration: none;
     }
+    /* Step E (E3): 모든 버튼 disabled 시각 명확화 — 클릭 불가 인지 안 되던 결함 해소
+       Step E (E3): clear visual disabled state — was visually identical to enabled */
+    .btn:disabled, .btn[disabled],
+    .btn-primary:disabled, .btn--primary:disabled,
+    .btn-ghost:disabled, .btn--ghost:disabled {
+      opacity: .45;
+      cursor: not-allowed;
+      transform: none;
+      box-shadow: none;
+    }
+    .btn:disabled:hover, .btn[disabled]:hover {
+      background: inherit;
+      transform: none;
+      box-shadow: none;
+    }
     /* Ghost — 기존 .btn-ghost + 새 .btn--ghost */
     .btn-ghost, .btn--ghost {
       background: transparent;
@@ -734,11 +749,16 @@
       <div class="nav-logo-icon">⚡</div>
       <strong>SCAManager</strong>
     </a>
+    {# Step E (E1): nav 햄버거 + Overview/Insights 링크는 로그인 후에만 노출.
+       비로그인 상태에서 클릭 시 /login 으로 리다이렉트되므로 시각 노출 자체가 무의미.
+       Step E (E1): Hamburger + nav links shown only when authenticated. #}
+    {% if current_user %}
     <button class="nav-hamburger" id="navHamburger" aria-label="메뉴" aria-expanded="false">☰</button>
     <div class="nav-links" id="navLinks">
       <a class="nav-link" href="/">Overview</a>
       <a class="nav-link" href="/insights">Insights</a>
     </div>
+    {% endif %}
     <div class="nav-spacer"></div>
     {% if current_user %}
     <div class="nav-user">

--- a/src/templates/insights.html
+++ b/src/templates/insights.html
@@ -21,7 +21,20 @@
     color:var(--text-primary);
   }
   .chip-label:hover { border-color:var(--accent); }
-  .chip-label input[type=checkbox] { display:none; }
+  /* Step E (E4): a11y — 키보드 포커스 가시화 (display:none input 은 포커스 불가)
+     Step E (E4): keyboard a11y — input visible to AT but visually hidden,
+     focus state shown on parent .chip-label via :focus-within */
+  .chip-label input[type=checkbox] {
+    position: absolute;
+    opacity: 0;
+    width: 1px;
+    height: 1px;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+  }
+  .chip-label:focus-within { outline: 2px solid var(--accent); outline-offset: 2px; }
   .chip-label.checked { background:rgba(94,106,210,.15); border-color:var(--accent); color:var(--accent); font-weight:600; }
 
   /* ─── 기간 선택 + 비교 버튼 행 / Days selector + compare row ─── */

--- a/src/templates/overview.html
+++ b/src/templates/overview.html
@@ -197,7 +197,13 @@
   .gst-header { margin-bottom: 1.2rem; }
   .gst-title { margin: 0 0 0.3rem; font-size: 20px; }
   .gst-subtitle { margin: 0; color: var(--text-muted); font-size: 14px; }
+  /* Step E (E5): 데스크탑 ≥1024px 에서 3-col grid (튜토리얼 카드 가로 펼침)
+     모바일은 1-col 유지 (col 너비 부족). 빈 상태 카드 가독성 향상.
+     Step E (E5): 3-col grid on desktop ≥1024px; 1-col stack on mobile */
   .gst-steps { display: flex; flex-direction: column; gap: 0.9rem; }
+  @media (min-width: 1024px) {
+    .gst-steps { display: grid; grid-template-columns: repeat(3, 1fr); align-items: stretch; }
+  }
   .gst-step { display: flex; gap: 1rem; align-items: flex-start;
               padding: 1rem 1.1rem; background: var(--bg-hover);
               border-radius: 10px; border: 1px solid var(--border); }

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -15,8 +15,14 @@
     color: var(--text-primary);
     font-family: 'Menlo', 'Consolas', monospace;
   }
+  /* Step E (E2): chart-card 명시 height — maintainAspectRatio:false 와 페어
+     Step E (E2): explicit height paired with maintainAspectRatio:false (no mobile squish) */
   .chart-card {
     padding: 1.25rem 1.5rem;
+  }
+  .chart-card .chart-wrap-inner {
+    position: relative;
+    height: 200px;
   }
   .chart-label {
     font-size: 11px;
@@ -224,10 +230,12 @@
   <a class="settings-btn" href="/repos/{{ repo_name }}/settings">⚙️ 설정</a>
 </div>
 
-<!-- 점수 차트 / Score chart -->
+<!-- 점수 차트 / Score chart — Step E (E2): canvas 명시 height 컨테이너로 감싸 모바일 압착 회피 -->
 <div class="card chart-card">
   <div class="chart-label">점수 추이</div>
-  <canvas id="scoreChart" height="80"></canvas>
+  <div class="chart-wrap-inner">
+    <canvas id="scoreChart"></canvas>
+  </div>
 </div>
 
 <!-- 분석 이력 / Analysis history -->
@@ -368,7 +376,10 @@
           }
         },
         responsive: true,
-        maintainAspectRatio: true
+        /* Step E (E2): false 로 변경 — chart-wrap-inner 컨테이너 height(200px) 가
+           폭과 무관하게 보장되어 모바일 압착 + canvas height attr 깜빡임 회피.
+           Step E (E2): false → no width-driven height resize → no mobile squish */
+        maintainAspectRatio: false
       }
     });
   }


### PR DESCRIPTION
7-페이지 4-에이전트 감사 잔여 P1/P2 핵심 5건을 일괄 처리.
Step A→E 5 PR 시리즈로 감사 결함 65건 거의 전부 해소.

== E1: nav 비로그인 가드 (base.html L737~742) ==
이전: login 페이지에서도 nav 햄버거 + Overview/Insights 링크 노출 → 사용자 클릭 시 /login 으로 리다이렉트되지만 시각 노출 자체가 무의미.

src/templates/base.html — nav 햄버거 + .nav-links 를 {% if current_user %} 로 감쌈. 로그아웃 후 다시 login 진입 시 깔끔.

== E2: Chart.js maintainAspectRatio false + 컨테이너 height 명시 (2 페이지) == 이전: maintainAspectRatio:true + canvas height="80"/100 attribute 조합 → 모바일에서 canvas 가 폭 변화에 따라 비율 유지하려고 height 깜빡임 +
좁은 화면에서 차트 50px 미만으로 압착.

src/templates/repo_detail.html:
- .chart-card .chart-wrap-inner { position: relative; height: 200px } 추가
- <canvas id="scoreChart" height="80"> → wrap div 안에 height attr 제거
- maintainAspectRatio: true → false

src/templates/analysis_detail.html:
- .trend-section .chart-wrap-inner { position: relative; height: 200px } 추가
- <canvas id="trendChart" height="100"> → wrap div 안에 height attr 제거
- maintainAspectRatio: true → false

== E3: 모든 .btn disabled 시각 명확화 (base.html) ==
이전: add_repo 등에서 disabled button 이 풀 채도 보라색으로 활성처럼 보여 사용자가 클릭 가능한 줄 알고 누름.

base.html — .btn:disabled / .btn-primary:disabled / .btn--ghost:disabled 공통 스타일: opacity .45 + cursor: not-allowed + transform/shadow 제거 + hover 시 변화 없음.

== E4: insights chip 키보드 포커스 a11y (insights.html) == 이전: .chip-label input[type=checkbox] { display:none } → AT/키보드 포커스 완전 불가능. 마우스 사용자만 사용 가능.

insights.html — display:none 제거하고 sr-only 패턴 (position:absolute opacity:0 width/height:1px clip:rect 0 0 0 0) 으로 시각만 숨김 + AT 인식 유지 + .chip-label:focus-within { outline: 2px solid var(--accent) } 으로 키보드 포커스 시 chip 외곽 강조.

== E5: overview gst-steps 데스크탑 3-col grid (overview.html) == 이전: 빈 상태 (튜토리얼) 의 3 step 카드가 1-col 세로 누적 → 데스크탑
1440px 화면에서 빈 영역 큼.

overview.html — @media (min-width: 1024px) 에서
.gst-steps { display: grid; grid-template-columns: repeat(3, 1fr) } 적용. 모바일은 기존 flex column 유지.

== 5-way sync 보존 ==
- form 필드명 + JS 헬퍼 시그니처 + 백엔드 핸들러 모두 불변
- 변경 영향: 5 templates (base + repo_detail + analysis_detail + insights + overview)

== 검증 ==
- tests/unit/ui/ 106 PASS (회귀 0건)
- pylint src/ 10.00/10 유지 (template-only)

== UI 감사 사이클 마무리 ==
4-에이전트 감사 65건 결함 처리 완료:
- Step A: 환각 토큰 + base.html 공통 (S1~S4) — root cause fix
- Step B: 모바일 전용 (B1~B4) — iOS 줌인, 미디어쿼리, 테이블
- Step C: Chart.js vendoring + claude-dark 호환 (C1~C4)
- Step D: 색 의미 토큰 통일 (D1~D4) — --warning 신규
- Step E: 페이지별 polish (E1~E5) — nav 가드, chart aspect, a11y, disabled, grid

잔여 follow-up (소규모, 별도 처리 가능):
- analysis_detail 9 카드 데스크탑 2-col 레이아웃
- file 아이콘 fallback emoji
- preset-table 모바일 가독성
- score-bar-track 너비 확장 등

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
