### PR TITLE
feat(dashboard): Phase 1 PR 4 — MVP-B /dashboard 라우트 신설

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ src/
 ├── main.py                     # FastAPI 앱, lifespan(DB 마이그레이션 + http_client), 전체 라우터 등록 + StaticFiles `/static` mount (UI 감사 Step C)
 ├── static/
 │   └── vendor/
-│       └── chart.umd.min.js    # Chart.js 4.4.0 UMD min vendoring — CDN 차단/오프라인 환경 호환 (UI 감사 Step C). 사용처: repo_detail / analysis_detail
+│       └── chart.umd.min.js    # Chart.js 4.4.0 UMD min vendoring — CDN 차단/오프라인 환경 호환 (UI 감사 Step C). 사용처: repo_detail / analysis_detail / dashboard
 ├── config.py                   # pydantic-settings 환경변수 관리, postgres:// URL 자동 변환
 ├── constants.py                # 전역 상수 단일 출처 — 점수배점/감점가중치/AI기본값/등급/알림한도/HTTP타임아웃/캐시TTL
 ├── crypto.py                   # encrypt_token()/decrypt_token() — TOKEN_ENCRYPTION_KEY
@@ -87,6 +87,7 @@ src/
 ├── services/                   # use case 계층 — 신규 오케스트레이션 모듈의 배치 장소 (기존 pipeline/engine/manager 는 도메인 위치 유지)
 │   ├── analytics_service.py    # 집계 단일 출처 — weekly_summary, moving_average, resolve_chat_id (top_issues / author_trend / repo_comparison / leaderboard 는 Phase 1 PR 1~3 폐기)
 │   ├── cron_service.py         # 주기적 실행 — run_weekly_reports, run_trend_check
+│   ├── dashboard_service.py    # /dashboard MVP-B (Phase 1 PR 4) — dashboard_kpi (KPI 4 카드), dashboard_trend (라인 차트), frequent_issues_v2 (Q7 신규 · category/language/tool 포함)
 │   └── merge_retry_service.py  # process_pending_retries 워커 (CI-aware Auto Merge 재시도)
 ├── auth/
 │   ├── session.py              # get_current_user() + require_login Depends
@@ -185,14 +186,15 @@ src/
 │   └── internal_cron.py        # POST /api/internal/cron/weekly|trend — INTERNAL_CRON_API_KEY 전용
 ├── ui/
 │   ├── _helpers.py             # get_accessible_repo · webhook_base_url · delete_repo_cascade · templates
-│   ├── router.py               # aggregator — routes 5개 include (Phase 1 PR 3 에서 insights 폐기, catch-all `/repos/{name}` 마지막)
+│   ├── router.py               # aggregator — routes 6개 include (Phase 1 PR 3 insights 폐기, PR 4 dashboard 추가, catch-all `/repos/{name}` 마지막)
 │   └── routes/
 │       ├── overview.py         # GET /
+│       ├── dashboard.py        # GET /dashboard (Phase 1 PR 4 — MVP-B; supersedes /insights)
 │       ├── add_repo.py         # /repos/add (GET/POST) · /api/github/repos
 │       ├── settings.py         # /repos/{name}/settings · reinstall-hook · reinstall-webhook
 │       ├── actions.py          # /repos/{name}/delete
 │       └── detail.py           # /repos/{name}/analyses/{id} · /repos/{name}
-├── templates/                  # add_repo, base, login, overview, repo_detail, analysis_detail, settings (insights / insights_me 는 Phase 1 PR 2~3 폐기)
+├── templates/                  # add_repo, base, login, overview, repo_detail, analysis_detail, settings, dashboard (insights / insights_me 는 Phase 1 PR 2~3 폐기)
 ├── cli/
 │   ├── __main__.py             # python -m src.cli review
 │   ├── git_diff.py             # 로컬 git diff 수집

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,11 +2,11 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-05-02 기준 — 그룹 59: 대시보드 v2 목업 + Phase 1 PR 1 (top_issues 폐기) 진행 중)
+## 현재 수치 (2026-05-02 기준 — 그룹 59: 대시보드 v2 목업 + Phase 1 PR 1~4 (MVP-B `/dashboard` 신설 완료))
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 단위 테스트 | **1984개** | pytest 9.0.3 (0 failed, 5 skipped) — Phase H+I 15 PR 신규 +37 + UI 감사 cleanup PR-4 회귀 가드 +12 + cleanup PR-D2 5-way sync 5번째 layer 가드 +5 (StaticFiles vendoring + 환각 토큰 / claude-dark / nav guard / chip a11y / chart aspect / safe-area / iOS 줌인 / PRESETS 9 키 / JS 헬퍼 12종 / themechange 페어) |
+| 단위 테스트 | **1984개** | pytest 9.0.3 — 그룹 59 PR 1~4 진행 중 변동: PR 1 (-3) + PR 2 (-6) + PR 3 (-12) + PR 4 (+19) = -2, 총 1984 → 1982 (집계 시점에 따라 1984 ± 환경 fail 7건 동일 pre-existing) |
 | 통합 테스트 | **72개** | tests/integration/ — Phase 4 PR-T5 +25 (e2e_pipeline_scenarios — webhook→pipeline→gate 종단간) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
@@ -69,7 +69,8 @@
 | **#187** Fix dashboard v2 mockup width alignment | 가로폭 정합성 3건 — topbar 풀폭 vs page 1200 어긋남 (`.topbar-inner` wrapper, max-width 1200) + chart-card padding 28→24 (모든 카드 동일) + 차트 종횡비 3.4:1 → 2.8:1 (height 320→380, 모바일 240→260). Overview ↔ Insight topbar 위치 통일 |
 | **#188** Chore/insights cleanup top issues | Phase 1 PR 1 — `analytics_service.top_issues` 함수 + `/insights/me` 라우트 호출처 + `templates/insights_me.html` 자주 발생 이슈 블록 + `tests/unit/services/test_analytics_service.py::TestTopIssues` 4 + `tests/unit/ui/test_insights_routes.py` mock 3 + 통합 테스트 1 폐기. 회귀 가드 신규 `tests/unit/services/test_analytics_service_deprecations.py` (+2) — `hasattr(svc, "top_issues") == False` + `pytest.raises(ImportError)` 패턴 |
 | **#189** Chore/insights cleanup me page | Phase 1 PR 2 — `analytics_service.author_trend` 함수 + `src/api/insights.py::get_author_trend` REST 엔드포인트 + `src/ui/routes/insights.py::insights_me` 라우트 + `_compute_kpi` 헬퍼 + **`templates/insights_me.html` 파일 통째 삭제** + `templates/insights.html` "내 추세 →" 링크 + 관련 테스트 10건 (TestAuthorTrend 4 + test_insights_api author_trend 3 + test_insights_routes me 3) 폐기. 회귀 가드 +4 (`test_author_trend_function_removed/import_raises`, `test_insights_me_route_removed`, `test_get_author_trend_api_removed`). themechange / chart vendoring 가드 (test_router.py) `insights_me.html` 참조 제거 |
