### PR TITLE
chore(tests): pre-existing 2 fail 깊은 fix (PR B-2) — 환경 의존성 제거

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,7 +6,7 @@
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 단위 테스트 | **1987개** | pytest 9.0.3 — Phase 1 (그룹 59) +1 → 그룹 60 PR B-1 (mock fix 5/7) 환경 fail 7→2 = **1980 → 1985 passed** (Phase 1 진입 시점과 동일 수치, fail 만 감소) |
+| 단위 테스트 | **1987개** | pytest 9.0.3 — Phase 1 +1 → 그룹 60 PR B-1 (5/7 fix) → PR B-2 (남은 2건 fix) **= 1987 passed / 0 failed** (pre-existing 7 fail 완전 해소, 환경 의존성 제거) |
 | 통합 테스트 | **72개** | tests/integration/ — Phase 4 PR-T5 +25 (e2e_pipeline_scenarios — webhook→pipeline→gate 종단간) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
@@ -79,7 +79,8 @@
 | PR | 핵심 변경 |
 |----|---------|
 | **#194** Docs/phase1 retro policy 11 evolution | **정책 11 신설** (UI/시각 변경 PR 본문 최상단 "🚨 Claude 시각 검증 불가" 8 조합 체크리스트 의무) + **정책 2 진화** (Phase 종료 시 일괄 회신 묶음) + **정책 3 진화** (자율 판단 보고 PR 본문 Summary 직후 + 이의 가능성 ≥ 중 강조) + **정책 7 강화** (PR 단위 = 응집 단위 분할 — nav/redirect/라우트 동일 PR 의무). 회고 정리 문서 신규 (`docs/reports/2026-05-02-phase1-retrospective.md`) |
-| **#195 (진행 중)** Chore/preexisting 7 fail triage (B-1) | **pre-existing 7 fail 분류 + 5건 fix** — origin 일관 = `src.webhook.providers.github.get_webhook_secret` mock 누락 (PR 1~5 무관, 이전 사이클부터 잔존). test_issues.py 5 케이스에 `patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET)` 1줄 추가 → 5/7 통과. **남은 2건 (test_router.py 의 fallback 동작 검증, test_pipeline.py 의 settings.github_token import 시점) 은 origin 다름 (fallback 의도 자체 검증 + settings instance lazy issue) → 별도 PR (B-2) 분리 의무**. 본 PR 후 환경 fail = 1985 passed / 2 failed |
+| **#195** Chore/preexisting 7 fail triage (B-1) | **pre-existing 7 fail 분류 + 5건 fix** — origin 일관 = `src.webhook.providers.github.get_webhook_secret` mock 누락 (PR 1~5 무관, 이전 사이클부터 잔존). test_issues.py 5 케이스에 `patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET)` 1줄 추가 → 5/7 통과. 남은 2건 = 별도 PR B-2 분리 |
+| **#196 (진행 중)** Chore/preexisting 2 fail fix B-2 | **남은 2 fail 깊은 fix** — 근본 원인: 환경 의존성 (`GITHUB_WEBHOOK_SECRET=dev_secret` + `GITHUB_TOKEN=''` 가 일부 환경에 export 되어 conftest 의 setdefault 무효). fix: (a) test_pipeline.py — `patch("src.worker.pipeline.settings")` 직접 mock + github_token 주입 (b) test_router.py — `patch("src.webhook._helpers.repository_repo.find_by_full_name")` 직접 mock + `_helpers.settings` 직접 mock. **결과: 1985→1987 passed / 0 failed** (pre-existing 7 fail 완전 해소). Phase 2 진입 전 환경 의존성 정리 완료 |
 
 **5-way sync 영향**: 0 (docs only)
 

--- a/tests/unit/webhook/test_router.py
+++ b/tests/unit/webhook/test_router.py
@@ -157,33 +157,36 @@ def test_webhook_uses_repo_specific_secret(client):
 
 
 def test_webhook_falls_back_to_global_secret_for_legacy_repo(client):
-    """webhook_secret이 없는 레거시 리포는 전역 시크릿으로 검증한다."""
+    """webhook_secret이 없는 레거시 리포는 전역 시크릿으로 검증한다.
+
+    PR B-2 (2026-05-02): 환경 의존성 제거 — repository_repo + settings 직접 mock.
+    근본 원인: 일부 환경 (devcontainer 등) 에 `GITHUB_WEBHOOK_SECRET=dev_secret` 이
+    export 되어 있어 conftest 의 `setdefault('test_secret')` 가 작동 안 함.
+    fix: `_helpers.settings` 직접 mock 으로 환경 무관 secret 주입.
+    """
     import hmac, hashlib
     from unittest.mock import patch, MagicMock
 
     payload = b'{"repository": {"full_name": "owner/legacy-repo"}, "ref": "refs/heads/main", "after": "abc123", "commits": []}'
-    global_secret = "test_secret"  # conftest.py의 GITHUB_WEBHOOK_SECRET
+    global_secret = "test_secret"
     sig = "sha256=" + hmac.new(global_secret.encode(), payload, hashlib.sha256).hexdigest()
 
     mock_repo = MagicMock()
-    mock_repo.webhook_secret = None   # 레거시 리포
-    mock_db = MagicMock()
-    mock_db.query.return_value.filter.return_value.first.return_value = mock_repo
-    mock_db.query.return_value.filter_by.return_value.first.return_value = mock_repo
-    mock_db.__enter__ = MagicMock(return_value=mock_db)
-    mock_db.__exit__ = MagicMock(return_value=None)
+    mock_repo.webhook_secret = None   # 레거시 리포 — fallback 경로 진입
 
