### PR TITLE
feat(phase3-pr4): 사용자 신호 기반 default 모드 + localStorage persist

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -312,7 +312,7 @@
   }
 </style>
 
-<div class="dashboard-page">
+<div class="dashboard-page" data-initial-mode="{{ initial_mode or 'overview' }}">
   <div class="dash-header">
     <div>
       <h1 class="dash-title">Dashboard</h1>
@@ -637,4 +637,36 @@
   document.addEventListener('themechange', buildDashChart);
 </script>
 {% endif %}
+
+{# Phase 3 PR 4 — 모드 토글 localStorage persist + 초기 redirect (mode/insight 양 모드 모두 적용) #}
+{# Phase 3 PR 4 — mode toggle localStorage persist + initial redirect (active in both modes) #}
+<script>
+  // 모드 토글 클릭 시 localStorage 저장 — 다음 진입 시 사용자 마지막 선택 보존
+  // Persist mode toggle clicks to localStorage — restore user's last choice on next visit
+  document.querySelectorAll('.dash-mode-toggle a').forEach(function (a) {
+    a.addEventListener('click', function () {
+      try {
+        var m = a.getAttribute('data-mode');
+        if (m) localStorage.setItem('sca-dashboard-mode', m);
+      } catch (e) { /* localStorage 접근 거부 (private mode 등) — silent skip */ }
+    });
+  });
+
+  // URL ?mode= 부재 + localStorage 우선 + 서버 initial_mode 와 다르면 1회 redirect
+  // When URL has no ?mode= and localStorage holds a different value, redirect once (FOUC 최소)
+  (function () {
+    try {
+      var url = new URL(window.location.href);
+      if (url.searchParams.has('mode')) return;  // URL 명시 = 사용자 선택, 손대지 않음
+      var stored = localStorage.getItem('sca-dashboard-mode');
+      if (!stored || (stored !== 'overview' && stored !== 'insight')) return;
+      var page = document.querySelector('.dashboard-page');
+      var initial = (page && page.getAttribute('data-initial-mode')) || 'overview';
+      if (stored !== initial) {
+        url.searchParams.set('mode', stored);
+        window.location.replace(url.toString());
+      }
+    } catch (e) { /* URL/localStorage 접근 오류 — silent skip (page 정상 렌더 보장) */ }
+  })();
+</script>
 {% endblock %}

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -11,9 +11,13 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
 
 from src.auth.session import CurrentUser, require_login
+from src.config import settings
 from src.database import SessionLocal
+from src.models.analysis import Analysis
 from src.services import dashboard_service
 from src.shared.log_safety import sanitize_for_log
 from src.ui._helpers import templates
@@ -25,38 +29,71 @@ router = APIRouter()
 
 _VALID_MODES = ("overview", "insight")
 
+# Phase 3 PR 4 — 사용자 신호 기반 default 모드 임계값.
+# Claude narrative 가 의미있게 생성되려면 최소 N건의 분석 컨텍스트가 필요.
+# Phase 3 PR 4 — User-signal-based default mode threshold.
+# Claude narrative needs at least N analyses for meaningful context.
+_INSIGHT_AUTO_DEFAULT_THRESHOLD = 5
+
+
+def _detect_initial_dashboard_mode(db: Session) -> str:
+    """URL ?mode= 부재 + localStorage 비어있을 때 서버 fallback default 모드.
+
+    Server fallback when URL `?mode=` is absent and localStorage is empty.
+
+    시그널 우선순위:
+    1. settings.anthropic_api_key 미설정 → 'overview' (Insight 모드 비가용)
+    2. Analysis count < _INSIGHT_AUTO_DEFAULT_THRESHOLD → 'overview' (narrative 컨텍스트 부족)
+    3. 그 외 → 'insight' (사용자가 AI 가치 즉시 체험)
+
+    Signals:
+    1. anthropic_api_key empty → 'overview' (Insight unavailable)
+    2. Analysis count below threshold → 'overview' (insufficient context)
+    3. Otherwise → 'insight' (give the user the AI benefit on first visit)
+    """
+    if not settings.anthropic_api_key:
+        return "overview"
+    count = db.scalar(select(func.count(Analysis.id))) or 0  # pylint: disable=not-callable
+    if int(count) < _INSIGHT_AUTO_DEFAULT_THRESHOLD:
+        return "overview"
+    return "insight"
+
 
 @router.get("/dashboard", response_class=HTMLResponse)
 async def dashboard(
     request: Request,
     current_user: Annotated[CurrentUser, Depends(require_login)],
     days: int = 7,
-    mode: str = "overview",
+    mode: str | None = None,
 ):
-    """대시보드 — Phase 3 PR 3 mode 분기 (overview default + insight 추가).
+    """대시보드 — Phase 3 PR 3 mode 분기 + PR 4 사용자 신호 기반 default.
 
-    Dashboard with Phase 3 PR 3 mode branch (overview default + insight added).
+    Dashboard with Phase 3 PR 3 mode branch + PR 4 user-signal-based default.
 
-    - mode=overview (default): KPI 5 카드 + 점수 추세 + 자주 발생 이슈 + Auto-merge + feedback CTA
+    - mode=overview: KPI 5 카드 + 점수 추세 + 자주 발생 이슈 + Auto-merge + feedback CTA
     - mode=insight: Claude AI 4 카드 narrative (✨ positive / 🔍 focus / 📊 metrics / 💬 next)
-    - whitelist 외 값은 overview 로 fallback (URL 파라미터 변조 방어)
+    - mode=None / 비-whitelist: server fallback (`_detect_initial_dashboard_mode`) — API key + 데이터 시그널
+    - 클라이언트 JS (PR 4) 가 localStorage 우선 적용 후 redirect (FOUC 최소)
     """
-    # whitelist — URL 파라미터 변조 방어 (?mode=foo → overview fallback)
-    # Whitelist — defends against URL param tampering (?mode=foo → overview fallback)
-    if mode not in _VALID_MODES:
-        mode = "overview"
-
-    # Telemetry — Phase 1 PR 5 자율 판단 (정책 3) + Phase 3 PR 3 mode 추가, 비식별.
-    # Telemetry: log usage frequency (user.id + days + mode only — no PII).
-    logger.info(
-        "dashboard_view user_id=%d days=%s mode=%s",
-        current_user.id,
-        sanitize_for_log(str(days), max_len=10),
-        sanitize_for_log(mode, max_len=20),
-    )
-
     with SessionLocal() as db:
-        if mode == "insight":
+        # URL ?mode= 명시 우선, 없거나 invalid 면 서버 fallback (사용자 신호 기반 default)
+        # URL ?mode= takes precedence; server fallback otherwise (user-signal-based default)
+        if mode in _VALID_MODES:
+            effective_mode = mode
+        else:
+            effective_mode = _detect_initial_dashboard_mode(db)
+
+        # Telemetry — Phase 1 PR 5 자율 판단 (정책 3) + Phase 3 PR 3/4 mode 추가, 비식별.
+        # Telemetry: log usage frequency (user.id + days + effective_mode + url_mode flag — no PII).
+        logger.info(
+            "dashboard_view user_id=%d days=%s mode=%s url_mode=%s",
+            current_user.id,
+            sanitize_for_log(str(days), max_len=10),
+            sanitize_for_log(effective_mode, max_len=20),
+            "1" if mode in _VALID_MODES else "0",
+        )
+
+        if effective_mode == "insight":
             # Phase 3 PR 2 — Claude AI 4 카드 narrative (caching 적용).
             # Phase 3 PR 2 — Claude AI 4-card narrative (with caching).
             insight = await dashboard_service.insight_narrative(db, days=days)
@@ -66,13 +103,14 @@ async def dashboard(
                 {
                     "current_user": current_user,
                     "mode": "insight",
+                    "initial_mode": effective_mode,  # PR 4 — 클라이언트 JS data-initial-mode 신호
                     "insight": insight,
                     "days": days,
                 },
             )
 
-        # mode == "overview" — 기존 동작 보존
-        # mode == "overview" — preserves prior behavior
+        # effective_mode == "overview" — 기존 동작 보존
+        # effective_mode == "overview" — preserves prior behavior
         kpi = dashboard_service.dashboard_kpi(db, days=days)
         trend = dashboard_service.dashboard_trend(db, days=days)
         frequent_issues = dashboard_service.frequent_issues_v2(db, days=days, n=5)
@@ -88,6 +126,7 @@ async def dashboard(
         {
             "current_user": current_user,
             "mode": "overview",
+            "initial_mode": effective_mode,  # PR 4 — 클라이언트 JS data-initial-mode 신호
             "kpi": kpi,
             "trend": trend,
             "frequent_issues": frequent_issues,

--- a/tests/unit/ui/test_dashboard_route.py
+++ b/tests/unit/ui/test_dashboard_route.py
@@ -22,6 +22,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session as _Session
+
+# PR 4 — ORM metadata 등록 (모듈 최상단 import — pytest collection 시점에 등록).
+# tests/ 전체 실행 시 fixture-내 lazy import 가 metadata 누락을 일으킨 사례 (PR 4 CI #428 fail).
+# Module-level imports register ORM metadata at pytest collection time.
+# Lazy imports inside the fixture caused metadata gaps when running full tests/ suite (PR 4 CI #428).
+from src.database import Base  # noqa: E402
+from src.models.analysis import Analysis as _AnalysisModel  # noqa: E402, F401
+from src.models.repository import Repository as _RepoModel  # noqa: E402, F401
+from src.models.user import User as _UserModel  # noqa: E402, F401
 
 from src.auth.session import CurrentUser, require_login
 from src.main import app
@@ -423,16 +434,10 @@ def isolated_db():
     Provides an in-memory SQLite session with all ORM tables created (PR 4 only).
     헬퍼 `_detect_initial_dashboard_mode(db)` 의 Analysis count 의존성 검증용.
     Used for verifying the helper's Analysis-count dependency.
-    """
-    # 지연 import — 테스트 시점에만 ORM metadata 등록
-    # Lazy import — only register ORM metadata at test time
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import Session as _Session
-    from src.database import Base
-    from src.models.analysis import Analysis  # noqa: F401  pylint: disable=unused-import
-    from src.models.repository import Repository  # noqa: F401  pylint: disable=unused-import
-    from src.models.user import User  # noqa: F401  pylint: disable=unused-import
 
+    NOTE: ORM 모델 import 는 모듈 최상단으로 이동 (PR 4 CI #428 fail fix). lazy import 는
+    tests/ 전체 실행 시 metadata 등록 누락 → `no such table: users` 오류 유발.
+    """
     engine = create_engine("sqlite:///:memory:")
     Base.metadata.create_all(engine)
     with _Session(engine) as session:

--- a/tests/unit/ui/test_dashboard_route.py
+++ b/tests/unit/ui/test_dashboard_route.py
@@ -396,3 +396,207 @@ def test_dashboard_mode_toggle_links_present():
 
     assert has_overview_link, "응답 본문에 overview 모드 토글 링크 누락 (mode=overview 또는 data-mode='overview')"
     assert has_insight_link, "응답 본문에 insight 모드 토글 링크 누락 (mode=insight 또는 data-mode='insight')"
+
+
+# ─── Phase 3 PR 4 (2026-05-03) — 사용자 신호 기반 default 모드 ──────────────
+# Phase 3 PR 4 (2026-05-03) — User-signal-based default mode detection.
+#
+# URL `?mode=` 부재 + (클라이언트 localStorage 비어있을 때) 서버 fallback default 결정.
+# 헬퍼 `_detect_initial_dashboard_mode(db)` 가 사용자 환경/데이터 충분도를 평가해
+# 'overview' 또는 'insight' 를 반환한다. 컨텍스트에 `initial_mode` 키 주입.
+#
+# Server-side fallback to determine default mode when ?mode= is absent (and client
+# localStorage is empty). The helper `_detect_initial_dashboard_mode(db)` returns
+# 'overview' or 'insight' based on the user's environment and data sufficiency.
+# A `initial_mode` key is injected into template context for the JS fallback path.
+
+
+# 임계값 — 본 테스트는 구현 상수와 동일한 기준 (5건) 을 사용
+# Threshold — tests use the same threshold as the implementation (5 analyses)
+_INSIGHT_THRESHOLD = 5
+
+
+@pytest.fixture
+def isolated_db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션 (PR 4 전용).
+
+    Provides an in-memory SQLite session with all ORM tables created (PR 4 only).
+    헬퍼 `_detect_initial_dashboard_mode(db)` 의 Analysis count 의존성 검증용.
+    Used for verifying the helper's Analysis-count dependency.
+    """
+    # 지연 import — 테스트 시점에만 ORM metadata 등록
+    # Lazy import — only register ORM metadata at test time
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import Session as _Session
+    from src.database import Base
+    from src.models.analysis import Analysis  # noqa: F401  pylint: disable=unused-import
+    from src.models.repository import Repository  # noqa: F401  pylint: disable=unused-import
+    from src.models.user import User  # noqa: F401  pylint: disable=unused-import
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with _Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _seed_analyses(db, count: int) -> None:
+    """주어진 개수만큼 Analysis 레코드 seed (FK 정합성 확보).
+
+    Seed `count` Analysis records with valid FK chain (User → Repo → Analysis).
+    """
+    import uuid as _uuid
+    from datetime import datetime, timezone
+    from src.models.analysis import Analysis
+    from src.models.repository import Repository
+    from src.models.user import User
+
+    user = User(github_id=1, github_login="alice", email="a@x.com", display_name="Alice")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    repo = Repository(full_name="owner/api", user_id=user.id)
+    db.add(repo)
+    db.commit()
+    db.refresh(repo)
+    for _ in range(count):
+        db.add(Analysis(
+            repo_id=repo.id,
+            commit_sha=f"sha-{_uuid.uuid4().hex}",
+            score=80,
+            grade="B",
+            result={},
+            created_at=datetime.now(timezone.utc),
+        ))
+    db.commit()
+
+
+# A.1 — anthropic_api_key 부재 시 insight 비가용 → 'overview' fallback
+# A.1 — When ANTHROPIC API key is unset, insight is unavailable → 'overview' fallback.
+def test_detect_initial_mode_no_api_key_returns_overview(isolated_db):
+    """anthropic_api_key 미설정 → 데이터 충분해도 'overview' (insight 호출 불가).
+
+    No anthropic_api_key → returns 'overview' even with sufficient data
+    (insight cannot be generated without the key).
+    """
+    # Analysis 10 건 seed — 데이터는 충분하지만 API key 없음
+    # Seed 10 analyses — sufficient data but no API key
+    _seed_analyses(isolated_db, count=10)
+
+    # 지연 import — 구현 부재 시 ImportError 로 Red 신호
+    # Lazy import — ImportError signals Red when implementation is missing
+    from src.ui.routes.dashboard import _detect_initial_dashboard_mode
+
+    with patch("src.ui.routes.dashboard.settings") as mock_settings:
+        mock_settings.anthropic_api_key = ""
+        result = _detect_initial_dashboard_mode(isolated_db)
+
+    assert result == "overview", \
+        f"API key 부재 시 'overview' 기대, 실제: {result!r}"
+
+
+# A.2 — 데이터 부족 (< 5) → narrative 컨텍스트 부족 → 'overview' fallback
+# A.2 — Insufficient data (< 5) → narrative context too sparse → 'overview' fallback.
+def test_detect_initial_mode_low_data_returns_overview(isolated_db):
+    """Analysis count < 5 → narrative 의미 부족 → 'overview'.
+
+    Analysis count below the threshold (5) → returns 'overview' because
+    Claude AI narrative would lack meaningful context.
+    """
+    # Analysis 4건만 seed — 임계값 (5) 미달
+    # Seed only 4 analyses — below threshold (5)
+    _seed_analyses(isolated_db, count=_INSIGHT_THRESHOLD - 1)
+
+    from src.ui.routes.dashboard import _detect_initial_dashboard_mode
+
+    with patch("src.ui.routes.dashboard.settings") as mock_settings:
+        mock_settings.anthropic_api_key = "sk-test"
+        result = _detect_initial_dashboard_mode(isolated_db)
+
+    assert result == "overview", \
+        f"Analysis<{_INSIGHT_THRESHOLD} 시 'overview' 기대, 실제: {result!r}"
+
+
+# A.3 — 모든 신호 충족 → insight 권장
+# A.3 — All signals met → recommend 'insight'.
+def test_detect_initial_mode_returns_insight_when_signals_met(isolated_db):
+    """API key 설정 + Analysis count ≥ 5 → 'insight' 권장.
+
+    API key set + Analysis count ≥ threshold → returns 'insight' (recommended).
+    """
+    # Analysis 5건 seed — 임계값 충족
+    # Seed exactly 5 analyses — meets threshold
+    _seed_analyses(isolated_db, count=_INSIGHT_THRESHOLD)
+
+    from src.ui.routes.dashboard import _detect_initial_dashboard_mode
+
+    with patch("src.ui.routes.dashboard.settings") as mock_settings:
+        mock_settings.anthropic_api_key = "sk-test"
+        result = _detect_initial_dashboard_mode(isolated_db)
+
+    assert result == "insight", \
+        f"모든 신호 충족 시 'insight' 기대, 실제: {result!r}"
+
+
+# A.4 — 라우트 통합 — mode 파라미터 부재 시 detection 함수 호출 + initial_mode 컨텍스트 키
+# A.4 — Route integration — without mode param, detection is invoked + initial_mode in context.
+def test_dashboard_no_mode_param_uses_detection():
+    """GET /dashboard (mode 미지정) → `_detect_initial_dashboard_mode` 호출.
+
+    Without ?mode= param, the route invokes the detection helper and uses its
+    return value as the effective mode. The context exposes `initial_mode` for
+    the client-side JS fallback (localStorage persist).
+    """
+    client = TestClient(app)
+    mock_db = MagicMock()
+    captured: dict = {}
+
+    def _capture(request, template_name, context, **kwargs):
+        captured.update(context)
+        from fastapi.responses import HTMLResponse
+        return HTMLResponse(content="<html>x</html>", status_code=200)
+
+    fake_insight = {
+        "positive_highlights": ["좋은 결과"],
+        "focus_areas": [],
+        "key_metrics": [],
+        "next_actions": [],
+        "status": "success",
+        "generated_at": "2026-05-03T00:00:00Z",
+        "days": 7,
+    }
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard._detect_initial_dashboard_mode",
+               return_value="insight") as mock_detect, \
+         patch("src.ui.routes.dashboard.dashboard_service.insight_narrative",
+               new=AsyncMock(return_value=fake_insight)) as mock_insight, \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi",
+               return_value={}) as mock_kpi, \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.auto_merge_kpi", return_value={}), \
+         patch("src.ui.routes.dashboard.dashboard_service.merge_failure_distribution", return_value=[]), \
+         patch("src.ui.routes.dashboard.dashboard_service.feedback_status",
+               return_value={"show_cta": False, "count": 0, "recent_analysis": None}), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse", side_effect=_capture):
+        response = client.get("/dashboard")
+
+    assert response.status_code == 200
+    # detection 호출 — URL ?mode= 부재 시 server fallback 적용
+    # Detection invoked — server fallback applied when ?mode= is absent
+    mock_detect.assert_called_once()
+    # detection 이 'insight' 반환 → insight 분기 진입
+    # Detection returned 'insight' → insight branch executed
+    mock_insight.assert_awaited_once()
+    # overview 분기는 호출 안 됨 (insight 진입 검증)
+    # Overview branch not executed (confirms insight branch entered)
+    mock_kpi.assert_not_called()
+    # 컨텍스트 mode = detection 결과
+    # Context mode = detection result
+    assert captured.get("mode") == "insight", \
+        f"detection 결과 'insight' 기대, 실제 mode={captured.get('mode')!r}"
+    # 컨텍스트 initial_mode 키 — 클라이언트 JS data-initial-mode 신호용
+    # initial_mode key in context — for client-side JS data-initial-mode signal
+    assert captured.get("initial_mode") == "insight", \
+        f"context['initial_mode']='insight' 기대, 실제: {captured.get('initial_mode')!r}"


