### PR TITLE
test(ui): UI 감사 사이클 cleanup PR-4 — 회귀 가드 12건 (Step A~E + cleanup PR-1)

### DIFF
--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -265,3 +265,37 @@ def test_lifespan_warmup_ping_handles_failure_silently(caplog):
         "GitHub API warm-up ping skipped" in rec.message
         for rec in caplog.records
     ), "warmup 실패 INFO 로그가 남지 않았습니다"
+
+
+# --- PR-4 G1: StaticFiles `/static/vendor/chart.umd.min.js` 200 응답 가드 ---
+# UI 감사 Step C 회귀 가드 — Chart.js vendoring 이 정상 마운트됐는지 확인
+# UI audit Step C regression guard — verify Chart.js is correctly mounted
+
+def test_static_chartjs_returns_200(client):
+    """StaticFiles `/static/vendor/chart.umd.min.js` 가 200 + JS Content-Type 반환.
+    Verify vendored Chart.js is served successfully.
+
+    회귀 위험: src/main.py 의 app.mount('/static', StaticFiles(...)) 가 실수로
+    제거되거나 src/static/vendor/chart.umd.min.js 가 git history 에서 사라질 때 차단.
+    Regression guard: blocks accidental removal of mount or vendored asset.
+    """
+    response = client.get("/static/vendor/chart.umd.min.js")
+    assert response.status_code == 200, (
+        f"Chart.js vendored 자원 응답 실패: {response.status_code} "
+        f"— src/main.py StaticFiles mount 또는 src/static/vendor/chart.umd.min.js 누락"
+    )
+    # 파일 크기 sanity check (Chart.js 4.4.0 UMD min 약 200KB)
+    # File size sanity check (~200KB for Chart.js 4.4.0 UMD min)
+    assert len(response.content) > 100_000, (
+        f"Chart.js 파일 크기 비정상: {len(response.content)} bytes (200KB+ 기대)"
+    )
+    # UMD 시그니처 확인 — 첫 부분에 Chart.js 라이선스 주석 포함
+    # UMD signature check — Chart.js license header in the first bytes
+    head = response.content[:200]
+    assert b"Chart.js" in head, "Chart.js UMD 시그니처 누락 — 다른 파일이 마운트됨"
+
+
+def test_static_missing_file_returns_404(client):
+    """존재하지 않는 static 자원은 404 반환 (graceful)."""
+    response = client.get("/static/vendor/nonexistent.js")
+    assert response.status_code == 404

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -1748,3 +1748,145 @@ def test_telegram_connected_status_hides_otp_button():
         # 다른 테스트에 영향을 주지 않도록 오버라이드 복원
         # Restore the override so other tests are not affected.
         app.dependency_overrides[require_login] = lambda: _test_user