-    with patch("src.webhook._helpers.SessionLocal", return_value=mock_db):
-        with patch("src.webhook.providers.github.run_analysis_pipeline"):
-            r = client.post(
-                "/webhooks/github",
-                content=payload,
-                headers={
-                    "X-Hub-Signature-256": sig,
-                    "X-GitHub-Event": "push",
-                    "Content-Type": "application/json",
-                },
-            )
+    with patch("src.webhook._helpers.repository_repo.find_by_full_name", return_value=mock_repo), \
+         patch("src.webhook._helpers.settings") as mock_helpers_settings, \
+         patch("src.webhook.providers.github.run_analysis_pipeline"):
+        mock_helpers_settings.github_webhook_secret = global_secret
+        r = client.post(
+            "/webhooks/github",
+            content=payload,
+            headers={
+                "X-Hub-Signature-256": sig,
+                "X-GitHub-Event": "push",
+                "Content-Type": "application/json",
+            },
+        )
     assert r.status_code == 202
 
 

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -394,17 +394,24 @@ async def test_pipeline_falls_back_to_settings_token_when_no_owner():
         "commits": [{"message": "fix: legacy"}],
     }
 
+    # settings.github_token 을 직접 mock — conftest 의 GITHUB_TOKEN 환경변수가
+    # 빈 문자열로 이미 export 된 환경에서는 setdefault 가 작동 안 함.
+    # PR B-2 (2026-05-02): 환경 의존성 제거.
     from src.worker.pipeline import run_analysis_pipeline
     with (
+        patch("src.worker.pipeline.settings") as mock_settings,
         patch("src.worker.pipeline.SessionLocal", return_value=mock_db),
         patch("src.worker.pipeline.repository_repo.find_by_full_name", return_value=repo),
         patch("src.worker.pipeline.analysis_repo.find_by_sha", return_value=None),
         patch("src.worker.pipeline.get_push_files", return_value=[]) as mock_get_files,
     ):
+        mock_settings.github_token = "ghp_test"
+        mock_settings.telegram_chat_id = ""  # _ensure_repo path 에서 사용
+        mock_settings.anthropic_api_key = ""
         await run_analysis_pipeline("push", event_data)
 
     mock_get_files.assert_called_once()
-    assert mock_get_files.call_args[0][0] == "ghp_test"  # conftest의 GITHUB_TOKEN
+    assert mock_get_files.call_args[0][0] == "ghp_test"  # mock 으로 주입한 token
 
 
 async def test_pr_body_included_in_commit_message(mock_deps):


### PR DESCRIPTION
## ⚠️ 자율 판단 보고 (정책 3 진화 — PR 본문 최상단)

- **근본 원인 발견**: 일부 환경 (devcontainer / WSL 등) 에 `GITHUB_WEBHOOK_SECRET=dev_secret`, `GITHUB_TOKEN=''` 가 export 되어 있음. conftest.py 의 `os.environ.setdefault('test_secret')` 는 이미 export 된 변수에 대해 무효 → settings instance 가 환경 값 그대로 보존.
- **fix 전략 변경**: 환경변수 강제 reset 대신 **테스트 안에서 settings/repository_repo 직접 mock** 으로 환경 의존성 제거. 모든 CI 환경에서 동일 결과 보장.

## 폐기 7 fail 완전 해소

| # | Test | 처리 |
|---|------|------|
| 1~5 | test_issues.py × 5 | PR B-1 (#195) 머지 완료 | | 6 | test_router.py::test_webhook_falls_back_to_global_secret_for_legacy_repo | **본 PR fix** | | 7 | test_pipeline.py::test_pipeline_falls_back_to_settings_token_when_no_owner | **본 PR fix** |

## 본 PR fix 패턴

### test_pipeline.py
```python
with (
    patch("src.worker.pipeline.settings") as mock_settings,  # 신규
    # ... 기존 mock
):
    mock_settings.github_token = "ghp_test"
    mock_settings.telegram_chat_id = ""  # _ensure_repo path
    mock_settings.anthropic_api_key = ""
    await run_analysis_pipeline(...)
```

### test_router.py
```python
with patch("src.webhook._helpers.repository_repo.find_by_full_name", return_value=mock_repo), \
     patch("src.webhook._helpers.settings") as mock_helpers_settings, \  # 신규
     patch("src.webhook.providers.github.run_analysis_pipeline"):
    mock_helpers_settings.github_webhook_secret = global_secret  # 환경 무관
```

## 영향
- 단위 테스트: **1985 passed / 2 fail → 1987 passed / 0 failed** (+2 passed, -2 fail)
- pre-existing 7 fail 누적 미해결 부담 해소 (Phase 1 회고 P0 #5 완전 처리)
- pylint: 코드 변경 0 (테스트만)
- 5-way sync: 0 영향
- 환경 의존성: 일부 환경의 `GITHUB_WEBHOOK_SECRET=dev_secret` 등 export 와 무관하게 동작

## Phase 2 진입 전 사전 의무 (사용자 승인) 진행 상황
- A: PR #194 (정책 + 회고) ✓
- B-1: PR #195 (5/7 fix) ✓
- B-2: 본 PR (남은 2/7 fix) ✓
- C: analysis_feedbacks row 수 ≥10 검증 (다음)
- D: Phase 2 착수

## 🔍 사용자 검증 필요
- [ ] CI / Railway 빌드에서 1987 passed / 0 fail 확인
- [ ] 본 fix 가 실제 운영 환경 (Railway PostgreSQL) 에서도 동일 동작 확인 (mock fix 라 코드 흐름 영향 0 — 검증 형식적)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