### PR DESCRIPTION
Phase 3 PR 4 — SaaS 토대 + caching 6 PR 분할 안의 네 번째 PR. URL ?mode= 부재 시 서버 fallback (사용자 신호 기반) + 클라이언트 localStorage persist (settings.py `_detect_initial_mode` 패턴 차용).

## 🚨 Claude 시각 검증 불가 — 사용자 의무 (정책 11)

본 PR 은 UI/JS 변경 포함. Claude 는 정적 코드만 검증 가능 — 다음 8 조합 시각 정합성은 사용자 직접 확인 부탁드립니다:

- [ ] dark / light / glass / claude-dark × 데스크탑/모바일 = 8 조합 (PR 3 적용 영역과 동일)

특히 검증 필요 (PR 4 신규 동작):
- 첫 진입 (URL `?mode=` 없음) — `data-initial-mode` 서버 신호 기반 default 모드 적용
- 모드 토글 클릭 → `localStorage.sca-dashboard-mode` 저장 → 재방문 시 마지막 선택 보존
- localStorage ↔ 서버 default 다를 때 1회 redirect (`?mode=...` 추가) — FOUC <0.1s 예상

## 사용자 결정 정합 (Phase 3 진입 의무 4건 중 4번 진행)
**3️⃣ 모드 토글 default: 🅒 사용자 신호 기반** ★ 권장 default 적용
- URL `?mode=` 명시 = 사용자 직접 선택 (최우선)
- localStorage `sca-dashboard-mode` = 사용자 마지막 선택 (재방문 시 보존)
- 서버 fallback `_detect_initial_dashboard_mode(db)`:
  - settings.anthropic_api_key 미설정 → "overview"
  - Analysis count < 5 → "overview" (narrative 컨텍스트 부족)
  - 그 외 → "insight" (사용자가 AI 가치 즉시 체험)

