### PR TITLE
chore(tests): pre-existing 7 fail 분류 + 5건 fix (PR B-1)

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,7 +6,7 @@
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 단위 테스트 | **1987개** | pytest 9.0.3 — 그룹 59 Phase 1 5 PR 누적 변동: PR 1 (-3) + PR 2 (-6) + PR 3 (-12) + PR 4 (+19) + PR 5 (+3) = +1, 총 1986 → 1987 (환경 fail 7건 pre-existing 동일) |
+| 단위 테스트 | **1987개** | pytest 9.0.3 — Phase 1 (그룹 59) +1 → 그룹 60 PR B-1 (mock fix 5/7) 환경 fail 7→2 = **1980 → 1985 passed** (Phase 1 진입 시점과 동일 수치, fail 만 감소) |
 | 통합 테스트 | **72개** | tests/integration/ — Phase 4 PR-T5 +25 (e2e_pipeline_scenarios — webhook→pipeline→gate 종단간) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
@@ -78,7 +78,8 @@
 
 | PR | 핵심 변경 |
 |----|---------|
-| **#194 (진행 중)** Docs/phase1 retro policy 11 evolution | **정책 11 신설** (UI/시각 변경 PR 본문 최상단 "🚨 Claude 시각 검증 불가" 8 조합 체크리스트 의무) + **정책 2 진화** (Phase 종료 시 일괄 회신 묶음) + **정책 3 진화** (자율 판단 보고 PR 본문 Summary 직후 + 이의 가능성 ≥ 중 강조) + **정책 7 강화** (PR 단위 = 응집 단위 분할 — nav/redirect/라우트 동일 PR 의무). 회고 정리 문서 신규 (`docs/reports/2026-05-02-phase1-retrospective.md`) |
+| **#194** Docs/phase1 retro policy 11 evolution | **정책 11 신설** (UI/시각 변경 PR 본문 최상단 "🚨 Claude 시각 검증 불가" 8 조합 체크리스트 의무) + **정책 2 진화** (Phase 종료 시 일괄 회신 묶음) + **정책 3 진화** (자율 판단 보고 PR 본문 Summary 직후 + 이의 가능성 ≥ 중 강조) + **정책 7 강화** (PR 단위 = 응집 단위 분할 — nav/redirect/라우트 동일 PR 의무). 회고 정리 문서 신규 (`docs/reports/2026-05-02-phase1-retrospective.md`) |
+| **#195 (진행 중)** Chore/preexisting 7 fail triage (B-1) | **pre-existing 7 fail 분류 + 5건 fix** — origin 일관 = `src.webhook.providers.github.get_webhook_secret` mock 누락 (PR 1~5 무관, 이전 사이클부터 잔존). test_issues.py 5 케이스에 `patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET)` 1줄 추가 → 5/7 통과. **남은 2건 (test_router.py 의 fallback 동작 검증, test_pipeline.py 의 settings.github_token import 시점) 은 origin 다름 (fallback 의도 자체 검증 + settings instance lazy issue) → 별도 PR (B-2) 분리 의무**. 본 PR 후 환경 fail = 1985 passed / 2 failed |
 
 **5-way sync 영향**: 0 (docs only)
 

--- a/tests/unit/webhook/test_issues.py
+++ b/tests/unit/webhook/test_issues.py
@@ -96,6 +96,7 @@ def test_issues_event_with_valid_signature_returns_202():
     # router 가 잡은 로컬 참조(src.webhook.router)를 patch 해야 BackgroundTask 가
     # mock 을 타고 실 DNS 조회를 회피한다.
     with patch("src.webhook.providers.github.settings") as mock_settings, \
+         patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET), \
          patch("src.webhook.providers.github.SessionLocal", return_value=_mock_db()), \
          patch("src.webhook.providers.github.get_repo_config", return_value=repo_config), \
          patch("src.webhook.providers.github.notify_n8n_issue") as mock_notify:
@@ -124,6 +125,7 @@ def test_issues_event_registers_background_task_when_n8n_url_present():
         registered_tasks.append(func)
 
     with patch("src.webhook.providers.github.settings") as mock_settings, \
+         patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET), \
          patch("src.webhook.providers.github.SessionLocal", return_value=_mock_db()), \
          patch("src.webhook.providers.github.get_repo_config", return_value=repo_config):
         mock_settings.github_webhook_secret = SECRET
