### PR TITLE
feat(dashboard): Phase 2 PR 2 — feedback CTA banner (analysis_feedbac…

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,7 +6,7 @@
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 단위 테스트 | **1998개** | pytest 9.0.3 — Phase 2 PR 1 (auto_merge_kpi 6 + merge_failure_distribution 5 = +11 신규) **= 1998 passed / 0 failed** |
+| 단위 테스트 | **2004개** | pytest 9.0.3 — Phase 2 PR 2 (feedback_status 6 신규) **= 2004 passed / 0 failed** |
 | 통합 테스트 | **72개** | tests/integration/ — Phase 4 PR-T5 +25 (e2e_pipeline_scenarios — webhook→pipeline→gate 종단간) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |

--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -21,6 +21,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from src.models.analysis import Analysis
+from src.models.analysis_feedback import AnalysisFeedback
 from src.models.merge_attempt import MergeAttempt
 from src.models.repository import Repository
 from src.scorer.calculator import calculate_grade
@@ -340,3 +341,40 @@ def merge_failure_distribution(
         }
         for reason, cnt in sorted_items[:n]
     ]
+
+
+# ─── Phase 2 PR 2: feedback CTA ────────────────────────────────────────────
+
+
+def feedback_status(db: Session, *, threshold: int = 10) -> dict[str, Any]:
+    """Dashboard CTA 카드 데이터 — feedback 누적 부족 시 사용자 행동 유도.
+
+    운영 데이터 (MCP 검증, 2026-05-02): analysis_feedbacks row=0
+    → CTA 카드로 thumbs +/- 클릭 유도. count >= threshold 시 자동 숨김.
+
+    Returns:
+        {
+          "show_cta": bool,
+          "count": int,
+          "recent_analysis": {"id": int, "repo_full_name": str} | None,
+        }
+    """
+    count = db.scalar(
+        select(func.count(AnalysisFeedback.id))  # pylint: disable=not-callable
+    ) or 0
+
+    recent: dict[str, Any] | None = None
+    row = db.execute(
+        select(Analysis.id, Repository.full_name)
+        .join(Repository, Analysis.repo_id == Repository.id)
+        .order_by(Analysis.created_at.desc())
+        .limit(1)
+    ).first()
+    if row is not None:
+        recent = {"id": row.id, "repo_full_name": row.full_name}
+
+    return {
+        "show_cta": count < threshold,
+        "count": int(count),
+        "recent_analysis": recent,
+    }

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -140,6 +140,43 @@
     height: 320px;
   }
 
