### PR TITLE
chore(supabase-compat): \echo 제거 + runbook 4 옵션 + CLAUDE.md 운영 DB 정보

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,9 @@ CLI Hook (로컬 pre-push 자동 코드리뷰):
 
 전체 환경변수 목록: `docs/reference/env-vars.md`
 
-## Railway 배포
+## Railway 배포 + 운영 DB 환경
+
+**운영 DB (2026-05-02 기준)**: Supabase PostgreSQL + 온프레미스 PostgreSQL 이중 setup. Railway PostgreSQL 도 호환 (legacy 또는 staging). 모든 환경에 동일 alembic 마이그레이션 적용 — schema 일관성 보장. 운영 SQL 검증 도구 `scripts/dev/verify_phase2_data.sql` + runbook `docs/runbooks/phase2-data-readiness.md` 가 4 환경 (Supabase Dashboard / Supabase MCP / 온프레미스 psql / Railway) 모두 호환 (`\echo` meta-command 미사용 + `section` 라벨 컬럼).
 
 ```bash
 # 시작 명령 (railway.toml에 설정됨 — --proxy-headers 포함)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -6,7 +6,7 @@
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 단위 테스트 | **2004개** | pytest 9.0.3 — Phase 2 PR 2 (feedback_status 6 신규) **= 2004 passed / 0 failed** |
+| 단위 테스트 | **2004개** | pytest 9.0.3 — Phase 2 PR 1 + PR 2 + Supabase 호환 fix PR (docs only, 코드 변경 0) **= 2004 passed / 0 failed** |
 | 통합 테스트 | **72개** | tests/integration/ — Phase 4 PR-T5 +25 (e2e_pipeline_scenarios — webhook→pipeline→gate 종단간) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
@@ -81,7 +81,10 @@
 | **#194** Docs/phase1 retro policy 11 evolution | **정책 11 신설** (UI/시각 변경 PR 본문 최상단 "🚨 Claude 시각 검증 불가" 8 조합 체크리스트 의무) + **정책 2 진화** (Phase 종료 시 일괄 회신 묶음) + **정책 3 진화** (자율 판단 보고 PR 본문 Summary 직후 + 이의 가능성 ≥ 중 강조) + **정책 7 강화** (PR 단위 = 응집 단위 분할 — nav/redirect/라우트 동일 PR 의무). 회고 정리 문서 신규 (`docs/reports/2026-05-02-phase1-retrospective.md`) |
 | **#195** Chore/preexisting 7 fail triage (B-1) | **pre-existing 7 fail 분류 + 5건 fix** — origin 일관 = `src.webhook.providers.github.get_webhook_secret` mock 누락 (PR 1~5 무관, 이전 사이클부터 잔존). test_issues.py 5 케이스에 `patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET)` 1줄 추가 → 5/7 통과. 남은 2건 = 별도 PR B-2 분리 |
 | **#196** Chore/preexisting 2 fail fix B-2 | **남은 2 fail 깊은 fix** — 근본 원인: 환경 의존성 (`GITHUB_WEBHOOK_SECRET=dev_secret` + `GITHUB_TOKEN=''` 가 일부 환경에 export 되어 conftest 의 setdefault 무효). fix: (a) test_pipeline.py — `patch("src.worker.pipeline.settings")` 직접 mock + github_token 주입 (b) test_router.py — `patch("src.webhook._helpers.repository_repo.find_by_full_name")` 직접 mock + `_helpers.settings` 직접 mock. **결과: 1985→1987 passed / 0 failed** (pre-existing 7 fail 완전 해소). Phase 2 진입 전 환경 의존성 정리 완료 |
-| **#197 (진행 중)** Chore/phase2 data readiness verification (PR C) | **Phase 2 진입 전 데이터 검증 도구** — 기획서 §6.1 Q4 (사용자 승인) 후속. 신규 `scripts/dev/verify_phase2_data.sql` (5건 SELECT — analysis_feedbacks / merge_attempts / failure_reason 분포 / analyses / author_login) + `docs/runbooks/phase2-data-readiness.md` (결과 해석 매트릭스 + Phase 2 진입 4 옵션 결정). 실행 = 사용자 운영 DB (Railway PostgreSQL) — 결과 회신 후 Claude 가 Phase 2 PR 시리즈 자율 판단 결정 |
+| **#197** Chore/phase2 data readiness verification (PR C) | **Phase 2 진입 전 데이터 검증 도구** — 기획서 §6.1 Q4 (사용자 승인) 후속. 신규 `scripts/dev/verify_phase2_data.sql` (5건 SELECT) + runbook (Railway only 옵션 3종) |
+| **Phase 2 PR 1** Feat/phase2 auto-merge KPI card | **Auto-merge KPI + 실패 사유 카드** (운영 데이터 16.6% / unstable_ci 79% 반영). 신규 service 2종 (`auto_merge_kpi` 단순+retry-aware, `merge_failure_distribution` Top N + 비율). KPI 그리드 4→5 + 보조 카드 1. 신규 테스트 +11. **결과: 1987→1998 passed** |
+| **Phase 2 PR 2** Feat/phase2 feedback CTA banner | **feedback CTA banner** (analysis_feedbacks row=0 운영 데이터 대응). 신규 service `feedback_status` (조건부 CTA, count<10 시만 표시) + `#feedbackCard` anchor 링크. 신규 테스트 +6. **결과: 1998→2004 passed** |
+| **Supabase 호환 fix PR (진행 중)** Chore/supabase-compat-sql-runbook-claudemd | **PR #197 본체 후속** — `\echo` meta-command 제거 + 각 SELECT 첫 컬럼 `section` 라벨 → Supabase Dashboard SQL Editor 호환. runbook 4 옵션 확장 (Supabase Dashboard / Supabase MCP / 온프레미스 psql / Railway). CLAUDE.md L303 운영 DB 환경 정보 갱신 (Railway only → Supabase + 온프레미스 + Railway 이중/삼중 setup) |
 
 **5-way sync 영향**: 0 (docs only)
 

