### PR TITLE
docs(phase3): 기획서 갱신 — 사용자 회신 (SaaS 전환 + caching) 반영 + Phase 3 PR 6분할 안

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -77,7 +77,8 @@
 | **#206** Chore/remove leaderboard feature completely | **🔴 Q3 정정 — 리더보드 기능 완전 폐기** (사용자 명시 요청). Alembic 0025 + ORM/dataclass/API/UI/핸들러 5-way sync. 회귀 가드 +2 (column/dataclass 부재). 기존 가드 정정 ("Q3 보존" → "Q3 정정 폐기") |
 | **#207** Docs/cycle-61 final stale sync | **그룹 60+61 종료 후 stale 일괄 정리** — 5 에이전트 병렬 검증 결과 P0 9 / P1 5 / P2 5 처리. STATE 수치 정정 + design rework Q3 정정 + INDEX 결정 완료 + static-assets `insights_me` → `dashboard.html` + merge-retry `leaderboard` 정정 + collaboration retro 헤더 1줄 + CLAUDE.md L90 KPI 4↔5 명확화 |
 | **#208** Feat/policy-13 e2e + integration guards | **정책 13 강화 종단간 자동화 가드 신설** — `test_oauth_flow_smoke.py` +10 + `e2e/test_dashboard.py` +14 |
-| **(진행 중)** Chore/integration pre-existing 24 fail triage | **🎯 24 fail 일괄 해소** (conftest autouse 1건). 근본 원인 = 그룹 60 PR B-1/B-2 와 동일 패턴 (devcontainer 등 환경의 `GITHUB_WEBHOOK_SECRET=dev_secret` export → conftest setdefault 무효 → settings 의 secret 으로 HMAC 검증 401). fix = `tests/integration/conftest.py` 에 autouse fixture 추가 — `patch("src.webhook.providers.github.get_webhook_secret", return_value="test_secret")` 일괄 적용. **24 fail → 0 fail** (test_e2e_pipeline_scenarios 20 + test_webhook_to_gate 4 모두 해소). 신규 webhook integration test 도 자동 적용 — 환경 의존성 영구 격리 |
+| **#209** Chore/integration pre-existing 24 fail triage | **🎯 24 fail 일괄 해소** (conftest autouse 1건) — 그룹 60 PR B-1/B-2 와 동일 패턴 (`get_webhook_secret` mock 누락). **24 → 0 fail**. 환경 의존성 영구 격리 |
+| **(진행 중)** Docs/phase3-spec-update-saas-caching | **Phase 3 기획서 갱신** (사용자 회신 반영) — §5.3 5-Phase 로드맵 진화: Phase 1+2 완료 표기 + **Phase 3 = SaaS 전환 토대 + Insight 모드 + caching** 우선순위 대전환 (이전 단순 "모드 토글" → 지금 6 PR 분할 안: caching 인프라 / Insight service / 모드 토글 / default 모드 / RLS 권한 / 회귀 가드). §8 신설: 사용자 회신 표 (Anthropic 비용 ~$25 / single-tenant → SaaS / leaderboard 폐기) + Phase 3 진입 의무 4건 (caching 패턴 / Insight 카드 4종 / 모드 토글 default / RLS 모델 결정) |
 
 **5-way sync 영향**: 5/5 모두 적용 (정책 7 강화 응집 단위 — "리더보드 완전 폐기")
 

--- a/docs/design/2026-05-02-insight-dashboard-rework.md
+++ b/docs/design/2026-05-02-insight-dashboard-rework.md
@@ -174,17 +174,27 @@
 3. **MVP-B 는 차별 가치 + 검증 가능성 균형** — Chart.js vendoring 재사용 (UI 감사 Step C 자산 활용)
 4. **AI 정합도 / Auto-merge 성공률 은 Phase 2 차별 KPI 로 분리** — 데이터 부족 위험 (FB row 수 미상) 을 Phase 1 의존성에서 제외
 