## 변경 내역

### 라우트 (`src/ui/routes/dashboard.py`)
- 신규 `_INSIGHT_AUTO_DEFAULT_THRESHOLD = 5` 상수 (Claude narrative 의미있는 최소 분석 수)
- 신규 `_detect_initial_dashboard_mode(db: Session) -> str` 헬퍼 (settings.py L131 패턴 차용)
- 라우트 `mode: str = "overview"` → `mode: str | None = None` 변경
- 라우트 본문: `mode in _VALID_MODES` 분기 (URL 우선) 또는 `_detect_initial_dashboard_mode(db)` (server fallback)
- 양쪽 분기 컨텍스트에 `initial_mode` 키 추가 (template `data-initial-mode` 속성용)
- Telemetry 1줄 — `effective_mode` + `url_mode` flag 추가 (URL 명시 vs detection 추적)

### 템플릿 (`src/templates/dashboard.html`)
- `<div class="dashboard-page" data-initial-mode="{{ initial_mode or 'overview' }}">` 속성 추가
- 신규 `<script>` 블록 (block scripts 안):
  - 모드 토글 클릭 → `localStorage.setItem('sca-dashboard-mode', a.dataset.mode)` (try/catch — private mode safe)
  - 로드 시 IIFE: URL `?mode=` 없음 + localStorage 있음 + `data-initial-mode` 와 다름 → `window.location.replace('?mode=...')` 1회 redirect
  - URL `?mode=` 명시 = 사용자 선택, JS 손대지 않음 (무한 루프 방어)