--- a/docs/runbooks/phase2-data-readiness.md
+++ b/docs/runbooks/phase2-data-readiness.md
@@ -87,23 +87,32 @@ psql "$DATABASE_URL" -f scripts/dev/verify_phase2_data.sql
 
 ---
 
-## 부록 — Railway 운영 환경 접근 방법
+## 부록 — 운영 DB 접근 방법
 
-### 옵션 A: Railway Dashboard
-1. Railway 프로젝트 → Database (PostgreSQL) → Query 탭
-2. SQL 내용 paste + Run
-3. 결과 표 회신
+SCAManager 운영 DB (2026-05-02 기준): **Supabase + 온프레미스 PostgreSQL 이중 setup** + Railway 호환.
+SQL 본체는 모든 환경에서 동일 동작 (PR 갱신 — `\echo` meta-command 제거).
 
-### 옵션 B: psql CLI
+### 옵션 A: Supabase Dashboard SQL Editor ★ 권장 (이중 setup 의 주 환경)
+1. Supabase 프로젝트 → SQL Editor
+2. `scripts/dev/verify_phase2_data.sql` 전체 내용 paste + Run
+3. 5건 결과 (각 SELECT 별 결과 표) 회신
+
+### 옵션 B: Supabase MCP (Claude 직접 실행) ★ 자동화
+- Claude 가 `mcp__claude_ai_Supabase__execute_sql` 도구로 직접 실행
+- 사용자가 project ID 공유 + 인증 OK 시 → 결과 분석 + 다음 단계 즉시 진행 (수동 실행 부담 0)
+- 본 사이클 검증 완료 (project: `qaoirpyhldlkeoyppfwq`)
+
+### 옵션 C: 온프레미스 PostgreSQL psql CLI
 ```bash
-# Railway DATABASE_URL 가져오기
-railway variables --service Postgres
-# 또는 Railway 대시보드 Variables 탭에서 복사
-
 psql "$DATABASE_URL" -f scripts/dev/verify_phase2_data.sql > phase2_results.txt
 cat phase2_results.txt  # 회신 내용
 ```
 
-### 옵션 C: Claude Code (Bash via SCAManager DEV 환경)
-- `.env` 의 `DATABASE_URL` 이 운영 DB 인 경우만 가능
-- 일반적으로 dev 환경 = 별도 DB → 의미 있는 결과 안 나옴 (옵션 A/B 권장)
+### 옵션 D: Railway PostgreSQL Dashboard
+1. Railway 프로젝트 → Database (PostgreSQL) → Query 탭
+2. SQL paste + Run
+3. 결과 회신
+
+### 옵션 E: Claude Code (Bash via SCAManager DEV 환경)
+- `.env` 의 `DATABASE_URL` 이 운영 DB 인 경우만 의미 있음
+- 일반적으로 dev 환경 = 별도 DB → 옵션 A/B/C/D 권장

