### PR TITLE
fix(ui): UI 감사 사이클 cleanup PR-3 — chart-wrap clamp + .btn:disabled 확장…

### DIFF
--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -181,15 +181,15 @@
   .nav-btn.disabled { opacity: 0.38; cursor: default; pointer-events: none; }
   .nav-label { font-size: 0.82rem; color: var(--text-muted); flex: 1; text-align: center; }
   /* 트렌드 차트 섹션 */
-  /* Step E (E2): 차트 컨테이너 명시 height — maintainAspectRatio:false 와 페어
-     Step E (E2): explicit height paired with maintainAspectRatio:false */
+  /* Step E (E2) + PR-3 F1: 차트 컨테이너 viewport 비례 clamp — 데스크탑 빈약 시각 회피
+     Step E + PR-3 F1: viewport-relative clamp avoids desktop chart squish */
   .trend-section {
     margin-bottom: 1.25rem;
     padding: 1rem 1.25rem;
   }
   .trend-section .chart-wrap-inner {
     position: relative;
-    height: 200px;
+    height: clamp(200px, 30vw, 320px);
   }
   .trend-section-title {
     font-size: 13px;
@@ -568,6 +568,9 @@
   var accent = s.getPropertyValue('--accent').trim() || '#6366f1';
   var muted  = s.getPropertyValue('--text-muted').trim() || '#64748b';
   var border = s.getPropertyValue('--border').trim() || '#2d3748';
+  /* PR-3 F3: tooltip 색을 테마 토큰에서 동적 read — 라이트/claude-dark 부조화 해소 */
+  var tipBg   = s.getPropertyValue('--bg-card').trim() || '#1c1c23';
+  var tipText = s.getPropertyValue('--text-primary').trim() || '#e2e2e8';
   /* Step D: 현재 분석 강조 색을 var(--danger) 에서 읽기 (3-테마 + claude-dark 호환)
      Step D: read current-point highlight from var(--danger) for theme harmony */
   var dangerColor = s.getPropertyValue('--danger').trim() || '#ef4444';
@@ -618,9 +621,11 @@
       plugins: {
         legend: { display: false },
         tooltip: {
-          backgroundColor: 'rgba(0,0,0,0.75)',
-          titleColor: '#fff',
-          bodyColor: '#e2e8f0',
+          backgroundColor: tipBg,
+          titleColor: tipText,
+          bodyColor: tipText,
+          borderColor: border,
+          borderWidth: 1,
           padding: 8,
           cornerRadius: 6,
           callbacks: {

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -589,17 +589,29 @@
       box-shadow: 0 3px 12px rgba(94,106,210,.4);
       text-decoration: none;
     }
-    /* Step E (E3): 모든 버튼 disabled 시각 명확화 — 클릭 불가 인지 안 되던 결함 해소
-       Step E (E3): clear visual disabled state — was visually identical to enabled */
+    /* Step E (E3) + PR-3 F2: 모든 버튼 disabled 시각 명확화 — 자체 클래스까지 확장
+       Step E + PR-3 F2: clear disabled state across all button variants */
     .btn:disabled, .btn[disabled],
     .btn-primary:disabled, .btn--primary:disabled,
-    .btn-ghost:disabled, .btn--ghost:disabled {
+    .btn-ghost:disabled, .btn--ghost:disabled,
+    .btn--danger:disabled,
+    button:disabled.fb-btn, button:disabled.nav-btn,
+    button:disabled.page-btn, button:disabled.gate-mode-btn,
+    button:disabled.hook-btn, button:disabled.btn-save-new,
+    button:disabled.btn-warning, button:disabled.compare-btn,
+    button:disabled.mode-toggle-btn, button:disabled.filter-btn,
+    button:disabled.settings-link {
       opacity: .45;
       cursor: not-allowed;
       transform: none;
       box-shadow: none;
     }
-    .btn:disabled:hover, .btn[disabled]:hover {
+    .btn:disabled:hover, .btn[disabled]:hover,
+    button:disabled.fb-btn:hover, button:disabled.nav-btn:hover,
+    button:disabled.page-btn:hover, button:disabled.gate-mode-btn:hover,
+    button:disabled.hook-btn:hover, button:disabled.btn-save-new:hover,
+    button:disabled.btn-warning:hover, button:disabled.compare-btn:hover,
+    button:disabled.mode-toggle-btn:hover, button:disabled.filter-btn:hover {
       background: inherit;
       transform: none;
       box-shadow: none;

--- a/src/templates/insights_me.html
+++ b/src/templates/insights_me.html
@@ -162,6 +162,10 @@
     var gradeB    = readVar('--grade-b', '#60a5fa');
     var gradeC    = readVar('--grade-c', '#fbbf24');
     var gradeD    = readVar('--grade-d', '#fb923c');
+    /* PR-3 F3: tooltip 색을 테마 토큰에서 동적 read */
+    var tipBg     = readVar('--bg-card', '#1c1c23');
+    var tipText   = readVar('--text-primary', '#e2e2e8');
+    var border    = readVar('--border', '#2c2c38');
 
     var gradeBoundaries = {
       id: 'gradeBoundaries',
@@ -231,6 +235,13 @@
         plugins: {
           legend: { display: false },
           tooltip: {
+            backgroundColor: tipBg,
+            titleColor: tipText,
+            bodyColor: tipText,
+            borderColor: border,
+            borderWidth: 1,
+            padding: 8,
+            cornerRadius: 6,
             callbacks: {
               label: function(ctx) { return '점수: ' + ctx.parsed.y; }
             }

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -15,14 +15,14 @@
     color: var(--text-primary);
     font-family: 'Menlo', 'Consolas', monospace;
   }
-  /* Step E (E2): chart-card 명시 height — maintainAspectRatio:false 와 페어
-     Step E (E2): explicit height paired with maintainAspectRatio:false (no mobile squish) */
+  /* Step E (E2) + PR-3 F1: chart-card 명시 height — viewport 비례 clamp 로 데스크탑/모바일 양쪽 적정
+     Step E + PR-3 F1: viewport-relative clamp keeps chart legible on both desktop and mobile */
   .chart-card {
     padding: 1.25rem 1.5rem;
   }
   .chart-card .chart-wrap-inner {
     position: relative;
-    height: 200px;
+    height: clamp(200px, 30vw, 320px);
   }
   .chart-label {
     font-size: 11px;
@@ -322,7 +322,11 @@
     const accent  = s.getPropertyValue('--accent').trim()  || '#6366f1';
     const muted   = s.getPropertyValue('--text-muted').trim() || '#64748b';
     const border  = s.getPropertyValue('--border').trim()  || '#2d3748';
-    return { accent, muted, border };
+    /* PR-3 F3: tooltip 색을 테마 토큰에서 동적 read — 라이트/claude-dark 부조화 해소
+       PR-3 F3: dynamic tooltip colors from theme tokens (light + claude-dark harmony) */
+    const tipBg   = s.getPropertyValue('--bg-card').trim() || '#1c1c23';
+    const tipText = s.getPropertyValue('--text-primary').trim() || '#e2e2e8';
+    return { accent, muted, border, tipBg, tipText };
   }
 
   let chart;
@@ -368,9 +372,11 @@
         plugins: {
           legend: { display: false },
           tooltip: {
-            backgroundColor: 'rgba(0,0,0,0.75)',
-            titleColor: '#fff',
-            bodyColor: '#e2e8f0',
+            backgroundColor: getThemeColors().tipBg,
+            titleColor: getThemeColors().tipText,
+            bodyColor: getThemeColors().tipText,
+            borderColor: getThemeColors().border,
+            borderWidth: 1,
             padding: 10,
             cornerRadius: 8
           }


### PR DESCRIPTION
… + tooltip 토큰화

5-에이전트 정합성 감사 P1 결함 3건 처리.

== F1: chart-wrap-inner viewport 비례 clamp (Step E E2 회귀 보완) == 이전: Step E (PR #168) 가 chart-wrap-inner { height: 200px } 고정으로 설정. 모바일 압착은 회피했으나 데스크탑 (1280-1920px) 에서도 200px →
시각 빈약 (이전 추정 240~320px 대비 33~45% 축소).

src/templates/repo_detail.html L23~26 (`.chart-card .chart-wrap-inner`) src/templates/analysis_detail.html L190~193 (`.trend-section .chart-wrap-inner`)

해결: `height: clamp(200px, 30vw, 320px);`
- 모바일 320px viewport: 30vw=96px → clamp 하한 200px 적용
- 768px viewport: 30vw=230px
- 1280px 데스크탑: 30vw=384px → clamp 상한 320px 적용
- 1920px: 320px (상한 도달)

== F2: .btn:disabled selector 확장 (Step E E3 회귀 보완) == 이전: Step E (PR #168) 가 `.btn / .btn-primary / .btn-ghost / .btn--*` selector 만 disabled 스타일 적용. 페이지별 자체 button 클래스 (.fb-btn / .nav-btn / .page-btn / .gate-mode-btn / .hook-btn / .btn-save-new / .btn-warning / .compare-btn / .mode-toggle-btn / .filter-btn / .settings-link) 는 disabled 시각 변화 없음.

src/templates/base.html — `.btn:disabled` selector list 확장 + hover state reset 도 동일 selector list 적용.

이제 모든 button 변형이 disabled 시 opacity .45 + cursor: not-allowed + transform/shadow 제거.

== F3: Chart.js tooltip 시맨틱 토큰화 ==
이전: 3 페이지 (repo_detail, analysis_detail, insights_me) 모두 tooltip backgroundColor `rgba(0,0,0,0.75)` + bodyColor `#e2e8f0` 하드코딩.
- 라이트 테마: 베이지 배경 페이지 + 검정 tooltip 부조화
- claude-dark 테마: warm cream 톤 + 차가운 회백색 텍스트 부조화

해결: `getComputedStyle` 으로 `--bg-card` + `--text-primary` + `--border` 동적 read → tooltip backgroundColor / titleColor / bodyColor / borderColor 주입. 4-테마 (dark/light/glass/claude-dark) 자동 정합.

src/templates/repo_detail.html getThemeColors() 에 tipBg/tipText 추가. src/templates/analysis_detail.html buildChart IIFE 에 tipBg/tipText 추가. src/templates/insights_me.html buildChart() 안 readVar tipBg/tipText/border 추가.

themechange 이벤트 리스너가 이미 chart 재빌드 → 테마 전환 시 tooltip 색 즉시 반영 (Step C C4 와 같은 패턴).

== 5-way sync 보존 ==
- form 필드명 + JS 헬퍼 시그니처 + 백엔드 핸들러 모두 불변
- 변경 영향: 4 templates (base + repo_detail + analysis_detail + insights_me)

== 검증 ==
- tests/unit/ui/ 106 PASS (회귀 0건)
- pylint 영향 없음 (template-only)

== 다음 PR ==
- PR-4 (follow-up): analysis_detail 9 카드 데스크탑 2-col 레이아웃 + Step C/E 회귀 가드 (StaticFiles 200, chart-wrap-inner, nav 가드, chip sr-only)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
