### PR TITLE
fix(pipeline): Analysis.result["issues"] JSON 에 category + language 추…

### DIFF
--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -73,7 +73,16 @@ def build_analysis_result_dict(
         "test_feedback": ai_review.test_feedback,
         "file_feedbacks": ai_review.file_feedbacks,
         "issues": [
-            {"tool": i.tool, "severity": i.severity, "message": i.message, "line": i.line}
+            # category / language 추가 — 향후 dashboard 에서 언어별·카테고리별 사후 분석 가능
+            # category / language added so future dashboards can slice by language/category
+            {
+                "tool": i.tool,
+                "severity": i.severity,
+                "message": i.message,
+                "line": i.line,
+                "category": i.category,
+                "language": i.language,
+            }
             for r in analysis_results
             for i in r.issues
         ],

--- a/tests/unit/worker/test_pipeline_result_dict.py
+++ b/tests/unit/worker/test_pipeline_result_dict.py
@@ -1,0 +1,132 @@
+"""build_analysis_result_dict 회귀 가드 — Analysis.result JSON 직렬화 보강.
+
+Issue: Phase 11 시점 build_analysis_result_dict 가 issues JSON 에 category /
+language 필드를 직렬화하지 않았음 (pipeline.py:75-79). dashboard 재설계
+기획 (PR #181) 의 데이터 자산 정찰에서 발견 — 향후 언어별·카테고리별
+사후 분석 차단 위험.
+
+본 모듈은 직렬화 필드 6 종 (tool, severity, message, line, category, language)
+보존을 회귀 가드로 검증.
+
+Regression guard for build_analysis_result_dict — ensures issues JSON contains
+all 6 fields so future dashboards can slice by language/category.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+
+from src.worker.pipeline import build_analysis_result_dict
+
+
+# ─── 더블 (의존성 모킹) ─────────────────────────────────────────────────────
+
+
+@dataclass
+class _StubIssue:
+    tool: str = "pylint"
+    severity: str = "warning"
+    message: str = "unused import"
+    line: int = 12
+    category: str = "code_quality"
+    language: str = "python"
+
+
+@dataclass
+class _StubAnalysisResult:
+    issues: list[_StubIssue] = field(default_factory=list)
+
+
+def _make_ai_review() -> SimpleNamespace:
+    """AiReviewResult 형 더블 — pipeline 함수가 attribute 만 사용하므로 SimpleNamespace 충분."""
+    return SimpleNamespace(
+        status="success",
+        summary="ok",
+        suggestions=[],
+        commit_message_feedback="commit ok",
+        code_quality_feedback="cq ok",
+        security_feedback="sec ok",
+        direction_feedback="dir ok",
+        test_feedback="test ok",
+        file_feedbacks=[],
+    )
+
+
+def _make_score_result(total: int = 80) -> SimpleNamespace:
+    return SimpleNamespace(
+        total=total,
+        grade="B",
+        breakdown={"code_quality": 25, "security": 18, "commit_message": 13, "ai_review": 21, "test_coverage": 8},
+    )
+
+
+# ─── 회귀 가드 ──────────────────────────────────────────────────────────────
+
+
+def test_issues_json_contains_six_fields() -> None:
+    """issues JSON 의 각 항목은 6 필드 (tool/severity/message/line/category/language) 모두 포함.
+
+    Phase 11 ~ 그룹 58 사이에는 4 필드 (tool/severity/message/line) 만 직렬화됐었다.
+    PR (그룹 58 후속) 에서 category + language 추가. 본 가드가 silent 회귀 차단.
+    """
+    issue = _StubIssue(category="security", language="ruby")
+    result = build_analysis_result_dict(
+        ai_review=_make_ai_review(),
+        score_result=_make_score_result(),
+        analysis_results=[_StubAnalysisResult(issues=[issue])],
+        source="pr",
+    )
+
+    assert "issues" in result, "issues 키 자체 누락"
+    assert len(result["issues"]) == 1, f"issues 개수 불일치: {len(result['issues'])}"
+
+    issue_dict: dict[str, Any] = result["issues"][0]
+    expected_keys = {"tool", "severity", "message", "line", "category", "language"}
+    actual_keys = set(issue_dict.keys())
+    missing = expected_keys - actual_keys
+    extra = actual_keys - expected_keys
+    assert not missing, f"필수 필드 누락 (silent 회귀): {missing}"
+    assert not extra, f"예상 외 필드 추가 (스키마 검증 필요): {extra}"
+
+    # 값 보존 검증
+    assert issue_dict["tool"] == "pylint"
+    assert issue_dict["severity"] == "warning"
+    assert issue_dict["message"] == "unused import"
+    assert issue_dict["line"] == 12
+    assert issue_dict["category"] == "security"
+    assert issue_dict["language"] == "ruby"
+
+
+def test_issues_json_multi_results_preserves_order() -> None:
+    """여러 analysis_result 의 issues 가 모두 순서대로 직렬화."""
+    r1 = _StubAnalysisResult(issues=[
+        _StubIssue(tool="pylint", message="A", language="python", category="code_quality"),
+        _StubIssue(tool="bandit", message="B", language="python", category="security"),
+    ])
+    r2 = _StubAnalysisResult(issues=[
+        _StubIssue(tool="rubocop", message="C", language="ruby", category="code_quality"),
+    ])
+
+    result = build_analysis_result_dict(
+        ai_review=_make_ai_review(),
+        score_result=_make_score_result(),
+        analysis_results=[r1, r2],
+        source="push",
+    )
+
+    assert len(result["issues"]) == 3
+    assert [i["message"] for i in result["issues"]] == ["A", "B", "C"]
+    assert [i["language"] for i in result["issues"]] == ["python", "python", "ruby"]
+    assert [i["category"] for i in result["issues"]] == ["code_quality", "security", "code_quality"]
+
+
+def test_issues_json_empty_when_no_issues() -> None:
+    """이슈 0건일 때 issues 는 빈 리스트 (None 아님)."""
+    result = build_analysis_result_dict(
+        ai_review=_make_ai_review(),
+        score_result=_make_score_result(),
+        analysis_results=[_StubAnalysisResult(issues=[])],
+        source="cli",
+    )
+    assert result["issues"] == [], "이슈 0건 시 빈 리스트여야 함 (None 또는 누락 X)"


### PR DESCRIPTION
…가 (+3 가드)

dashboard 재설계 기획 (PR #181, 그룹 58) 의 데이터 자산 정찰에서 발견: build_analysis_result_dict 가 issues JSON 에 category / language 미직렬화 (pipeline.py:75-79) → 향후 dashboard 의 "언어별 / 카테고리별 사후 분석" 차단.

== 변경 ==

src/worker/pipeline.py:75-86
- 4 필드 → 6 필드: · 기존: tool / severity / message / line · 추가: category / language

dataclass AnalysisIssue (analyzer/pure/registry.py:36-45) 에는 이미 category + language 가 있으나 JSON 직렬화에서 누락. 1줄 fix 로 신규 데이터부터 즉시 복구.

== 회귀 가드 +3 (정책 4 — 단언과 가드 묶음) ==

tests/unit/worker/test_pipeline_result_dict.py 신규:

1. test_issues_json_contains_six_fields
   - 6 필드 모두 존재 + 값 보존 검증
   - silent 회귀 (필드 누락 / 추가) 차단
   - missing/extra 양방향 가드

2. test_issues_json_multi_results_preserves_order
   - 여러 analysis_result 의 issues 가 순서대로 직렬화
   - language/category 도 순서 보존

3. test_issues_json_empty_when_no_issues
   - 이슈 0건 시 빈 리스트 (None 아님)
   - CLI Hook (정적분석 없이 AI 만) 케이스 등 커버

== 5-way sync 보존 ==
- form 필드명 + JS 헬퍼 + RepoConfig + ORM 모두 불변
- Analysis.result JSON 스키마만 +2 필드 (backward-compatible 추가)
- DB 마이그레이션 X (JSON 컬럼)

== 검증 ==
- tests/unit/worker/test_pipeline_result_dict.py 3 PASS
- pylint src/worker/pipeline.py 10.00/10
- 단위 테스트 1984 → 1987 (+3)
- 사전 환경 의존성 1 실패 (test_pipeline_falls_back_to_settings_token_when_no_owner) 는 본 PR 무관 (다른 사이클들에서 확인됨)

== 후방 호환성 (backward compatibility) ==

기존 Analysis 레코드의 result["issues"] 항목은 4 필드만 있음. 신규 데이터부터 6 필드. 향후 dashboard / 분석 코드 작성 시 .get("category", "unknown") 패턴 의무 — 기존 데이터 NULL 대응.

== 자율 판단 보고 (정책 3) ==

1. **rule_id 추가 보류** — dashboard 기획서 "추가 수집 권장 데이터" 에 명시됐으나 AnalysisIssue dataclass 자체에 rule_id 필드가 없음. 1줄 fix 로 불가능 → 별도 PR 필요. 본 PR 은 dataclass 변경 없이 가능한 2 필드 (category/language) 만.

2. **별도 PR (PR-2) 로 분리** — 정책 7 (PR 단위) + 코드 변경이라 STATE/정책 docs PR (PR-1) 와 분리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
