### PR TITLE
feat(phase3-pr2): Insight 모드 service — dashboard_service.insight_narr…

### DIFF
--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -10,21 +10,35 @@ Phase 2 함수 (운영 데이터 기반 — MCP 검증 결과: success_rate 16.6
 - auto_merge_kpi — Auto-merge 시도 success rate (단순 + retry-aware distinct PR 기준)
 - merge_failure_distribution — 실패 사유 Top N + 비율 (운영 신호: unstable_ci 압도적)
 
+Phase 3 함수 (PR 2):
+- insight_narrative — Claude AI 기반 4 카드 인사이트 (positive / focus / metrics / next).
+  PR 1 의 `build_cached_system_param` 헬퍼로 system prompt cache 5분 적용.
+
 now 인자 의존성 주입 패턴 (analytics_service 와 동일).
 """
 from __future__ import annotations
 
+import json
+import logging
+import re
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+import anthropic
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
+from src.config import settings
 from src.models.analysis import Analysis
 from src.models.analysis_feedback import AnalysisFeedback
 from src.models.merge_attempt import MergeAttempt
 from src.models.repository import Repository
 from src.scorer.calculator import calculate_grade
+from src.shared.anthropic_caching import build_cached_system_param
+from src.shared.claude_metrics import extract_anthropic_usage, log_claude_api_call
+
+logger = logging.getLogger(__name__)
 
 
 # ─── KPI ──────────────────────────────────────────────────────────────────
@@ -378,3 +392,229 @@ def feedback_status(db: Session, *, threshold: int = 10) -> dict[str, Any]:
         "count": int(count),
         "recent_analysis": recent,
     }
+
+
+# ─── Phase 3 PR 2: Insight 모드 narrative ──────────────────────────────────
+
+
+_INSIGHT_SYSTEM_PROMPT = (
+    "You are SCAManager's code-quality insight analyst. "
+    "Given recent dashboard metrics for a developer, generate a concise "
+    "narrative as 4 cards. Always reply in Korean. Output strict JSON only "
+    "(no preamble, no trailing text, no code fences).\n\n"
+    "Cards (JSON keys):\n"
+    "1. positive_highlights (list[str], 3~5 items): ✨ recent strengths "
+    "(grades, secure code, test coverage wins).\n"
+    "2. focus_areas (list[str], 3~5 items): 🔍 areas needing attention "
+    "(recurring issues, declining trends, low scores).\n"
+    "3. key_metrics (list[dict], exactly 4 items): 📊 numeric highlights, "
+    'each {"label": str, "value": str, "delta": str}. '
+    "delta uses + / - prefix.\n"
+    "4. next_actions (list[str], 2~4 items): 💬 suggested next moves "
+    "(specific, actionable, prioritized).\n\n"
+    "Tone: concise, encouraging but honest. Avoid generic advice — refer "
+    "to the actual numbers. Each list item ≤ 80 Korean characters.\n\n"
+    'Return JSON: {"positive_highlights": [...], "focus_areas": [...], '
+    '"key_metrics": [...], "next_actions": [...]}'
+)
+
+
+def _empty_narrative_cards() -> dict[str, list]:
+    """4 카드 모두 빈 list — no_api_key / no_data / api_error / parse_error 공용 fallback.
+
+    Empty 4-card structure used as the fallback for non-success status values.
+    """
+    return {
+        "positive_highlights": [],
+        "focus_areas": [],
+        "key_metrics": [],
+        "next_actions": [],
+    }
+
+
+def _build_insight_response(
+    *, status: str, days: int, cards: dict[str, list] | None = None
+) -> dict[str, Any]:
+    """insight_narrative 응답 dict 빌더 — status + 4 카드 + generated_at + days.
+
+    Helper that builds the insight_narrative response dict.
+    """
+    base = cards if cards is not None else _empty_narrative_cards()
+    return {
+        **base,
+        "status": status,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "days": days,
+    }
+
+
+def _extract_insight_json(text: str) -> str:
+    """Claude 응답에서 JSON 페이로드 추출 — 코드 블록 우선, 첫 `{` ~ 마지막 `}` fallback.
+
+    Extract a JSON payload from a Claude response — prefer fenced blocks,
+    fall back to the first `{` to the last `}`. Mirrors ai_review._extract_json_payload.
+    """
+    cleaned = text.strip()
+    block = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", cleaned, re.DOTALL | re.IGNORECASE)
+    if block:
+        return block.group(1)
+    first, last = cleaned.find("{"), cleaned.rfind("}")
+    if first != -1 and last > first:
+        return cleaned[first:last + 1]
+    return cleaned
+
+
+def _build_insight_user_prompt(
+    *,
+    days: int,
+    kpi: dict[str, Any],
+    trend: list[dict[str, Any]],
+    frequent: list[dict[str, Any]],
+    auto_merge: dict[str, Any],
+) -> str:
+    """4 헬퍼 결과를 Claude 가 읽을 수 있는 user message 로 직렬화.
+
+    Serializes the 4 dashboard helper outputs into a Claude-friendly user message.
+    """
+    payload = {
+        "window_days": days,
+        "kpi": kpi,
+        "trend_last_n_points": trend[-min(len(trend), 14):],  # 최근 N 포인트만 (토큰 절약)
+        "frequent_issues": frequent,
+        "auto_merge": auto_merge,
+    }
+    return (
+        f"다음은 최근 {days}일간의 dashboard 데이터입니다. "
+        "위 4 카드 JSON 형식으로 narrative 를 생성해주세요.\n\n"
+        f"```json\n{json.dumps(payload, ensure_ascii=False, default=str)}\n```"
+    )
+
+
+async def _call_insight_claude_api(
+    client: anthropic.AsyncAnthropic, model: str, user_prompt: str
+) -> str | None:
+    """Claude Messages API 호출 + caching system 인자 + 토큰 로깅. 실패 시 None.
+
+    Calls the Claude Messages API with cached system param and logs tokens.
+    Returns response text on success, None on any exception (caller maps to api_error).
+    """
+    start = time.perf_counter()
+    try:
+        response = await client.messages.create(
+            model=model,
+            max_tokens=1500,
+            system=build_cached_system_param(_INSIGHT_SYSTEM_PROMPT),
+            messages=[{"role": "user", "content": user_prompt}],
+        )
+        duration_ms = (time.perf_counter() - start) * 1000
+        input_tokens, output_tokens = extract_anthropic_usage(response)
+        usage = getattr(response, "usage", None)
+        log_claude_api_call(
+            model=model,
+            duration_ms=duration_ms,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            status="success",
+            cache_read_tokens=getattr(usage, "cache_read_input_tokens", 0) or 0,
+            cache_creation_tokens=getattr(usage, "cache_creation_input_tokens", 0) or 0,
+        )
+        return response.content[0].text
+    except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        # anthropic / httpx / 네트워크 오류 모두 graceful fallback (caller 가 api_error 처리)
+        # All anthropic/httpx/network errors fall through to graceful fallback (caller maps to api_error)
+        duration_ms = (time.perf_counter() - start) * 1000
+        log_claude_api_call(
+            model=model,
+            duration_ms=duration_ms,
+            input_tokens=0,
+            output_tokens=0,
+            status="error",
+            error_type=type(exc).__name__,
+        )
+        logger.exception("insight_narrative API call failed, returning api_error")
+        return None
+
+
+def _parse_insight_cards(text: str) -> dict[str, list] | None:
+    """Claude 응답 text 에서 4 카드 dict 추출. invalid JSON 시 None.
+
+    Parses 4-card dict from Claude response text. Returns None on invalid JSON.
+    """
+    try:
+        data = json.loads(_extract_insight_json(text))
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("insight_narrative parse_error: %s", text[:200])
+        return None
+    return {
+        "positive_highlights": [str(s) for s in data.get("positive_highlights", [])],
+        "focus_areas": [str(s) for s in data.get("focus_areas", [])],
+        "key_metrics": [m for m in data.get("key_metrics", []) if isinstance(m, dict)],
+        "next_actions": [str(s) for s in data.get("next_actions", [])],
+    }
+
+
+async def insight_narrative(
+    db: Session,
+    days: int = 7,
+    *,
+    now: datetime | None = None,
+    api_key: str | None = None,
+) -> dict[str, Any]:
+    """Claude AI 기반 4 카드 인사이트 narrative — Phase 3 PR 2.
+
+    Generates a 4-card narrative (positive / focus / metrics / next) using Claude AI.
+    Reuses the PR 1 `build_cached_system_param` helper for 5-minute system prompt caching.
+
+    Args:
+        db: SQLAlchemy 세션. SQLAlchemy session.
+        days: 윈도우 일수 (default 7). Window size in days.
+        now: 의존성 주입용 — None 시 현재 시각. Injection point — defaults to now.
+        api_key: None 시 settings.anthropic_api_key 사용. Defaults to settings on None.
+
+    Returns:
+        {
+            "positive_highlights": list[str],   # ✨ 잘한 것 (3~5건)
+            "focus_areas": list[str],           # 🔍 신경 쓸 것 (3~5건)
+            "key_metrics": list[dict],          # 📊 숫자 [{"label", "value", "delta"}] × 4
+            "next_actions": list[str],          # 💬 다음 (2~4건)
+            "status": "success" | "no_api_key" | "no_data" | "api_error" | "parse_error",
+            "generated_at": "YYYY-MM-DDTHH:MM:SSZ",
+            "days": int,
+        }
+    """
+    # API key fallback — 명시 인자 우선, 없으면 settings
+    # API key fallback — explicit arg wins, otherwise settings
+    effective_key = api_key if api_key is not None else settings.anthropic_api_key
+    if not effective_key:
+        return _build_insight_response(status="no_api_key", days=days)
+
+    _now = now or datetime.now(timezone.utc)
+
+    # 4 dashboard 헬퍼 호출로 컨텍스트 수집
+    # Collect context by invoking the 4 dashboard helpers
+    kpi = dashboard_kpi(db, days, now=_now)
+    trend = dashboard_trend(db, days, now=_now)
+    frequent = frequent_issues_v2(db, days, now=_now)
+    auto_merge = auto_merge_kpi(db, days, now=_now)
+
+    # 데이터 0건이면 Claude API 호출 비용 발생 안 시킴 (cost-saver early return)
+    # Skip Claude API call when there's no data (cost-saver early return)
+    if int(kpi.get("analysis_count", {}).get("value", 0) or 0) == 0:
+        return _build_insight_response(status="no_data", days=days)
+
+    user_prompt = _build_insight_user_prompt(
+        days=days, kpi=kpi, trend=trend, frequent=frequent, auto_merge=auto_merge
+    )
+
+    # ai_review.py 와 동일 timeout/max_retries 패턴 — SDK 기본값 변경 면역
+    # Same timeout/max_retries pattern as ai_review.py — immune to SDK default changes
+    client = anthropic.AsyncAnthropic(api_key=effective_key, timeout=60.0, max_retries=2)
+    text = await _call_insight_claude_api(client, settings.claude_review_model, user_prompt)
+    if text is None:
+        return _build_insight_response(status="api_error", days=days)
+
+    cards = _parse_insight_cards(text)
+    if cards is None:
+        return _build_insight_response(status="parse_error", days=days)
+
+    return _build_insight_response(status="success", days=days, cards=cards)

--- a/tests/unit/services/test_dashboard_service_insight_narrative.py
+++ b/tests/unit/services/test_dashboard_service_insight_narrative.py
@@ -1,0 +1,306 @@
+"""dashboard_service.insight_narrative 단위 테스트 — Phase 3 PR 2 (TDD Red).
+
+본 파일이 검증하는 함수 (구현 미존재 단계 — Red):
+    src/services/dashboard_service.py::insight_narrative(db, days, *, now, api_key) -> dict
+
+핵심 동작:
+- DB seed (Analysis) → 4 개 dashboard 헬퍼 (kpi/trend/frequent/auto_merge) 호출 →
+  Claude AI 가 4 카드 narrative 생성 (positive_highlights / focus_areas / key_metrics / next_actions).
+- system prompt 는 PR 1 의 `build_cached_system_param` 헬퍼 경유 (5분 ephemeral cache).
+- API key 없음 / 데이터 없음 / API 오류 / 파싱 오류 모두 graceful — status 필드로 시그널.
+
+This module verifies the new `insight_narrative` async service function (TDD Red — not yet implemented).
+The function reads dashboard context from DB, calls Claude AI (with prompt caching), and returns
+a 4-card narrative dict. Failures are surfaced via the `status` field, never raised.
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from src.database import Base
+from src.models.analysis import Analysis  # noqa: F401  (Base.metadata 등록 / register on metadata)
+from src.models.repository import Repository  # noqa: F401
+from src.models.user import User  # noqa: F401
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션.
+
+    Provides an in-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def seeded_repo(db):
+    """user + repo 1건 seed — Analysis FK 충족용.
+
+    Seeds one user + one repo so Analysis rows have valid FKs.
+    """
+    user = User(github_id=1, github_login="alice", email="a@x.com", display_name="Alice")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    repo = Repository(full_name="owner/api", user_id=user.id)
+    db.add(repo)
+    db.commit()
+    db.refresh(repo)
+    return repo
+
+
+def _make_analysis(
+    db: Session,
+    repo_id: int,
+    score: int,
+    *,
+    offset_hours: int = 0,
+    result: dict[str, Any] | None = None,
+) -> Analysis:
+    """Analysis 레코드 헬퍼 — 점수 / created_at offset / result dict 주입 가능.
+
+    Helper to insert an Analysis row with score / created_at offset / result dict.
+    """
+    created = datetime.now(timezone.utc) - timedelta(hours=offset_hours)
+    a = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{uuid.uuid4().hex}",
+        score=score,
+        grade="B",
+        result=result or {},
+        created_at=created,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def _seed_recent_analyses(db: Session, repo_id: int, scores: list[int]) -> None:
+    """최근 7일 분포로 Analysis 여러 건 seed.
+
+    Seeds multiple Analysis rows distributed across the last 7 days.
+    """
+    for idx, score in enumerate(scores):
+        _make_analysis(db, repo_id, score, offset_hours=idx * 12)
+
+
+# ─── Anthropic mock 헬퍼 ────────────────────────────────────────────────────
+
+
+_VALID_NARRATIVE_JSON = (
+    '{'
+    '"positive_highlights": ["A등급 분석 5건 달성", "보안 HIGH 0건 유지", "테스트 점수 평균 14.2"],'
+    '"focus_areas": ["pylint warning 12건 누적", "커밋 메시지 quality 12점 (스케일링 전)"],'
+    '"key_metrics": ['
+    '{"label": "평균 점수", "value": "84.2", "delta": "+3.1"},'
+    '{"label": "분석 건수", "value": "5", "delta": "+2"},'
+    '{"label": "보안 HIGH", "value": "0", "delta": "0"},'
+    '{"label": "Auto-merge 성공", "value": "100%", "delta": "+10%"}'
+    '],'
+    '"next_actions": ["pylint 경고 해소", "커밋 메시지 가이드 공유"]'
+    '}'
+)
+
+
+def _make_anthropic_response(text: str) -> MagicMock:
+    """Anthropic Messages API 응답 객체 mock — content[0].text + usage.
+
+    Builds a MagicMock matching the Anthropic Messages API response shape.
+    """
+    fake_msg = MagicMock()
+    text_block = MagicMock()
+    text_block.text = text
+    fake_msg.content = [text_block]
+    fake_msg.usage = MagicMock(
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=100,
+    )
+    return fake_msg
+
+
+# ─── Tests (TDD Red) ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_insight_narrative_returns_4_cards_on_success(db, seeded_repo):
+    """정상 경로 — DB seed + Claude 응답 valid JSON → 4 카드 narrative + status=success."""
+    # 데이터 seed (5건, 80~95 점수 분포, 최근 7일)
+    # Seed 5 analyses (scores 80-95, distributed in last 7 days)
+    _seed_recent_analyses(db, seeded_repo.id, [80, 85, 88, 92, 95])
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        return_value=_make_anthropic_response(_VALID_NARRATIVE_JSON)
+    )
+
+    # 구현부에서 anthropic.AsyncAnthropic 을 사용한다고 가정
+    # Assumes the implementation uses anthropic.AsyncAnthropic
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative  # late import (TDD Red)
+        result = await insight_narrative(db, days=7, api_key="sk-test")
+
+    assert result["status"] == "success"
+    assert len(result["positive_highlights"]) == 3
+    assert len(result["focus_areas"]) == 2
+    assert len(result["key_metrics"]) == 4
+    assert len(result["next_actions"]) == 2
+    assert result["days"] == 7
+    # ISO 8601 형식 검증 — fromisoformat 으로 round-trip 가능해야 함
+    # Verify ISO 8601 format — must round-trip through fromisoformat
+    assert result["generated_at"] is not None
+    datetime.fromisoformat(result["generated_at"].replace("Z", "+00:00"))
+
+
+@pytest.mark.asyncio
+async def test_insight_narrative_no_api_key_returns_empty_cards(db, seeded_repo):
+    """API key 미설정 (빈 문자열) → status=no_api_key + 4 카드 빈 list, Claude 호출 X."""
+    _seed_recent_analyses(db, seeded_repo.id, [85, 90])
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        return_value=_make_anthropic_response(_VALID_NARRATIVE_JSON)
+    )
+
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative
+        result = await insight_narrative(db, days=7, api_key="")
+
+    assert result["status"] == "no_api_key"
+    assert result["positive_highlights"] == []
+    assert result["focus_areas"] == []
+    assert result["key_metrics"] == []
+    assert result["next_actions"] == []
+    # Claude API 호출이 일어나면 안 됨 (early return)
+    # Claude API must NOT be called (early return on missing key)
+    fake_client.messages.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_insight_narrative_no_data_returns_no_data_status(db):
+    """DB 빈 (Analysis 0건) → status=no_data + 4 카드 빈 list, Claude 호출 X."""
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        return_value=_make_anthropic_response(_VALID_NARRATIVE_JSON)
+    )
+
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative
+        result = await insight_narrative(db, days=7, api_key="sk-test")
+
+    assert result["status"] == "no_data"
+    assert result["positive_highlights"] == []
+    assert result["focus_areas"] == []
+    assert result["key_metrics"] == []
+    assert result["next_actions"] == []
+    # 데이터 0건이면 Claude API 호출 비용 발생 안 시킴
+    # Skip the Claude API call when there is no data (cost-saver)
+    fake_client.messages.create.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_insight_narrative_uses_caching_helper(db, seeded_repo):
+    """system prompt 가 PR 1 의 build_cached_system_param 헬퍼 경유 — 1회 호출 + str 인자."""
+    _seed_recent_analyses(db, seeded_repo.id, [80, 85, 90])
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        return_value=_make_anthropic_response(_VALID_NARRATIVE_JSON)
+    )
+
+    # build_cached_system_param 의 실제 동작을 우회하지 않으면서 호출 카운트만 spy
+    # Spy the helper without bypassing its actual behavior
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ), patch(
+        "src.services.dashboard_service.build_cached_system_param",
+        wraps=lambda text, **kw: [{"type": "text", "text": text, "cache_control": {"type": "ephemeral"}}],
+    ) as mock_helper:
+        from src.services.dashboard_service import insight_narrative
+        await insight_narrative(db, days=7, api_key="sk-test")
+
+    # 1 회 호출
+    # Called exactly once
+    assert mock_helper.call_count == 1
+    # 첫 위치 인자가 str 인지 검증 (system prompt 본문)
+    # First positional arg must be the system prompt string
+    args, _kwargs = mock_helper.call_args
+    assert isinstance(args[0], str)
+    assert len(args[0]) > 0
+
+
+@pytest.mark.asyncio
+async def test_insight_narrative_api_error_graceful(db, seeded_repo):
+    """Claude API 호출이 예외 raise → status=api_error + 4 카드 빈 list, 예외 propagate X."""
+    _seed_recent_analyses(db, seeded_repo.id, [85, 90])
+
+    fake_client = MagicMock()
+    # generic Exception 으로 검증 (anthropic.APIError 도 동일 graceful 경로)
+    # Use a generic Exception (anthropic.APIError follows the same graceful path)
+    fake_client.messages.create = AsyncMock(side_effect=RuntimeError("simulated API failure"))
+
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative
+        # 예외가 호출자에게 전파되면 안 됨
+        # Exception must NOT propagate to the caller
+        result = await insight_narrative(db, days=7, api_key="sk-test")
+
+    assert result["status"] == "api_error"
+    assert result["positive_highlights"] == []
+    assert result["focus_areas"] == []
+    assert result["key_metrics"] == []
+    assert result["next_actions"] == []
+
+
+@pytest.mark.asyncio
+async def test_insight_narrative_parse_error_returns_parse_error_status(db, seeded_repo):
+    """Claude 응답이 invalid JSON → status=parse_error + 4 카드 빈 list."""
+    _seed_recent_analyses(db, seeded_repo.id, [85, 90])
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        return_value=_make_anthropic_response("not a json text — Claude returned prose only")
+    )
+
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative
+        result = await insight_narrative(db, days=7, api_key="sk-test")
+
+    assert result["status"] == "parse_error"
+    assert result["positive_highlights"] == []
+    assert result["focus_areas"] == []
+    assert result["key_metrics"] == []
+    assert result["next_actions"] == []


