### PR TITLE
feat(phase3-pr3): Insight 모드 라우트 + 4 카드 템플릿 + 모드 토글 UI

### DIFF
--- a/e2e/test_dashboard.py
+++ b/e2e/test_dashboard.py
@@ -59,28 +59,34 @@ def test_dashboard_kpi_labels_present(page, base_url):
 
 
 def test_dashboard_range_toggle_present(page, base_url):
-    """1d / 7d / 30d / 90d 토글 4 링크 모두 존재."""
+    """1d / 7d / 30d / 90d 토글 4 링크 모두 존재.
+
+    Phase 3 PR 3 — URL 형식이 `?mode={mode}&days={n}` 으로 변경 (모드 토글 페어 보존).
+    range toggle 4 links present (URL format updated to `?mode=...&days=...` in Phase 3 PR 3).
+    """
     page.goto(f"{base_url}/dashboard")
     for days in (1, 7, 30, 90):
-        link = page.locator(f'.dash-range-toggle a[href="/dashboard?days={days}"]')
+        link = page.locator(
+            f'.dash-range-toggle a[href="/dashboard?mode=overview&days={days}"]'
+        )
         assert link.count() == 1, f"days={days} 링크 누락"
 
 
 def test_dashboard_default_range_7_active(page, base_url):
-    """default = days=7 — active 표시."""
+    """default = days=7 — active 표시. Phase 3 PR 3: href 에 mode=overview 포함."""
     page.goto(f"{base_url}/dashboard")
     active = page.locator('.dash-range-toggle a.active')
     assert active.count() == 1
-    assert active.first.get_attribute("href") == "/dashboard?days=7"
+    assert active.first.get_attribute("href") == "/dashboard?mode=overview&days=7"
 
 
 def test_dashboard_30d_range_navigates(page, base_url):
-    """30d 클릭 시 /dashboard?days=30 으로 이동 + active 갱신."""
+    """30d 클릭 시 /dashboard?mode=overview&days=30 이동 + active 갱신 (Phase 3 PR 3)."""
     page.goto(f"{base_url}/dashboard")
-    page.click('.dash-range-toggle a[href="/dashboard?days=30"]')
-    page.wait_for_url(f"{base_url}/dashboard?days=30")
+    page.click('.dash-range-toggle a[href="/dashboard?mode=overview&days=30"]')
+    page.wait_for_url(f"{base_url}/dashboard?mode=overview&days=30")
     active = page.locator('.dash-range-toggle a.active')
-    assert active.first.get_attribute("href") == "/dashboard?days=30"
+    assert active.first.get_attribute("href") == "/dashboard?mode=overview&days=30"
 
 
 # ─── chart vendoring (회고 P0 #5 검증) ─────────────────────────────────

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -212,6 +212,85 @@
     color: var(--text-muted); font-size: 14px;
   }
 