@@ -157,6 +159,7 @@ def test_issues_event_ignored_when_no_n8n_webhook_url():
         registered_tasks.append(func)
 
     with patch("src.webhook.providers.github.settings") as mock_settings, \
+         patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET), \
          patch("src.webhook.providers.github.SessionLocal", return_value=_mock_db()), \
          patch("src.webhook.providers.github.get_repo_config", return_value=repo_config):
         mock_settings.github_webhook_secret = SECRET
@@ -199,6 +202,7 @@ def test_unknown_event_returns_ignored():
     # 알 수 없는 이벤트 타입 → {"status": "ignored"} 반환
     payload = json.dumps({"repository": {"full_name": "owner/repo"}}).encode()
     with patch("src.webhook.providers.github.settings") as mock_settings, \
+         patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET), \
          patch("src.webhook.providers.github.SessionLocal", return_value=_mock_db()):
         mock_settings.github_webhook_secret = SECRET
         resp = client.post(
@@ -251,6 +255,7 @@ def test_issues_event_passes_repo_token_to_notify():
             captured_kwargs.update(kwargs)
 
     with patch("src.webhook.providers.github.settings") as mock_settings, \
+         patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET), \
          patch("src.webhook.providers.github.SessionLocal", return_value=mock_db), \
          patch("src.webhook.providers.github.get_repo_config", return_value=repo_config):
         mock_settings.github_webhook_secret = SECRET


### PR DESCRIPTION
## ⚠️ 자율 판단 보고 (정책 3 진화 — PR 본문 최상단)

- **PR 분리 결정**: 7 fail 중 5건 (test_issues 영역) 은 동일 origin (mock 누락) → 본 PR 으로 일괄 fix. 남은 2건 (test_router.py + test_pipeline.py) 은 origin 다름 (fallback 의도 검증 + settings instance lazy) → 별도 PR (B-2) 분리. PR 단일 응집 단위 원칙 (정책 7 강화) 준수.
- **남은 2건 skip 처리 안 함** — 회귀 가드 의도 보존 (Phase 2 진입 전 B-2 의무).

## Phase 1 회고 결과 P0 #5 처리 (Phase 2 사전 의무 B)

5-에이전트 회고 P0 #5: pre-existing 7 fail 처리 부담 누적. 본 PR = Phase 2 진입 전 사전 의무 B 의 1단계.

## 7 fail 분류 결과

| # | Test | Origin | 처리 |
|---|------|--------|------|
| 1~5 | test_issues.py × 5 | mock 누락 (`get_webhook_secret` patch 부재) | ✅ 본 PR fix | | 6 | test_router.py::test_webhook_falls_back_to_global_secret_for_legacy_repo | `_helpers.SessionLocal` mock 적용 안 됨 (의도: fallback 자체 검증) | PR B-2 | | 7 | test_pipeline.py::test_pipeline_falls_back_to_settings_token_when_no_owner | settings.github_token = '' (conftest GITHUB_TOKEN 환경변수 미반영, settings module lazy load 추정) | PR B-2 |

## 본 PR fix 패턴

기존:
```python
with patch("src.webhook.providers.github.settings") as mock_settings, \
     patch("src.webhook.providers.github.SessionLocal", return_value=_mock_db()), \
     patch("src.webhook.providers.github.get_repo_config", return_value=repo_config):
    mock_settings.github_webhook_secret = SECRET
```

수정:
```python
with patch("src.webhook.providers.github.settings") as mock_settings, \
     patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET), \  # 추가
     patch("src.webhook.providers.github.SessionLocal", return_value=_mock_db()), \
     patch("src.webhook.providers.github.get_repo_config", return_value=repo_config):
    mock_settings.github_webhook_secret = SECRET
```

근본 원인: `src/webhook/providers/github.py:28` 의 `from src.webhook._helpers import get_webhook_secret` 직접 import. mock 적용 시 `src.webhook.providers.github.get_webhook_secret` 경로 필수.

## 영향
- 단위 테스트: 1980 passed / 7 fail → **1985 passed / 2 fail** (+5 passed, -5 fail)
- Phase 1 진입 시점 (1986) 과 동일 수치 (회복)
- pylint: 코드 변경 0 (테스트만)
- 5-way sync: 0

## 🔍 사용자 검증 필요
- [ ] CI / Railway 빌드에서 1985 passed 동일 수치 확인
- [ ] B-2 PR 진행 신호 (남은 2건 깊은 fix 또는 skip 처리)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
