### PR TITLE
docs(audit): cleanup PR-D5 — P2 polish (STATE 표 보강 + CodeQL 행 + CLAUD…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,7 +364,7 @@ git checkout -b <브랜치명>   # 브랜치 생성 (main 직접 커밋 금지)
 - **Phase 완료 조건**: 테스트 전체 통과 + `/lint` 통과 + (파이프라인 변경 시 `pipeline-reviewer` 승인) 세 조건이 모두 충족될 때만 Phase 완료를 선언한다.
 - **완료 시 필수 5-step**: 작업이 완료되면 반드시 ① 커밋 → ② PR 생성(`gh pr create`) → ③ `git push` → ④ `docs/STATE.md` 수치 갱신 → ⑤ **CLAUDE.md 아키텍처 섹션 동기화** (신규 파일 추가·삭제·이름 변경 시 `src/` 트리와 `### 핵심 데이터 흐름` 내 언급 갱신) 를 순서대로 수행한다. 예외 없음.
 - **README.md 배지 동기화**: 테스트 수·pylint·커버리지 수치가 바뀌면 `README.md` 14~18줄 배지도 함께 갱신한다. 수치 출처는 항상 `docs/STATE.md`.
-- **CLAUDE.md 아키텍처 동기화 체크리스트**: `src/` 하위에 파일 추가 시 아래 항목을 순서대로 확인한다. 누락 시 다음 Phase 착수 전 반드시 보완한다. (전례: Phase 11에서 6개 파일 추가 후 CLAUDE.md에 5개 누락 → 3-에이전트 감사에서 발견, PR #73)
+- **CLAUDE.md 아키텍처 동기화 체크리스트**: `src/` 하위에 파일 추가 시 아래 항목을 순서대로 확인한다. 누락 시 다음 Phase 착수 전 반드시 보완한다. **전례 2건**: (1) Phase 11에서 6개 파일 추가 후 CLAUDE.md에 5개 누락 → 3-에이전트 감사에서 발견, PR #73. (2) 2026-05-01 UI 감사 cleanup PR-D1 — `_merge_attempt_states.py` (Phase 3 PR-B1 도입분) + `static/vendor/chart.umd.min.js` (UI 감사 Step C) 트리 누락 → 5-에이전트 정합성 감사에서 발견.
 
   | 위치 | 확인 사항 |
   |------|----------|

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -22,6 +22,7 @@
 | 지원 언어 (정적분석) | **37개+** | Semgrep 22 + ESLint 2 + ShellCheck 1 + cppcheck 1 + slither 1 + rubocop 1 + golangci-lint 1 + Python 3 도구 |
 | Tier1 정적분석 도구 | **10종** | pylint·flake8·bandit·semgrep·eslint·shellcheck·cppcheck·slither·**rubocop**·**golangci-lint** |
 | pytest-asyncio | **1.3.0** | Python 3.14 DeprecationWarning 제거 완료 |
+| CodeQL | **✅ pass** | `.github/workflows/codeql.yml` — 주 1회 실행. 본 README 배지 (L15) 와 페어 |
 
 ## 주요 파일 역할 (빠른 참조)
 
@@ -48,7 +49,10 @@
 | `src/gate/retry_policy.py` | 순수 함수: should_retry · compute_next_retry_at · is_expired · mergeable_state_terminality |
 | `src/github_client/checks.py` | get_ci_status · get_required_check_contexts (5분 TTL 캐시) |
 | `src/services/merge_retry_service.py` | process_pending_retries — CI-aware 재시도 워커 |
-| `src/static/vendor/chart.umd.min.js` | Chart.js 4.4.0 UMD min vendoring (UI 감사 Step C) — CDN 차단/오프라인 환경에서 빈 차트 회피. `src/main.py` 의 StaticFiles `/static` mount 로 노출. 사용 페이지: repo_detail / analysis_detail / insights_me |
+| `src/gate/native_automerge.py` | enable_or_fallback() — GraphQL `enablePullRequestAutoMerge` 우선 + REST `merge_pr` 폴백 (Tier 3 PR-A, 그룹 52) |
+| `src/gate/_merge_attempt_states.py` | MergeAttempt.state lifecycle 정규 상수 (LEGACY/ENABLED_PENDING_MERGE/ACTUALLY_MERGED/DISABLED_EXTERNALLY) — Phase 3 PR-B1 도입 |
+| `src/github_client/graphql.py` | GraphQL POST 래퍼 + `enablePullRequestAutoMerge` mutation + `EnableAutoMergeResult` 분류 + 5xx 자동 재시도 (Phase H PR-1B-2, `_GRAPHQL_*` 상수) |
+| `src/static/vendor/chart.umd.min.js` | Chart.js 4.4.0 UMD min vendoring (UI 감사 Step C) — CDN 차단/오프라인 환경에서 빈 차트 회피. `src/main.py` 의 StaticFiles `/static` mount 로 노출. 사용 페이지: repo_detail / analysis_detail / insights_me. 운영 가이드: `docs/runbooks/static-assets.md` (PR-D4) |
 | `tests/conftest.py` | 환경변수 주입 + _webhook_secret_cache autouse 클리어 |
 
 ## 작업 이력 (그룹별)

--- a/docs/reports/INDEX.md
+++ b/docs/reports/INDEX.md
@@ -12,7 +12,7 @@
 | 단위 테스트 수·커버리지·pylint | [STATE.md 헤더](../STATE.md) |
 | 아키텍처·작업 규칙·주의사항 | [CLAUDE.md](../../CLAUDE.md) |
 | README 배지 | [README.md L21-25](../../README.md) |
-| 최신 작업 이력 | [STATE.md 그룹 54](../STATE.md) |
+| 최신 작업 이력 | [STATE.md 그룹 57](../STATE.md) |
 
 ---
 

--- a/e2e/test_theme.py
+++ b/e2e/test_theme.py
@@ -71,3 +71,21 @@ def test_dropdown_closes_on_outside_click(page, base_url):
     # Click outside the dropdown.
     page.click("h2, .overview-header h2, body", position={"x": 10, "y": 10})
     assert not page.is_visible(".theme-switcher.open")
+
+
+def test_claude_dark_theme_switch(page, base_url):
+    """PR-D5 회귀 가드 — claude-dark 테마 옵션 (Phase 1B 도입) 클릭 + 적용 검증.
+
+    이전 e2e 는 dark/light/glass 만 검증 → claude-dark 누락. PR #150 신규 4번째 옵션.
+    Previous e2e covered dark/light/glass only; claude-dark (PR #150) was missing.
+    """
+    page.goto(base_url)
+    page.click("#themeToggle")
+    page.wait_for_selector(".theme-switcher.open", timeout=2000)
+    # claude-dark 옵션 존재 + 클릭 가능
+    # claude-dark option must exist + be clickable
+    page.click('.theme-option[data-theme="claude-dark"]')
+    assert page.get_attribute("body", "data-theme") == "claude-dark"
+    # 드롭다운 자동 닫힘
+    # Dropdown auto-closes
+    assert not page.is_visible(".theme-switcher.open")


### PR DESCRIPTION
…E 전례 + claude-dark e2e)

5-에이전트 정합성 감사 P2 핵심 4건 처리. 미매핑 PR 17건 메타 sync 는 보류 (역사 정리 가치 < 시간 부담). 코드 변경 0 (e2e 테스트 +1).

== 처리 항목 ==

**1. STATE.md "현재 수치" 표에 CodeQL 행 추가 (P2-1)**
이전: README.md L15 가 CodeQL 배지 표시하나 STATE 표에 행 없음 → 단일 진실 소스 불일치.
수정: "CodeQL | ✅ pass | .github/workflows/codeql.yml — 주 1회 실행" 추가.

**2. STATE.md "주요 파일 역할" 표에 신규 파일 3종 등재 (P2-2)**
이전: native_automerge.py / _merge_attempt_states.py / graphql.py 가 빠른 참조 표에 미등재 (CLAUDE.md `src/` 트리에는 존재).
수정:
- native_automerge.py — Tier 3 PR-A enable_or_fallback (그룹 52)
- _merge_attempt_states.py — MergeAttempt.state lifecycle 정규 상수 (Phase 3 PR-B1)
- graphql.py — GraphQL 래퍼 + EnableAutoMergeResult + 5xx 자동 재시도

**3. CLAUDE.md L367 "전례" 항목에 본 감사 결과 추가 (P2-8)**
이전: "전례: Phase 11에서 6개 파일 추가 후 5개 누락 (PR #73)" 단일 사례. 수정: 전례 2건으로 확장 — (1) Phase 11 PR #73, (2) 2026-05-01 UI 감사 cleanup PR-D1 — `_merge_attempt_states.py` + `static/vendor/chart.umd.min.js` 누락 → 5-에이전트 정합성 감사에서 발견. 향후 동일 패턴 재발 방지 학습.

**4. e2e/test_theme.py 에 claude-dark 케이스 추가 (P2 from agent 5)** 이전: dark/light/glass 만 e2e 검증 → claude-dark (PR #150 신규 4번째 옵션) 누락. claude-dark 미커버.
수정: test_claude_dark_theme_switch 신규 +1 — 옵션 클릭 + body data-theme 설정 + 드롭다운 자동 닫힘 검증.

**5. reports/INDEX.md 최신 작업 이력 링크 갱신**
이전: "[STATE.md 그룹 54](../STATE.md)" — 그룹 54 시점 stale. 수정: 그룹 57 로 갱신.

== 보류 (별도 메타 PR 권장) ==

미매핑 PR 17건 그룹 매핑은 단일 PR 부담 + 역사 정리 가치 < 시간 부담:
- 그룹 51.5 신설 (PR #91 plan archive + #93/#95~#97 BPR/silent skip/HTTP 분류/base ref)
- 그룹 52.5 신설 (PR #109~#115 — Tier 3 Phase 1~3 결과물)
- 그룹 53/54 부속 PR # 명시 (#122~#126 / #127 + #145~#148)
- 그룹 43↔44 위치 swap (시간 역순 일관성)

향후 정기 STATE sync (월 1회) 시 일괄 처리 권장.

== 5-way sync 보존 ==
- 코드 변경 0
- form 필드명 + JS 헬퍼 + 백엔드 핸들러 모두 불변
- 변경 영향: 3 docs (STATE.md + CLAUDE.md + reports/INDEX) + 1 e2e test +1

== 검증 ==
- e2e/test_theme.py 추가는 Playwright 환경 (CI) 에서만 실행 — 본 Codespaces 로컬 검증 생략 (make test-e2e 필요)
- 단위 테스트 영향 0 (e2e 격리)
- pylint 영향 없음 (docs only + e2e .py)

== UI 감사 사이클 cleanup 시리즈 종결 ==

PR-D1 (P0 7건) → PR-D2 (회귀 가드 +5) → PR-D3 (P1 5건) → PR-D4 (신규 가이드 2종) → PR-D5 (P2 polish 4건) = 5 PR 분할 완료. 5-에이전트 정합성 감사 27 결함 중 22건 처리 (남은 5건 = 미매핑 PR 17건 메타 sync — 역사 정리 보류).

향후 작업: docs/reports/2026-05-01-ui-audit-cycle-retrospective.md (PR-D4) 의 학습 패턴 (4/5-에이전트 감사 + Step 분할 + cleanup PR 4 갈래 + 환각 토큰 + claude-dark 토큰 매트릭스) 을 다음 사이클에 적용 권장.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