### PR DESCRIPTION
…ative 4 카드 + Claude AI + caching

Phase 3 PR 2 — SaaS 전환 토대 + caching 6 PR 분할 안의 두 번째 PR.

## 변경 내역

### 신설 함수 (`src/services/dashboard_service.py`)
- `insight_narrative(db, days=7, *, now=None, api_key=None) -> dict[str, Any]` (async)
  - 4 dashboard 헬퍼 (kpi/trend/frequent/auto_merge) 결과를 컨텍스트로 Claude API 호출
  - PR 1 의 `build_cached_system_param` 재사용 (5분 ephemeral system prompt cache)
  - 4 카드 JSON 응답 반환: `positive_highlights` / `focus_areas` / `key_metrics` / `next_actions`
  - 5 status: `success` / `no_api_key` / `no_data` / `api_error` / `parse_error`

### 보조 헬퍼 5건
- `_INSIGHT_SYSTEM_PROMPT` (constant) — Korean response + JSON only + 4 cards 명세
- `_empty_narrative_cards()` — fallback 4 카드 빈 list 빌더
- `_build_insight_response(*, status, days, cards)` — 응답 dict 빌더 (status + cards + generated_at + days)
- `_extract_insight_json(text)` — Claude 응답에서 JSON 추출 (코드 블록 우선 + `{`~`}` fallback). ai_review._extract_json_payload 패턴 차용
- `_build_insight_user_prompt(*, days, kpi, trend, frequent, auto_merge)` — Claude user message 직렬화
- `_call_insight_claude_api(client, model, user_prompt) -> str | None` — Messages API 호출 + 토큰 로깅 + graceful fallback (None on error)
- `_parse_insight_cards(text) -> dict | None` — JSON parse + 4 카드 추출 + invalid 시 None

