### PR TITLE
chore(integration): pre-existing 24 fail 일괄 해소 — conftest autouse fix…

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -7,7 +7,7 @@
 | 지표 | 값 | 비고 |
 |------|-----|------|
 | 단위 테스트 | **2010개** | pytest 9.0.3 — 그룹 60+61 누적 +24 (Phase 1 +1 + Phase 2 +17 + P0 OAuth +4 + leaderboard 폐기 +2) **= 2010 collected / 2009 passed / 2 skipped / 0 failed** |
-| 통합 테스트 | **82개** | tests/integration/ — 그룹 61 PR #208 (정책 13 강화) +10 (test_oauth_flow_smoke — smoke check 3 + 인증 flow 4 endpoint 3 + insights redirect 3 + 성능 1) |
+| 통합 테스트 | **82개** | tests/integration/ — 그룹 61 PR #208 (정책 13 강화) +10 + PR #209 (24 fail 해소 — conftest autouse) **= 79 passed / 3 skipped / 0 failed** |
 | E2E 테스트 | **65개** | `make test-e2e` (Chromium Playwright) — 그룹 61 PR #208 +14 (test_dashboard — 페이지 로드 + KPI 5 카드 + range toggle + chart vendoring + JS 런타임 + insights redirect + nav Dashboard 링크) |
 | SonarCloud Quality Gate | **OK** | CI #6 (2026-04-23) 반영 |
 | SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
@@ -76,7 +76,8 @@
 |----|---------|
 | **#206** Chore/remove leaderboard feature completely | **🔴 Q3 정정 — 리더보드 기능 완전 폐기** (사용자 명시 요청). Alembic 0025 + ORM/dataclass/API/UI/핸들러 5-way sync. 회귀 가드 +2 (column/dataclass 부재). 기존 가드 정정 ("Q3 보존" → "Q3 정정 폐기") |
 | **#207** Docs/cycle-61 final stale sync | **그룹 60+61 종료 후 stale 일괄 정리** — 5 에이전트 병렬 검증 결과 P0 9 / P1 5 / P2 5 처리. STATE 수치 정정 + design rework Q3 정정 + INDEX 결정 완료 + static-assets `insights_me` → `dashboard.html` + merge-retry `leaderboard` 정정 + collaboration retro 헤더 1줄 + CLAUDE.md L90 KPI 4↔5 명확화 |
-| **#208 (진행 중)** Feat/policy-13 e2e + integration guards | **정책 13 강화 종단간 자동화 가드 신설** (회고 P0 #5 검증 환류 갭 + P0 OAuth 사고 후속). (a) `tests/integration/test_oauth_flow_smoke.py` (+10) — smoke check 3 + 인증 flow 4 endpoint 3 + insights redirect 3 + 성능 1. (b) `e2e/test_dashboard.py` (+14) — 페이지 로드 + KPI 5 카드 + range toggle + chart vendoring + JS 런타임 + insights redirect + nav Dashboard 링크 (Playwright). 통합/E2E 가 운영 endpoint smoke check 자동 실행 → 다음 OAuth/redirect_uri 같은 외부 변경 사고 즉시 발견 가능 |
+| **#208** Feat/policy-13 e2e + integration guards | **정책 13 강화 종단간 자동화 가드 신설** — `test_oauth_flow_smoke.py` +10 + `e2e/test_dashboard.py` +14 |
+| **(진행 중)** Chore/integration pre-existing 24 fail triage | **🎯 24 fail 일괄 해소** (conftest autouse 1건). 근본 원인 = 그룹 60 PR B-1/B-2 와 동일 패턴 (devcontainer 등 환경의 `GITHUB_WEBHOOK_SECRET=dev_secret` export → conftest setdefault 무효 → settings 의 secret 으로 HMAC 검증 401). fix = `tests/integration/conftest.py` 에 autouse fixture 추가 — `patch("src.webhook.providers.github.get_webhook_secret", return_value="test_secret")` 일괄 적용. **24 fail → 0 fail** (test_e2e_pipeline_scenarios 20 + test_webhook_to_gate 4 모두 해소). 신규 webhook integration test 도 자동 적용 — 환경 의존성 영구 격리 |
 
 **5-way sync 영향**: 5/5 모두 적용 (정책 7 강화 응집 단위 — "리더보드 완전 폐기")
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,10 +1,26 @@
-"""Integration test 자동 마킹.
+"""Integration test 자동 마킹 + webhook secret 환경 의존성 격리.
 
 이 디렉토리의 모든 테스트는 실제 subprocess/DB/외부 I/O 를 검증하므로
 기본적으로 `@pytest.mark.slow` 가 자동 부여된다. 빠른 유닛 실행만 원하면
 `pytest tests/ -m "not slow"` 로 격리할 수 있다.