--- a/scripts/dev/verify_phase2_data.sql
+++ b/scripts/dev/verify_phase2_data.sql
@@ -1,21 +1,28 @@
 -- Phase 2 진입 전 데이터 충분성 검증 SQL.
 -- Phase 2 readiness check: data sufficiency for new dashboard KPI cards.
 --
--- 사용법:
---   psql "$DATABASE_URL" -f scripts/dev/verify_phase2_data.sql
+-- 운영 환경 호환성 (PR 갱신 — 2026-05-02):
+--   ✓ Supabase Dashboard SQL Editor (전체 paste + Run)
+--   ✓ Supabase MCP (Claude 직접 실행 — mcp__claude_ai_Supabase__execute_sql)
+--   ✓ 온프레미스 PostgreSQL (psql CLI: psql "$DATABASE_URL" -f scripts/dev/verify_phase2_data.sql)
+--   ✓ Railway PostgreSQL (psql CLI 또는 Dashboard Query)
 --
--- 또는 Railway 콘솔에서 직접 실행. 결과를 Claude 에게 회신하면 Phase 2 진입 여부 결정.
+-- psql `\echo` meta-command 제거 — Supabase SQL Editor 호환.
+-- 각 SELECT 의 첫 컬럼 'section' 으로 결과 그룹 식별.
 --
 -- 검증 항목 (Phase 2 KPI 후보별):
 -- 1. analysis_feedbacks row 수 — AI 정합도 카드 (thumbs +1/-1 비율)
 -- 2. merge_attempts row 수 — Auto-merge 성공률 카드
--- 3. 최근 30일 활성도 — 카드 표시 가치 측정
+-- 3. failure_reason 분포 — Phase 3 advisor 활용
+-- 4. analyses 활성도 — 현재 KPI 카드 보강 검증
+-- 5. author_login 분포 — Q5 모드 토글 Phase 3 가치 측정
+--
+-- 컬럼명 주의: merge_attempts 는 attempted_at (created_at 아님 — MCP 검증 결과 반영).
 
-\echo '=== Phase 2 Data Readiness Check ==='
-\echo ''
 
-\echo '── (1) analysis_feedbacks 전체 + 최근 30일 + 분포 (AI 정합도 KPI 입력) ──'
+-- ── (1) analysis_feedbacks 전체 + 최근 30일 + 분포 (AI 정합도 KPI 입력) ──
 SELECT
+    '1_analysis_feedbacks'                                  AS section,
     COUNT(*)                                                AS total_feedbacks,
     COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days') AS last_30d,
     COUNT(*) FILTER (WHERE thumbs = 1)                      AS thumbs_up,
@@ -24,11 +31,12 @@ SELECT
     COUNT(DISTINCT analysis_id)                             AS distinct_analyses
 FROM analysis_feedbacks;
 
-\echo ''
-\echo '── (2) merge_attempts 전체 + 최근 30일 + 성공률 (Auto-merge 성공률 KPI 입력) ──'
+
+-- ── (2) merge_attempts 전체 + 최근 30일 + 성공률 (Auto-merge 성공률 KPI 입력) ──
 SELECT
+    '2_merge_attempts'                                      AS section,
     COUNT(*)                                                AS total_attempts,
-    COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days') AS last_30d,
+    COUNT(*) FILTER (WHERE attempted_at >= NOW() - INTERVAL '30 days') AS last_30d,
     COUNT(*) FILTER (WHERE success = TRUE)                  AS success_count,
     COUNT(*) FILTER (WHERE success = FALSE)                 AS failure_count,
     ROUND(
@@ -38,21 +46,23 @@ SELECT
     COUNT(DISTINCT failure_reason) FILTER (WHERE success = FALSE) AS distinct_failure_reasons
 FROM merge_attempts;
 
-\echo ''
-\echo '── (3) merge_attempts 실패 사유별 분포 (Phase 3 merge_failure_advisor 후속 활용) ──'
+
+-- ── (3) merge_attempts 실패 사유별 분포 (Phase 3 merge_failure_advisor 후속 활용) ──
 SELECT
-    COALESCE(failure_reason, '(none)')                     AS reason,
+    '3_failure_reason'                                      AS section,
+    COALESCE(failure_reason, '(none)')                      AS reason,
     COUNT(*)                                                AS occurrences,
-    COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days') AS last_30d
+    COUNT(*) FILTER (WHERE attempted_at >= NOW() - INTERVAL '30 days') AS last_30d
 FROM merge_attempts
 WHERE success = FALSE
 GROUP BY failure_reason
 ORDER BY occurrences DESC
 LIMIT 10;
 
-\echo ''
-\echo '── (4) analyses 전체 + 최근 7/30일 + 보안 HIGH (현재 KPI 카드 보강 검증) ──'
+
+-- ── (4) analyses 전체 + 최근 7/30일 + 활성도 (현재 KPI 카드 보강 검증) ──
 SELECT
+    '4_analyses'                                            AS section,
     COUNT(*)                                                AS total_analyses,
     COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '7 days')  AS last_7d,
     COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days') AS last_30d,