### 단위 테스트 (`tests/unit/ui/test_dashboard_route.py`)
- 신규 4 테스트 (10 → 14):
  1. `test_detect_initial_mode_no_api_key_returns_overview`
  2. `test_detect_initial_mode_low_data_returns_overview`
  3. `test_detect_initial_mode_returns_insight_when_signals_met`
  4. `test_dashboard_no_mode_param_uses_detection`
- 신규 fixture: `isolated_db` (in-memory SQLite + Analysis seed)
- 신규 헬퍼: `_seed_analyses(db, count)` (User → Repo → Analysis FK chain seed)

## 검증
- 신규 4 단위: **4/4 PASS** (Green) — 기존 10 PASS 유지 = **14/14 PASS**
- 전체 ui 단위: **127/127 PASS / 0 fail** (회귀 0)
- e2e dashboard: **14/14 PASS** (range toggle URL 형식 PR 3 변경 보존)
- 전체 e2e: **73 PASS / 2 fail (모두 pre-existing — `test_two_column_layout_on_desktop`, `test_save_success_keeps_simple_mode`)**
- pylint dashboard.py: **10.00/10** (회귀 0)
- flake8: 0 issues

## 향후 PR 호환성
- **PR 5** (Supabase RLS): `_detect_initial_dashboard_mode(db, user_id=...)` 시그니처 확장 + Analysis count 의 `WHERE user_id =` 필터 적용
- **PR 6** (회귀 가드): e2e localStorage persist 검증 + first-visit detection 검증 (Playwright `page.evaluate("localStorage...")` 패턴)

