### PR TITLE
docs(state): 그룹 58 + 정책 10 본문 환경 한계 반영 (PAT 현행 유지 결정)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,8 +519,19 @@ git push -u origin <branch>
 | 🅒 **사용자 수동** | 위 둘 다 불가 시만 | URL 안내 — **최후 폴백** |
 
 **금지**:
-- ❌ 옵션 🅒 를 default 로 사용 — 사용자 부담 증가
 - ❌ "PR 생성은 사용자가 직접" 위임 (정책 7 PR 단위와 모순)
+- ⚠️ 옵션 🅒 (URL 폴백) 는 환경 한계 시 일시 default 가능 — 단, 매 사이클 시작 시 환경 fix 시도 의무
+
+**현재 SCAManager 환경 상태 (2026-05-02 사용자 결정 반영)**:
+- gh CLI: 부재 (apt install 시 DNS 차단)
+- GITHUB_TOKEN 환경변수: GitHub OAuth 앱 client_secret 추정 — **API `Bad credentials 401`** (PR 생성/머지 불가)
+- **사용자 결정 (2026-05-02): GitHub PAT 발급 현행 유지** — 별도 PAT 환경변수 추가 안 함
+- → **정책 10 옵션 🅒 (URL 폴백) 가 사실상 default 운영** — 본 환경 한정. 환경 변경 시 자동 옵션 🅐 또는 🅑 로 전환
+
+**다음 세션 Claude 행동 지침**:
+1. 새 PR push 후 옵션 🅐 / 🅑 시도 (gh / API)
+2. 401 또는 부재 시 즉시 옵션 🅒 (URL 안내) — 매번 환경 fix 시도 비효율 회피
+3. 사용자가 향후 PAT 발급 결정 시 본 섹션 갱신 의무
 
 **SCAManager 기본 PR body 템플릿** (자동 채움):
 ```markdown
@@ -800,4 +811,4 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 
 ## 현재 상태
 
-최신 수치는 [docs/STATE.md](docs/STATE.md) 참조 — 단위 테스트 1980개 | 통합 72개 | E2E 53개 | pylint 10.00 | 커버리지 95% | SonarCloud QG OK · Security A · Reliability A · Maintainability A · Tier1 정적분석 10종 · Observability (Sentry + Claude metrics + stage timing + MergeAttempt) · AI 점수 피드백 루프 · Settings Minimal Mode · Onboarding 3단계 튜토리얼 · 5-렌즈 감사 95+ 통과 · Phase F Quick Win + F.1/F.3 완료 · Phase G 완료 (P1-5건 수정) · Phase 9 자기 분석 루프 방지 완료 · Phase 10 Telegram 확장 완료 (cron + /stats·/connect 명령) · Phase 11 팀/멀티 리포 인사이트 완료 (author_trend + leaderboard + /insights 대시보드) · 툴링 안전장치 (testpaths + ORM-마이그레이션 완전성 검사 67개) · Phase 12 CI-aware Auto Merge 재시도 완료 (merge_retry_queue + check_suite 웹훅 + 1분 cron) · Settings UI/UX 리디자인 완료 (수신/발신 웹훅 분리 + 온보딩 배너) → Phase 2A Progressive 재설계 완료 (PR #152, #153) — `<details>` 아코디언 제거 + `.adv-only` 평탄화 + W2 분리 5 카드 + 단순 모드 5 핵심 필드 + 사용자 신호 기반 첫 진입 (`_detect_initial_mode`) + ●○ 점 상태 표시 8종 → **UI 감사 사이클 12 PR (#156, #159, #160, #163~#168) + 5-에이전트 정합성 cleanup 5 PR (#169, #170, #172, #173 + 본 sync PR) 완료** — Settings P0 핫픽스 (5건) + 7-페이지 4-에이전트 감사 (P0 32+P1 18+P2 15=65건) → Step A~E 시리즈로 root cause 처리 (환각 토큰 alias / safe-area-inset / WCAG 2.5.5 / Chart.js vendoring `src/static/vendor/` + StaticFiles `/static` mount / claude-dark 차트 색 동적 read / 색 의미 토큰 통일 `--warning` 신규 / nav 비로그인 가드 / chip a11y) → cleanup 4 PR 로 코드 결함 (claude-dark 토큰 8종 + 환각 alias 2종 + Step B/D 누락) + 문서 동기화 + P1 polish (chart-wrap clamp + .btn:disabled 확장 + tooltip 토큰화) + 회귀 가드 12건 · Loop Guard Layer 3-b 화이트리스트 봇 한정 (PR #100 — `is_whitelisted_bot()` 헬퍼 + 사람 발신 무제한 통과) · Tier 3 PR-A 완료 (PR #103) — `enablePullRequestAutoMerge` GraphQL mutation + REST 폴백 · Phase 4 Critical 테스트 갭 5 PR 완료 (PR-T1~T5, +197 tests) — analyzer/tools, ai_review_errors, scorer_edges, engine_guards, pipeline_helpers, merge_retry_helpers, pr_a_scenarios, e2e_pipeline_scenarios · **Phase H+I 15 PR 완료 + 회고/문서 동기화 1 PR = 16 PR 머지 (12-에이전트 감사 Critical 10건 100% 처리) — timeout/race-recovery/Telegram 429/gate parallel/PyGithub async/joinedload opt-in/parity guard/HMAC parity (이전 모든 semi-auto 콜백 401 거부 functional bug 해소)/composite indexes/cascade ; 외부 의존성 추가 0**
+최신 수치는 [docs/STATE.md](docs/STATE.md) 참조 — 단위 테스트 1984개 | 통합 72개 | E2E 53개 | pylint 10.00 | 커버리지 95% | SonarCloud QG OK · Security A · Reliability A · Maintainability A · Tier1 정적분석 10종 · Observability (Sentry + Claude metrics + stage timing + MergeAttempt) · AI 점수 피드백 루프 · Settings Minimal Mode · Onboarding 3단계 튜토리얼 · 5-렌즈 감사 95+ 통과 · Phase F Quick Win + F.1/F.3 완료 · Phase G 완료 (P1-5건 수정) · Phase 9 자기 분석 루프 방지 완료 · Phase 10 Telegram 확장 완료 (cron + /stats·/connect 명령) · Phase 11 팀/멀티 리포 인사이트 완료 (author_trend + leaderboard + /insights 대시보드) · 툴링 안전장치 (testpaths + ORM-마이그레이션 완전성 검사 67개) · Phase 12 CI-aware Auto Merge 재시도 완료 (merge_retry_queue + check_suite 웹훅 + 1분 cron) · Settings UI/UX 리디자인 완료 (수신/발신 웹훅 분리 + 온보딩 배너) → Phase 2A Progressive 재설계 완료 (PR #152, #153) — `<details>` 아코디언 제거 + `.adv-only` 평탄화 + W2 분리 5 카드 + 단순 모드 5 핵심 필드 + 사용자 신호 기반 첫 진입 (`_detect_initial_mode`) + ●○ 점 상태 표시 8종 → **UI 감사 사이클 12 PR (#156, #159, #160, #163~#168) + 5-에이전트 정합성 cleanup 5 PR (#169, #170, #172, #173 + 본 sync PR) 완료** — Settings P0 핫픽스 (5건) + 7-페이지 4-에이전트 감사 (P0 32+P1 18+P2 15=65건) → Step A~E 시리즈로 root cause 처리 (환각 토큰 alias / safe-area-inset / WCAG 2.5.5 / Chart.js vendoring `src/static/vendor/` + StaticFiles `/static` mount / claude-dark 차트 색 동적 read / 색 의미 토큰 통일 `--warning` 신규 / nav 비로그인 가드 / chip a11y) → cleanup 4 PR 로 코드 결함 (claude-dark 토큰 8종 + 환각 alias 2종 + Step B/D 누락) + 문서 동기화 + P1 polish (chart-wrap clamp + .btn:disabled 확장 + tooltip 토큰화) + 회귀 가드 12건 · Loop Guard Layer 3-b 화이트리스트 봇 한정 (PR #100 — `is_whitelisted_bot()` 헬퍼 + 사람 발신 무제한 통과) · Tier 3 PR-A 완료 (PR #103) — `enablePullRequestAutoMerge` GraphQL mutation + REST 폴백 · Phase 4 Critical 테스트 갭 5 PR 완료 (PR-T1~T5, +197 tests) — analyzer/tools, ai_review_errors, scorer_edges, engine_guards, pipeline_helpers, merge_retry_helpers, pr_a_scenarios, e2e_pipeline_scenarios · **Phase H+I 15 PR 완료 + 회고/문서 동기화 1 PR = 16 PR 머지 (12-에이전트 감사 Critical 10건 100% 처리) — timeout/race-recovery/Telegram 429/gate parallel/PyGithub async/joinedload opt-in/parity guard/HMAC parity (이전 모든 semi-auto 콜백 401 거부 functional bug 해소)/composite indexes/cascade ; 외부 의존성 추가 0**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
-[![Tests](https://img.shields.io/badge/Tests-1980_unit_+_72_integration-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-1984_unit_+_72_integration-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
 [![E2E](https://img.shields.io/badge/E2E-53_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,11 +2,11 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-05-01 기준 — Phase H+I + UI 감사 사이클 (12 PR + cleanup) 완료)
+## 현재 수치 (2026-05-02 기준 — 그룹 58: 협업 정책 1~10 + Insight Dashboard 근본 재설계 기획 완료)
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 단위 테스트 | **1980개** | pytest 9.0.3 (0 failed, 5 skipped) — Phase H+I 15 PR 신규 +37 + UI 감사 cleanup PR-4 회귀 가드 +12 (StaticFiles vendoring + 환각 토큰 / claude-dark / nav guard / chip a11y / chart aspect / safe-area / iOS 줌인) |
+| 단위 테스트 | **1984개** | pytest 9.0.3 (0 failed, 5 skipped) — Phase H+I 15 PR 신규 +37 + UI 감사 cleanup PR-4 회귀 가드 +12 + cleanup PR-D2 5-way sync 5번째 layer 가드 +5 (StaticFiles vendoring + 환각 토큰 / claude-dark / nav guard / chip a11y / chart aspect / safe-area / iOS 줌인 / PRESETS 9 키 / JS 헬퍼 12종 / themechange 페어) |
 | 통합 테스트 | **72개** | tests/integration/ — Phase 4 PR-T5 +25 (e2e_pipeline_scenarios — webhook→pipeline→gate 종단간) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
@@ -56,6 +56,48 @@
 | `tests/conftest.py` | 환경변수 주입 + _webhook_secret_cache autouse 클리어 |
 
 ## 작업 이력 (그룹별)
+
+### 그룹 58 (2026-05-02 · 협업 정책 6건 + Insight Dashboard 근본 재설계 기획 — PR #180, #181, #182)
+
+**목표**: 그룹 57 (UI 감사 사이클 cleanup) 머지 후 단일 작업일에 (a) 사용자 ↔ Claude 협업 회고 → 정책 5건 합의 → 정책 추가 4건 → 총 정책 1~10 default 적용, (b) 사용자 발화 *"프로젝트 사활"* 으로 Insight Dashboard 근본 재설계 5-에이전트 기획 + 시각 목업 2종.
+
+**관련 PR**:
+
+| PR | 핵심 변경 |
+|----|---------|
+| **#180** Docs/collaboration retrospective and policy | 5-에이전트 협업 회고 (`docs/reports/2026-05-01-collaboration-retrospective.md` 신규) + CLAUDE.md "사용자 협업 정책 (2026-05-01 합의)" 섹션 신설 — 정책 1~9 본문 (장단점 명시 / PR 검증 미완료 섹션 / 자율 판단 보고 / 단언+가드 묶음 / 사이클 종료 신호 / line:span 인용 / PR 단위 / 다중 에이전트 회고 / 자유 발언) |
+| **#181** Docs/design insight dashboard rework | 5-에이전트 기획서 (`docs/design/2026-05-02-insight-dashboard-rework.md`) — 데이터 자산 정찰 + 사용자 가치 매트릭스 + 컨셉 5건 비교 + 경쟁 벤치마크 15 제품 + MVP 4 옵션 매트릭스 + 5-Phase 로드맵. 시각 목업 2건 (`docs/design/mockups/2026-05-02-dashboard-concept-c-stripe.html` Stripe-style + `e-ai-note.html` Claude 톤). 폐기 대상: `analytics_service.author_trend` / `repo_comparison` / `leaderboard` / **`top_issues`** (사용자 결정 — 미사용/보류 코드 0 원칙) |
+| **#182** Docs/collaboration retrospective and policy (정책 10 추가) | CLAUDE.md 정책 10 — **PR 직접 생성 의무** (gh CLI 또는 GitHub API, URL 폴백은 최후) + 헬퍼 스크립트 신규 `scripts/dev/create_pr.sh` (GitHub API + curl + jq 패턴) |
+
+**5-에이전트 협업 회고 결과** (PR #180):
+- 사이클 정량: 25+ PR / 92 결함 / 회귀 0 / **사용자 거부 0건**
+- 위험 신호: revert 0 = 검토 안 됐을 가능성, 결함 6 PR 후 발견 (claude-dark) = 시각 smoke test 부재
+- 사용자 합의 5건 → 정책 1, 7, 8, 9 + 보조 6 (총 5건 + 보조 1)
+- 추가 정책 (사용자 후속 발화) 정책 10 (PR 직접 생성)
+
+**5-에이전트 dashboard 기획 결과** (PR #181):
+- 폐기 LOC 880 (`author_trend`/`repo_comparison`/`leaderboard`/`top_issues` + 페이지 2 + 라우트 2 + 테스트 3)
+- 권장 MVP-B (Pulse + Trend, 1~2일, 신규 ~450 LOC, 순 -430 LOC)
+- 권장 컨셉: C (Stripe) + E (AI 노트) 모드 토글 — 사활 결정 단일 베팅 위험 회피
+- 5-Phase 로드맵 (총 6~9일)
+
+**정책 10 환경 한계** (PR #182):
+- gh CLI 부재 + apt install DNS 차단 + GITHUB_TOKEN 401 (OAuth secret 추정)
+- 사용자 결정 (2026-05-02 사후): **PAT 발급 현행 유지** → 정책 10 옵션 🅒 (URL 폴백) 사실상 default
+- 본 그룹의 `Conflict 발생 → 해결` 흐름: PR #180 머지 후 정책 10 추가 commit 의 동일 영역 conflict (CLAUDE.md + 회고 본문) → `--ours` 채택 (정책 10 본문 보존) → merge commit `91683c8` → #182 로 머지
+
+**5-way sync 영향**: 0 (모두 docs + 신규 헬퍼 스크립트)
+
+**테스트**: 1984 유지 (cleanup PR-4 +12 + cleanup PR-D2 +5 = 1980 → 1984, 본 그룹 코드 변경 0)
+**품질**: pylint 10.00/10 유지
+
+**잔여 follow-up** (다음 사이클):
+- dashboard 컨셉 결정 (Q5 컨셉 / Q6 default 모드 / Q7 자주 발생 이슈 카드 처리) — 사용자 시각 목업 검토 후
+- 정책 10 본문 갱신 (PAT 현행 유지 결정 반영, 본문 ↔ 환경 일관성)
+- `Analysis.result["issues"]` JSON 직렬화 보강 (`category/language/rule_id` 추가, 1줄 fix)
+- 미매핑 PR 17건 메타 sync (월 1회 정기 sync 권장 — 보류 유지)
+
+---
 
 ### 그룹 57 (2026-05-01 · UI 감사 사이클 12 PR + 정합성 cleanup — PR #158, #159, #160, #161~#168, #169~#173 + 후속 메타 sync 시리즈 PR-D1~D5)
 
@@ -1172,7 +1214,7 @@ README 배지를 Claude/자체 산출 수치가 아닌 **외부 SaaS 가 직접 
 ## 갱신 방법
 
 ```bash
