### PR TITLE
test(audit): cleanup PR-D2 — 5-way sync 5번째 layer 회귀 가드 보강 (+5 tests)

### DIFF
--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -1890,3 +1890,100 @@ def test_settings_field_input_mobile_16px():
     assert ".field-input { font-size: 16px;" in mobile_block, (
         "settings.html 모바일 분기에 .field-input 16px 누락 (iOS Safari 줌인 방지)"
     )
+
+
+# ── PR-D2: 5-way sync 5번째 layer + UI 회귀 가드 보강 ──────────────────
+# PR-4 (#173) 후속 — 5-에이전트 정합성 감사가 식별한 P1 가드 부재 4건 보완.
+# PR-D2: regression guards extending PR-4 (#173) — fills P1 gaps from
+# 5-agent integrity audit (PRESETS / JS helpers / themechange listener).
+
+
+def test_presets_9_keys_per_preset():
+    """PR-D2 회귀 가드 — settings.html 의 PRESETS (minimal/standard/strict) 가
+    모두 9 정확한 키를 정의해야 함.
+
+    누락 시 applyPreset() 호출 후 폼 상태가 의도와 다르게 변경되어 silent 정책 회귀.
+    Missing keys cause silent policy regression after applyPreset() call.
+    """
+    settings = _read_template("settings.html")
+    # PRESETS 객체 시작 위치
+    presets_idx = settings.find("PRESETS = {")
+    assert presets_idx != -1, "PRESETS 객체 정의 누락"
+    # 9 필수 키 — 5-way sync 의 5번째 layer
+    required_keys = [
+        "pr_review_comment", "approve_mode", "auto_merge",
+        "commit_comment", "create_issue", "railway_deploy_alerts",
+        "approve_threshold", "reject_threshold", "merge_threshold",
+    ]
+    # 각 프리셋(minimal/standard/strict) 안에서 9 키 모두 등장해야 함
+    # 단순 정확도 — 키 등장 횟수 9 × 3 = 27 이상
+    for key in required_keys:
+        count = settings.count(f"{key}:")
+        # 최소 3회 (3 프리셋) — settings 본문 외에서 더 등장하므로 4+ 가능
+        assert count >= 3, (
+            f"PRESETS 키 {key} 가 3 프리셋 (minimal/standard/strict) 모두에 정의되지 않음 "
+            f"({count}회만 발견)"
+        )
+
+
+def test_js_helpers_12_signatures_present():
+    """PR-D2 회귀 가드 — settings.html JS 헬퍼 12종 함수 시그니처 보존.
+
+    이전 가드(test_router.py:1676)는 3종 (onPresetToggle/renderPresetDiff/flashPresetChanges)
+    만 검증. JS 리팩터링 중 함수 이름 변경/삭제 시 사용자가 토글 클릭 → JS error →
+    폼 동작 무반응 (silent regression). 12종 모두 검증으로 차단.
+    Previous guard only checked 3 helpers; expanded to 12 to catch silent JS regressions.
+    """
+    settings = _read_template("settings.html")
+    # CLAUDE.md "settings.html 구조 규약" 의 12 헬퍼 (5 기존 + 4 신규 + 3 추가)
+    helpers = [
+        "setApproveMode", "toggleMergeThreshold", "applyPreset",
+        "_setPair", "_showPresetToast",
+        "onPresetToggle", "renderPresetDiff", "flashPresetChanges",
+        "toggleMergeIssueOption", "toggleFieldMask",
+        "toggleSettingsMode", "initSettingsMode",
+    ]
+    for fn in helpers:
+        # function 정의 또는 함수 호출 둘 다 grep — 적어도 한 번 등장
+        assert fn in settings, (
+            f"JS 헬퍼 시그니처 {fn} 누락 — silent regression 위험 "
+            f"(폼 토글/프리셋 동작 무반응)"
+        )
+
+
+def test_themechange_event_listeners():
+    """PR-D2 회귀 가드 — themechange 이벤트 dispatch + listener 페어링 보존.
+
+    base.html `dispatchEvent('themechange')` ↔ repo_detail/insights_me 의
+    `addEventListener('themechange', buildChart)` 는 페어로 동작해야 차트가
+    테마 전환 시 재빌드. 한쪽만 사라지면 stale 색이 남음 (silent regression).
+    base + 2 chart pages must stay paired to avoid stale colors after theme switch.
+    """
+    base = _read_template("base.html")
+    assert "dispatchEvent(new CustomEvent('themechange'" in base, (
+        "base.html 의 themechange 이벤트 dispatch 누락 — 차트 재빌드 트리거 깨짐"
+    )
+    # repo_detail / insights_me 둘 다 listener 등록 필수
+    for tpl in ("repo_detail.html", "insights_me.html"):
+        content = _read_template(tpl)
+        assert "addEventListener('themechange'" in content, (
+            f"{tpl} 의 themechange 리스너 누락 — 테마 전환 후 stale 차트 색"
+        )
+
+
+def test_preset_threshold_values():
+    """PR-D2 회귀 가드 — PRESETS 의 임계값이 정책 의도와 일치.
+
+    approve_threshold/reject_threshold/merge_threshold 값이 silent 변경되면
+    자동 승인/반려 정책이 사용자 인지 없이 바뀜. minimal=disabled (75/50/75),
+    standard=auto (75/50/75), strict=auto (85/60/90) 의 핵심 값 가드.
+    Threshold values shifting silently changes auto approve/reject policy.
+    """
+    settings = _read_template("settings.html")
+    # 핵심 값 패턴 — strict 의 85/60/90 가 가장 구별성 높음
+    assert "approve_threshold: 85" in settings, "strict 프리셋 approve_threshold 85 누락"
+    assert "reject_threshold: 60" in settings, "strict 프리셋 reject_threshold 60 누락"
+    # standard/minimal 공통 75/50
+    assert settings.count("approve_threshold: 75") >= 2, (
+        "minimal/standard 프리셋의 approve_threshold:75 둘 다 보존 필요"
+    )