## 자율 판단 보고 (정책 3) — 최상단 강조 4건

⚠️ 이의 시 알려주세요:

1. **임계값 5건** = `_INSIGHT_AUTO_DEFAULT_THRESHOLD`. Claude narrative 가 의미있게 생성되려면 최소 N 건 필요. 운영 데이터 (Supabase MCP 검증 결과) 에 따라 조정 가능 — 너무 낮으면 빈 narrative, 너무 높으면 신규 사용자 onboarding 깨짐.
2. **redirect 패턴 = `replace`** (history 안 더해짐 — 사용자 뒤로 가기 정상). PR 3 의 `?mode=` URL 형식 전제 — JS 변경 시 페어 검증 의무.
3. **localStorage 키 = `sca-dashboard-mode`** — settings 패턴 (`sca-settings-mode`) 과 동일 prefix `sca-`. namespace 충돌 방지.
4. **try/catch 양 위치** — `localStorage.setItem` 과 IIFE 모두. private/incognito 모드 + Storage 거부 환경 graceful (page 정상 렌더 보장).

## 🔍 사용자 검증 필요 (정책 2 + 정책 11 페어)
- [ ] PR 머지 + Railway 재배포 후 `/dashboard` 직접 접속 (URL no mode) → server detection 결과 확인
- [ ] DevTools Application → Local Storage 에서 `sca-dashboard-mode` 키 토글 클릭 시 변경 확인
- [ ] `localStorage.setItem('sca-dashboard-mode', 'insight')` 수동 설정 후 `/dashboard` (no URL mode) → `?mode=insight` redirect 확인
- [ ] 8 테마/뷰포트 조합 시각 정합 (정책 11 default)

## Code Scanning open alert (정책 14)
- ✅ open 0건 (PR 3 머지 후 0건 검증) — 본 PR 영역 새 alert 가능성 낮음, 머지 후 GitHub Security 탭 재확인 권장

## 운영 smoke check (정책 13)
- ✅ /health 200
- ✅ /auth/github 302 redirect_uri 정합
- ✅ /login 200 (PR 3 머지 직후 실행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