-### 5.3 5-Phase 로드맵
+### 5.3 5-Phase 로드맵 (2026-05-02 사용자 회신 후 갱신)
 
-| Phase | 목표 | 핵심 변경 | 예상 PR | 시간 |
-|-------|------|---------|--------|------|
-| **Phase 1** | MVP-B 출시 | 신규 `/dashboard` + 폐기 자원 정리 + 회귀 가드 + telemetry 1줄 | 2~3 | **1~2일** |
-| Phase 2 | 차별 KPI 추가 | Auto-merge 성공률 + AI 정합도 카드 (FB row 수 ≥10 검증 후) | 2 | 1~2일 |
-| Phase 3 | 모드 토글 (Claude 톤) | 데이터 모드 ↔ 노트 모드 (Anthropic SDK + caching) | 2 | 2일 |
-| Phase 4 | 모바일 우월 + 단축키 | scroll-snap + 키보드 (`g d`, `?`) | 2 | 1~2일 |
-| Phase 5 | Telegram 미러링 | `/dashboard` Telegram 명령 (`_handle_stats` 패턴 차용) | 1 | 1일 |
+| Phase | 상태 | 목표 | 핵심 변경 | 예상 PR | 시간 |
+|-------|-----|------|---------|--------|------|
+| **Phase 1** | ✅ 완료 (그룹 60) | MVP-B 출시 | 신규 `/dashboard` + 폐기 자원 정리 + 회귀 가드 + telemetry 1줄 | 5 PR | 단일 작업일 |
+| **Phase 2** | ✅ 완료 (그룹 60) | 차별 KPI + CTA | Auto-merge 성공률 (단순+retry-aware) + 실패 사유 + feedback CTA banner | 3 PR (Auto-merge + CTA + Supabase 호환) | 단일 작업일 |
+| **Phase 3 (갱신)** | 진입 의무 | **SaaS 전환 토대 + Insight 모드 + caching** | (a) Anthropic prompt caching (Sonnet input 90% 절감) (b) 모드 토글 📊/💬 (c) Insight 모드 (Claude 톤 노트 — 사용자별 분기 토대) (d) RLS / 멀티 테넌트 권한 모델 (Supabase RLS 차용) | **6~8 PR** | **3~5일** |
+| Phase 4 | 보류 | 모바일 우월 + 단축키 | scroll-snap + 키보드 (`g d`, `?`) | 2 | 1~2일 |
+| Phase 5 | 보류 | Telegram 미러링 | `/dashboard` Telegram 명령 (`_handle_stats` 패턴 차용) | 1 | 1일 |
 
-**총 합계**: 9~10 PR · **6~9 작업일**
+**총 합계 (Phase 3 갱신 후)**: ~16 PR · ~5~9 작업일 (Phase 1+2 완료 = 8 PR / 1일 = 진행 ↑)
+
+**Phase 3 PR 분할 안 (응집 단위 — 정책 7 강화)**:
+| PR # | 응집 단위 | 시간 |
+|------|---------|-----|
+| Phase 3 PR 1 | **Anthropic prompt caching 인프라** — `src/analyzer/io/ai_review.py` + `src/services/dashboard_service.py` (Insight 모드 함수 신설 시) Sonnet system prompt + few-shot caching 적용 | 1~2시간 |
+| Phase 3 PR 2 | **Insight 모드 service** — `dashboard_service::insight_narrative(db, user_id, days, *, now)` (Claude API + caching + ✨ 잘한 것 / 🔍 신경 쓸 것 / 📊 숫자 / 💬 다음 4 카드) | 2~3시간 |
+| Phase 3 PR 3 | **Insight 모드 라우트 + 템플릿** — `/dashboard?mode=insight` + `dashboard.html` 모드 토글 (📊/💬) + Insight 노트 카드 4종 + 차트 cache 보존 (모드 전환 시 재요청 X) | 1~2시간 |
+| Phase 3 PR 4 | **사용자 신호 기반 default 모드** — `_detect_initial_mode` 헬퍼 (settings 패턴 차용) + `?mode` URL 파라미터 + localStorage persist | 1시간 |
+| Phase 3 PR 5 | **SaaS 전환 토대 — RLS 권한 모델** (Supabase RLS 또는 SQLAlchemy session-level filter) — `Repository.user_id` 기반 dashboard 격리 | 2~3시간 |
+| Phase 3 PR 6 | **Insight 모드 회귀 가드 + 통합/E2E** — Claude API mock + caching mock + 모드 토글 e2e | 1~2시간 |
 
 ---
 