### 신설 테스트 (`tests/unit/services/test_dashboard_service_insight_narrative.py`)
- 6 단위 테스트 (모두 Green 6/6):
  1. `test_insight_narrative_returns_4_cards_on_success` — 정상 4 카드 + status=success + ISO 8601 generated_at
  2. `test_insight_narrative_no_api_key_returns_empty_cards` — api_key="" → no_api_key + Claude 호출 X
  3. `test_insight_narrative_no_data_returns_no_data_status` — DB 빈 → no_data + Claude 호출 X (cost-saver)
  4. `test_insight_narrative_uses_caching_helper` — `build_cached_system_param` 1회 + str 인자 검증
  5. `test_insight_narrative_api_error_graceful` — RuntimeError raise → api_error (예외 propagate X)
  6. `test_insight_narrative_parse_error_returns_parse_error_status` — invalid JSON → parse_error

## 사용자 결정 정합 (Phase 3 진입 의무 4건 중 2번)
**2️⃣ Insight 카드 4종: 🅐 4종 모두** ★ 권장 default 적용 (✨ / 🔍 / 📊 / 💬)

## 검증
- 신규 6 단위 테스트: **6/6 PASS** (Green, 1.05s → cleanup 후 0.72s)
- services + ui 영역: **218 PASS / 0 fail**
- 전체 단위 suite: **2010+6=2016 collected / 5 fail (모두 pre-existing — main 동일 fail 검증)**
- pylint dashboard_service.py: **10.00/10** (R0914 발생 → 헬퍼 추출 cleanup 후 회복 +0.06)
- flake8 / bandit: 0 issues