-| **#190 (진행 중)** Chore/insights cleanup compare page | Phase 1 PR 3 — `analytics_service.{repo_comparison, leaderboard}` 함수 + `src/api/insights.py` 파일 통째 삭제 (router 비어 — main.py L23/L158 정리) + `src/ui/routes/insights.py` 파일 통째 삭제 (ui/router.py L16/L26 정리) + **`templates/insights.html` 파일 통째 삭제** + 테스트 파일 3종 통째 삭제 (`test_analytics_service_insights.py`, `test_insights_api.py`, `test_insights_routes.py` — 총 22 테스트). 회귀 가드 +7 (`{repo_comparison,leaderboard}_function_removed/import_raises`, `insights_compare_route_removed`, `get_{repo_compare,leaderboard}_api_removed`). chip a11y 가드 폐기 (insights.html 부재) |
+| **#190** Chore/insights cleanup compare page | Phase 1 PR 3 — `analytics_service.{repo_comparison, leaderboard}` 함수 + `src/api/insights.py` 파일 통째 삭제 (router 비어 — main.py L23/L158 정리) + `src/ui/routes/insights.py` 파일 통째 삭제 (ui/router.py L16/L26 정리) + **`templates/insights.html` 파일 통째 삭제** + 테스트 파일 3종 통째 삭제 (`test_analytics_service_insights.py`, `test_insights_api.py`, `test_insights_routes.py` — 총 22 테스트). 회귀 가드 +7 (`{repo_comparison,leaderboard}_function_removed/import_raises`, `insights_compare_route_removed`, `get_{repo_compare,leaderboard}_api_removed`). chip a11y 가드 폐기 (insights.html 부재) |
+| **#191 (진행 중)** Feat/dashboard mvp-b route | Phase 1 PR 4 — **신규 `/dashboard` MVP-B 라우트** (사용자 결정 Q1=🅑/Q5=C+E/Q6=사용자 신호/Q7=신규 함수 모두 적용). 신규 service 모듈 `src/services/dashboard_service.py` (3 함수: `dashboard_kpi` KPI 4 카드 [평균 점수/분석 건수/보안 HIGH/활성 리포] + delta vs 직전 윈도우, `dashboard_trend` 날짜별 평균, `frequent_issues_v2` Q7 신규 — category/language/tool 보존). 신규 라우트 `src/ui/routes/dashboard.py` + 템플릿 `src/templates/dashboard.html` (Claude × Linear scoped 디자인 — `.dashboard-page` wrapper, base.html 4-테마 공존, Crimson Pro 시스템 serif fallback). Chart.js vendoring 재사용 + themechange 페어. 신규 단위 테스트 +19 (service 14 + 라우트 5). chart vendoring + themechange 가드에 `dashboard.html` 추가 |
 
 **Phase 1 PR 분할 계획** (사용자 승인 — 5 PR):
 1. **PR 1 (#188 진행 중)**: `top_issues` 폐기

--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -1,0 +1,225 @@
+"""Dashboard service — Phase 1 PR 4 (MVP-B 신규 함수).
+Dashboard service for the new /dashboard route (replaces deprecated /insights/*).
+
+함수 3종:
+- dashboard_kpi(db, days, *, now) -> KPI 4 카드 (평균 점수 / 분석 건수 / 보안 HIGH / 활성 리포)
+- dashboard_trend(db, days, *, now) -> 날짜별 평균 점수 추세 (라인 차트)
+- frequent_issues_v2(db, days, *, n, now) -> global 자주 발생 이슈 (Q7 신규 — category/language/tool 포함)
+
+기존 analytics_service 의 (top_issues / author_trend / repo_comparison / leaderboard) 폐기 4종을 대체하는
+새 데이터 모델. now 인자 의존성 주입 패턴 (analytics_service 와 동일) — freezegun 미사용.
+
+Replaces deprecated analytics_service.{top_issues,author_trend,repo_comparison,leaderboard}.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from src.models.analysis import Analysis
+from src.models.repository import Repository
+from src.scorer.calculator import calculate_grade
+
+
+# ─── KPI ──────────────────────────────────────────────────────────────────
+
+
+def dashboard_kpi(
+    db: Session,
+    days: int = 7,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """KPI 4 카드 데이터 — 현재 days 윈도우 + 직전 동일 days 윈도우 비교 (delta).
+
+    Returns:
+        {
+          "avg_score": {"value": float|None, "grade": str|None, "delta": float|None},
+          "analysis_count": {"value": int, "delta": int},
+          "high_security_issues": {"value": int, "delta": int},
+          "active_repos": {"value": int, "total": int, "delta": int},
+        }
+
+    delta = 현재 윈도우 - 직전 윈도우 (양수 = 개선, 단 high_security_issues 는 음수가 개선).
+    """
+    _now = now or datetime.now(timezone.utc)
+    cur_since = _now - timedelta(days=days)
+    prev_since = _now - timedelta(days=days * 2)
+
+    # 현재 + 직전 윈도우 분석 (delta 비교용)
+    # Pull current and previous window analyses (for delta comparison)
+    cur_analyses = list(db.scalars(
+        select(Analysis)
+        .where(Analysis.created_at >= cur_since)
+        .where(Analysis.created_at <= _now)
+    ).all())
+    prev_analyses = list(db.scalars(
+        select(Analysis)
+        .where(Analysis.created_at >= prev_since)
+        .where(Analysis.created_at < cur_since)
+    ).all())
+
+    total_repos = db.scalar(select(func.count(Repository.id)))  # pylint: disable=not-callable
+
+    return {
+        "avg_score": _kpi_avg(cur_analyses, prev_analyses),
+        "analysis_count": {
+            "value": len(cur_analyses),
+            "delta": len(cur_analyses) - len(prev_analyses),
+        },
+        "high_security_issues": _kpi_security(cur_analyses, prev_analyses),
+        "active_repos": _kpi_active_repos(cur_analyses, prev_analyses, int(total_repos or 0)),
+    }
+
+
+def _kpi_avg(cur: list[Analysis], prev: list[Analysis]) -> dict[str, Any]:
+    """평균 점수 + 등급 + delta 카드 빌더."""
+    cur_scored = [a.score for a in cur if a.score is not None]
+    prev_scored = [a.score for a in prev if a.score is not None]
+    avg_value = round(sum(cur_scored) / len(cur_scored), 1) if cur_scored else None
+    prev_avg = round(sum(prev_scored) / len(prev_scored), 1) if prev_scored else None
+    grade = calculate_grade(int(avg_value)) if avg_value is not None else None
+    delta = (
+        round(avg_value - prev_avg, 1) if (avg_value is not None and prev_avg is not None) else None
+    )
+    return {"value": avg_value, "grade": grade, "delta": delta}
+
+
+def _kpi_security(cur: list[Analysis], prev: list[Analysis]) -> dict[str, int]:
+    """보안 HIGH 이슈 카운트 + delta 카드 빌더."""
+    cur_high = _count_high_security(cur)
+    return {"value": cur_high, "delta": cur_high - _count_high_security(prev)}
+
+
+def _kpi_active_repos(
+    cur: list[Analysis], prev: list[Analysis], total: int
+) -> dict[str, int]:
+    """활성 리포 수 + 전체 + delta 카드 빌더."""
+    cur_active = len({a.repo_id for a in cur})
+    return {
+        "value": cur_active,
+        "total": total,
+        "delta": cur_active - len({a.repo_id for a in prev}),
+    }
+
+
+def _count_high_security(analyses: list[Analysis]) -> int:
+    """Analysis.result['issues'] JSON 중 category=security AND severity=HIGH 카운트.
+
+    PR #185 회귀 가드로 issues JSON 에 category/severity 필드 보장됨.
+    """
+    total = 0
+    for a in analyses:
+        result = a.result or {}
+        for issue in result.get("issues", []):
+            if not isinstance(issue, dict):
+                continue
+            if issue.get("category") == "security" and issue.get("severity", "").upper() == "HIGH":
+                total += 1
+    return total
+
+
+# ─── 추세 (라인 차트) ─────────────────────────────────────────────────────
+
+
+def dashboard_trend(
+    db: Session,
+    days: int = 7,
+    *,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """날짜별 평균 점수 추세 (라인 차트용).
+
+    Returns:
+        [{"date": "YYYY-MM-DD", "avg_score": float, "count": int}, ...]
+        날짜 오름차순.
+    """
+    _now = now or datetime.now(timezone.utc)
+    since = _now - timedelta(days=days)
+
+    analyses = db.scalars(
+        select(Analysis)
+        .where(Analysis.created_at >= since)
+        .where(Analysis.score.isnot(None))
+        .order_by(Analysis.created_at.asc())
+    ).all()
+
+    # Python-side 날짜별 그룹화 — SQLite/PG 날짜 함수 불일치 회피
+    daily: dict[str, list[int]] = {}
+    for a in analyses:
+        date_str = a.created_at.strftime("%Y-%m-%d") if a.created_at else ""
+        if date_str:
+            daily.setdefault(date_str, []).append(a.score)
+
+    return [
+        {
+            "date": date_str,
+            "avg_score": round(sum(scores) / len(scores), 1),
+            "count": len(scores),
+        }
+        for date_str, scores in sorted(daily.items())
+    ]
+
+
+# ─── 자주 발생 이슈 (Q7 신규) ─────────────────────────────────────────────
+
+
+def frequent_issues_v2(
+    db: Session,
+    days: int = 7,
+    *,
+    n: int = 5,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """global 자주 발생 이슈 — category/language/tool 보존.
+
+    폐기된 top_issues 와 차이:
+    - repo_id 인자 제거 (global 집계)
+    - category/language/tool 필드 반환
+
+    Returns:
+        [{"message": str, "count": int, "category": str, "language": str, "tool": str}, ...]
+        빈도 내림차순, 최대 n 개.
+    """
+    _now = now or datetime.now(timezone.utc)
+    since = _now - timedelta(days=days)
+
+    analyses = db.scalars(
+        select(Analysis)
+        .where(Analysis.created_at >= since)
+        .where(Analysis.result.isnot(None))
+    ).all()
+
+    # message 키로 카운트 + 첫 번째 발견 시점의 category/language/tool 저장
+    counter: dict[str, int] = {}
+    meta: dict[str, dict[str, str]] = {}
+    for a in analyses:
+        result = a.result or {}
+        for issue in result.get("issues", []):
+            if not isinstance(issue, dict):
+                continue
+            key = issue.get("message") or issue.get("code")
+            if not key:
+                continue
+            counter[key] = counter.get(key, 0) + 1
+            if key not in meta:
+                meta[key] = {
+                    "category": issue.get("category", ""),
+                    "language": issue.get("language", ""),
+                    "tool": issue.get("tool", ""),
+                }
+
+    sorted_items = sorted(counter.items(), key=lambda x: x[1], reverse=True)
+    return [
+        {
+            "message": msg,
+            "count": cnt,
+            "category": meta[msg]["category"],
+            "language": meta[msg]["language"],
+            "tool": meta[msg]["tool"],
+        }
+        for msg, cnt in sorted_items[:n]
+    ]

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1,0 +1,370 @@
+{% extends "base.html" %}
+{% block title %}Dashboard · SCAManager{% endblock %}
+
+{# Phase 1 PR 4 — MVP-B 신규 페이지. /insights (PR 1~3 폐기) 후속. #}
+{# Claude × Linear 디자인 시스템 부분 적용 (scoped — 다른 페이지 영향 0). #}
+
+{% block content %}
+<style>
+  /* ────────────────────────────────────────────────────────────────
+     Dashboard 전용 scoped 토큰 — 다른 페이지 영향 X.
+     v2 목업 (docs/design/mockups/2026-05-02-dashboard-v2-overview.html) 디자인 시스템 일부.
+     운영 base.html 의 4-테마 (dark/light/glass/claude-dark) 와 공존.
+     Crimson Pro 는 시스템 serif fallback (Phase 4 에서 base 통합 시 Google Fonts 추가 결정).
+     ──────────────────────────────────────────────────────────────── */
+  .dashboard-page {
+    --d-accent: #D97757;
+    --d-accent-soft: rgba(217, 119, 87, 0.08);
+    --d-success: #9CAF88;
+    --d-warning: #D4A574;
+    --d-danger: #C84E3F;
+    --d-grade-a: #9CAF88;
+    --d-grade-b: #A8A595;
+    --d-grade-c: #D4A574;
+    --d-grade-d: #C8895E;
+    --d-grade-f: #C84E3F;
+    --d-font-heading: Charter, Georgia, 'Crimson Pro', serif;
+  }
+  body[data-theme="claude-dark"] .dashboard-page {
+    --d-accent: #E08968;
+    --d-success: #A8BA94;
+    --d-warning: #DDB585;
+    --d-danger: #D45F50;
+  }
+
+  .dashboard-page {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 32px 16px 64px;
+  }
+
+  .dash-header {
+    display: flex; align-items: flex-end; justify-content: space-between;
+    margin-bottom: 32px; gap: 16px; flex-wrap: wrap;
+  }
+  .dash-title {
+    font-family: var(--d-font-heading);
+    font-size: 32px; font-weight: 600;
+    letter-spacing: -.02em;
+    margin: 0 0 4px;
+    color: var(--text-primary);
+  }
+  .dash-subtitle {
+    font-size: 14px; color: var(--text-muted);
+    margin: 0;
+  }
+
+  .dash-range-toggle {
+    display: inline-flex; gap: 1px; padding: 3px;
+    background: var(--bg-elevated, var(--card-bg, rgba(255,255,255,.04)));
+    border-radius: 9px;
+    border: 1px solid var(--border, rgba(255,255,255,.08));
+  }
+  .dash-range-toggle a {
+    padding: 7px 14px; border-radius: 6px;
+    font-size: 13px; font-weight: 500;
+    color: var(--text-muted); text-decoration: none;
+    min-height: 40px; box-sizing: border-box;
+    display: inline-flex; align-items: center;
+    transition: all .15s ease;
+  }
+  .dash-range-toggle a.active {
+    background: var(--bg-elevated, var(--card-bg, #fff));
+    color: var(--text-primary);
+    font-weight: 600;
+    box-shadow: 0 1px 2px rgba(0,0,0,.06);
+  }
+
+  /* KPI 4 카드 — 동일 높이 정합 (목업 v2 정합성 PR #187 패턴) */
+  .dash-kpi-grid {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px;
+    margin-bottom: 24px;
+  }
+  .dash-kpi {
+    background: var(--card-bg, var(--bg-surface, rgba(255,255,255,.04)));
+    border: 1px solid var(--border, rgba(255,255,255,.08));
+    border-radius: 14px;
+    padding: 20px;
+    display: flex; flex-direction: column;
+    min-height: 152px;
+    transition: border-color .2s ease;
+  }
+  .dash-kpi:hover { border-color: var(--d-accent); }
+  .dash-kpi-label {
+    font-size: 12px; color: var(--text-muted); font-weight: 500;
+    margin-bottom: 12px; min-height: 18px;
+  }
+  .dash-kpi-row {
+    display: flex; align-items: baseline; gap: 8px;
+    margin-bottom: 8px; min-height: 38px;
+  }
+  .dash-kpi-value {
+    font-family: var(--d-font-heading);
+    font-size: 36px; font-weight: 600;
+    letter-spacing: -.02em; line-height: 1;
+    color: var(--text-primary);
+  }
+  .dash-kpi-grade { font-size: 14px; font-weight: 600; color: var(--text-muted); }
+  .dash-kpi-grade.A { color: var(--d-grade-a); }
+  .dash-kpi-grade.B { color: var(--d-grade-b); }
+  .dash-kpi-grade.C { color: var(--d-grade-c); }
+  .dash-kpi-grade.D { color: var(--d-grade-d); }
+  .dash-kpi-grade.F { color: var(--d-grade-f); }
+  .dash-kpi-delta {
+    font-size: 12px; font-weight: 500;
+    display: inline-flex; align-items: center; gap: 4px;
+    margin-top: auto;  /* 항상 카드 하단 고정 */
+    min-height: 16px;
+  }
+  .dash-kpi-delta.up { color: var(--d-success); }
+  .dash-kpi-delta.down { color: var(--d-danger); }
+  .dash-kpi-delta.neu { color: var(--text-muted); }
+
+  /* Chart card */
+  .dash-chart-card {
+    background: var(--card-bg, var(--bg-surface, rgba(255,255,255,.04)));
+    border: 1px solid var(--border, rgba(255,255,255,.08));
+    border-radius: 14px;
+    padding: 20px;
+    margin-bottom: 24px;
+  }
+  .dash-section-title {
+    font-family: var(--d-font-heading);
+    font-size: 18px; font-weight: 600;
+    letter-spacing: -.01em;
+    margin: 0 0 16px;
+    color: var(--text-primary);
+  }
+  .dash-chart-wrap {
+    position: relative;
+    height: 320px;
+  }
+
+  /* 자주 발생 이슈 카드 */
+  .dash-issues-card {
+    background: var(--card-bg, var(--bg-surface, rgba(255,255,255,.04)));
+    border: 1px solid var(--border, rgba(255,255,255,.08));
+    border-radius: 14px;
+    padding: 20px;
+  }
+  .dash-issue-row {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0;
+    border-bottom: 1px solid var(--border, rgba(255,255,255,.08));
+    min-height: 56px;
+  }
+  .dash-issue-row:last-child { border-bottom: none; }
+  .dash-issue-msg {
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+    font-size: 13px; color: var(--text-primary);
+  }
+  .dash-issue-meta {
+    font-size: 11px; color: var(--text-subtle, var(--text-muted));
+    margin-top: 2px;
+  }
+  .dash-issue-badge {
+    padding: 3px 10px; border-radius: 12px;
+    background: var(--bg-input, rgba(255,255,255,.04));
+    font-size: 11px; font-weight: 600;
+    color: var(--text-muted);
+    font-family: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  }
+
+  .dash-empty-state {
+    padding: 32px; text-align: center;
+    color: var(--text-muted); font-size: 14px;
+  }
+
+  /* 모바일 (< 768px) */
+  @media (max-width: 768px) {
+    .dashboard-page { padding: 24px 12px 64px; }
+    .dash-title { font-size: 26px; }
+    .dash-kpi-grid { grid-template-columns: 1fr 1fr; gap: 12px; }
+    .dash-kpi { padding: 16px; min-height: 132px; }
+    .dash-kpi-value { font-size: 28px; }
+    .dash-chart-wrap { height: 240px; }
+  }
+  @media (max-width: 480px) {
+    .dash-kpi-grid { grid-template-columns: 1fr; }
+    .dash-range-toggle a { min-height: 44px; }
+  }
+</style>
+
+<div class="dashboard-page">
+  <div class="dash-header">
+    <div>
+      <h1 class="dash-title">Dashboard</h1>
+      <p class="dash-subtitle">우리 코드는 어떻게 흘러가고 있나요</p>
+    </div>
+    <nav class="dash-range-toggle" aria-label="기간 선택 / Period selector">
+      <a href="/dashboard?days=1" {% if days == 1 %}class="active"{% endif %}>1d</a>
+      <a href="/dashboard?days=7" {% if days == 7 %}class="active"{% endif %}>7d</a>
+      <a href="/dashboard?days=30" {% if days == 30 %}class="active"{% endif %}>30d</a>
+      <a href="/dashboard?days=90" {% if days == 90 %}class="active"{% endif %}>90d</a>
+    </nav>
+  </div>
+
+  {# KPI 4 카드 #}
+  <div class="dash-kpi-grid">
+    <div class="dash-kpi">
+      <div class="dash-kpi-label">평균 점수</div>
+      <div class="dash-kpi-row">
+        <span class="dash-kpi-value">{{ kpi.avg_score.value if kpi.avg_score.value is not none else '—' }}</span>
+        {% if kpi.avg_score.grade %}<span class="dash-kpi-grade {{ kpi.avg_score.grade }}">{{ kpi.avg_score.grade }}</span>{% endif %}
+      </div>
+      {% if kpi.avg_score.delta is not none %}
+        {% if kpi.avg_score.delta > 0 %}
+          <div class="dash-kpi-delta up">▲ +{{ kpi.avg_score.delta }} vs 직전 {{ days }}일</div>
+        {% elif kpi.avg_score.delta < 0 %}
+          <div class="dash-kpi-delta down">▼ {{ kpi.avg_score.delta }} vs 직전 {{ days }}일</div>
+        {% else %}
+          <div class="dash-kpi-delta neu">— 변동 없음</div>
+        {% endif %}
+      {% else %}
+        <div class="dash-kpi-delta neu">— 비교 데이터 없음</div>
+      {% endif %}
+    </div>
+
+    <div class="dash-kpi">
+      <div class="dash-kpi-label">분석 건수</div>
+      <div class="dash-kpi-row">
+        <span class="dash-kpi-value">{{ kpi.analysis_count.value }}</span>
+      </div>
+      {% if kpi.analysis_count.delta > 0 %}
+        <div class="dash-kpi-delta up">▲ +{{ kpi.analysis_count.delta }} vs 직전 {{ days }}일</div>
+      {% elif kpi.analysis_count.delta < 0 %}
+        <div class="dash-kpi-delta down">▼ {{ kpi.analysis_count.delta }} vs 직전 {{ days }}일</div>
+      {% else %}
+        <div class="dash-kpi-delta neu">— 변동 없음</div>
+      {% endif %}
+    </div>
+
+    <div class="dash-kpi">
+      <div class="dash-kpi-label">보안 이슈 (HIGH)</div>
+      <div class="dash-kpi-row">
+        <span class="dash-kpi-value">{{ kpi.high_security_issues.value }}</span>
+      </div>
+      {% if kpi.high_security_issues.delta > 0 %}
+        <div class="dash-kpi-delta down">▲ +{{ kpi.high_security_issues.delta }} (악화)</div>
+      {% elif kpi.high_security_issues.delta < 0 %}
+        <div class="dash-kpi-delta up">▼ {{ kpi.high_security_issues.delta }} (개선)</div>
+      {% else %}
+        <div class="dash-kpi-delta neu">— 변동 없음</div>
+      {% endif %}
+    </div>
+
+    <div class="dash-kpi">
+      <div class="dash-kpi-label">활성 리포</div>
+      <div class="dash-kpi-row">
+        <span class="dash-kpi-value">{{ kpi.active_repos.value }}</span>
+        <span class="dash-kpi-grade">/ {{ kpi.active_repos.total }}</span>
+      </div>
+      {% if kpi.active_repos.delta > 0 %}
+        <div class="dash-kpi-delta up">▲ +{{ kpi.active_repos.delta }} vs 직전 {{ days }}일</div>
+      {% elif kpi.active_repos.delta < 0 %}
+        <div class="dash-kpi-delta down">▼ {{ kpi.active_repos.delta }} vs 직전 {{ days }}일</div>
+      {% else %}
+        <div class="dash-kpi-delta neu">— 변동 없음</div>
+      {% endif %}
+    </div>
+  </div>
+
+  {# 점수 추세 라인 차트 #}
+  <div class="dash-chart-card">
+    <h2 class="dash-section-title">점수 추세 ({{ days }}일)</h2>
+    {% if trend %}
+      <div class="dash-chart-wrap">
+        <canvas id="dashTrendChart"></canvas>
+      </div>
+    {% else %}
+      <div class="dash-empty-state">
+        최근 {{ days }}일간 분석 데이터가 없습니다.
+      </div>
+    {% endif %}
+  </div>
+
+  {# 자주 발생 이슈 #}
+  <div class="dash-issues-card">
+    <h2 class="dash-section-title">자주 발생 이슈 (최근 {{ days }}일)</h2>
+    {% if frequent_issues %}
+      {% for issue in frequent_issues %}
+      <div class="dash-issue-row">
+        <div>
+          <div class="dash-issue-msg">{{ issue.message }}</div>
+          <div class="dash-issue-meta">
+            {{ issue.tool or '—' }} · {{ issue.language or '—' }} · {{ issue.category or '—' }}
+          </div>
+        </div>
+        <span class="dash-issue-badge">{{ issue.count }}</span>
+      </div>
+      {% endfor %}
+    {% else %}
+      <div class="dash-empty-state">최근 {{ days }}일간 발견된 이슈가 없습니다.</div>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{% if trend %}
+<script src="/static/vendor/chart.umd.min.js"></script>
+<script>
+  // 추세 데이터 (서버 주입) — autoescape 안전
+  // Trend data (server-injected) — autoescape safe
+  const trendData = {{ trend | tojson }};
+
+  function readVar(name, fallback) {
+    const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    return v || fallback;
+  }
+
+  let dashChart = null;
+  function buildDashChart() {
+    const ctx = document.getElementById('dashTrendChart');
+    if (!ctx) return;
+    if (dashChart) dashChart.destroy();
+
+    const accent = readVar('--d-accent', '#D97757') || '#D97757';
+    const muted = readVar('--text-muted', '#888');
+    const subtle = readVar('--text-subtle', muted);
+    const border = readVar('--border', 'rgba(255,255,255,.08)');
+
+    dashChart = new Chart(ctx, {
+      type: 'line',
+      data: {
+        labels: trendData.map(d => d.date),
+        datasets: [{
+          label: '평균 점수',
+          data: trendData.map(d => d.avg_score),
+          borderColor: accent,
+          backgroundColor: accent + '22',
+          tension: 0.35,
+          pointRadius: 3,
+          pointHoverRadius: 5,
+          borderWidth: 2,
+          fill: true,
+        }]
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        scales: {
+          y: { min: 0, max: 100,
+               ticks: { color: subtle, stepSize: 25, font: { size: 11 } },
+               grid: { color: border, drawTicks: false } },
+          x: { ticks: { color: subtle, font: { size: 11 } }, grid: { display: false } }
+        },
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: true, padding: 10, cornerRadius: 8 }
+        }
+      }
+    });
+  }
+
+  buildDashChart();
+  // base.html dispatchEvent('themechange') ↔ dashboard 차트 재빌드 (UI 감사 Step C 패턴 통일)
+  document.addEventListener('themechange', buildDashChart);
+</script>
+{% endif %}
+{% endblock %}

--- a/src/ui/router.py
+++ b/src/ui/router.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter
 from src.ui.routes import (
     actions,
     add_repo,
+    dashboard,
     detail,
     overview,
     settings,
@@ -22,8 +23,7 @@ router = APIRouter()
 # 구체 경로 → 일반 경로 순
 # Specific routes first, catch-all route last.
 router.include_router(overview.router)       # GET /
-# NOTE: GET /insights (compare + leaderboard) removed in Phase 1 PR 3 (2026-05-02).
-# /dashboard (PR 4) supersedes; PR 5 will add /insights → /dashboard 301 redirect.
+router.include_router(dashboard.router)      # GET /dashboard (Phase 1 PR 4 — MVP-B; supersedes /insights)
 router.include_router(add_repo.router)       # GET/POST /repos/add, /api/github/repos
 router.include_router(settings.router)       # /repos/{name}/settings, reinstall-*
 router.include_router(actions.router)        # /repos/{name}/delete

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -1,0 +1,45 @@
+"""Dashboard UI 라우트 — Phase 1 PR 4 (MVP-B 신규 라우트).
+Dashboard UI route — replaces deprecated /insights / /insights/me (PR 1~3).
+
+GET /dashboard?days={1|7|30|90} — KPI 4 카드 + 라인 차트 + 자주 발생 이슈.
+"""
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import HTMLResponse
+
+from src.auth.session import CurrentUser, require_login
+from src.database import SessionLocal
+from src.services import dashboard_service
+from src.ui._helpers import templates
+
+router = APIRouter()
+
+
+@router.get("/dashboard", response_class=HTMLResponse)
+def dashboard(
+    request: Request,
+    current_user: Annotated[CurrentUser, Depends(require_login)],
+    days: int = 7,
+):
+    """대시보드 — KPI 4 카드 + 점수 추세 차트 + 자주 발생 이슈.
+    Dashboard — KPI 4 cards + score trend chart + frequent issues.
+    """
+    with SessionLocal() as db:
+        kpi = dashboard_service.dashboard_kpi(db, days=days)
+        trend = dashboard_service.dashboard_trend(db, days=days)
+        frequent_issues = dashboard_service.frequent_issues_v2(db, days=days, n=5)
+
+    return templates.TemplateResponse(
+        request,
+        "dashboard.html",
+        {
+            "current_user": current_user,
+            "kpi": kpi,
+            "trend": trend,
+            "frequent_issues": frequent_issues,
+            "days": days,
+        },
+    )

--- a/tests/unit/services/test_dashboard_service.py
+++ b/tests/unit/services/test_dashboard_service.py
@@ -1,0 +1,306 @@
+"""dashboard_service 단위 테스트 — Phase 1 PR 4 (MVP-B 신규 함수).
+
+신규 함수 3종 검증:
+- dashboard_kpi(db, days, *, now) -> dict (KPI 4 카드 — 평균 점수 / 분석 건수 / 보안 이슈 / 활성 리포)
+- dashboard_trend(db, days, *, now) -> list[dict] (날짜별 평균 추세)
+- frequent_issues_v2(db, days, *, n, now) -> list[dict] (자주 발생 이슈 — Q7 신규 함수)
+
+In-memory SQLite + Base.metadata.create_all 자체 fixture 사용.
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.repository import Repository
+from src.models.user import User
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션을 제공한다."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def user(db):
+    u = User(github_id=1, github_login="tester", email="t@x.com", display_name="Tester")
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def repos(db, user):
+    """3개 리포 fixture — 활성 리포 카운트 검증용."""
+    repo_objs = []
+    for name in ("owner/api", "owner/web", "owner/cli"):
+        r = Repository(full_name=name, user_id=user.id)
+        db.add(r)
+        repo_objs.append(r)
+    db.commit()
+    for r in repo_objs:
+        db.refresh(r)
+    return repo_objs
+
+
+def _make_analysis(
+    db: Session,
+    repo_id: int,
+    score: int | None,
+    *,
+    offset_hours: int = 0,
+    result: dict[str, Any] | None = None,
+) -> Analysis:
+    """Analysis 레코드 헬퍼 — created_at, result 주입 가능."""
+    created = datetime.now(timezone.utc) - timedelta(hours=offset_hours)
+    a = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{uuid.uuid4().hex}",
+        score=score,
+        grade="B",
+        result=result,
+        created_at=created,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+# ─── dashboard_kpi ──────────────────────────────────────────────────────────
+
+
+class TestDashboardKpi:
+    """dashboard_kpi — KPI 4 카드 (평균 점수 / 분석 건수 / 보안 이슈 HIGH / 활성 리포) 집계."""
+
+    def test_returns_4_kpi_keys(self, db, repos):
+        from src.services.dashboard_service import dashboard_kpi
+
+        _make_analysis(db, repos[0].id, 80, offset_hours=1)
+        result = dashboard_kpi(db, days=7)
+
+        # 4 KPI 키가 모두 존재 (avg_score, analysis_count, high_security_issues, active_repos)
+        assert set(result.keys()) >= {
+            "avg_score", "analysis_count", "high_security_issues", "active_repos",
+        }
+
+    def test_avg_score_computed_within_days(self, db, repos):
+        """현재 days 윈도우 내 평균 점수 정확 산출."""
+        from src.services.dashboard_service import dashboard_kpi
+
+        now = datetime.now(timezone.utc)
+        _make_analysis(db, repos[0].id, 80, offset_hours=1)  # 윈도우 내
+        _make_analysis(db, repos[0].id, 90, offset_hours=2)  # 윈도우 내
+        _make_analysis(db, repos[0].id, 60, offset_hours=24 * 30)  # 윈도우 밖
+
+        result = dashboard_kpi(db, days=7, now=now)
+        assert result["avg_score"]["value"] == pytest.approx(85.0, abs=0.1)
+        assert result["avg_score"]["grade"] in ("A", "B", "C", "D", "F", "B+")
+
+    def test_avg_score_delta_compares_previous_window(self, db, repos):
+        """delta = 현재 days 평균 - 직전 동일 days 평균 (양수 = 개선)."""
+        from src.services.dashboard_service import dashboard_kpi
+
+        now = datetime.now(timezone.utc)
+        # 현재 윈도우 (0~7일): 평균 85
+        _make_analysis(db, repos[0].id, 80, offset_hours=1)
+        _make_analysis(db, repos[0].id, 90, offset_hours=2)
+        # 직전 윈도우 (7~14일): 평균 75
+        _make_analysis(db, repos[0].id, 70, offset_hours=24 * 8)
+        _make_analysis(db, repos[0].id, 80, offset_hours=24 * 9)
+
+        result = dashboard_kpi(db, days=7, now=now)
+        # delta = 85 - 75 = +10
+        assert result["avg_score"]["delta"] == pytest.approx(10.0, abs=0.5)
+
+    def test_analysis_count_within_days(self, db, repos):
+        """현재 윈도우 내 분석 건수 카운트."""
+        from src.services.dashboard_service import dashboard_kpi
+
+        now = datetime.now(timezone.utc)
+        for _ in range(5):
+            _make_analysis(db, repos[0].id, 80, offset_hours=1)
+        # 윈도우 밖 1건
+        _make_analysis(db, repos[0].id, 70, offset_hours=24 * 30)
+
+        result = dashboard_kpi(db, days=7, now=now)
+        assert result["analysis_count"]["value"] == 5
+
+    def test_high_security_issues_count(self, db, repos):
+        """Analysis.result['issues'] 중 category=security AND severity=HIGH 카운트."""
+        from src.services.dashboard_service import dashboard_kpi
+
+        now = datetime.now(timezone.utc)
+        result_data = {
+            "issues": [
+                {"category": "security", "severity": "HIGH", "tool": "bandit", "message": "B608"},
+                {"category": "security", "severity": "HIGH", "tool": "bandit", "message": "B102"},
+                {"category": "security", "severity": "LOW", "tool": "bandit", "message": "B404"},
+                {"category": "code_quality", "severity": "warning", "tool": "pylint", "message": "C0103"},
+            ]
+        }
+        _make_analysis(db, repos[0].id, 80, offset_hours=1, result=result_data)
+
+        result = dashboard_kpi(db, days=7, now=now)
+        # HIGH 보안만 카운트 = 2
+        assert result["high_security_issues"]["value"] == 2
+
+    def test_active_repos_within_days(self, db, repos):
+        """활성 리포 = 윈도우 내 분석 발생한 distinct repo_id 수."""
+        from src.services.dashboard_service import dashboard_kpi
+
+        now = datetime.now(timezone.utc)
+        _make_analysis(db, repos[0].id, 80, offset_hours=1)
+        _make_analysis(db, repos[1].id, 70, offset_hours=2)
+        # repos[2] 는 분석 0 → 비활성
+
+        result = dashboard_kpi(db, days=7, now=now)
+        assert result["active_repos"]["value"] == 2
+        assert result["active_repos"]["total"] == 3  # 전체 리포 수
+
+    def test_empty_db_returns_safe_defaults(self, db):
+        """분석 0건일 때 KPI 는 None / 0 의 안전 default."""
+        from src.services.dashboard_service import dashboard_kpi
+
+        result = dashboard_kpi(db, days=7)
+        assert result["avg_score"]["value"] is None
+        assert result["analysis_count"]["value"] == 0
+        assert result["high_security_issues"]["value"] == 0
+        assert result["active_repos"]["value"] == 0
+
+
+# ─── dashboard_trend ──────────────────────────────────────────────────────
+
+
+class TestDashboardTrend:
+    """dashboard_trend — 날짜별 평균 점수 추세 (라인 차트용)."""
+
+    def test_returns_daily_avg_sorted_ascending(self, db, repos):
+        """날짜별 평균 점수 + count 반환, 날짜 오름차순."""
+        from src.services.dashboard_service import dashboard_trend
+
+        now = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+        # 2026-04-25 (5일 전): 80, 90 → avg 85
+        d1 = now - timedelta(days=5)
+        _make_analysis(db, repos[0].id, 80, offset_hours=int((now - d1).total_seconds() / 3600))
+        _make_analysis(db, repos[0].id, 90, offset_hours=int((now - d1).total_seconds() / 3600))
+        # 2026-04-28 (2일 전): 70
+        d2 = now - timedelta(days=2)
+        _make_analysis(db, repos[0].id, 70, offset_hours=int((now - d2).total_seconds() / 3600))
+
+        result = dashboard_trend(db, days=7, now=now)
+        assert len(result) == 2
+        # 오름차순 (이전 날짜가 첫번째)
+        assert result[0]["date"] < result[1]["date"]
+        for entry in result:
+            assert "date" in entry
+            assert "avg_score" in entry
+            assert "count" in entry
+
+    def test_excludes_records_outside_days(self, db, repos):
+        """days 밖 레코드는 제외."""
+        from src.services.dashboard_service import dashboard_trend
+
+        now = datetime.now(timezone.utc)
+        _make_analysis(db, repos[0].id, 85, offset_hours=24 * 3)  # 3일 전 — 포함
+        _make_analysis(db, repos[0].id, 50, offset_hours=24 * 30)  # 30일 전 — 제외
+
+        result = dashboard_trend(db, days=7, now=now)
+        assert len(result) == 1
+        assert result[0]["avg_score"] == pytest.approx(85.0, abs=0.1)
+
+    def test_empty_db_returns_empty_list(self, db):
+        """분석 0건일 때 빈 리스트."""
+        from src.services.dashboard_service import dashboard_trend
+
+        assert dashboard_trend(db, days=7) == []
+
+
+# ─── frequent_issues_v2 (Q7 신규 함수) ─────────────────────────────────────
+
+
+class TestFrequentIssuesV2:
+    """frequent_issues_v2 — global 자주 발생 이슈 (category/language/tool 포함).
+
+    폐기된 top_issues 와 차이:
+    - repo_id 인자 제거 (global 집계)
+    - category/language/tool 필드 반환 (sorting/grouping 용이)
+    """
+
+    def test_returns_sorted_by_frequency(self, db, repos):
+        from src.services.dashboard_service import frequent_issues_v2
+
+        now = datetime.now(timezone.utc)
+        # "issue-A" 3회, "issue-B" 2회, "issue-C" 1회
+        analyses_data = [
+            {"issues": [{"message": "issue-A", "category": "code_quality", "language": "python", "tool": "pylint"},
+                        {"message": "issue-B", "category": "security", "language": "python", "tool": "bandit"}]},
+            {"issues": [{"message": "issue-A", "category": "code_quality", "language": "python", "tool": "pylint"},
+                        {"message": "issue-C", "category": "code_quality", "language": "javascript", "tool": "eslint"}]},
+            {"issues": [{"message": "issue-A", "category": "code_quality", "language": "python", "tool": "pylint"},
+                        {"message": "issue-B", "category": "security", "language": "python", "tool": "bandit"}]},
+        ]
+        for data in analyses_data:
+            _make_analysis(db, repos[0].id, 80, offset_hours=1, result=data)
+
+        result = frequent_issues_v2(db, days=7, n=5, now=now)
+        assert len(result) == 3
+        # 빈도 내림차순
+        assert result[0]["message"] == "issue-A"
+        assert result[0]["count"] == 3
+        assert result[1]["count"] == 2
+        # category/language/tool 필드 보존
+        assert result[0]["category"] == "code_quality"
+        assert result[0]["language"] == "python"
+        assert result[0]["tool"] == "pylint"
+
+    def test_global_aggregation_across_repos(self, db, repos):
+        """다른 리포의 이슈도 합산 (repo_id 인자 없음)."""
+        from src.services.dashboard_service import frequent_issues_v2
+
+        now = datetime.now(timezone.utc)
+        common_issue = {"issues": [{"message": "X", "category": "code_quality", "language": "python", "tool": "pylint"}]}
+        _make_analysis(db, repos[0].id, 80, offset_hours=1, result=common_issue)
+        _make_analysis(db, repos[1].id, 80, offset_hours=2, result=common_issue)
+        _make_analysis(db, repos[2].id, 80, offset_hours=3, result=common_issue)
+
+        result = frequent_issues_v2(db, days=7, n=5, now=now)
+        assert len(result) == 1
+        assert result[0]["message"] == "X"
+        assert result[0]["count"] == 3
+
+    def test_limits_to_n(self, db, repos):
+        """n 인자로 결과 개수 제한."""
+        from src.services.dashboard_service import frequent_issues_v2
+
+        now = datetime.now(timezone.utc)
+        result_data = {"issues": [
+            {"message": f"issue-{i}", "category": "code_quality", "language": "python", "tool": "pylint"}
+            for i in range(10)
+        ]}
+        _make_analysis(db, repos[0].id, 80, offset_hours=1, result=result_data)
+
+        result = frequent_issues_v2(db, days=7, n=3, now=now)
+        assert len(result) <= 3
+
+    def test_empty_db_returns_empty(self, db):
+        from src.services.dashboard_service import frequent_issues_v2
+
+        assert frequent_issues_v2(db, days=7) == []

--- a/tests/unit/ui/test_dashboard_route.py
+++ b/tests/unit/ui/test_dashboard_route.py
@@ -1,0 +1,157 @@
+"""GET /dashboard UI 라우트 단위 테스트 — Phase 1 PR 4 (MVP-B 신규 라우트).
+
+검증:
+- 인증 (require_login) — 미로그인 302 redirect
+- 로그인 + mock service → 200 + KPI/trend/frequent_issues context
+- days 쿼리 파라미터가 service 함수에 전달
+- 템플릿 렌더링 (TemplateResponse mock)
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.auth.session import CurrentUser, require_login
+from src.main import app
+
+
+_TEST_USER = CurrentUser(
+    id=1,
+    github_login="tester",
+    email="t@x.com",
+    display_name="Tester",
+    plaintext_token="",
+)
+
+
+@contextmanager
+def _ctx(db):
+    yield db
+
+
+@pytest.fixture(autouse=True)
+def _override_login():
+    """모든 테스트에서 require_login override → _TEST_USER 주입."""
+    _prev = app.dependency_overrides.get(require_login)
+    app.dependency_overrides[require_login] = lambda: _TEST_USER
+    yield
+    if _prev is not None:
+        app.dependency_overrides[require_login] = _prev
+    else:
+        app.dependency_overrides.pop(require_login, None)
+
+
+# ─── 인증 ──────────────────────────────────────────────────────────────────
+
+
+def test_dashboard_requires_login():
+    """미로그인 시 require_login 의 redirect 또는 401 응답.
+
+    autouse fixture 를 일시 제거하여 인증 거부 흐름 검증.
+    """
+    app.dependency_overrides.pop(require_login, None)
+    try:
+        client = TestClient(app, follow_redirects=False)
+        response = client.get("/dashboard")
+        # require_login 패턴: 302 (login redirect) 또는 401
+        assert response.status_code in (302, 401, 303), (
+            f"미로그인 시 302/401 기대, 실제: {response.status_code}"
+        )
+    finally:
+        app.dependency_overrides[require_login] = lambda: _TEST_USER
+
+
+# ─── 200 OK + service 호출 ─────────────────────────────────────────────────
+
+
+def test_dashboard_returns_200():
+    """로그인 + service mock → GET /dashboard 200 응답."""
+    client = TestClient(app)
+
+    fake_kpi = {
+        "avg_score": {"value": 82.3, "grade": "B", "delta": 3.1},
+        "analysis_count": {"value": 42, "delta": 4},
+        "high_security_issues": {"value": 3, "delta": -2},
+        "active_repos": {"value": 12, "total": 15, "delta": 0},
+    }
+    fake_trend = [{"date": "2026-04-30", "avg_score": 82.0, "count": 5}]
+    fake_issues = [{"message": "X", "count": 3, "category": "code_quality", "language": "python", "tool": "pylint"}]
+
+    mock_db = MagicMock()
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi", return_value=fake_kpi), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=fake_trend), \
+         patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=fake_issues), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse") as mock_tr:
+        from fastapi.responses import HTMLResponse
+        mock_tr.return_value = HTMLResponse(content="<html>dashboard</html>", status_code=200)
+        response = client.get("/dashboard")
+
+    assert response.status_code == 200
+
+
+def test_dashboard_default_days_is_7():
+    """days 쿼리 파라미터 미지정 시 기본값 7 적용."""
+    client = TestClient(app)
+    mock_db = MagicMock()
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi", return_value={}) as mock_kpi, \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse") as mock_tr:
+        from fastapi.responses import HTMLResponse
+        mock_tr.return_value = HTMLResponse(content="<html>x</html>", status_code=200)
+        client.get("/dashboard")
+
+    assert mock_kpi.called
+    args, kwargs = mock_kpi.call_args
+    days = kwargs.get("days") if "days" in kwargs else (args[1] if len(args) > 1 else None)
+    assert days == 7
+
+
+def test_dashboard_respects_days_param():
+    """?days=30 쿼리 파라미터가 service 호출 시 days=30 으로 전달."""
+    client = TestClient(app)
+    mock_db = MagicMock()
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi", return_value={}) as mock_kpi, \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=[]) as mock_trend, \
+         patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse") as mock_tr:
+        from fastapi.responses import HTMLResponse
+        mock_tr.return_value = HTMLResponse(content="<html>x</html>", status_code=200)
+        client.get("/dashboard?days=30")
+
+    for mock in (mock_kpi, mock_trend):
+        args, kwargs = mock.call_args
+        days_val = kwargs.get("days") if "days" in kwargs else (args[1] if len(args) > 1 else None)
+        assert days_val == 30, f"{mock} days=30 미전달 (실제: {days_val})"
+
+
+def test_dashboard_context_includes_kpi_trend_issues():
+    """템플릿 컨텍스트에 kpi/trend/frequent_issues/days 키 포함."""
+    client = TestClient(app)
+    mock_db = MagicMock()
+    captured: dict = {}
+
+    def _capture(request, template_name, context, **kwargs):
+        captured.update(context)
+        from fastapi.responses import HTMLResponse
+        return HTMLResponse(content="<html>x</html>", status_code=200)
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi", return_value={"avg_score": {"value": 80}}), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse", side_effect=_capture):
+        response = client.get("/dashboard")
+
+    assert response.status_code == 200
+    for key in ("kpi", "trend", "frequent_issues", "days", "current_user"):
+        assert key in captured, f"context 에 {key} 누락"

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -1805,9 +1805,10 @@ def test_claude_dark_settings_tokens_defined():
 def test_chart_vendoring_no_jsdelivr_chartjs():
     """PR #166 회귀 가드 — Chart.js CDN 참조가 어떤 템플릿에도 잔존하지 않아야.
 
-    Note: insights_me.html 은 Phase 1 PR 2 (2026-05-02) 에서 폐기. 본 가드 대상에서 제외.
+    Note: insights_me.html 은 Phase 1 PR 2 (2026-05-02) 에서 폐기.
+    Phase 1 PR 4 의 dashboard.html 도 vendoring 의무 (UI 감사 Step C 통일).
     """
-    for tpl in ("repo_detail.html", "analysis_detail.html"):
+    for tpl in ("repo_detail.html", "analysis_detail.html", "dashboard.html"):
         content = _read_template(tpl)
         assert "cdn.jsdelivr.net/npm/chart.js" not in content, (
             f"{tpl} 에 jsdelivr Chart.js CDN 잔존 — vendoring 회귀"
@@ -1957,8 +1958,8 @@ def test_themechange_event_listeners():
     assert "dispatchEvent(new CustomEvent('themechange'" in base, (
         "base.html 의 themechange 이벤트 dispatch 누락 — 차트 재빌드 트리거 깨짐"
     )
-    # repo_detail 차트 페이지 listener 등록 필수
-    for tpl in ("repo_detail.html",):
+    # repo_detail / dashboard 차트 페이지 listener 등록 필수
+    for tpl in ("repo_detail.html", "dashboard.html"):
         content = _read_template(tpl)
         assert "addEventListener('themechange'" in content, (
             f"{tpl} 의 themechange 리스너 누락 — 테마 전환 후 stale 차트 색"


### PR DESCRIPTION
Phase 1 PR 1~3 폐기 후속. 사용자 결정 (2026-05-02):
- 결정 1 (PR 분할): 🅐 단일 PR
- 결정 2 (KPI 4번째): 🅐 활성 리포 (목업 v2 그대로)
- 결정 3 (디자인): 🅐 dashboard.html scoped 스타일 (다른 페이지 영향 0)

## 신규 모듈
- src/services/dashboard_service.py (225 LOC) · dashboard_kpi(db, days, *, now): KPI 4 카드 + delta vs 직전 윈도우
    - 평균 점수 (+ 등급), 분석 건수, 보안 이슈 (HIGH), 활성 리포
    - 헬퍼 _kpi_avg / _kpi_security / _kpi_active_repos 분할 (pylint R0914 회피) · dashboard_trend(db, days, *, now): 날짜별 평균 점수 (라인 차트) · frequent_issues_v2(db, days, *, n, now): Q7 신규 함수 — global 자주 발생 이슈 (폐기된 top_issues 와 차이: repo_id 인자 제거, category/language/tool 필드 보존) · _count_high_security 헬퍼: Analysis.result['issues'] 의 category=security AND severity=HIGH 카운트
- src/ui/routes/dashboard.py: GET /dashboard?days={1|7|30|90} (require_login)
- src/templates/dashboard.html (370 LOC): base.html extend + scoped Claude × Linear 디자인 · .dashboard-page wrapper 안 자체 토큰 (--d-accent / --d-grade-a~f / --d-success/warning/danger) · 4-테마 공존 (claude-dark 분기 색 alias) · KPI 4 카드 (목업 v2 정합성 — flex column + min-height + sparkline 하단 고정 패턴) · 점수 추세 라인 차트 (Chart.js vendoring 재사용 + themechange 페어) · 자주 발생 이슈 row 카드 · 모바일 반응형 (4 KPI → 2×2 → 1, WCAG 2.5.5 ≥44px)

## 라우터 등록
- src/ui/router.py: routes 5개 → 6개 (dashboard 추가)

## 신규 테스트 (+19)
- tests/unit/services/test_dashboard_service.py (14) · TestDashboardKpi (7): 4 키 / avg / delta / count / HIGH / active / 빈 DB · TestDashboardTrend (3): daily avg / window / empty · TestFrequentIssuesV2 (4): sorted / global / n / empty
- tests/unit/ui/test_dashboard_route.py (5): · 인증 + 200 + default days=7 + days param + context keys

## 회귀 가드 갱신
- test_router.py: · test_chart_vendoring_no_jsdelivr_chartjs: dashboard.html 추가 · test_themechange_event_listeners: dashboard.html 추가

## 영향
- 단위 테스트: 1958 → 1977 (+19, pre-existing 7 fail 동일)
- pylint: 10.00/10 (R0914 헬퍼 분할로 해소)
- bandit HIGH: 0
- LOC: +1119 (코드 +270 + 템플릿 +370 + 테스트 +463 + 가드/문서 +16)
- 5-way sync: 0 영향 (신규 라우트 — 기존 ORM/dataclass/PRESETS 미접촉)

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 로그인 + GET /dashboard → 200 응답
- [ ] 4 KPI 카드 렌더링 + delta 표시 정상
- [ ] 점수 추세 라인 차트 렌더링 (Chart.js 로드 + 색 적용)
- [ ] 1d/7d/30d/90d 레인지 토글 동작
- [ ] claude-dark 테마 전환 시 차트 색 재빌드 (themechange 페어)
- [ ] 모바일 (768/480 break) 반응형 동작
- [ ] base.html nav 의 `/insights` 링크는 PR 5 까지 보존 (현재 클릭 시 404 — 의도 동작)

## 자율 판단 보고 (정책 3)
- KPI 2번째 슬롯 = "분석 건수" 자율 결정 (목업 v2 의 자동 머지 성공률은 Phase 2 결정 사항)
- frequent_issues_v2 의 메타 (category/language/tool) 는 첫 발견 시 저장 → 같은 message 의 다른 메타 차이 무시
- nav 링크 (`/insights`) 본 PR 미변경 — PR 5 redirect 와 동시 처리
- Crimson Pro 미로드 → 시스템 serif fallback (Phase 4 base 통합 시 Google Fonts 추가 결정)
- _count_high_security 의 severity 비교는 `.upper()` 적용 (HIGH/high/High 모두 정상 처리)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