+  /* Phase 2 PR 2 — feedback CTA banner (조건부) */
+  .dash-cta-banner {
+    background: linear-gradient(135deg, var(--accent-faint, rgba(217,119,87,.08)) 0%, transparent 100%);
+    border: 1px solid var(--d-accent);
+    border-radius: 14px;
+    padding: 16px 20px;
+    margin-bottom: 24px;
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 16px; flex-wrap: wrap;
+  }
+  .dash-cta-text {
+    flex: 1; min-width: 220px;
+  }
+  .dash-cta-title {
+    font-family: var(--d-font-heading);
+    font-size: 16px; font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 4px;
+  }
+  .dash-cta-meta {
+    font-size: 13px; color: var(--text-muted);
+    margin: 0;
+  }
+  .dash-cta-btn {
+    padding: 10px 18px; min-height: 40px;
+    border-radius: 8px; font-size: 13px; font-weight: 600;
+    text-decoration: none; box-sizing: border-box;
+    background: var(--d-accent); color: #fff; border: 1px solid var(--d-accent);
+    display: inline-flex; align-items: center; gap: 6px;
+    transition: all .15s ease;
+  }
+  .dash-cta-btn:hover { opacity: 0.9; transform: translateY(-1px); }
+  @media (max-width: 480px) {
+    .dash-cta-banner { padding: 14px; }
+    .dash-cta-btn { width: 100%; justify-content: center; min-height: 44px; }
+  }
+
   /* 자주 발생 이슈 카드 */
   .dash-issues-card {
     background: var(--card-bg, var(--bg-surface, rgba(255,255,255,.04)));
@@ -207,7 +244,29 @@
     </nav>
   </div>
 
-  {# KPI 4 카드 #}
+  {# Phase 2 PR 2 — feedback CTA banner (조건부, count < threshold 시만 표시) #}
+  {% if feedback and feedback.show_cta %}
+  <div class="dash-cta-banner" role="region" aria-label="피드백 요청">
+    <div class="dash-cta-text">
+      <p class="dash-cta-title">📝 AI 점수에 피드백을 남겨주세요</p>
+      <p class="dash-cta-meta">
+        {% if feedback.count == 0 %}
+          분석 결과 페이지의 👍 / 👎 버튼으로 점수 정합도를 알려주시면 AI 정확도가 개선됩니다.
+        {% else %}
+          현재까지 {{ feedback.count }}건의 피드백이 있습니다 — 더 정확한 AI 정합도 측정을 위해 피드백을 남겨주세요.
+        {% endif %}
+      </p>
+    </div>
+    {% if feedback.recent_analysis %}
+    <a class="dash-cta-btn"
+       href="/repos/{{ feedback.recent_analysis.repo_full_name }}/analyses/{{ feedback.recent_analysis.id }}#feedbackCard">
+      → 최근 분석 보기
+    </a>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {# KPI 5 카드 (Phase 1 4 + Phase 2 Auto-merge) #}
   <div class="dash-kpi-grid">
     <div class="dash-kpi">
       <div class="dash-kpi-label">평균 점수</div>

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -44,9 +44,11 @@ def dashboard(
         kpi = dashboard_service.dashboard_kpi(db, days=days)
         trend = dashboard_service.dashboard_trend(db, days=days)
         frequent_issues = dashboard_service.frequent_issues_v2(db, days=days, n=5)
-        # Phase 2 PR 1 (2026-05-02): Auto-merge KPI + 실패 분포 (운영 데이터 기반).
+        # Phase 2 PR 1: Auto-merge KPI + 실패 분포.
         auto_merge = dashboard_service.auto_merge_kpi(db, days=days)
         merge_failures = dashboard_service.merge_failure_distribution(db, days=days, n=5)
+        # Phase 2 PR 2 (2026-05-02): feedback CTA — 운영 row=0 → 사용자 행동 유도.
+        feedback = dashboard_service.feedback_status(db)
 
     return templates.TemplateResponse(
         request,
@@ -58,6 +60,7 @@ def dashboard(
             "frequent_issues": frequent_issues,
             "auto_merge": auto_merge,
             "merge_failures": merge_failures,
+            "feedback": feedback,
             "days": days,
         },
     )

--- a/tests/unit/services/test_dashboard_feedback_status.py
+++ b/tests/unit/services/test_dashboard_feedback_status.py
@@ -1,0 +1,149 @@
+"""dashboard_service.feedback_status 단위 테스트.
+
+Phase 2 PR 2 (2026-05-02): MCP 운영 데이터 (analysis_feedbacks row=0) 기반 CTA.
+사용자 참여 유도 → AI 정합도 카드 데이터 누적 (Phase 3 진입 토대).
+
+함수: feedback_status(db, *, threshold=10) -> dict
+- show_cta: bool — CTA 카드 표시 여부 (count < threshold)
+- count: int — 전체 feedback row 수
+- recent_analysis: dict|None — 최근 분석 (CTA 링크 대상)
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.analysis_feedback import AnalysisFeedback
+from src.models.repository import Repository
+from src.models.user import User
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def user(db):
+    u = User(github_id=1, github_login="tester", email="t@x.com", display_name="Tester")
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def repo(db, user):
+    r = Repository(full_name="owner/repo", user_id=user.id)
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _make_analysis(db: Session, repo_id: int, *, offset_hours: int = 0) -> Analysis:
+    a = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{uuid.uuid4().hex}",
+        score=80,
+        grade="B",
+        created_at=datetime.now(timezone.utc) - timedelta(hours=offset_hours),
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def _make_feedback(db: Session, *, analysis_id: int, user_id: int, thumbs: int = 1) -> None:
+    fb = AnalysisFeedback(
+        analysis_id=analysis_id,
+        user_id=user_id,
+        thumbs=thumbs,
+    )
+    db.add(fb)
+    db.commit()
+
+
+# ─── feedback_status ──────────────────────────────────────────────────────
+
+
+class TestFeedbackStatus:
+    """feedback_status — dashboard CTA 카드 데이터."""
+
+    def test_returns_required_keys(self, db):
+        from src.services.dashboard_service import feedback_status
+
+        result = feedback_status(db)
+        for key in ("show_cta", "count", "recent_analysis"):
+            assert key in result, f"key 누락: {key}"
+
+    def test_show_cta_when_count_below_threshold(self, db, repo, user):
+        """feedback row 수가 threshold 미만이면 CTA 표시."""
+        from src.services.dashboard_service import feedback_status
+
+        a = _make_analysis(db, repo.id)
+        _make_feedback(db, analysis_id=a.id, user_id=user.id)
+
+        result = feedback_status(db, threshold=10)
+        assert result["show_cta"] is True
+        assert result["count"] == 1
+
+    def test_hide_cta_when_count_meets_threshold(self, db, repo, user):
+        """feedback row 수가 threshold 이상이면 CTA 숨김 (충분히 누적).
+
+        UNIQUE (analysis_id, user_id) 제약 → 10 distinct analysis × 1 feedback 패턴.
+        """
+        from src.services.dashboard_service import feedback_status
+
+        # 10 distinct analysis 각각 1 feedback (UNIQUE 제약 회피)
+        for i in range(10):
+            a = _make_analysis(db, repo.id, offset_hours=i)
+            fb = AnalysisFeedback(analysis_id=a.id, user_id=user.id, thumbs=1 if i % 2 == 0 else -1)
+            db.add(fb)
+        db.commit()
+
+        result = feedback_status(db, threshold=10)
+        assert result["show_cta"] is False
+        assert result["count"] == 10
+
+    def test_show_cta_when_empty(self, db):
+        """feedback 0건 (운영 데이터 패턴) → CTA 표시 + recent_analysis None."""
+        from src.services.dashboard_service import feedback_status
+
+        result = feedback_status(db, threshold=10)
+        assert result["show_cta"] is True
+        assert result["count"] == 0
+        assert result["recent_analysis"] is None
+
+    def test_recent_analysis_includes_repo_full_name_and_id(self, db, repo):
+        """CTA 링크 대상 = 가장 최근 분석 (id + repo.full_name)."""
+        from src.services.dashboard_service import feedback_status
+
+        # 오래된 + 최근 분석 2건
+        old = _make_analysis(db, repo.id, offset_hours=24)
+        new = _make_analysis(db, repo.id, offset_hours=1)
+
+        result = feedback_status(db)
+        assert result["recent_analysis"] is not None
+        assert result["recent_analysis"]["id"] == new.id
+        assert result["recent_analysis"]["repo_full_name"] == "owner/repo"
+        # old 가 아닌 new 가 반환됨
+        assert result["recent_analysis"]["id"] != old.id
+
+    def test_recent_analysis_none_when_no_analyses(self, db):
+        from src.services.dashboard_service import feedback_status
+
+        result = feedback_status(db)
+        assert result["recent_analysis"] is None

--- a/tests/unit/ui/test_dashboard_route.py
+++ b/tests/unit/ui/test_dashboard_route.py
@@ -86,6 +86,9 @@ def test_dashboard_returns_200():
          patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi", return_value=fake_kpi), \
          patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=fake_trend), \
          patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=fake_issues), \
+         patch("src.ui.routes.dashboard.dashboard_service.auto_merge_kpi", return_value={}), \
+         patch("src.ui.routes.dashboard.dashboard_service.merge_failure_distribution", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.feedback_status", return_value={"show_cta": False, "count": 0, "recent_analysis": None}), \
          patch("src.ui.routes.dashboard.templates.TemplateResponse") as mock_tr:
         from fastapi.responses import HTMLResponse
         mock_tr.return_value = HTMLResponse(content="<html>dashboard</html>", status_code=200)
@@ -105,6 +108,7 @@ def test_dashboard_default_days_is_7():
          patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
          patch("src.ui.routes.dashboard.dashboard_service.auto_merge_kpi", return_value={}), \
          patch("src.ui.routes.dashboard.dashboard_service.merge_failure_distribution", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.feedback_status", return_value={"show_cta": False, "count": 0, "recent_analysis": None}), \
          patch("src.ui.routes.dashboard.templates.TemplateResponse") as mock_tr:
         from fastapi.responses import HTMLResponse
         mock_tr.return_value = HTMLResponse(content="<html>x</html>", status_code=200)
@@ -127,6 +131,7 @@ def test_dashboard_respects_days_param():
          patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
          patch("src.ui.routes.dashboard.dashboard_service.auto_merge_kpi", return_value={}), \
          patch("src.ui.routes.dashboard.dashboard_service.merge_failure_distribution", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.feedback_status", return_value={"show_cta": False, "count": 0, "recent_analysis": None}), \
          patch("src.ui.routes.dashboard.templates.TemplateResponse") as mock_tr:
         from fastapi.responses import HTMLResponse
         mock_tr.return_value = HTMLResponse(content="<html>x</html>", status_code=200)
@@ -155,11 +160,12 @@ def test_dashboard_context_includes_kpi_trend_issues():
          patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
          patch("src.ui.routes.dashboard.dashboard_service.auto_merge_kpi", return_value={"value": 16.6}), \
          patch("src.ui.routes.dashboard.dashboard_service.merge_failure_distribution", return_value=[{"reason": "unstable_ci", "count": 5, "share_pct": 79.0}]), \
+         patch("src.ui.routes.dashboard.dashboard_service.feedback_status", return_value={"show_cta": True, "count": 0, "recent_analysis": None}), \
          patch("src.ui.routes.dashboard.templates.TemplateResponse", side_effect=_capture):
         response = client.get("/dashboard")
 
     assert response.status_code == 200
     # Phase 1 + Phase 2 PR 1 신규 키
     for key in ("kpi", "trend", "frequent_issues", "days", "current_user",
-                "auto_merge", "merge_failures"):
+                "auto_merge", "merge_failures", "feedback"):
         assert key in captured, f"context 에 {key} 누락"


### PR DESCRIPTION
…ks row=0 운영 데이터 대응)

## ⚠️ 자율 판단 보고 (정책 3 진화 — PR 본문 최상단)

- **응집 단위** (정책 7 강화): "feedback 데이터 누적 유도" 단일 응집 — service + 라우트 + 템플릿 + 테스트 동일 PR.
- **analysis_detail.html thumbs UI 변경 X** — 이미 충분히 명확 (👍/👎 + 메시지 + Claude AI hint, L292-312). 운영 row=0 = 사용자가 페이지 안 보거나 스크롤 안 함 → dashboard 에서 "최근 분석 보기" 링크로 유도가 더 효과적.
- **CTA 위치**: 페이지 헤더 직후 (KPI 그리드 위) — 사용자 첫 시야 진입.
- **CTA 표시 조건** = `feedback.count < threshold(10)` — 충분 누적 시 자동 숨김.
- **anchor link** = `#feedbackCard` (analysis_detail.html L293의 id) — 페이지 내 thumbs 카드로 즉시 스크롤.

## 신규 service 함수
- `feedback_status(db, *, threshold=10) -> dict` (`src/services/dashboard_service.py`) · `show_cta`: bool — count < threshold · `count`: int — 전체 feedback row 수 · `recent_analysis`: {id, repo_full_name} | None — CTA 링크 대상 (가장 최근 분석)

## 라우트 + 템플릿
- `src/ui/routes/dashboard.py` — `feedback` context 추가
- `src/templates/dashboard.html` — 조건부 CTA banner · 위치: 페이지 헤더 직후 (KPI 그리드 위) · 형태: gradient + accent border + "최근 분석 보기" 버튼 · 메시지: count=0 / count>0 분기 (1~9건 누적 시 격려 메시지) · 모바일 반응형: 480px↓ 버튼 풀 폭 (min-height 44px WCAG 2.5.5)

## 신규 테스트 (+6)
- TestFeedbackStatus (6): 키 / show_cta < threshold / hide >= threshold / empty / recent_analysis 정확성 / no analyses
- 라우트 테스트 5건 patch 갱신 (feedback_status mock 추가)

## 영향
- 단위 테스트: 1998 → **2004 passed / 0 failed** (+6)
- pylint: 10.00/10
- 5-way sync: 0
- 운영 영향: feedback row=0 인 환경에서 CTA banner 즉시 노출 → 사용자 thumbs 클릭 유도

## 🚨 Claude 시각 검증 불가 — 사용자 의무 (정책 11)

본 PR 은 dashboard.html UI 변경 포함. 8 조합 검증 부탁드립니다:

- [ ] dark / light / glass / claude-dark 데스크탑 — CTA banner gradient + accent border
- [ ] 동 4 테마 모바일 (375~767px) — banner 줄바꿈 + 버튼 풀 폭
- [ ] CTA 클릭 시 → /repos/{full_name}/analyses/{id}#feedbackCard 정상 이동
- [ ] thumbs 누른 후 dashboard 새로고침 → CTA 메시지 변경 (count=0 → count=1)
- [ ] feedback 10건 누적 시 → CTA 자동 숨김 (운영 시뮬레이션)
- [ ] CTA banner 와 KPI 그리드 사이 간격 (24px margin-bottom)
- [ ] glass 테마 backdrop-filter 와 banner gradient 충돌 여부
- [ ] 모바일 480px↓ 버튼 min-height 44px (WCAG 2.5.5 터치 영역)

## Phase 2 진입 매트릭스 진행
- 검증 1 (analysis_feedbacks=0) → 본 PR 으로 데이터 누적 유도 시작
- 검증 2 (merge_attempts 337) → PR 1 머지 완료 (Auto-merge 카드)
- Phase 3 (Insight 모드) 진입 토대 마련

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