## 향후 PR 호환성
- **PR 3** (라우트 + 템플릿 + 모드 토글 UI): `await insight_narrative(db, days=days, now=...)` 직접 호출
- **PR 5** (Supabase RLS): 본 함수 시그니처에 `user_id` 추가 + WHERE 절 필터 적용 — 본 PR 시그니처는 응집 단위 부합 (다른 dashboard_service 함수와 동일 시그니처 패턴 — user_id 없음)
- **PR 6** (E2E 회귀 가드): `/dashboard?mode=insight` e2e + caching mock + 4 카드 시각

## 핵심 학습
- 헬퍼 분리 패턴 (`_call_insight_claude_api` + `_parse_insight_cards`) → R0914 25/15 → 단순 흐름 회복
- `# pylint: disable=broad-exception-caught` + `# noqa: BLE001` 페어 (anthropic SDK 의 다양한 예외 graceful 처리 default)
- mock spy 패턴: `wraps=lambda` 로 실제 동작 + 호출 카운트 검증 동시 (test #4)

## 🔍 사용자 검증 필요 (정책 2)
- [ ] PR 머지 + Railway 재배포 후 PR 3 (라우트 추가) 머지 시점에 `/dashboard?mode=insight` 동작 확인
- [ ] Sentry/로그에 `insight_narrative` 호출의 `cache_creation_tokens` (첫 호출) → `cache_read_tokens` (5분 내 두 번째 호출) 전환 확인
- [ ] (선택) 운영 opt-out — `DISABLE_PROMPT_CACHE=1` 시 본 함수의 caching 미적용 확인

## 자율 판단 보고 (정책 3)
- TDD 우선 — test-writer 에이전트 디스패치 (CLAUDE.md L735 default) → Red 6 → 구현 → R0914 발생 → 헬퍼 추출 cleanup → Green 6/6 + pylint 10.00 회복
- pre-existing 5 fail 본 PR 영역 외 — 이전 PR 1 commit body 와 동일 (gate/engine 2 + telegram_provider 3) — 다음 사이클 cleanup 또는 Phase 3 PR 6 회귀 가드 묶음 권장
- `_call_insight_claude_api` 분리 = 향후 PR 5 (RLS) 에서 user_id 인자 추가 시 헬퍼 시그니처 영향 0 — 응집 단위 보호

## Code Scanning open alert (정책 14)
- ✅ open 0건 (사이클 62 종료 시점 기준 — 본 PR 영역 새 alert 가능성 낮음, 머지 후 GitHub Security 탭 재확인 권장)

## 운영 smoke check (정책 13)
- ✅ /health 200
- ✅ /auth/github 302 redirect_uri 정합
- ✅ /login 200 (PR 1 머지 직후 실행 — 본 PR 머지 후 동일 실행 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