+  /* Phase 3 PR 3 — 모드 토글 (Overview / Insight). dash-range-toggle 와 동일 디자인 패턴 */
+  /* Phase 3 PR 3 — mode toggle (Overview / Insight). Same pattern as dash-range-toggle */
+  .dash-mode-toggle {
+    display: inline-flex; gap: 1px; padding: 3px;
+    background: var(--bg-elevated, var(--card-bg, rgba(255,255,255,.04)));
+    border-radius: 9px;
+    border: 1px solid var(--border, rgba(255,255,255,.08));
+    margin-right: 8px;
+  }
+  .dash-mode-toggle a {
+    padding: 7px 14px; border-radius: 6px;
+    font-size: 13px; font-weight: 500;
+    color: var(--text-muted); text-decoration: none;
+    min-height: 40px; box-sizing: border-box;
+    display: inline-flex; align-items: center; gap: 4px;
+    transition: all .15s ease;
+  }
+  .dash-mode-toggle a.active {
+    background: var(--bg-elevated, var(--card-bg, #fff));
+    color: var(--text-primary);
+    font-weight: 600;
+    box-shadow: 0 1px 2px rgba(0,0,0,.06);
+  }
+
+  /* Phase 3 PR 3 — Insight 4 카드 grid (✨ positive / 🔍 focus / 📊 metrics / 💬 next) */
+  /* Phase 3 PR 3 — Insight 4-card grid (✨ positive / 🔍 focus / 📊 metrics / 💬 next) */
+  .dash-insight-grid {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 16px;
+    margin-bottom: 24px;
+  }
+  .dash-insight-card {
+    background: var(--card-bg, var(--bg-surface, rgba(255,255,255,.04)));
+    border: 1px solid var(--border, rgba(255,255,255,.08));
+    border-radius: 14px;
+    padding: 20px 22px;
+    min-height: 200px;
+  }
+  .dash-insight-title {
+    font-family: var(--d-font-heading);
+    font-size: 16px; font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 14px;
+    display: flex; align-items: center; gap: 8px;
+  }
+  .dash-insight-list {
+    list-style: none; padding: 0; margin: 0;
+    display: flex; flex-direction: column; gap: 10px;
+  }
+  .dash-insight-list li {
+    font-size: 14px; line-height: 1.5;
+    color: var(--text-primary);
+    padding-left: 16px; position: relative;
+  }
+  .dash-insight-list li::before {
+    content: "·"; position: absolute; left: 4px; top: -2px;
+    color: var(--d-accent); font-weight: 700; font-size: 16px;
+  }
+  .dash-insight-metric {
+    display: flex; align-items: baseline; justify-content: space-between;
+    padding: 8px 0; border-bottom: 1px solid var(--border, rgba(255,255,255,.06));
+  }
+  .dash-insight-metric:last-child { border-bottom: none; }
+  .dash-insight-metric-label { font-size: 13px; color: var(--text-muted); }
+  .dash-insight-metric-value {
+    font-family: var(--d-font-heading);
+    font-size: 18px; font-weight: 600; color: var(--text-primary);
+  }
+  .dash-insight-metric-delta {
+    font-size: 12px; margin-left: 8px; color: var(--text-muted);
+  }
+  .dash-insight-status {
+    text-align: center; padding: 32px;
+    color: var(--text-muted); font-size: 14px;
+    background: var(--card-bg, var(--bg-surface, rgba(255,255,255,.04)));
+    border: 1px dashed var(--border, rgba(255,255,255,.08));
+    border-radius: 14px;
+    margin-bottom: 24px;
+  }
+
   /* 모바일 — KPI 5 → 데스크탑 5 / tablet 3 / 모바일 2 / xs 1 */
   @media (max-width: 1024px) {
     .dash-kpi-grid { grid-template-columns: repeat(3, 1fr); }
@@ -223,6 +302,9 @@
     .dash-kpi { padding: 16px; min-height: 132px; }
     .dash-kpi-value { font-size: 28px; }
     .dash-chart-wrap { height: 240px; }
+    .dash-insight-grid { grid-template-columns: 1fr; }
+    .dash-insight-card { min-height: auto; padding: 18px; }
+    .dash-mode-toggle a { min-height: 44px; }
   }
   @media (max-width: 480px) {
     .dash-kpi-grid { grid-template-columns: 1fr; }
@@ -236,13 +318,78 @@
       <h1 class="dash-title">Dashboard</h1>
       <p class="dash-subtitle">우리 코드는 어떻게 흘러가고 있나요</p>
     </div>
-    <nav class="dash-range-toggle" aria-label="기간 선택 / Period selector">
-      <a href="/dashboard?days=1" {% if days == 1 %}class="active"{% endif %}>1d</a>
-      <a href="/dashboard?days=7" {% if days == 7 %}class="active"{% endif %}>7d</a>
-      <a href="/dashboard?days=30" {% if days == 30 %}class="active"{% endif %}>30d</a>
-      <a href="/dashboard?days=90" {% if days == 90 %}class="active"{% endif %}>90d</a>
-    </nav>
+    <div style="display:flex; align-items:center; flex-wrap:wrap; gap:8px;">
+      {# Phase 3 PR 3 — 모드 토글 (Overview default + Insight 신규) #}
+      {# Phase 3 PR 3 — mode toggle (Overview default + Insight new) #}
+      <nav class="dash-mode-toggle" aria-label="대시보드 모드 / Dashboard mode">
+        <a href="/dashboard?mode=overview&days={{ days }}"
+           data-mode="overview"
+           {% if mode == 'overview' %}class="active"{% endif %}>📊 Overview</a>
+        <a href="/dashboard?mode=insight&days={{ days }}"
+           data-mode="insight"
+           {% if mode == 'insight' %}class="active"{% endif %}>💬 Insight</a>
+      </nav>
+      <nav class="dash-range-toggle" aria-label="기간 선택 / Period selector">
+        <a href="/dashboard?mode={{ mode }}&days=1" {% if days == 1 %}class="active"{% endif %}>1d</a>
+        <a href="/dashboard?mode={{ mode }}&days=7" {% if days == 7 %}class="active"{% endif %}>7d</a>
+        <a href="/dashboard?mode={{ mode }}&days=30" {% if days == 30 %}class="active"{% endif %}>30d</a>
+        <a href="/dashboard?mode={{ mode }}&days=90" {% if days == 90 %}class="active"{% endif %}>90d</a>
+      </nav>
+    </div>
   </div>
+
+  {# Phase 3 PR 3 — Insight 모드: Claude AI 4 카드. Overview 분기는 그대로 보존 #}
+  {# Phase 3 PR 3 — Insight mode: Claude AI 4 cards. Overview branch is preserved as-is #}
+  {% if mode == 'insight' %}
+    {% if insight and insight.status == 'success' %}
+    <div class="dash-insight-grid" role="region" aria-label="AI Insight 4 카드">
+      <div class="dash-insight-card">
+        <h2 class="dash-insight-title">✨ 잘한 것</h2>
+        <ul class="dash-insight-list">
+          {% for item in insight.positive_highlights %}<li>{{ item }}</li>{% endfor %}
+        </ul>
+      </div>
+      <div class="dash-insight-card">
+        <h2 class="dash-insight-title">🔍 신경 쓸 것</h2>
+        <ul class="dash-insight-list">
+          {% for item in insight.focus_areas %}<li>{{ item }}</li>{% endfor %}
+        </ul>
+      </div>
+      <div class="dash-insight-card">
+        <h2 class="dash-insight-title">📊 숫자</h2>
+        <div>
+          {% for m in insight.key_metrics %}
+          <div class="dash-insight-metric">
+            <span class="dash-insight-metric-label">{{ m.label }}</span>
+            <span>
+              <span class="dash-insight-metric-value">{{ m.value }}</span>
+              {% if m.delta %}<span class="dash-insight-metric-delta">{{ m.delta }}</span>{% endif %}
+            </span>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+      <div class="dash-insight-card">
+        <h2 class="dash-insight-title">💬 다음</h2>
+        <ul class="dash-insight-list">
+          {% for item in insight.next_actions %}<li>{{ item }}</li>{% endfor %}
+        </ul>
+      </div>
+    </div>
+    {% elif insight and insight.status == 'no_api_key' %}
+    <div class="dash-insight-status">
+      🔑 ANTHROPIC_API_KEY 미설정 — Insight 모드는 AI 분석이 필요합니다. Railway Variables 에서 키를 설정해주세요.
+    </div>
+    {% elif insight and insight.status == 'no_data' %}
+    <div class="dash-insight-status">
+      📭 최근 {{ days }}일 분석 데이터가 부족합니다 — 분석 결과가 누적된 후 다시 시도해주세요.
+    </div>
+    {% else %}
+    <div class="dash-insight-status">
+      ⚠️ AI Insight 생성 실패 ({{ insight.status if insight else 'unknown' }}) — 잠시 후 다시 시도해주세요.
+    </div>
+    {% endif %}
+  {% else %}
 
   {# Phase 2 PR 2 — feedback CTA banner (조건부, count < threshold 시만 표시) #}
   {% if feedback and feedback.show_cta %}
@@ -421,11 +568,15 @@
     {% endfor %}
   </div>
   {% endif %}
+
+  {% endif %}{# end of mode == 'overview' branch (Phase 3 PR 3) #}
 </div>
 {% endblock %}
 
 {% block scripts %}
-{% if trend %}
+{# Phase 3 PR 3 — Insight 모드는 차트 미사용 (4 카드 narrative). overview 모드 + trend 데이터 있을 때만 차트 #}
+{# Phase 3 PR 3 — Insight mode skips the chart (4-card narrative). Chart only when overview mode + trend data exists #}
+{% if mode != 'insight' and trend %}
 <script src="/static/vendor/chart.umd.min.js"></script>
 <script>
   // 추세 데이터 (서버 주입) — autoescape 안전

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -23,24 +23,56 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+_VALID_MODES = ("overview", "insight")
+
+
 @router.get("/dashboard", response_class=HTMLResponse)
-def dashboard(
+async def dashboard(
     request: Request,
     current_user: Annotated[CurrentUser, Depends(require_login)],
     days: int = 7,
+    mode: str = "overview",
 ):
-    """대시보드 — KPI 4 카드 + 점수 추세 차트 + 자주 발생 이슈.
-    Dashboard — KPI 4 cards + score trend chart + frequent issues.
+    """대시보드 — Phase 3 PR 3 mode 분기 (overview default + insight 추가).
+
+    Dashboard with Phase 3 PR 3 mode branch (overview default + insight added).
+
+    - mode=overview (default): KPI 5 카드 + 점수 추세 + 자주 발생 이슈 + Auto-merge + feedback CTA
+    - mode=insight: Claude AI 4 카드 narrative (✨ positive / 🔍 focus / 📊 metrics / 💬 next)
+    - whitelist 외 값은 overview 로 fallback (URL 파라미터 변조 방어)
     """
-    # Telemetry — Phase 1 PR 5 자율 판단 (정책 3): 사용 빈도 측정 1줄, 비식별 (user.id + days).
-    # Telemetry: log usage frequency (user.id + days only — no PII).
+    # whitelist — URL 파라미터 변조 방어 (?mode=foo → overview fallback)
+    # Whitelist — defends against URL param tampering (?mode=foo → overview fallback)
+    if mode not in _VALID_MODES:
+        mode = "overview"
+
+    # Telemetry — Phase 1 PR 5 자율 판단 (정책 3) + Phase 3 PR 3 mode 추가, 비식별.
+    # Telemetry: log usage frequency (user.id + days + mode only — no PII).
     logger.info(
-        "dashboard_view user_id=%d days=%s",
+        "dashboard_view user_id=%d days=%s mode=%s",
         current_user.id,
         sanitize_for_log(str(days), max_len=10),
+        sanitize_for_log(mode, max_len=20),
     )
 
     with SessionLocal() as db:
+        if mode == "insight":
+            # Phase 3 PR 2 — Claude AI 4 카드 narrative (caching 적용).
+            # Phase 3 PR 2 — Claude AI 4-card narrative (with caching).
+            insight = await dashboard_service.insight_narrative(db, days=days)
+            return templates.TemplateResponse(
+                request,
+                "dashboard.html",
+                {
+                    "current_user": current_user,
+                    "mode": "insight",
+                    "insight": insight,
+                    "days": days,
+                },
+            )
+
+        # mode == "overview" — 기존 동작 보존
+        # mode == "overview" — preserves prior behavior
         kpi = dashboard_service.dashboard_kpi(db, days=days)
         trend = dashboard_service.dashboard_trend(db, days=days)
         frequent_issues = dashboard_service.frequent_issues_v2(db, days=days, n=5)
@@ -55,6 +87,7 @@ def dashboard(
         "dashboard.html",
         {
             "current_user": current_user,
+            "mode": "overview",
             "kpi": kpi,
             "trend": trend,
             "frequent_issues": frequent_issues,

--- a/tests/unit/ui/test_dashboard_route.py
+++ b/tests/unit/ui/test_dashboard_route.py
@@ -1,16 +1,24 @@
 """GET /dashboard UI 라우트 단위 테스트 — Phase 1 PR 4 (MVP-B 신규 라우트).
+GET /dashboard UI route unit tests — Phase 1 PR 4 (MVP-B new route).
 
 검증:
 - 인증 (require_login) — 미로그인 302 redirect
 - 로그인 + mock service → 200 + KPI/trend/frequent_issues context
 - days 쿼리 파라미터가 service 함수에 전달
 - 템플릿 렌더링 (TemplateResponse mock)
+
+Phase 3 PR 3 (2026-05-03) 추가 — `mode=overview|insight` 분기 검증:
+Phase 3 PR 3 (2026-05-03) added — `mode=overview|insight` branch verification:
+- default mode = overview (기존 동작 보존)
+- mode=insight → dashboard_service.insight_narrative (async) 호출 + insight 컨텍스트 주입
+- whitelist 외 값 → overview 로 fallback
+- 모드 토글 UI 링크 2건 (overview / insight) 존재
 """
 # pylint: disable=redefined-outer-name
 from __future__ import annotations
 
 from contextlib import contextmanager
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -169,3 +177,222 @@ def test_dashboard_context_includes_kpi_trend_issues():
     for key in ("kpi", "trend", "frequent_issues", "days", "current_user",
                 "auto_merge", "merge_failures", "feedback"):
         assert key in captured, f"context 에 {key} 누락"
+
+
+# ─── Phase 3 PR 3 (2026-05-03) — mode=overview|insight 분기 ────────────────
+# Phase 3 PR 3 (2026-05-03) — mode=overview|insight branch.
+
+
+@pytest.fixture
+def mock_insight_success():
+    """insight_narrative 성공 응답 mock — async (AsyncMock).
+    Mock for insight_narrative success response — async (AsyncMock).
+    """
+    fake_data = {
+        "positive_highlights": ["좋은 결과"],
+        "focus_areas": ["주의"],
+        "key_metrics": [],
+        "next_actions": ["다음"],
+        "status": "success",
+        "generated_at": "2026-05-03T00:00:00Z",
+        "days": 7,
+    }
+    with patch(
+        "src.ui.routes.dashboard.dashboard_service.insight_narrative",
+        new=AsyncMock(return_value=fake_data),
+    ) as mock:
+        yield mock
+
+
+def test_dashboard_default_mode_is_overview():
+    """mode 미지정 → 기존 overview 동작 보존 + 컨텍스트 mode='overview'.
+    No mode param → preserves existing overview behavior + context mode='overview'.
+
+    회귀 가드 — Phase 3 PR 3 의 mode 분기 도입이 기존 동작 깨지 않음 검증.
+    """
+    client = TestClient(app)
+    mock_db = MagicMock()
+    captured: dict = {}
+
+    def _capture(request, template_name, context, **kwargs):
+        captured.update(context)
+        from fastapi.responses import HTMLResponse
+        return HTMLResponse(content="<html>x</html>", status_code=200)
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi", return_value={"avg_score": {"value": 80}}) as mock_kpi, \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.auto_merge_kpi", return_value={}), \
+         patch("src.ui.routes.dashboard.dashboard_service.merge_failure_distribution", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.feedback_status", return_value={"show_cta": False, "count": 0, "recent_analysis": None}), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse", side_effect=_capture):
+        response = client.get("/dashboard")
+
+    assert response.status_code == 200
+    # overview 분기 → dashboard_kpi 가 호출돼야 함 (insight 분기에서는 호출 안 됨)
+    assert mock_kpi.called, "default mode=overview 시 dashboard_kpi 호출 누락"
+    # 컨텍스트에 mode='overview' 키 주입 (Phase 3 PR 3 신규 요구사항)
+    assert captured.get("mode") == "overview", \
+        f"default mode 컨텍스트 'overview' 기대, 실제: {captured.get('mode')!r}"
+
+
+def test_dashboard_mode_overview_explicit():
+    """mode=overview 명시 시 default 와 동일하게 KPI 카드 렌더링 + mode 키.
+    Explicit mode=overview behaves identically to default + mode key.
+    """
+    client = TestClient(app)
+    mock_db = MagicMock()
+    captured: dict = {}
+
+    def _capture(request, template_name, context, **kwargs):
+        captured.update(context)
+        from fastapi.responses import HTMLResponse
+        return HTMLResponse(content="<html>x</html>", status_code=200)
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi", return_value={"avg_score": {"value": 75}}) as mock_kpi, \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.auto_merge_kpi", return_value={}), \
+         patch("src.ui.routes.dashboard.dashboard_service.merge_failure_distribution", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.feedback_status", return_value={"show_cta": False, "count": 0, "recent_analysis": None}), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse", side_effect=_capture):
+        response = client.get("/dashboard?mode=overview")
+
+    assert response.status_code == 200
+    assert mock_kpi.called, "mode=overview 명시 시 dashboard_kpi 호출 누락"
+    assert captured.get("mode") == "overview", \
+        f"mode=overview 컨텍스트 키 'overview' 기대, 실제: {captured.get('mode')!r}"
+
+
+def test_dashboard_mode_insight_calls_narrative(mock_insight_success):
+    """mode=insight → insight_narrative (async) 호출 + 응답 200.
+    mode=insight → insight_narrative (async) called + 200 response.
+
+    핵심 검증:
+    - insight_narrative 가 정확히 1회 await 됨
+    - 응답 본문 또는 컨텍스트에 insight 데이터 흔적 존재 (positive_highlights 등)
+    """
+    client = TestClient(app)
+    mock_db = MagicMock()
+    captured: dict = {}
+
+    def _capture(request, template_name, context, **kwargs):
+        captured.update(context)
+        from fastapi.responses import HTMLResponse
+        # 컨텍스트의 insight.positive_highlights 흔적을 응답에 노출 — 검증 보조
+        # Expose insight.positive_highlights trace in response body — verification aid.
+        body = "<html>insight</html>"
+        insight = context.get("insight")
+        if insight and insight.get("positive_highlights"):
+            body = f"<html>insight: {insight['positive_highlights'][0]}</html>"
+        return HTMLResponse(content=body, status_code=200)
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse", side_effect=_capture):
+        response = client.get("/dashboard?mode=insight")
+
+    assert response.status_code == 200
+    # insight_narrative 가 정확히 1회 await 됨 (overview 분기에서는 호출 안 됨)
+    mock_insight_success.assert_awaited_once()
+    # 컨텍스트에 insight 키 + mode=insight 주입
+    assert captured.get("mode") == "insight", f"mode 컨텍스트 키 'insight' 기대, 실제: {captured.get('mode')!r}"
+    assert "insight" in captured, "context 에 insight 키 누락"
+    assert captured["insight"]["positive_highlights"] == ["좋은 결과"]
+    # 응답 본문에 insight 데이터 노출 (템플릿 렌더 결과 흔적)
+    assert "좋은 결과" in response.text
+
+
+def test_dashboard_invalid_mode_falls_back_to_overview():
+    """whitelist 외 mode 값 → overview 로 fallback (KPI 카드 렌더링).
+    Mode value not in whitelist → falls back to overview (KPI cards rendered).
+
+    보안 검증 — mode 파라미터의 임의 값 주입은 default 분기로 흡수.
+    """
+    client = TestClient(app)
+    mock_db = MagicMock()
+    captured: dict = {}
+
+    def _capture(request, template_name, context, **kwargs):
+        captured.update(context)
+        from fastapi.responses import HTMLResponse
+        return HTMLResponse(content="<html>x</html>", status_code=200)
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi", return_value={"avg_score": {"value": 70}}) as mock_kpi, \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.auto_merge_kpi", return_value={}), \
+         patch("src.ui.routes.dashboard.dashboard_service.merge_failure_distribution", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.feedback_status", return_value={"show_cta": False, "count": 0, "recent_analysis": None}), \
+         patch("src.ui.routes.dashboard.dashboard_service.insight_narrative", new=AsyncMock()) as mock_insight, \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse", side_effect=_capture):
+        response = client.get("/dashboard?mode=invalid_value")
+
+    assert response.status_code == 200
+    # invalid mode → overview fallback → dashboard_kpi 호출 + insight_narrative 미호출
+    assert mock_kpi.called, "invalid mode 시 overview fallback (dashboard_kpi 호출) 누락"
+    mock_insight.assert_not_awaited()
+    # 컨텍스트 mode 도 'overview' 로 정규화 (whitelist 외 값 → overview)
+    assert captured.get("mode") == "overview", \
+        f"invalid mode → 'overview' 정규화 기대, 실제: {captured.get('mode')!r}"
+
+
+def test_dashboard_mode_toggle_links_present():
+    """모드 토글 UI 링크 2건 (overview / insight) 응답 본문에 존재.
+    Mode toggle UI links (overview / insight) present in response body.
+
+    UI 정합성 — 사용자가 모드 전환 가능해야 함. 링크 형식은 유연하게 검증
+    (querystring 또는 data attribute 모두 수용).
+    """
+    client = TestClient(app)
+    mock_db = MagicMock()
+
+    # 실제 템플릿을 렌더하기 위해 TemplateResponse mock X (실제 dashboard.html 사용).
+    # Use real template render — TemplateResponse not mocked.
+    # Jinja UndefinedError 회피 위해 모든 KPI 필드 (delta 포함) 명시.
+    # Provide all KPI fields (incl. delta) to avoid Jinja UndefinedError.
+    fake_kpi = {
+        "avg_score": {"value": 80, "grade": "B", "delta": 0},
+        "analysis_count": {"value": 0, "delta": 0},
+        "high_security_issues": {"value": 0, "delta": 0},
+        "active_repos": {"value": 0, "total": 0, "delta": 0},
+    }
+    fake_auto_merge = {
+        "value": None,
+        "final_success_rate_pct": None,
+        "delta": None,
+        "distinct_prs": 0,
+        "final_success_prs": 0,
+        "attempts": 0,
+        "successes": 0,
+    }
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi", return_value=fake_kpi), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.auto_merge_kpi", return_value=fake_auto_merge), \
+         patch("src.ui.routes.dashboard.dashboard_service.merge_failure_distribution", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.feedback_status", return_value={"show_cta": False, "count": 0, "recent_analysis": None}):
+        response = client.get("/dashboard")
+
+    assert response.status_code == 200
+    body = response.text
+
+    # overview 토글 — href 또는 data-mode 형식 허용
+    has_overview_link = (
+        "mode=overview" in body
+        or 'data-mode="overview"' in body
+        or "data-mode='overview'" in body
+    )
+    # insight 토글 — href 또는 data-mode 형식 허용
+    has_insight_link = (
+        "mode=insight" in body
+        or 'data-mode="insight"' in body
+        or "data-mode='insight'" in body
+    )
+
+    assert has_overview_link, "응답 본문에 overview 모드 토글 링크 누락 (mode=overview 또는 data-mode='overview')"
+    assert has_insight_link, "응답 본문에 insight 모드 토글 링크 누락 (mode=insight 또는 data-mode='insight')"


### PR DESCRIPTION
Phase 3 PR 3 — SaaS 토대 + caching 6 PR 분할 안의 세 번째 PR. 라우트 + 템플릿 + UI 응집 단위 (정책 7 강화 — URL/화면/데이터 3종 동시).

## 🚨 Claude 시각 검증 불가 — 사용자 의무 (정책 11)

본 PR 은 UI/시각 변경 포함. Claude 는 정적 코드만 검증 가능 — 다음 8 조합 시각 정합성은 사용자 직접 확인 부탁드립니다:

- [ ] dark 테마 데스크탑 (1440px+)
- [ ] light 테마 데스크탑
- [ ] glass 테마 데스크탑
- [ ] claude-dark 테마 데스크탑
- [ ] dark 테마 모바일 (375px)
- [ ] light 테마 모바일
- [ ] glass 테마 모바일
- [ ] claude-dark 테마 모바일

특히 검증 필요 (변경 영역 한정):
- 모드 토글 (📊 Overview / 💬 Insight) 두 링크 active 상태 + hover 시각
- 4 카드 grid (✨/🔍/📊/💬) — 데스크탑 2x2 / 모바일 1열 반응형
- Insight 모드 status 분기 (no_api_key / no_data / api_error 시 dash-insight-status 카드)
- range toggle (1d/7d/30d/90d) 신규 URL 형식 (?mode=overview&days=N)

## 변경 내역

### 라우트 (`src/ui/routes/dashboard.py`)
- `def dashboard(...)` → `async def dashboard(...)` 변환
- `mode: str = "overview"` 신규 인자 추가 + whitelist 검증 (URL 변조 방어)
- `mode == "insight"` 시 `await dashboard_service.insight_narrative(db, days=days)` 호출
- 양쪽 분기 컨텍스트에 `mode` 키 주입
- Telemetry 1줄 → mode 추가 (비식별)

### 템플릿 (`src/templates/dashboard.html`)
- 신규 CSS: `.dash-mode-toggle` (range-toggle 와 동일 패턴) + `.dash-insight-grid` (2x2 → 1열) + `.dash-insight-card` + `.dash-insight-list` + `.dash-insight-metric` + `.dash-insight-status` (fallback)
- dash-header 우측에 모드 토글 nav 추가 (📊 Overview / 💬 Insight)
- range-toggle 4 링크 URL 갱신: `/dashboard?days=N` → `/dashboard?mode={{ mode }}&days=N`
- `{% if mode == 'insight' %}` 분기 — 4 카드 (positive/focus/metrics/next) + status fallback (no_api_key/no_data/error)
- `{% else %}` 분기 — 기존 KPI/차트/이슈/CTA 보존
- `{% block scripts %}` 의 chart 조건 — `{% if mode != 'insight' and trend %}` 로 갱신 (insight 모드는 차트 미사용)

### 단위 테스트 (`tests/unit/ui/test_dashboard_route.py`)
- 신규 5 테스트 추가:
  1. `test_dashboard_default_mode_is_overview`
  2. `test_dashboard_mode_overview_explicit`
  3. `test_dashboard_mode_insight_calls_narrative` (AsyncMock)
  4. `test_dashboard_invalid_mode_falls_back_to_overview`
  5. `test_dashboard_mode_toggle_links_present`

### E2E 테스트 (`e2e/test_dashboard.py`)
- range toggle 셀렉터 3건 정합 갱신: `/dashboard?days=N` → `/dashboard?mode=overview&days=N`
- 회귀 가드 보존 (1d/7d/30d/90d 4 링크 + active 표시 + 30d navigate)

## 사용자 결정 정합 (Phase 3 진입 의무 4건 중 3번 진행)
**3️⃣ 모드 토글 default: 본 PR = `mode=overview` URL default** — PR 4 (사용자 신호 기반 default + localStorage persist) 가 후속.

## 검증
- 신규 5 단위 테스트: **5/5 PASS** (Green) — 기존 5 PASS 유지 = **10/10 PASS**
- e2e dashboard: **14/14 PASS** (range toggle 3건 갱신 후 + insight 라우트 영향 0)
- 전체 단위 suite: **2021 PASS / 5 fail (모두 pre-existing — gate/engine 2 + telegram_provider 3, PR 1+2 commit body 와 동일)**
- pylint dashboard.py: **10.00/10** (회귀 0)
- flake8: 0 issues

## 향후 PR 호환성
- **PR 4** (사용자 신호 기반 default): 본 PR 의 `mode` URL 파라미터 기반 → `_detect_initial_mode` 헬퍼로 첫 진입 분기 + localStorage persist
- **PR 5** (Supabase RLS): `insight_narrative(db, user_id=user.id, days=days)` 시그니처 확장 시 라우트도 user.id 전달
- **PR 6** (회귀 가드): `/dashboard?mode=insight` e2e + 4 카드 시각 + 모드 토글 활성 상태

## 자율 판단 보고 (정책 3) — 최상단 강조 4건

⚠️ 이의 시 알려주세요:

1. **모드 토글 위치 = dash-header 우측 + range-toggle 옆** — 별도 라인 아님. 사유: header 영역 일관성 + 모바일 반응형 wrap. 시각 검증 후 별도 라인 선호 시 알려주시면 PR 폴로업.
2. **range toggle URL 형식 갱신** = `?mode={mode}&days=N` — 모드 전환 시 days 보존 / days 변경 시 mode 보존. 단점: URL 길이 +13 chars. 의도: 모드↔기간 페어 보존.
3. **4 카드 grid 2x2 (데스크탑) → 1열 (모바일)** — 4 카드 모두 동일 비중. 별도 우선순위 (예: positive 가 메인) 선호 시 알려주시면 grid 분할 변경.
4. **Insight 차트 미표시** — Insight 모드는 narrative 만 (차트는 overview 의 가치). 사용자가 Insight 에서도 차트 원하면 PR 4 시점에 양쪽 표시 가능.

## 🔍 사용자 검증 필요 (정책 2 + 정책 11 페어)
- [ ] PR 머지 + Railway 재배포 후 `/dashboard?mode=insight` 직접 접속 → 4 카드 또는 status 메시지 표시 확인
- [ ] 모드 토글 클릭 시 양쪽 mode 정상 전환 + active 상태 시각
- [ ] range toggle (1d/7d/30d/90d) 클릭 시 mode 보존 확인
- [ ] 8 테마/뷰포트 조합 시각 정합 (정책 11 default)

## Code Scanning open alert (정책 14)
- ✅ open 0건 (사이클 62 종료 시점 + PR 1/PR 2 머지 후 0건 검증) — 본 PR 영역 새 alert 가능성 낮음, 머지 후 GitHub Security 탭 재확인 권장

## 운영 smoke check (정책 13)
- ✅ /health 200
- ✅ /auth/github 302 redirect_uri 정합
- ✅ /login 200 (PR 2 머지 직후 실행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
