### PR TITLE
fix(design): v2 목업 가로폭 정합성 — topbar wrapper + chart padding + 차트 종횡비

### DIFF
--- a/docs/design/mockups/2026-05-02-dashboard-v2-insight.html
+++ b/docs/design/mockups/2026-05-02-dashboard-v2-insight.html
@@ -89,10 +89,18 @@
     .topbar {
       background: var(--bg-surface);
       border-bottom: 1px solid var(--border);
-      padding: 0 32px;
       height: 56px;
-      display: flex; align-items: center; gap: 16px;
       position: sticky; top: 0; z-index: 50;
+    }
+    /* topbar 내부 max-width — Insight 페이지 (max-width 880) 와 다른 1200 사용:
+       두 모드 (Overview 1200 / Insight 880) topbar 정렬은 동일 max-width 1200 으로 통일.
+       이렇게 하면 Overview ↔ Insight 모드 전환 시 topbar 컨텐츠 위치가 안 바뀜. */
+    .topbar-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 32px;
+      height: 100%;
+      display: flex; align-items: center; gap: 16px;
     }
     .topbar-logo {
       font-family: var(--font-heading);
@@ -335,7 +343,7 @@
        Mobile (< 768px)
        ──────────────────────────────────────────────────────────────── */
     @media (max-width: 768px) {
-      .topbar { padding: 0 16px; gap: 8px; }
+      .topbar-inner { padding: 0 16px; gap: 8px; }
       .topbar-nav { gap: 0; }
       .topbar-nav a { padding: 6px 8px; font-size: 12px; }
       .topbar-mode { display: none; }
@@ -382,22 +390,24 @@
 
   <!-- Top Bar -->
   <div class="topbar">
-    <a href="#" class="topbar-logo">
-      <span class="topbar-logo-mark">⚡</span>
-      SCAManager
-    </a>
-    <div class="topbar-nav">
-      <a href="#">Repos</a>
-      <a href="#" class="active">Dashboard</a>
-      <a href="#">Settings</a>
+    <div class="topbar-inner">
+      <a href="#" class="topbar-logo">
+        <span class="topbar-logo-mark">⚡</span>
+        SCAManager
+      </a>
+      <div class="topbar-nav">
+        <a href="#">Repos</a>
+        <a href="#" class="active">Dashboard</a>
+        <a href="#">Settings</a>
+      </div>
+      <div class="topbar-spacer"></div>
+      <div class="topbar-mode">
+        <a href="2026-05-02-dashboard-v2-overview.html">📊 Overview</a>
+        <a href="#" class="active">💬 Insight</a>
+      </div>
+      <button class="topbar-theme">🌗</button>
+      <div class="topbar-user">U</div>
     </div>
-    <div class="topbar-spacer"></div>
-    <div class="topbar-mode">
-      <a href="2026-05-02-dashboard-v2-overview.html">📊 Overview</a>
-      <a href="#" class="active">💬 Insight</a>
-    </div>
-    <button class="topbar-theme">🌗</button>
-    <div class="topbar-user">U</div>
   </div>
 
   <!-- Page -->

--- a/docs/design/mockups/2026-05-02-dashboard-v2-overview.html
+++ b/docs/design/mockups/2026-05-02-dashboard-v2-overview.html
@@ -108,10 +108,16 @@
     .topbar {
       background: var(--bg-surface);
       border-bottom: 1px solid var(--border);
-      padding: 0 32px;
       height: 56px;
-      display: flex; align-items: center; gap: 16px;
       position: sticky; top: 0; z-index: 50;
+    }
+    /* topbar 내부 컨텐츠 max-width 1200 + 중앙 정렬 — page 와 좌우 정렬 통일 */
+    .topbar-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 32px;
+      height: 100%;
+      display: flex; align-items: center; gap: 16px;
     }
     .topbar-logo {
       font-family: var(--font-heading);
@@ -296,7 +302,7 @@
       background: var(--bg-surface);
       border: 1px solid var(--border);
       border-radius: 14px;
-      padding: 28px;
+      padding: 24px;  /* KPI/sec-card 와 동일 padding (정합) */
       margin-bottom: 24px;
     }
     .chart-header {
@@ -330,11 +336,11 @@
     }
     .chart-wrap-inner {
       position: relative;
-      /* 메인 차트 높이 — 데스크탑 320px 고정 (KPI 카드 4 폭과 비례 유지) */
-      height: 320px;
+      /* 메인 차트 높이 — 데스크탑 380px (종횡비 약 2.8:1, Stripe/Linear 표준) */
+      height: 380px;
     }
     @media (max-width: 768px) {
-      .chart-wrap-inner { height: 240px; }
+      .chart-wrap-inner { height: 260px; }
     }
 
     /* ────────────────────────────────────────────────────────────────
@@ -396,7 +402,7 @@
        Mobile (< 768px)
        ──────────────────────────────────────────────────────────────── */
     @media (max-width: 768px) {
-      .topbar { padding: 0 16px; gap: 8px; }
+      .topbar-inner { padding: 0 16px; gap: 8px; }
       .topbar-nav { gap: 0; }
       .topbar-nav a { padding: 6px 8px; font-size: 12px; }
       .topbar-mode { display: none; }  /* 모바일에선 별도 컨트롤 */
@@ -442,22 +448,24 @@
 
   <!-- Top Bar -->
   <div class="topbar">
-    <a href="#" class="topbar-logo">
-      <span class="topbar-logo-mark">⚡</span>
-      SCAManager
-    </a>
-    <div class="topbar-nav">
-      <a href="#">Repos</a>
-      <a href="#" class="active">Dashboard</a>
-      <a href="#">Settings</a>
+    <div class="topbar-inner">
+      <a href="#" class="topbar-logo">
+        <span class="topbar-logo-mark">⚡</span>
+        SCAManager
+      </a>
+      <div class="topbar-nav">
+        <a href="#">Repos</a>
+        <a href="#" class="active">Dashboard</a>
+        <a href="#">Settings</a>
+      </div>
+      <div class="topbar-spacer"></div>
+      <div class="topbar-mode">
+        <a href="#" class="active">📊 Overview</a>
+        <a href="2026-05-02-dashboard-v2-insight.html">💬 Insight</a>
+      </div>
+      <button class="topbar-theme">🌗</button>
+      <div class="topbar-user">U</div>
     </div>
-    <div class="topbar-spacer"></div>
-    <div class="topbar-mode">
-      <a href="#" class="active">📊 Overview</a>
-      <a href="2026-05-02-dashboard-v2-insight.html">💬 Insight</a>
-    </div>
-    <button class="topbar-theme">🌗</button>
-    <div class="topbar-user">U</div>
   </div>
 
   <!-- Page -->


### PR DESCRIPTION
PR #186 머지 후 잔여 정합성 이슈 3건 처리 (사용자 사이클 권장 수용 결과).

## 🅐 topbar 풀폭 vs page 1200 정렬 어긋남
- `.topbar` 풀폭 유지 (sticky 시각적 단절 방지) + 내부 `.topbar-inner` wrapper 추가 · max-width: 1200px + margin: 0 auto + padding: 0 32px · 화면 폭 1440px 시 topbar 컨텐츠와 page 컨텐츠 좌측 정렬 일치 (이전 120px 어긋남 해소)
- Insight 모드 (page max-width 880) topbar 도 동일 1200 으로 통일 → Overview ↔ Insight 모드 전환 시 topbar 컨텐츠 위치 안 바뀜
- mobile media query: `.topbar` → `.topbar-inner` 셀렉터 갱신

## 🅑 chart-card padding 28 → 24
- KPI / sec-card 와 동일 24px → 메인 차트 내부 컨텐츠 라인 정렬 통일

## 🅒 차트 종횡비 3.4:1 → 2.8:1
- chart-wrap-inner height: 320 → 380 (데스크탑) / 240 → 260 (모바일 768px↓)
- Stripe / Linear 표준 종횡비에 부합

목업 데이터 / 디자인 토큰 / 모드 토글 / 테마 토글 모두 변경 없음.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
