### PR TITLE
feat(phase3-pr1): Anthropic prompt caching 인프라 — 공용 헬퍼 + opt-out 환경변수

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -20,6 +20,7 @@ import anthropic
 from src.analyzer.pure.review_prompt import build_review_prompt, get_system_prompt
 from src.config import settings
 from src.constants import AI_DEFAULT_COMMIT_RAW, AI_DEFAULT_DIRECTION_RAW, AI_RAW_COMMIT_MAX, AI_RAW_DIRECTION_MAX
+from src.shared.anthropic_caching import build_cached_system_param
 from src.shared.claude_metrics import extract_anthropic_usage, log_claude_api_call
 
 logger = logging.getLogger(__name__)
@@ -78,21 +79,14 @@ async def review_code(
     system_text = get_system_prompt()
     start = time.perf_counter()
     try:
-        # 시스템 프롬프트에 cache_control 적용 — 5분 ephemeral 캐시.
-        # 캐시 히트 시 입력 토큰 비용이 1/10. 동일 시스템 프롬프트가 5분 내
-        # 재사용되면 cache_read_input_tokens 로 카운트되어 큰 비용 절감.
-        # System prompt is marked with cache_control (ephemeral, 5-min TTL).
-        # On cache hit, input cost drops 10×; reuse within 5 min reads from cache.
+        # 시스템 프롬프트에 cache_control 적용 — 5분 ephemeral 캐시 (공용 헬퍼 경유).
+        # `settings.disable_prompt_cache=True` 시 운영 opt-out (cache_control 미적용).
+        # System prompt with cache_control (ephemeral 5-min) via shared helper.
+        # `settings.disable_prompt_cache=True` opts out (cache_control omitted).
         response = await client.messages.create(
             model=model,
             max_tokens=1500,
-            system=[
-                {
-                    "type": "text",
-                    "text": system_text,
-                    "cache_control": {"type": "ephemeral"},
-                },
-            ],
+            system=build_cached_system_param(system_text),
             messages=[{"role": "user", "content": prompt}],
         )
         duration_ms = (time.perf_counter() - start) * 1000

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,9 @@ class Settings(BaseSettings):
     telegram_webhook_secret: str = ""  # Telegram setWebhook secret_token — 설정 시 헤더 검증
     anthropic_api_key: str = ""  # 빈 문자열이면 AI 리뷰 건너뜀
     claude_review_model: str = "claude-sonnet-4-6"  # AI 코드리뷰 모델 (환경변수 CLAUDE_REVIEW_MODEL로 오버라이드)
+    # 운영 opt-out — Anthropic prompt caching (5분 ephemeral) 비활성화 (default-on)
+    # Operational opt-out — disables Anthropic prompt caching (default-on, 5-min ephemeral)
+    disable_prompt_cache: bool = False
     api_key: str = ""  # 빈 문자열이면 인증 건너뜀
     internal_cron_api_key: str = ""  # 내부 cron 엔드포인트 전용 키 (admin api_key와 분리)
     # Internal cron endpoint key — separate from admin api_key

--- a/src/shared/anthropic_caching.py
+++ b/src/shared/anthropic_caching.py
@@ -1,0 +1,48 @@
+"""Anthropic prompt caching 헬퍼 — 공용 모듈.
+
+Anthropic Messages API 의 system 인자에 5분 ephemeral cache_control 을 적용해
+input 토큰 비용을 1/10 로 절감 (cache hit 시). 동일 system prompt 가 5분 내
+재사용되면 cache_read_input_tokens 로 카운트.
+
+Anthropic prompt caching helper — shared module.
+Applies 5-minute ephemeral `cache_control` to the Anthropic Messages API system
+parameter so input cost drops 10× on cache hit. Reuse within 5 min reads from cache.
+
+Phase 3 PR 1 — `src/analyzer/io/ai_review.py` 와 향후 `dashboard_service.py`
+(insight_narrative — Phase 3 PR 2) 양쪽이 본 헬퍼를 재사용한다. 운영 opt-out 은
+환경변수 DISABLE_PROMPT_CACHE=1 (또는 settings.disable_prompt_cache=True) 로 제어.
+
+기획 근거: docs/design/2026-05-02-insight-dashboard-rework.md §5.3 Phase 3 PR 1.
+"""
+from src.config import settings
+
+
+def build_cached_system_param(
+    text: str, *, disable_cache: bool | None = None
+) -> list[dict]:
+    """Anthropic Messages API system 인자용 list 빌더 (선택적 cache_control 적용).
+
+    Build a list for the Anthropic Messages API `system` parameter with optional
+    `cache_control` (ephemeral, 5-min TTL).
+
+    Args:
+        text: system prompt 본문 (caller 가 길이 검증 책임 — Anthropic 권장 ≥1024 토큰).
+              system prompt body (caller validates length — Anthropic recommends ≥1024 tokens).
+        disable_cache: True 시 cache_control 미적용 (인자 우선).
+                       None (default) 시 settings.disable_prompt_cache 따름.
+                       True omits cache_control (arg wins).
+                       None falls back to settings.disable_prompt_cache.
+
+    Returns:
+        cache 적용: [{"type": "text", "text": text, "cache_control": {"type": "ephemeral"}}]
+        cache 미적용 (opt-out): [{"type": "text", "text": text}]
+    """
+    # 인자가 명시되면 settings 무관하게 인자 우선
+    # Explicit arg overrides settings
+    if disable_cache is None:
+        disable_cache = bool(settings.disable_prompt_cache)
+
+    block: dict = {"type": "text", "text": text}
+    if not disable_cache:
+        block["cache_control"] = {"type": "ephemeral"}
+    return [block]

--- a/tests/unit/shared/test_anthropic_caching.py
+++ b/tests/unit/shared/test_anthropic_caching.py
@@ -1,0 +1,101 @@
+"""Anthropic prompt caching 헬퍼 단위 테스트.
+
+Unit tests for Anthropic prompt caching helper.
+
+Phase 3 PR 1 — TDD Red.
+- 신설 모듈 src/shared/anthropic_caching.py 의 build_cached_system_param() 검증
+- Validate build_cached_system_param() in the new src/shared/anthropic_caching.py module
+- 6 테스트: 정상 cache / 빈 문자열 / disable_cache=True / disable_cache=False / settings.disable_prompt_cache=True / settings.disable_prompt_cache=False
+- 6 tests: normal cache / empty string / disable_cache=True / disable_cache=False / settings.disable_prompt_cache=True / settings.disable_prompt_cache=False
+
+패턴:
+- settings 직접 mock 우선 (auto memory `test-env-setup.md` — 환경변수 stash 는 fallback)
+- Direct settings mock pattern (auto memory `test-env-setup.md` — env-var stash is fallback)
+"""
+from unittest.mock import patch
+
+import pytest
+
+# 구현 모듈 import — Red 단계에서 ModuleNotFoundError 예상
+# Import implementation module — ModuleNotFoundError expected during Red phase
+from src.shared import anthropic_caching
+
+
+# 정상 cache 적용 — 평문 입력에 cache_control ephemeral 키가 자동 부여되어야 함
+# Normal cache application — plain input must auto-receive cache_control ephemeral key
+def test_build_cached_system_param_applies_ephemeral_cache_control():
+    result = anthropic_caching.build_cached_system_param("hello world")
+    assert result == [
+        {
+            "type": "text",
+            "text": "hello world",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+# 빈 문자열 입력 — 길이 검증 책임은 caller, 헬퍼는 graceful 통과
+# Empty string input — length validation is caller's responsibility, helper passes through gracefully
+def test_build_cached_system_param_handles_empty_string():
+    result = anthropic_caching.build_cached_system_param("")
+    assert result == [
+        {
+            "type": "text",
+            "text": "",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+# disable_cache=True 인자 명시 시 cache_control 키 미존재 (opt-out 운영 분기)
+# When disable_cache=True is explicit, cache_control key must be absent (opt-out branch)
+def test_build_cached_system_param_disable_cache_true_omits_cache_control():
+    result = anthropic_caching.build_cached_system_param("hello", disable_cache=True)
+    assert result == [{"type": "text", "text": "hello"}]
+    # cache_control 키 자체가 없어야 함 (None 값도 안 됨)
+    # cache_control key must be wholly absent (None value not acceptable)
+    assert "cache_control" not in result[0]
+
+
+# disable_cache=False 인자 명시 시 settings 무관하게 cache_control 적용
+# When disable_cache=False is explicit, cache_control applies regardless of settings
+def test_build_cached_system_param_disable_cache_false_applies_cache_control():
+    # settings.disable_prompt_cache=True 여도 인자 우선
+    # Even if settings.disable_prompt_cache=True, the explicit arg wins
+    with patch.object(anthropic_caching, "settings") as mock_settings:
+        mock_settings.disable_prompt_cache = True
+        result = anthropic_caching.build_cached_system_param(
+            "hello", disable_cache=False
+        )
+    assert result == [
+        {
+            "type": "text",
+            "text": "hello",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]
+
+
+# disable_cache=None (default) + settings.disable_prompt_cache=True → opt-out
+# disable_cache=None (default) + settings.disable_prompt_cache=True → opt-out
+def test_build_cached_system_param_settings_disable_overrides_default():
+    with patch.object(anthropic_caching, "settings") as mock_settings:
+        mock_settings.disable_prompt_cache = True
+        result = anthropic_caching.build_cached_system_param("hello")
+    assert result == [{"type": "text", "text": "hello"}]
+    assert "cache_control" not in result[0]
+
+
+# disable_cache=None (default) + settings.disable_prompt_cache=False (default) → cache 적용
+# disable_cache=None (default) + settings.disable_prompt_cache=False (default) → cache applies
+def test_build_cached_system_param_default_path_applies_cache_control():
+    with patch.object(anthropic_caching, "settings") as mock_settings:
+        mock_settings.disable_prompt_cache = False
+        result = anthropic_caching.build_cached_system_param("hello")
+    assert result == [
+        {
+            "type": "text",
+            "text": "hello",
+            "cache_control": {"type": "ephemeral"},
+        }
+    ]

--- a/tests/unit/shared/test_anthropic_caching.py
+++ b/tests/unit/shared/test_anthropic_caching.py
@@ -14,8 +14,6 @@ Phase 3 PR 1 — TDD Red.
 """
 from unittest.mock import patch
 
-import pytest
-
 # 구현 모듈 import — Red 단계에서 ModuleNotFoundError 예상
 # Import implementation module — ModuleNotFoundError expected during Red phase
 from src.shared import anthropic_caching


### PR DESCRIPTION
Phase 3 PR 1 — SaaS 전환 토대 + caching 6 PR 분할 안의 첫 PR.

## 변경 내역

### 신설
- `src/shared/anthropic_caching.py` — 공용 헬퍼 모듈
  - `build_cached_system_param(text, *, disable_cache=None) -> list[dict]`
  - default-on cache (5분 ephemeral) + 환경변수 opt-out + 인자 우선
- `tests/unit/shared/test_anthropic_caching.py` — 6 단위 테스트 (정상/빈 문자열/disable_cache=True/False/settings 우선/default 경로)

### config 확장
- `src/config.py` — `disable_prompt_cache: bool = False` 신규 필드 (환경변수 `DISABLE_PROMPT_CACHE` 로 오버라이드)

### 리팩터링
- `src/analyzer/io/ai_review.py:86~95` — system 인자 dict literal (4줄) → `build_cached_system_param(system_text)` 1줄 호출
  - 동작 동일 (cache_control ephemeral 적용 보존)
  - DISABLE_PROMPT_CACHE=1 환경변수 시 자동 opt-out (운영 통제)

## 사용자 결정 정합 (Phase 3 진입 의무 4건 중 1번)
**1️⃣ caching 패턴: 🅐 default-on + opt-out 환경변수** ★ 권장 default 적용

## 검증
- 신규 6 단위 테스트: **6/6 PASS** (Green)
- ai_review/shared/config 영역 전체: **136 PASS / 0 fail / 1 skip** (회귀 0)
- 전체 단위 suite: **2010 + 6 신규 = 2016 collected / 2010+6 passed / 5 fail (모두 pre-existing — gate/engine 2 + telegram_provider 3, main 동일 fail 검증)**
- pylint (변경 영역): **9.97/10** (main 9.91 대비 **+0.06 개선** — 헬퍼 추출로 ai_review 라인 단순화)
- flake8 (변경 영역): pre-existing 만 (config.py L67~ E116 — line shift)
- bandit (신규 모듈): **0 issues**

## 향후 PR 2 호환성
PR 2 (Insight 모드 service — `dashboard_service::insight_narrative`) 가 동일 헬퍼 재사용:
```python
from src.shared.anthropic_caching import build_cached_system_param

response = await client.messages.create(
    model=model,
    system=build_cached_system_param(insight_system_prompt),
    messages=[...],
)
```

## 운영 적용 가이드
- default: 환경변수 미설정 → `disable_prompt_cache=False` → cache 적용 (10× 비용 절감)
- 운영 통제: Railway Variables 에 `DISABLE_PROMPT_CACHE=1` 설정 → cache 즉시 미적용
- 검증: Railway 로그의 `cache_read_tokens`/`cache_creation_tokens` 필드 (이미 관측 적용)

## 🔍 사용자 검증 필요 (정책 2)
- [ ] PR 머지 + Railway 재배포 후 첫 분석 1회 실행 → Sentry/로그에 `cache_creation_tokens > 0` 확인 (cache 생성)
- [ ] 5분 이내 두 번째 분석 1회 실행 → `cache_read_tokens > 0` 확인 (cache hit)
- [ ] 운영 opt-out 검증 (선택): Railway Variables `DISABLE_PROMPT_CACHE=1` 설정 → 두 토큰 모두 0 확인 → 변수 제거 후 원복

## 자율 판단 보고 (정책 3)
- TDD 우선 — test-writer 에이전트 디스패치 (CLAUDE.md L735 default 의무) → Red 6건 → 구현 → Green 6/6
- ai_review.py 의 cache_control 직접 적용 (Phase 1 PR #3) 을 헬퍼로 추출 — PR 2 의 insight_narrative 가 재사용 가능 + 단일 책임 원칙
- pre-existing 5 fail (gate/engine 2 + telegram_provider 3) 는 본 PR 범위 외 — 별도 조사 권장 (다음 사이클 cleanup PR 또는 Phase 3 PR 6 회귀 가드와 묶어 처리 가능)
- lint 개선 (+0.06) 부수 효과 — 헬퍼 추출로 review_code() 라인 카운트 감소

## Code Scanning open alert (정책 14)
- ✅ open 0건 (사이클 62 종료 시점 기준 — 본 PR 영역 새 alert 0)

## 운영 smoke check (정책 13)
- ✅ /health 200
- ✅ /auth/github 302 redirect_uri 정합
- ✅ /login 200 (사이클 62 종료 시점 실행 — 본 PR 머지 후 동일 실행 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