@@ -60,13 +70,11 @@ SELECT
     ROUND(AVG(score)::numeric, 1)                           AS avg_score_all_time
 FROM analyses;
 
-\echo ''
-\echo '── (5) 활성 author (author_login) 분포 (Q5 mode toggle Phase 3 의 사용자별 노트 가치 측정) ──'
+
+-- ── (5) 활성 author (author_login) 분포 (Q5 모드 토글 Phase 3 의 사용자별 노트 가치 측정) ──
 SELECT
+    '5_author_login'                                        AS section,
     COUNT(DISTINCT author_login)                            AS distinct_authors,
     COUNT(*) FILTER (WHERE author_login IS NOT NULL)        AS with_author,
     COUNT(*) FILTER (WHERE author_login IS NULL)            AS without_author
 FROM analyses;
-
-\echo ''
-\echo '=== End of Phase 2 Readiness Check ==='


### PR DESCRIPTION
## ⚠️ 자율 판단 보고 (정책 3 진화 — PR 본문 최상단)

PR #197 본체 후속 (당시 cf05bfc 만 머지되어 Supabase 호환 갱신 미반영). Phase 2 PR 1/2 머지 완료 후 보류 작업 정리 — 응집 단위 (정책 7 강화) = "운영 DB 환경 호환". docs only 변경 — 코드 변경 0, 테스트 영향 0.

## 변경 항목

### 1. SQL Supabase 호환 (`scripts/dev/verify_phase2_data.sql`)
- `\echo` psql meta-command 모두 제거 (Supabase SQL Editor 미지원)
- 각 SELECT 첫 컬럼에 `'1_analysis_feedbacls'` 형식 `section` 라벨 추가
- merge_attempts 컬럼명 정정: `created_at` → `attempted_at` (MCP 검증 결과 반영)
- 결과: Supabase Dashboard / 온프레미스 psql / Railway 모두 동일 SQL 동작

### 2. runbook 4 옵션 확장 (`docs/runbooks/phase2-data-readiness.md`) 기존 3 옵션 (Railway / psql / DEV) → **4 + 1 옵션**:
- 옵션 A: Supabase Dashboard SQL Editor ★ (이중 setup 의 주 환경)
- 옵션 B: Supabase MCP (Claude 직접 실행 — `mcp__claude_ai_Supabase__execute_sql`) · 본 사이클 검증 완료 — project: qaoirpyhldlkeoyppfwq
- 옵션 C: 온프레미스 PostgreSQL psql CLI
- 옵션 D: Railway PostgreSQL Dashboard
- 옵션 E: SCAManager DEV 환경 (의미 ↓)

### 3. CLAUDE.md 운영 DB 환경 정보 (L303)
- 헤더: "Railway 배포" → "Railway 배포 + 운영 DB 환경"
- 이중/삼중 setup 명시 (Supabase + 온프레미스 + Railway)
- 모든 환경에 동일 alembic 마이그레이션 적용 = schema 일관성 보장
- 운영 SQL 검증 도구 호환성 명시 (4 환경 모두)

## 영향
- 단위 테스트: 2004 / 0 fail 유지 (docs only)
- 5-way sync: 0
- 다음 사이클: 동일 SQL/runbook/CLAUDE.md 가 모든 운영 환경에서 default 작동

## 🔍 사용자 검증 필요
- [ ] CLAUDE.md L303 운영 DB 환경 표기 정확성 (Supabase + 온프레미스 외 추가 환경?)
- [ ] runbook 4 옵션 중 옵션 A / B 실제 운영에서 가장 자주 사용하는 환경 확인

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