@@ -351,10 +361,34 @@ open docs/design/mockups/2026-05-02-dashboard-v2-overview.html
 
 ## 8. 다음 단계
 
-1. **본 기획 PR 머지** — 사용자 결정 반영
-2. **Phase 1 PR 시리즈 착수** — TDD Red → Green → Refactor (CLAUDE.md L583)
-3. **Phase 1 출시 후 회고** — 정책 8 (다중 에이전트) + 정책 9 (Claude 자유 발언) 적용
-4. **Phase 2~5 결정** — 회고 결과로 우선순위 조정
+### 8.1 Phase 1+2 완료 (2026-05-02 그룹 60+61) ✅
+
+- **본 기획 PR 머지** ✅
+- **Phase 1 PR 시리즈** = 5 PR 머지 완료 (그룹 60 #188~#193)
+- **Phase 1 회고** = 5 에이전트 병렬 회고 + Claude 자유 발언 → 정책 11/12 신설 + 정책 2/3/7 진화
+- **Phase 2** = Auto-merge KPI + feedback CTA + Supabase 호환 (3 PR 머지)
+- **Phase 1+2 통합 회고** = 정책 13 신설 + 정책 11 강화 (P0 OAuth 사고 후속)
+- **그룹 61 후속** = leaderboard Q3 정정 폐기 + stale sync + 종단간 가드 + integration 24 fail 정리
+
+### 8.2 사용자 회신 (2026-05-02 Phase 1+2 종료 직후)
+
+| 정보 | 회신 | 영향 |
+|------|------|------|
+| Anthropic API 비용 | ~$25 (집중 사용 시) / Sonnet 4.6 주, Opus 4.7 보조 | caching 우선 (90% 절감) |
+| 트래픽 / 사용자 수 | "저 혼자" (1인 운영) | dashboard_view 빈도 ↓ |
+| 운영 모델 | **"SaaS 했으면 좋겠습니다"** | **Phase 3 우선순위 대전환 — SaaS 전환 토대** |
+| 신규 요청 | **"팀 리더보드 기능 삭제"** | Q3 정정 폐기 (그룹 61 #206) |
+
+### 8.3 Phase 3 진입 의무 (다음 사이클)
+
+1. **Anthropic prompt caching 적용 패턴 확정** — 본 기획서 §5.3 Phase 3 PR 1 의 caching 전략. Sonnet system prompt + few-shot 예시 + (가능 시) tool definitions 모두 cache.
+2. **Insight 모드 카드 4종 디자인 결정** — v2 목업 (`docs/design/mockups/2026-05-02-dashboard-v2-insight.html`) 의 ✨ 잘한 것 / 🔍 신경 쓸 것 / 📊 숫자 / 💬 다음 4 카드 그대로 운영 적용 vs 디자인 정정
+3. **모드 토글 default 결정** — 사용자 신호 기반 (`_detect_initial_mode` 차용) 또는 단순 URL `?mode=insight` 기반
+4. **RLS 권한 모델 결정** — Supabase RLS (DB level) vs SQLAlchemy session-level filter (app level) — single-tenant → multi-tenant 전환 토대
+
+### 8.4 Phase 3 후 Phase 4/5
+
+Phase 4 (모바일 우월) + Phase 5 (Telegram 미러링) — Phase 3 SaaS 전환 후 우선순위 재논의 (멀티 사용자 시 Telegram 봇 = 사용자별 인증 필요 등).
 
 ---
 


### PR DESCRIPTION
## ⚠️ 자율 판단 보고 (정책 3 진화 — PR 본문 최상단)

- **응집 단위** = "Phase 3 진입 전 기획서 갱신" 단일 응집 (정책 7 강화 — docs only).
- **사용자 회신 반영** (2026-05-02 Phase 1+2 종료 직후) — single-tenant 가정 → SaaS 전환 의도 + Anthropic 비용 ~$25 / Sonnet 4.6 주.
- **Phase 3 우선순위 대전환** — 이전 "단순 모드 토글" (2일 / 2 PR) → 지금 "SaaS 전환 토대 + Insight 모드 + caching" (3~5일 / 6 PR).
- **다음 사이클 Claude 진입 의무 4건 명시** — caching 패턴 / Insight 카드 4종 / 모드 토글 default / RLS 모델 결정 — 사전 사용자 결정 또는 Claude 자율 판단 후 사용자 사후 검토.
- **변경 범위** = 1 파일 docs only — 코드 변경 0, 테스트 영향 0.

## Summary

본 사이클 (그룹 60+61 = 22 PR) 종료 후 다음 사이클 (Phase 3) 진입 전 기획서 갱신.

## 변경 (1 파일)

### docs/design/2026-05-02-insight-dashboard-rework.md

#### §5.3 5-Phase 로드맵 갱신
- Phase 1 ✅ 완료 (그룹 60, 5 PR)
- Phase 2 ✅ 완료 (그룹 60, 3 PR — Auto-merge KPI + CTA + Supabase 호환)
- **Phase 3 갱신** = "단순 모드 토글" → "SaaS 전환 토대 + Insight 모드 + caching" 6~8 PR / 3~5일
- Phase 4/5 보류 (Phase 3 SaaS 전환 후 우선순위 재논의)

#### §5.3 Phase 3 PR 6분할 안 (신규)
| PR | 응집 | 시간 |
|----|-----|-----|
| PR 1 | Anthropic prompt caching 인프라 (Sonnet input 90% 절감) | 1~2시간 | | PR 2 | Insight 모드 service (`insight_narrative` Claude API) | 2~3시간 | | PR 3 | Insight 모드 라우트 + 템플릿 + 모드 토글 | 1~2시간 |
| PR 4 | 사용자 신호 기반 default 모드 (`_detect_initial_mode`) | 1시간 | | PR 5 | SaaS 전환 토대 — RLS 권한 모델 (Supabase RLS 또는 SQLAlchemy session-level) | 2~3시간 | | PR 6 | Insight 모드 회귀 가드 + 통합/E2E (Claude API mock + caching mock) | 1~2시간 |

#### §8 다음 단계 신설
- 8.1 Phase 1+2 완료 (그룹 60+61 머지 표기)
- 8.2 사용자 회신 표 (Anthropic 비용 / 트래픽 / SaaS 의도 / leaderboard 삭제)
- 8.3 Phase 3 진입 의무 4건
- 8.4 Phase 4/5 후순위

## 영향
- 단위 테스트: 2010 / 0 fail 유지 (docs only)
- 통합 테스트: 79 / 0 fail 유지
- 5-way sync: 0
- **다음 세션 Claude**: Phase 3 진입 의무 4건 + 6 PR 분할 안 명시 → 정확한 PR 시리즈 시작 가능

## 🔍 사용자 검증 필요
- [ ] Phase 3 PR 6분할 안 적정성 (응집 단위 + 시간 추정)
- [ ] Phase 3 진입 의무 4건 사전 결정 vs 사이클 중 Claude 자율 판단 + 사후 검토 (어느 쪽 권장?)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