+
+[2026-05-02 그룹 61 — pre-existing 24 fail 정리]
+근본 원인: 그룹 60 PR B-1/B-2 와 동일 패턴 — devcontainer 등 일부 환경에서
+`GITHUB_WEBHOOK_SECRET=dev_secret` (또는 다른 값) 가 export 되어 conftest 의
+`os.environ.setdefault('test_secret')` 무효 → settings.github_webhook_secret =
+"dev_secret" → test 가 보낸 HMAC ("test_secret" 기반) 과 불일치 → 401.
+
+fix: integration test 의 모든 webhook 호출이 사용하는 `get_webhook_secret`
+함수를 autouse fixture 로 일괄 mock. 신규 webhook integration test 도 자동
+적용 → 환경 의존성 영구 격리.
 """
+from unittest.mock import patch
+
 import pytest
+
+# tests/integration/test_e2e_pipeline_scenarios.py:33 + test_webhook_to_gate.py 와 동일 값.
+# tests/conftest.py L7 의 GITHUB_WEBHOOK_SECRET=test_secret default 와도 일치.
+_INTEGRATION_TEST_SECRET = "test_secret"
 
 
 def pytest_collection_modifyitems(config, items):  # pylint: disable=unused-argument
@@ -12,3 +28,19 @@ def pytest_collection_modifyitems(config, items):  # pylint: disable=unused-argu
     for item in items:
         if "tests/integration/" in str(item.fspath).replace("\\", "/"):
             item.add_marker(pytest.mark.slow)
+
+
+@pytest.fixture(autouse=True)
+def _mock_webhook_secret_for_integration():
+    """integration test 에서 webhook secret 환경 의존성 격리.
+
+    `src.webhook.providers.github.get_webhook_secret` 을 일괄 mock 으로 대체 →
+    devcontainer 등 환경의 export 된 GITHUB_WEBHOOK_SECRET 영향 차단.
+    fix 범위: 24 pre-existing fail (test_e2e_pipeline_scenarios 20 + test_webhook_to_gate 4).
+    신규 webhook integration test 도 자동 적용.
+    """
+    with patch(
+        "src.webhook.providers.github.get_webhook_secret",
+        return_value=_INTEGRATION_TEST_SECRET,
+    ):
+        yield


### PR DESCRIPTION
…ture (그룹 60 B-1/B-2 패턴 차용)

## ⚠️ 자율 판단 보고 (정책 3 진화 — PR 본문 최상단)

- **응집 단위** (정책 7 강화) = "통합 테스트 환경 의존성 영구 격리" 단일 응집 (conftest 1줄 변경 + 메모리 노트 갱신).
- **근본 원인 = 그룹 60 PR B-1/B-2 와 동일 패턴** — devcontainer 환경의 `GITHUB_WEBHOOK_SECRET=dev_secret` export → conftest 의 `setdefault` 무효 → settings 의 secret 으로 HMAC 검증 → 401.
- **fix 효과 범위** = 24/24 (test_e2e_pipeline_scenarios 20 + test_webhook_to_gate 4) 모두 해소 + 신규 webhook integration test 도 자동 적용.
- **autouse fixture 의 영향** = `tests/integration/` 하위 모든 테스트에 patch 자동 적용. 단 `test_oauth_flow_smoke.py` (그룹 61 PR #208) 는 webhook 호출 없음 — patch 무관 (영향 0).
- **회귀 가드 의미** = test 작성 시 webhook secret 처리 부담 0 (conftest 가 격리). 신규 webhook integration test 작성 default 화.

## Summary

그룹 60 PR B-1/B-2 (pre-existing 7 unit fail 해소) + 그룹 61 PR #207 stale sync 후속. **24 pre-existing integration fail = 동일 환경 의존성 패턴** — autouse fixture 1건으로 일괄 해소.

## 변경 (2 파일)

### 1. tests/integration/conftest.py (+30 LOC)
- `_INTEGRATION_TEST_SECRET = "test_secret"` (test_e2e_pipeline_scenarios.py:33 / tests/conftest.py L7 default 와 일치)
- `@pytest.fixture(autouse=True) _mock_webhook_secret_for_integration` 신설 · `patch("src.webhook.providers.github.get_webhook_secret", return_value=_INTEGRATION_TEST_SECRET)`
- 모듈 docstring 갱신 — pre-existing 24 fail 정리 사례 + fix 패턴 명시

### 2. STATE.md
- 통합 테스트 수치 정확화: 82 collected / **79 passed / 3 skipped / 0 failed** (이전 표기 stale)
- 그룹 61 PR #208 머지 표기 + #209 (본 PR) 신설

### 3. ~/.claude/.../memory/test-env-setup.md
- pre-existing fail 해소 누적 (단위 7 + 통합 24 = 31건) 명시
- 통합 fix 패턴 (autouse fixture) default 화

## 영향
- 단위 테스트: 2010 collected / 2009 passed / 0 fail 유지 (코드 변경 0)
- **통합 테스트: 55 passed / 24 fail → 79 passed / 0 fail** (24 일괄 해소)
- E2E: 65 passed / 0 fail 유지
- pylint: 코드 변경 0 (테스트만)
- 5-way sync: 0
- **운영 영향**: 0 — 테스트 환경 격리만, 운영 코드 무변경

## 회고 P0 #5 (검증 환류 갭) 추가 자산화
| 항목 | 그룹 60 종료 시 | 그룹 61 종료 시 (본 PR 후) |
|------|--------------|-----------------------|
| pre-existing 단위 fail | 7 → 0 | 0 (PR B-1/B-2) |
| pre-existing 통합 fail | 24 (인지 X) | 0 (본 PR) |
| 환경 의존성 격리 패턴 | settings 직접 mock (단위) | + conftest autouse (통합) | | 신규 webhook integration test 부담 | 매번 patch 추가 의무 | autouse 자동 격리 |

## 🔍 사용자 검증 필요
- [ ] CI / Railway 빌드에서 통합 79 passed / 0 fail 확인
- [ ] 다음 신규 webhook integration test 작성 시 patch 추가 의무 X (conftest 자동 적용)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