-make test          # 단위 1980+ 통과 확인 (UI 감사 사이클 cleanup PR-D2 가드 +5 후 1985)
+make test          # 단위 1980+ 통과 확인 (UI 감사 사이클 cleanup PR-D2 가드 +5 후 1984)
 make lint          # pylint 10.00 + flake8 0건 + bandit HIGH 0개
 make test-cov      # 96%+ 유지 확인 (소폭 변동 가능)
 


### PR DESCRIPTION
🅐 STATE 그룹 58 신설 (PR #180/#181/#182 매핑)
🅑 정책 10 본문에 환경 한계 + 사용자 PAT 결정 명시

== 🅐 STATE 그룹 58 (2026-05-02) ==

협업 정책 6건 (1~6 → 9~10) + Insight Dashboard 근본 재설계 기획.

**PR 매핑**:
- #180 collaboration retrospective + 정책 1~9 본문
- #181 dashboard rework 기획서 + 컨셉 C/E 시각 목업 2종 + 폐기 결정 4종 (author_trend / repo_comparison / leaderboard / top_issues)
- #182 정책 10 (PR 직접 생성) + scripts/dev/create_pr.sh 헬퍼

**5-에이전트 결과**:
- 협업 회고: 25 PR / 92 결함 / revert 0 (위험 신호) → 정책 1, 7, 8, 9 도출
- dashboard 기획: 폐기 880 LOC + MVP-B 권장 + 5-Phase 로드맵 + C+E 모드 토글

**Conflict 처리** (PR #180 머지 후 정책 10 추가 commit 의 동일 영역 충돌):
- CLAUDE.md + collaboration-retrospective.md 의 정책 10 본문에서 충돌
- `--ours` 채택 → 정책 10 + 헬퍼 보존 → merge commit 91683c8 → #182 머지

**5-way sync**: 0 영향 (모두 docs + 신규 헬퍼)
**테스트**: 1980 → 1984 (PR-D2 +4, form 가드는 기존 test 행만 확장)

== 🅑 정책 10 본문 갱신 ==

이전 본문 모순:
- "옵션 🅒 default 사용 금지" 명시
- 그러나 환경 한계 (gh 부재 + GITHUB_TOKEN 401 + DNS 차단) 로 사실상 🅒 default

사용자 결정 (2026-05-02 사후): GitHub PAT 발급 현행 유지

본문 갱신:
- "현재 SCAManager 환경 상태 (2026-05-02)" 박스 신설: · gh CLI: 부재 (apt install DNS 차단) · GITHUB_TOKEN: GitHub OAuth client_secret 추정 → API 401 · 사용자 결정: PAT 발급 현행 유지 · 정책 10 옵션 🅒 (URL 폴백) 가 사실상 default
- "다음 세션 Claude 행동 지침" 신설:
  1. 새 PR push 후 옵션 🅐/🅑 시도
  2. 401 또는 부재 시 즉시 옵션 🅒 (URL 안내)
  3. 매번 환경 fix 시도 비효율 회피
  4. 사용자가 향후 PAT 결정 시 본 섹션 갱신 의무

이로써 다음 세션 Claude 가 본문 ↔ 환경 일관성 가지고 작동.

== 변경 영향 ==
- docs/STATE.md: 그룹 58 신설 (~50줄) + 헤더 + L9 수치 1980→1984
- CLAUDE.md: 정책 10 본문 환경 한계 박스 추가 + L814 수치 1984
- README.md: Tests 배지 1984

== 검증 ==
- pytest --collect-only → 1984 실측 일치 (이전 1985 명시는 +5 가드 중 form 가드 +0 누락)
- 코드 변경 0

== 다음 단계 ==

🅒 (Analysis.result issues JSON 직렬화 보강) 별도 PR 진행 — 데이터 손실 1줄 fix. 이후 사용자 dashboard 컨셉 결정 (Q5/Q6/Q7) 대기.

== 자율 판단 보고 (정책 3) ==

🅐 + 🅑 단일 PR 묶음 — 양쪽 모두 docs 정합성 보강 + 같은 영역 (CLAUDE.md / STATE.md) 변경이라 자연스러움. 분할 시 사용자 검토 부담 ↑. 🅒 (코드 변경) 는 별도 PR (정책 7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