+
+
+# ── PR-4 G2/G3: UI 감사 사이클 회귀 가드 ──────────────────────────────
+# Step A~E 핵심 변경이 향후 회귀로 사라지지 않도록 source-grep 어셔션 추가
+# Source-grep guards so Step A~E key changes don't silently regress
+
+from pathlib import Path  # noqa: E402
+
+_TEMPLATES_DIR = Path(__file__).resolve().parents[3] / "src" / "templates"
+
+
+def _read_template(name: str) -> str:
+    """템플릿 파일 내용 반환 — grep 기반 회귀 가드 헬퍼."""
+    return (_TEMPLATES_DIR / name).read_text(encoding="utf-8")
+
+
+def test_phantom_token_aliases_in_root():
+    """PR #169 cleanup 회귀 가드 — :root 에 환각 토큰 alias 5종 보존.
+
+    --bg-hover / --card-bg / --text (Step A) +
+    --accent-blue / --c-warning (PR-1 cleanup) 이 base.html :root 에 정의돼야.
+    """
+    base = _read_template("base.html")
+    for token in ("--bg-hover:", "--card-bg:", "--text:", "--accent-blue:", "--c-warning:"):
+        assert token in base, f"환각 토큰 alias {token} 가 base.html :root 에서 누락"
+
+
+def test_warning_token_defined_in_all_themes():
+    """PR #167 회귀 가드 — --warning 토큰이 4-테마 모두에 정의."""
+    base = _read_template("base.html")
+    assert base.count("--warning:") >= 3, (
+        f"--warning 토큰 정의가 부족 (3개 이상 기대 — dark/light/glass): "
+        f"{base.count('--warning:')}회"
+    )
+
+
+def test_claude_dark_settings_tokens_defined():
+    """PR #169 cleanup 회귀 가드 — claude-dark 의 settings 페이지 토큰 8종.
+
+    --grad-gate/merge/notify/hook + --title-gradient + --btn-gate-active-* +
+    --save-btn-* + --hint-* + --hook-btn-* 가 claude-dark 블록에 있어야.
+    """
+    base = _read_template("base.html")
+    # claude-dark 블록 안에서 --grad-gate 정의 확인
+    cd_idx = base.find('body[data-theme="claude-dark"]')
+    assert cd_idx != -1, "claude-dark 블록 누락"
+    cd_block_end = base.find("}", cd_idx + 100)  # 대략적 블록 끝
+    cd_block = base[cd_idx:cd_block_end + 200]  # 약간 여유
+    for token in ("--grad-gate:", "--save-btn-bg:", "--hint-bg:", "--hook-btn-tx:"):
+        assert token in cd_block, (
+            f"claude-dark 블록에 {token} 누락 — settings 페이지 시각 깨짐 위험"
+        )
+
+
+def test_chart_vendoring_no_jsdelivr_chartjs():
+    """PR #166 회귀 가드 — Chart.js CDN 참조가 어떤 템플릿에도 잔존하지 않아야."""
+    for tpl in ("repo_detail.html", "analysis_detail.html", "insights_me.html"):
+        content = _read_template(tpl)
+        assert "cdn.jsdelivr.net/npm/chart.js" not in content, (
+            f"{tpl} 에 jsdelivr Chart.js CDN 잔존 — vendoring 회귀"
+        )
+        assert "/static/vendor/chart.umd.min.js" in content, (
+            f"{tpl} 에 vendored Chart.js 참조 누락"
+        )
+
+
+def test_chart_aspect_ratio_false():
+    """PR #168 + PR-3 회귀 가드 — Chart.js maintainAspectRatio:false + chart-wrap-inner."""
+    for tpl in ("repo_detail.html", "analysis_detail.html"):
+        content = _read_template(tpl)
+        assert "maintainAspectRatio: false" in content, (
+            f"{tpl} 의 maintainAspectRatio:false 회귀"
+        )
+        assert "chart-wrap-inner" in content, (
+            f"{tpl} 의 chart-wrap-inner 컨테이너 누락"
+        )
+        assert "clamp(200px" in content, (
+            f"{tpl} 의 chart-wrap-inner clamp 회귀 (PR-3 F1)"
+        )
+
+
+def test_nav_login_guard():
+    """PR #168 E1 회귀 가드 — base.html nav 햄버거 + 링크가 {% if current_user %} 안.
+
+    비로그인 시 햄버거/Overview/Insights 링크 시각 노출 회피.
+    """
+    base = _read_template("base.html")
+    # 햄버거 버튼 마크업 (CSS 정의가 아닌 실제 <button id="navHamburger">) 직전에 가드
+    # Hamburger button markup (not the CSS rule) must be wrapped in {% if current_user %}
+    ham_idx = base.find('id="navHamburger"')
+    assert ham_idx != -1, "navHamburger 마크업 누락"
+    preceding = base[max(0, ham_idx - 300):ham_idx]
+    assert "{% if current_user %}" in preceding, (
+        "navHamburger 마크업 직전에 {% if current_user %} 가드 누락 — 비로그인 시 노출"
+    )
+
+
+def test_chip_a11y_sr_only_pattern():
+    """PR #168 E4 회귀 가드 — insights chip 의 sr-only 패턴 + focus-within outline."""
+    insights = _read_template("insights.html")
+    # display:none 이 chip-label input 에 잔존하면 안 됨
+    assert ".chip-label input[type=checkbox] { display:none" not in insights, (
+        "chip-label input 에 display:none 회귀 (a11y 깨짐)"
+    )
+    # sr-only 패턴 (position:absolute + opacity:0) 와 focus-within outline 존재
+    assert "position: absolute;" in insights and "clip: rect(0 0 0 0)" in insights, (
+        "chip-label sr-only 패턴 누락"
+    )
+    assert ".chip-label:focus-within" in insights, (
+        "chip-label focus-within outline 누락"
+    )
+
+
+def test_btn_disabled_extended_selectors():
+    """PR-3 F2 회귀 가드 — .btn:disabled selector 가 자체 button 클래스 커버."""
+    base = _read_template("base.html")
+    for cls in ("button:disabled.fb-btn", "button:disabled.nav-btn",
+                "button:disabled.gate-mode-btn", "button:disabled.hook-btn"):
+        assert cls in base, (
+            f".btn:disabled selector 에서 {cls} 누락 — disabled 시각 비일관"
+        )
+
+
+def test_safe_area_inset_in_nav_and_container():
+    """Step A S4 회귀 가드 — nav / .container 에 safe-area-inset 적용."""
+    base = _read_template("base.html")
+    assert "env(safe-area-inset-left)" in base, "safe-area-inset-left 미사용"
+    assert "env(safe-area-inset-right)" in base, "safe-area-inset-right 미사용"
+    assert "env(safe-area-inset-bottom" in base, "safe-area-inset-bottom 미사용"
+
+
+def test_settings_field_input_mobile_16px():
+    """PR #169 C4 회귀 가드 — settings.html 모바일 .field-input { font-size: 16px } (iOS 줌인 방지)."""
+    settings = _read_template("settings.html")
+    # 모바일 분기 안에 .field-input 16px 정의 존재
+    mobile_idx = settings.find("@media(max-width:639px)")
+    assert mobile_idx != -1, "모바일 분기 (@media max-width:639px) 누락"
+    block_end = settings.find("@media(min-width:640px)", mobile_idx)
+    mobile_block = settings[mobile_idx:block_end if block_end != -1 else mobile_idx + 1000]
+    assert ".field-input { font-size: 16px;" in mobile_block, (
+        "settings.html 모바일 분기에 .field-input 16px 누락 (iOS Safari 줌인 방지)"
+    )


