### PR TITLE
fix(ui): UI 감사 사이클 cleanup PR-1 — claude-dark 토큰 + 환각 alias + Step B/…

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -86,6 +86,10 @@
       --bg-hover: var(--table-row-hover);
       --card-bg:  var(--bg-card);
       --text:     var(--text-primary);
+      /* PR-1 C2: 후속 환각 토큰 alias 2종 — repo_detail / settings 잔존 참조 흡수
+         PR-1 C2: additional phantom-token aliases for repo_detail / settings */
+      --accent-blue: var(--accent);   /* repo_detail.html CLI Hook 안내 배너 */
+      --c-warning:   var(--warning);  /* settings.html 잔존 토큰명 (legacy) */
     }
 
     /* ── Phase 1A: Claude 톤 다크 모드 토큰 (warm black) ──────────────────
@@ -290,6 +294,27 @@
       --warning: var(--claude-warning);  /* sand #DDB585 */
       --success: var(--claude-success);  /* sage #A8BA94 */
       --danger:  var(--claude-danger);   /* muted red #D45F50 */
+
+      /* PR-1 C1: settings 페이지가 사용하는 토큰 8종 — claude-dark 미정의 시
+       * 카드 헤더 / 저장 버튼 / hint 패널 / hook 버튼이 통째로 깨졌음. 모든 그라디언트는
+       * claude warm 톤 (terracotta / sage / sand / orange) 으로 재정의.
+       * PR-1 C1: 8 settings-page tokens — without these, claude-dark broke
+       * settings card headers, save button, hint panels, hook buttons. */
+      --grad-gate:           linear-gradient(135deg, #D97757, #B85A3D);  /* claude orange */
+      --grad-merge:          linear-gradient(135deg, #A8BA94, #8AA476);  /* claude sage */
+      --grad-notify:         linear-gradient(135deg, #DDB585, #C49566);  /* claude sand */
+      --grad-hook:           linear-gradient(135deg, #C8895E, #A86F46);  /* claude terracotta */
+      --title-gradient:      linear-gradient(135deg, #D97757, #DDB585);  /* claude orange→sand */
+      --btn-gate-active-bg:  rgba(217,119,87,.15);
+      --btn-gate-active-bd:  var(--claude-accent);
+      --btn-gate-active-tx:  var(--claude-accent);
+      --save-btn-bg:         linear-gradient(135deg, #D97757, #B85A3D);
+      --save-btn-shadow:     rgba(217,119,87,.4);
+      --hint-bg:             rgba(217,119,87,.05);
+      --hint-border:         rgba(217,119,87,.15);
+      --hook-btn-bg:         rgba(200,137,94,.10);
+      --hook-btn-bd:         rgba(200,137,94,.30);
+      --hook-btn-tx:         #C8895E;  /* claude terracotta */
     }
 
     /* ── 네비게이션 ───────────────────────────── */

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -144,8 +144,10 @@
       width:24px; height:24px;
     }
   }
-  .approve-range::-webkit-slider-thumb { background:linear-gradient(135deg,#10b981,#34d399); box-shadow:0 2px 6px rgba(16,185,129,.4); }
-  .reject-range::-webkit-slider-thumb  { background:linear-gradient(135deg,#ef4444,#f87171); box-shadow:0 2px 6px rgba(239,68,68,.4); }
+  /* PR-1 C3 (Step D 누락분): 슬라이더 thumb 시맨틱 토큰화 — claude-dark sage/muted-red 자동 적용
+     PR-1 C3 (Step D missed): semantic tokens for slider thumbs */
+  .approve-range::-webkit-slider-thumb { background:var(--success); box-shadow:0 2px 6px rgba(74,222,128,.35); }
+  .reject-range::-webkit-slider-thumb  { background:var(--danger);  box-shadow:0 2px 6px rgba(248,113,113,.35); }
   .num-input {
     width:50px; background:var(--bg-input); border:1.5px solid var(--success);
     border-radius:6px; color:var(--success); text-align:center;
@@ -297,6 +299,9 @@
     /* P0-5 + P2-5: 모바일 좌우 0 (이중 패딩 해소) + iOS safe-area-inset
        P0-5 + P2-5: zero horizontal pad on mobile + iOS safe-area-inset */
     .settings-wrap { padding:1rem 0 calc(6rem + env(safe-area-inset-bottom, 0px)); }
+    /* PR-1 C4 (Step B 누락분): 모바일 input font-size 16px — iOS Safari focus zoom 회피
+       PR-1 C4: 16px on mobile prevents iOS Safari focus zoom (notify_chat_id, all webhook URLs) */
+    .field-input { font-size: 16px; }
   }
   @media(min-width:640px) {
     .settings-grid { grid-template-columns:1fr 1fr; }
@@ -467,8 +472,10 @@
     {% if onboarding_needed %}
     <!-- 온보딩 배너 — 알림 채널 미설정 + Telegram 미연결 시 표시 (P0-4: 빠른 설정 카드와 색/아이콘 분리) -->
     <!-- Onboarding banner — visually distinct from preset card (P0-4: amber + 👋 vs preset's purple + 🚀) -->
-    <div class="s-card" id="onboardingBanner" style="margin-bottom:1rem;border:1.5px solid var(--c-warning,#f59e0b);">
-      <div class="s-card-hdr" style="background:linear-gradient(135deg,#f59e0b,#d97706)">
+    <!-- PR-1 C3 (Step D 누락분): --c-warning → --warning + 온보딩 배너 헤더 시맨틱 토큰화
+         PR-1 C3: --c-warning → --warning + onboarding banner header semantic tokens -->
+    <div class="s-card" id="onboardingBanner" style="margin-bottom:1rem;border:1.5px solid var(--warning);">
+      <div class="s-card-hdr" style="background:var(--grad-notify)">
         <span class="hdr-icon">👋</span>
         <span class="hdr-title">시작하세요</span>
         <span class="hdr-badge">알림 채널 미설정</span>
@@ -820,7 +827,7 @@
             <div class="toggle-info">
               <div class="t-title">팀 리더보드 공개</div>
               <div class="t-desc">이 리포를 팀 인사이트 리더보드에 포함<br>
-                <span style="color:var(--c-warning,#f59e0b);font-size:.78rem;">옵션 기능 — 팀 합의 후 활성화 권장</span>
+                <span style="color:var(--warning);font-size:.78rem;">옵션 기능 — 팀 합의 후 활성화 권장</span>
               </div>
             </div>
             <label class="toggle-switch">


### PR DESCRIPTION
…D 누락 수정

5-에이전트 종합 정합성 감사 (Step A~E 머지 후) 가 식별한 P0 코드 결함 4건 처리.

== C1: claude-dark 누락 토큰 8종 정의 ==
이전: claude-dark 테마 활성 시 settings 페이지가 부분적으로 깨짐:
- 카드 헤더 (hdr-gate/merge/notify/hook) 흰색/투명
- 저장 버튼 (.btn-save-new) 무배경
- hint 패널 (.range-hint) 안 보임
- hook 버튼 (.hook-btn) 색상 부재

base.html `body[data-theme="claude-dark"]` 블록에 추가:
- --grad-gate         : claude orange (#D97757 → #B85A3D)
- --grad-merge        : claude sage (#A8BA94 → #8AA476)
- --grad-notify       : claude sand (#DDB585 → #C49566)
- --grad-hook         : claude terracotta (#C8895E → #A86F46)
- --title-gradient    : claude orange→sand
- --btn-gate-active-* : claude orange 계열
- --save-btn-bg       : claude orange 그라디언트
- --save-btn-shadow   : rgba(217,119,87,.4)
- --hint-bg/border    : rgba claude orange 옅게
- --hook-btn-bg/bd/tx : claude terracotta 계열

== C2: 환각 토큰 alias 2종 추가 ==
Step A 의 alias 패턴 (`--bg-hover`/`--card-bg`/`--text`) 이 다른 환각 토큰 2종 (`--accent-blue`, `--c-warning`) 까지 커버 안 함 → repo_detail / settings 3 곳에서 fallback hex 가 그대로 표시되어 claude-dark 베이지 톤과 충돌.

base.html `:root` 의 alias 블록에 추가:
- --accent-blue: var(--accent)   (repo_detail.html L212 CLI Hook 안내 배너)
- --c-warning:   var(--warning)  (settings.html legacy 토큰명)

== C3: settings.html Step D (PR #167) 누락 3건 명시 치환 == PR #167 commit message 는 "5+ places" 라고 명시했으나 실제로 settings.html 3 곳이 누락:

1. 슬라이더 thumb (L147-148): .approve-range { background:linear-gradient(135deg,#10b981,#34d399) } → background:var(--success) .reject-range  { background:linear-gradient(135deg,#ef4444,#f87171) } → background:var(--danger) (claude-dark 에서 sage / muted-red 자동 적용)

2. 온보딩 배너 헤더 (L472-473): border:1.5px solid var(--c-warning,#f59e0b) → var(--warning) background:linear-gradient(135deg,#f59e0b,#d97706) → var(--grad-notify)

3. 옵션 안내 텍스트 (L827): color:var(--c-warning,#f59e0b) → var(--warning)

== C4: settings.html .field-input iOS Safari 줌인 방지 (Step B 누락) == PR #165 (Step B) 가 add_repo / repo_detail / insights 의 input 만 16px 적용. settings.html `.field-input` (L196-202) 12px 가 누락되어 8개 password input (notify_chat_id, discord/slack/custom/n8n_webhook_url, email_recipients, railway_api_token, railway-webhook-url) 모두 iOS focus 시 자동 줌인.

settings.html @media(max-width:639px) 에 추가:
.field-input { font-size: 16px; }

== 5-way sync 보존 ==
- form 필드명 + JS 헬퍼 + 백엔드 핸들러 모두 불변
- 변경 영향: 2 templates (base.html + settings.html)

== 검증 ==
- tests/unit/ui/ 106 PASS (회귀 0건)
- 코드 변경 모두 CSS — 시각 결과만 변화

== 다음 PR ==
- PR-2: 문서 동기화 (STATE 그룹 57 + CLAUDE.md 트리/주의사항/현재상태)
- PR-3: P1 polish (chart-wrap-inner 모바일 분기, .btn:disabled 확장, tooltip 토큰화)
- PR-4: 추가 follow-up (analysis_detail 9 카드 데스크탑 2-col + 회귀 가드)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