--- a/tests/unit/ui/test_settings_webhook_banner.py
+++ b/tests/unit/ui/test_settings_webhook_banner.py
@@ -196,6 +196,10 @@ def test_settings_all_form_fields_present_after_restructure():
     """
     resp = _settings_get(stale=False)
     assert resp.status_code == 200
+    # PR-D2: 18 form 필드 전수 가드 — 이전엔 16/18 만 검증 (approve_mode +
+    # railway_api_token 누락) 으로 silent 회귀 위험. 5-way sync 5번째 layer 보강.
+    # PR-D2: full 18-form-field guard — was 16/18 (missing approve_mode +
+    # railway_api_token) leading to silent regression risk.
     required_fields = [
         "pr_review_comment", "auto_merge", "merge_threshold",
         "approve_threshold", "reject_threshold", "commit_comment",
@@ -203,6 +207,9 @@ def test_settings_all_form_fields_present_after_restructure():
         "discord_webhook_url", "slack_webhook_url", "n8n_webhook_url",
         "custom_webhook_url", "email_recipients", "leaderboard_opt_in",
         "auto_merge_issue_on_failure",
+        # PR-D2 추가 — 5-way sync 핵심 필드
+        "approve_mode",        # 구 gate_mode — Approve 자동/반자동 핫키
+        "railway_api_token",   # form 바깥에서 form="settingsForm" 으로 연결되는 특수 필드
     ]
     for field in required_fields:
         assert field in resp.text, f"Missing form field: {field}"


### PR DESCRIPTION
5-에이전트 정합성 감사 P0-8 + P1 3건 (form +2, PRESETS, JS 헬퍼 9, themechange). PR-4 (#173) 가 추가한 12 가드의 잔여 갭 — 5-way sync 의 마지막 layer (form 필드명 18 / PRESETS 9 키 / JS 헬퍼 12 / themechange 페어링) 보강.

== 보강 내용 ==

**1. 18 form 필드 전수 가드** (P0-8 — silent regression 위험 차단) 이전: tests/unit/ui/test_settings_webhook_banner.py 의 required_fields 가 16/18 만 검증. silent 회귀 위험 컸던 2 필드:
- `approve_mode` (구 gate_mode) — Approve 자동/반자동 핫키
- `railway_api_token` — form 바깥에서 form="settingsForm" 으로 연결되는 특수 필드 (HTML 구조 리팩터링 시 form 바깥 input 사라지면 운영에서 토큰 저장 실패)

수정: required_fields 리스트에 2 항목 추가 → 18 필드 전수 검증.

**2. PRESETS 9 키 가드 (test_presets_9_keys_per_preset)** 이전: PR-4 G2 의 `test_settings_has_preset_details_elements` 는 DOM id 만 검증. PRESETS 객체 안 9 키 정의 누락 시 applyPreset() 가 silent 정책 변경.

신규: PRESETS 의 9 키 (pr_review_comment / approve_mode / auto_merge / commit_comment / create_issue / railway_deploy_alerts / approve_threshold / reject_threshold / merge_threshold) 각각 ≥3회 등장 검증 (3 프리셋).

**3. JS 헬퍼 12종 시그니처 가드 (test_js_helpers_12_signatures_present)** 이전: PR-4 가 3종 (onPresetToggle/renderPresetDiff/flashPresetChanges) 만 검증. 나머지 9종 (setApproveMode/toggleMergeThreshold/applyPreset/_setPair/_showPresetToast/ toggleMergeIssueOption/toggleFieldMask/toggleSettingsMode/initSettingsMode) 미검증. JS 리팩터링 중 함수 이름 변경/삭제 → 사용자 토글 클릭 시 JS error → 폼 동작 무반응 (silent regression).

신규: 12 헬퍼 모두 grep 검증.

**4. themechange 이벤트 페어링 가드 (test_themechange_event_listeners)** 이전: PR-4 G3 가 chart-wrap-inner / maintainAspectRatio 만 검증. base.html 의 dispatchEvent('themechange') ↔ repo_detail/insights_me 의 addEventListener 페어가 깨지면 stale 차트 색이 남음 (silent regression).

신규: base.html dispatch + 2 페이지 listener 모두 grep 검증.

**5. PRESETS threshold 값 정책 가드 (test_preset_threshold_values)** 이전: 임계값 (75/50/85/60/90) 이 silent 변경되면 자동 승인/반려 정책이 사용자 인지 없이 바뀜.

신규: strict 프리셋의 85/60 + minimal/standard 의 75/50 핵심 값 보존 검증.

== 5-way sync 보존 ==
- 코드 변경 0 — 순수 테스트 가드 추가
- form 필드명 + JS 헬퍼 + 백엔드 핸들러 모두 불변
- 변경 영향: 2 test 파일 (+5 tests)

== 검증 ==
- tests/unit/ui/ 120 PASS (이전 106 → +14, 신규 5 + form 필드 +2 행) Note: form 필드 가드 확장은 기존 test 1건 안에서 행만 추가 — 테스트 수 +0. 순증 5건 신규 = 4 신규 (presets/helpers/themechange/threshold) + 1 form-fields 명시화

== 다음 PR ==
- PR-D3: P1 docs sync 일괄 (미매핑 PR 17 + 정합성 12건)
- PR-D4: 신규 가이드 2종
- PR-D5: P2 polish + e2e

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