### PR DESCRIPTION
5-에이전트 정합성 감사가 식별한 "Step C/E 회귀 가드 부재" P2 결함 처리.
PR-1~PR-3 의 핵심 변경이 향후 silent 회귀로 사라지지 않도록 source-grep 및 endpoint 어셔션 12건 추가.

== F4 (analysis_detail 9 카드 데스크탑 2-col) 별도 PR 권장 == 마크업 변경 범위 ↑ + 카드별 콘텐츠 폭 가정 (chart, 표) 영향 검증 필요.
회귀 가드 우선 → F4 는 별도 PR-5 권장 (사용자 결정 후 진행).

== 신규 회귀 가드 12건 ==

**G1 — StaticFiles vendoring (PR #166 Step C 회귀 가드)**:
- `test_static_chartjs_returns_200`: GET /static/vendor/chart.umd.min.js → 200 + 100KB+ + Chart.js UMD 시그니처 확인
- `test_static_missing_file_returns_404`: 누락 자원 graceful 404

**G2 — UI 컴포넌트 회귀 가드 (PR #168 Step E 회귀 가드)**:
- `test_phantom_token_aliases_in_root`: --bg-hover/--card-bg/--text/ --accent-blue/--c-warning 5종 alias 보존
- `test_warning_token_defined_in_all_themes`: --warning 토큰 4-테마 정의
- `test_claude_dark_settings_tokens_defined`: claude-dark 의 settings 페이지 토큰 8종 (--grad-gate/save-btn-bg/hint-bg/hook-btn-tx 등) 보존
- `test_chart_vendoring_no_jsdelivr_chartjs`: 3 페이지에 jsdelivr CDN 잔존 0
- `test_nav_login_guard`: navHamburger 마크업 직전 {% if current_user %} 가드 보존 (login 페이지 비노출)
- `test_chip_a11y_sr_only_pattern`: insights chip display:none 잔존 0 + sr-only 패턴 (position:absolute + clip:rect 0 0 0 0) + focus-within outline
- `test_btn_disabled_extended_selectors`: .btn:disabled selector 가 자체 button 클래스 (.fb-btn/.nav-btn/.gate-mode-btn/.hook-btn) 커버

**G3 — 차트 + 모바일 회귀 가드 (PR #168 Step E + PR-3 F1 회귀 가드)**:
- `test_chart_aspect_ratio_false`: 2 페이지의 maintainAspectRatio:false + chart-wrap-inner 컨테이너 + clamp(200px) 보존
- `test_safe_area_inset_in_nav_and_container`: env(safe-area-inset-*) 사용
- `test_settings_field_input_mobile_16px`: settings.html 모바일 .field-input { font-size: 16px } (iOS 줌인 방지) 보존

== 5-way sync 보존 ==
- 코드 변경 0 — 순수 테스트 가드 추가
- form 필드명 + JS 헬퍼 + 백엔드 핸들러 모두 불변
- 변경 영향: 2 test 파일

== 검증 ==
- tests/unit/test_main.py + tests/unit/ui/ 137 PASS (회귀 0 + 신규 12)
- pylint 영향 없음

== 다음 단계 (사용자 결정) ==
- (선택) F4: analysis_detail 9 카드 데스크탑 2-col 레이아웃 — 별도 PR-5
- (선택) Phase 2B: Cmd+K 명령 팔레트 — 디자인 기획서 정식 단계
- (선택) Phase 3: TV mode / PWA — 사용자 수요 검증 후

UI 감사 사이클 cleanup 4 PR (PR-1~PR-4) 완료 — 사이클 종결.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
