### PR TITLE
feat(phase3-pr5): SaaS 토대 — Supabase RLS 권한 모델 (앱 filter + alembic 00…

### DIFF
--- a/alembic/versions/0026_supabase_rls_policies.py
+++ b/alembic/versions/0026_supabase_rls_policies.py
@@ -1,0 +1,110 @@
+"""Phase 3 PR 5 — Supabase RLS 권한 모델 (PostgreSQL 전용)
+
+Revision ID: 0026supabasrlspolicies
+Revises: 0025dropleaderboardoptin
+Create Date: 2026-05-04
+
+Phase 3 PR 5 — SaaS 전환 토대. PostgreSQL Row Level Security (RLS) policy 적용:
+- repositories: user_id 기반 격리 (legacy NULL 호환)
+- analyses: repo_id → repositories.user_id 간접 격리 (subquery)
+- merge_attempts: repo_name → repositories.full_name → user_id 간접 격리
+
+세션 컨텍스트 변수: `app.user_id` (`SET LOCAL app.user_id = '<user_id>'` 패턴).
+SCAManager 는 Supabase Auth 미사용 (GitHub OAuth) — auth.uid() 미적용.
+세션 변수 미설정 시 (NULL) → policy USING 절이 user_id IS NULL 만 허용 (legacy admin 영역).
+
+SQLite (단위 테스트) 분기: op.execute 모두 skip — RLS 미지원 환경 호환.
+앱 레벨 filter (`src/services/dashboard_service.py::_apply_*_user_filter`) 가 1차 안전망.
+본 RLS policy 는 운영 환경 (Supabase) 의 2차 안전망 (DB 레벨 격리 — 앱 버그 시에도 데이터 누출 차단).
+
+회귀 가드: tests/unit/migrations/test_0026_rls_policies.py (3 테스트).
+"""
+# Phase 3 PR 5 — Supabase RLS permission model (PostgreSQL only)
+# Provides DB-level isolation as a 2nd safety layer; app-level filter
+# (src/services/dashboard_service.py::_apply_*_user_filter) is the 1st layer.
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+# Revision identifiers used by Alembic.
+revision = '0026supabasrlspolicies'
+down_revision = '0025dropleaderboardoptin'
+branch_labels = None
+depends_on = None
+
+
+# RLS policy SQL — repositories: user_id 기반 격리 + legacy NULL 허용
+# RLS policy SQL — repositories: user_id-based isolation + legacy NULL allowed
+_RLS_REPOSITORIES = """
+ALTER TABLE repositories ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS repositories_user_isolation ON repositories;
+
+CREATE POLICY repositories_user_isolation ON repositories
+    FOR ALL
+    USING (
+        user_id IS NULL
+        OR user_id = NULLIF(current_setting('app.user_id', true), '')::integer
+    );
+"""
+
+# analyses: repo_id 통한 간접 격리 (subquery — repositories RLS 와 페어 동작)
+# analyses: indirect isolation via repo_id (subquery — pairs with repositories RLS)
+_RLS_ANALYSES = """
+ALTER TABLE analyses ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS analyses_user_isolation ON analyses;
+
+CREATE POLICY analyses_user_isolation ON analyses
+    FOR ALL
+    USING (
+        repo_id IN (
+            SELECT id FROM repositories
+            WHERE user_id IS NULL
+               OR user_id = NULLIF(current_setting('app.user_id', true), '')::integer
+        )
+    );
+"""
+
+# merge_attempts: repo_name → repositories.full_name 간접 격리
+# merge_attempts: indirect isolation via repo_name → repositories.full_name
+_RLS_MERGE_ATTEMPTS = """
+ALTER TABLE merge_attempts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS merge_attempts_user_isolation ON merge_attempts;
+
+CREATE POLICY merge_attempts_user_isolation ON merge_attempts
+    FOR ALL
+    USING (
+        repo_name IN (
+            SELECT full_name FROM repositories
+            WHERE user_id IS NULL
+               OR user_id = NULLIF(current_setting('app.user_id', true), '')::integer
+        )
+    );
+"""
+
+
+def upgrade() -> None:
+    """PG 환경에서 3 테이블 RLS 활성화 + policy 생성. SQLite skip."""
+    # SQLite 단위 테스트 환경 — RLS 미지원, 모든 op.execute skip.
+    # SQLite unit-test environment — RLS unsupported, skip all op.execute.
+    if op.get_context().dialect.name != 'postgresql':
+        return
+
+    op.execute(_RLS_REPOSITORIES)
+    op.execute(_RLS_ANALYSES)
+    op.execute(_RLS_MERGE_ATTEMPTS)
+
+
+def downgrade() -> None:
+    """RLS policy 제거 + RLS 비활성화. PG 전용."""
+    if op.get_context().dialect.name != 'postgresql':
+        return
+
+    op.execute("DROP POLICY IF EXISTS merge_attempts_user_isolation ON merge_attempts;")
+    op.execute("ALTER TABLE merge_attempts DISABLE ROW LEVEL SECURITY;")
+    op.execute("DROP POLICY IF EXISTS analyses_user_isolation ON analyses;")
+    op.execute("ALTER TABLE analyses DISABLE ROW LEVEL SECURITY;")
+    op.execute("DROP POLICY IF EXISTS repositories_user_isolation ON repositories;")
+    op.execute("ALTER TABLE repositories DISABLE ROW LEVEL SECURITY;")

--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -44,13 +44,49 @@ logger = logging.getLogger(__name__)
 # ─── KPI ──────────────────────────────────────────────────────────────────
 
 
-def dashboard_kpi(
+def _apply_analysis_user_filter(query, user_id: int | None):
+    """Phase 3 PR 5 — Analysis 쿼리에 Repository.user_id 기반 권한 필터 적용.
+
+    Phase 3 PR 5 — apply Repository.user_id-based permission filter to Analysis queries.
+
+    user_id is None → 필터 미적용 (admin / legacy 호환).
+    user_id 명시 → Repository.user_id == user_id OR Repository.user_id IS NULL (legacy 리포 호환).
+
+    Pattern matches `src/ui/routes/overview.py:29` for app-level isolation.
+    DB-level RLS policy (alembic 0026) provides 2nd layer for PG/Supabase environments.
+    """
+    if user_id is None:
+        return query
+    return query.join(Repository, Analysis.repo_id == Repository.id).where(
+        (Repository.user_id == user_id) | (Repository.user_id.is_(None))
+    )
+
+
+def _apply_merge_attempt_user_filter(query, user_id: int | None):
+    """Phase 3 PR 5 — MergeAttempt 쿼리에 Repository.full_name 기반 권한 필터 적용.
+
+    MergeAttempt 는 repo_name (Repository.full_name) 으로 간접 격리.
+    """
+    if user_id is None:
+        return query
+    return query.join(Repository, MergeAttempt.repo_name == Repository.full_name).where(
+        (Repository.user_id == user_id) | (Repository.user_id.is_(None))
+    )
+
+
+def dashboard_kpi(  # pylint: disable=too-many-locals
     db: Session,
     days: int = 7,
     *,
     now: datetime | None = None,
+    user_id: int | None = None,
 ) -> dict[str, Any]:
     """KPI 4 카드 데이터 — 현재 days 윈도우 + 직전 동일 days 윈도우 비교 (delta).
+
+    Phase 3 PR 5: `user_id` 명시 시 Repository.user_id 기반 격리 + legacy NULL 호환.
+    user_id=None (default) 시 모든 리포 (admin / 단위 테스트 호환).
+    pylint too-many-locals — Phase 3 PR 5 user_id 필터 추가로 16/15. cur/prev/total
+    3 윈도우 페어 (각 query + 결과) = 6 + delta calc + KPI 4 카드 빌더 = 본 한도 자연.
 
     Returns:
         {
@@ -59,27 +95,26 @@ def dashboard_kpi(
           "high_security_issues": {"value": int, "delta": int},
           "active_repos": {"value": int, "total": int, "delta": int},
         }
-
-    delta = 현재 윈도우 - 직전 윈도우 (양수 = 개선, 단 high_security_issues 는 음수가 개선).
     """
     _now = now or datetime.now(timezone.utc)
     cur_since = _now - timedelta(days=days)
     prev_since = _now - timedelta(days=days * 2)
 
-    # 현재 + 직전 윈도우 분석 (delta 비교용)
-    # Pull current and previous window analyses (for delta comparison)
-    cur_analyses = list(db.scalars(
-        select(Analysis)
-        .where(Analysis.created_at >= cur_since)
-        .where(Analysis.created_at <= _now)
-    ).all())
-    prev_analyses = list(db.scalars(
-        select(Analysis)
-        .where(Analysis.created_at >= prev_since)
-        .where(Analysis.created_at < cur_since)
-    ).all())
+    # 현재 + 직전 윈도우 분석 (delta 비교용) + user_id 권한 필터
+    # Pull current and previous window analyses (for delta) + user_id permission filter
+    cur_q = select(Analysis).where(Analysis.created_at >= cur_since).where(Analysis.created_at <= _now)
+    prev_q = select(Analysis).where(Analysis.created_at >= prev_since).where(Analysis.created_at < cur_since)
+    cur_analyses = list(db.scalars(_apply_analysis_user_filter(cur_q, user_id)).all())
+    prev_analyses = list(db.scalars(_apply_analysis_user_filter(prev_q, user_id)).all())
 
-    total_repos = db.scalar(select(func.count(Repository.id)))  # pylint: disable=not-callable
+    # 활성 리포 total — user_id 기준
+    # Active repos total — by user_id
+    total_q = select(func.count(Repository.id))  # pylint: disable=not-callable
+    if user_id is not None:
+        total_q = total_q.where(
+            (Repository.user_id == user_id) | (Repository.user_id.is_(None))
+        )
+    total_repos = db.scalar(total_q)
 
     return {
         "avg_score": _kpi_avg(cur_analyses, prev_analyses),
@@ -147,8 +182,9 @@ def dashboard_trend(
     days: int = 7,
     *,
     now: datetime | None = None,
+    user_id: int | None = None,
 ) -> list[dict[str, Any]]:
-    """날짜별 평균 점수 추세 (라인 차트용).
+    """날짜별 평균 점수 추세 (라인 차트용). Phase 3 PR 5: user_id 권한 필터.
 
     Returns:
         [{"date": "YYYY-MM-DD", "avg_score": float, "count": int}, ...]
@@ -157,12 +193,13 @@ def dashboard_trend(
     _now = now or datetime.now(timezone.utc)
     since = _now - timedelta(days=days)
 
-    analyses = db.scalars(
+    base = (
         select(Analysis)
         .where(Analysis.created_at >= since)
         .where(Analysis.score.isnot(None))
         .order_by(Analysis.created_at.asc())
-    ).all()
+    )
+    analyses = db.scalars(_apply_analysis_user_filter(base, user_id)).all()
 
     # Python-side 날짜별 그룹화 — SQLite/PG 날짜 함수 불일치 회피
     daily: dict[str, list[int]] = {}
@@ -184,18 +221,15 @@ def dashboard_trend(
 # ─── 자주 발생 이슈 (Q7 신규) ─────────────────────────────────────────────
 
 
-def frequent_issues_v2(
+def frequent_issues_v2(  # pylint: disable=too-many-locals
     db: Session,
     days: int = 7,
     *,
     n: int = 5,
     now: datetime | None = None,
+    user_id: int | None = None,
 ) -> list[dict[str, Any]]:
-    """global 자주 발생 이슈 — category/language/tool 보존.
-
-    폐기된 top_issues 와 차이:
-    - repo_id 인자 제거 (global 집계)
-    - category/language/tool 필드 반환
+    """global 자주 발생 이슈 — category/language/tool 보존. Phase 3 PR 5: user_id 권한 필터.
 
     Returns:
         [{"message": str, "count": int, "category": str, "language": str, "tool": str}, ...]
@@ -204,11 +238,12 @@ def frequent_issues_v2(
     _now = now or datetime.now(timezone.utc)
     since = _now - timedelta(days=days)
 
-    analyses = db.scalars(
+    base = (
         select(Analysis)
         .where(Analysis.created_at >= since)
         .where(Analysis.result.isnot(None))
-    ).all()
+    )
+    analyses = db.scalars(_apply_analysis_user_filter(base, user_id)).all()
 
     # message 키로 카운트 + 첫 번째 발견 시점의 category/language/tool 저장
     counter: dict[str, int] = {}
@@ -250,8 +285,9 @@ def auto_merge_kpi(
     days: int = 7,
     *,
     now: datetime | None = None,
+    user_id: int | None = None,
 ) -> dict[str, Any]:
-    """Auto-merge 성공률 카드 데이터.
+    """Auto-merge 성공률 카드 데이터. Phase 3 PR 5: user_id 권한 필터.
 
     운영 데이터 (MCP 검증, 2026-05-02): single-attempt success rate 16.6%, unstable_ci 79%
     → 단순 시도 기준 외 distinct PR 의 final success rate 도 함께 반환 (retry queue 영향 보정).
@@ -260,16 +296,18 @@ def auto_merge_kpi(
     cur_since = _now - timedelta(days=days)
     prev_since = _now - timedelta(days=days * 2)
 
-    cur = list(db.scalars(
+    cur_q = (
         select(MergeAttempt)
         .where(MergeAttempt.attempted_at >= cur_since)
         .where(MergeAttempt.attempted_at <= _now)
-    ).all())
-    prev = list(db.scalars(
+    )
+    prev_q = (
         select(MergeAttempt)
         .where(MergeAttempt.attempted_at >= prev_since)
         .where(MergeAttempt.attempted_at < cur_since)
-    ).all())
+    )
+    cur = list(db.scalars(_apply_merge_attempt_user_filter(cur_q, user_id)).all())
+    prev = list(db.scalars(_apply_merge_attempt_user_filter(prev_q, user_id)).all())
 
     return {
         **_simple_success(cur, prev),
@@ -319,8 +357,9 @@ def merge_failure_distribution(
     *,
     n: int = 5,
     now: datetime | None = None,
+    user_id: int | None = None,
 ) -> list[dict[str, Any]]:
-    """실패 사유 Top N + 비율.
+    """실패 사유 Top N + 비율. Phase 3 PR 5: user_id 권한 필터.
 
     운영 신호: unstable_ci 가 79% 점유 — Phase 3 advisor 의 우선 처리 사유 식별.
 
@@ -331,11 +370,12 @@ def merge_failure_distribution(
     _now = now or datetime.now(timezone.utc)
     since = _now - timedelta(days=days)
 
-    failures = list(db.scalars(
+    base = (
         select(MergeAttempt)
         .where(MergeAttempt.attempted_at >= since)
         .where(MergeAttempt.success.is_(False))
-    ).all())
+    )
+    failures = list(db.scalars(_apply_merge_attempt_user_filter(base, user_id)).all())
 
     if not failures:
         return []
@@ -559,17 +599,20 @@ async def insight_narrative(
     *,
     now: datetime | None = None,
     api_key: str | None = None,
+    user_id: int | None = None,
 ) -> dict[str, Any]:
-    """Claude AI 기반 4 카드 인사이트 narrative — Phase 3 PR 2.
+    """Claude AI 기반 4 카드 인사이트 narrative — Phase 3 PR 2 + PR 5 (user_id 격리).
 
     Generates a 4-card narrative (positive / focus / metrics / next) using Claude AI.
     Reuses the PR 1 `build_cached_system_param` helper for 5-minute system prompt caching.
+    Phase 3 PR 5: `user_id` 명시 시 4 dashboard 헬퍼에 전파해 사용자별 격리 컨텍스트 사용.
 
     Args:
         db: SQLAlchemy 세션. SQLAlchemy session.
         days: 윈도우 일수 (default 7). Window size in days.
         now: 의존성 주입용 — None 시 현재 시각. Injection point — defaults to now.
         api_key: None 시 settings.anthropic_api_key 사용. Defaults to settings on None.
+        user_id: PR 5 — 사용자별 데이터 격리. None 시 모든 리포 (admin/legacy 호환).
 
     Returns:
         {
@@ -590,12 +633,12 @@ async def insight_narrative(
 
     _now = now or datetime.now(timezone.utc)
 
-    # 4 dashboard 헬퍼 호출로 컨텍스트 수집
-    # Collect context by invoking the 4 dashboard helpers
-    kpi = dashboard_kpi(db, days, now=_now)
-    trend = dashboard_trend(db, days, now=_now)
-    frequent = frequent_issues_v2(db, days, now=_now)
-    auto_merge = auto_merge_kpi(db, days, now=_now)
+    # 4 dashboard 헬퍼 호출로 컨텍스트 수집 + Phase 3 PR 5 user_id 격리
+    # Collect context by invoking the 4 dashboard helpers + PR 5 user_id isolation
+    kpi = dashboard_kpi(db, days, now=_now, user_id=user_id)
+    trend = dashboard_trend(db, days, now=_now, user_id=user_id)
+    frequent = frequent_issues_v2(db, days, now=_now, user_id=user_id)
+    auto_merge = auto_merge_kpi(db, days, now=_now, user_id=user_id)
 
     # 데이터 0건이면 Claude API 호출 비용 발생 안 시킴 (cost-saver early return)
     # Skip Claude API call when there's no data (cost-saver early return)

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -18,6 +18,7 @@ from src.auth.session import CurrentUser, require_login
 from src.config import settings
 from src.database import SessionLocal
 from src.models.analysis import Analysis
+from src.models.repository import Repository
 from src.services import dashboard_service
 from src.shared.log_safety import sanitize_for_log
 from src.ui._helpers import templates
@@ -36,24 +37,26 @@ _VALID_MODES = ("overview", "insight")
 _INSIGHT_AUTO_DEFAULT_THRESHOLD = 5
 
 
-def _detect_initial_dashboard_mode(db: Session) -> str:
+def _detect_initial_dashboard_mode(db: Session, user_id: int | None = None) -> str:
     """URL ?mode= 부재 + localStorage 비어있을 때 서버 fallback default 모드.
 
     Server fallback when URL `?mode=` is absent and localStorage is empty.
+    Phase 3 PR 5: `user_id` 명시 시 사용자별 분석 count 기준 (RLS 정합).
 
     시그널 우선순위:
     1. settings.anthropic_api_key 미설정 → 'overview' (Insight 모드 비가용)
-    2. Analysis count < _INSIGHT_AUTO_DEFAULT_THRESHOLD → 'overview' (narrative 컨텍스트 부족)
+    2. (user_id 격리된) Analysis count < _INSIGHT_AUTO_DEFAULT_THRESHOLD → 'overview'
     3. 그 외 → 'insight' (사용자가 AI 가치 즉시 체험)
-
-    Signals:
-    1. anthropic_api_key empty → 'overview' (Insight unavailable)
-    2. Analysis count below threshold → 'overview' (insufficient context)
-    3. Otherwise → 'insight' (give the user the AI benefit on first visit)
     """
     if not settings.anthropic_api_key:
         return "overview"
-    count = db.scalar(select(func.count(Analysis.id))) or 0  # pylint: disable=not-callable
+    count_q = select(func.count(Analysis.id))  # pylint: disable=not-callable
+    if user_id is not None:
+        # PR 5 — Repository.user_id 기반 사용자별 분석 count (legacy NULL 호환)
+        count_q = count_q.join(Repository, Analysis.repo_id == Repository.id).where(
+            (Repository.user_id == user_id) | (Repository.user_id.is_(None))
+        )
+    count = db.scalar(count_q) or 0
     if int(count) < _INSIGHT_AUTO_DEFAULT_THRESHOLD:
         return "overview"
     return "insight"
@@ -81,7 +84,7 @@ async def dashboard(
         if mode in _VALID_MODES:
             effective_mode = mode
         else:
-            effective_mode = _detect_initial_dashboard_mode(db)
+            effective_mode = _detect_initial_dashboard_mode(db, user_id=current_user.id)
 
         # Telemetry — Phase 1 PR 5 자율 판단 (정책 3) + Phase 3 PR 3/4 mode 추가, 비식별.
         # Telemetry: log usage frequency (user.id + days + effective_mode + url_mode flag — no PII).
@@ -94,9 +97,11 @@ async def dashboard(
         )
 
         if effective_mode == "insight":
-            # Phase 3 PR 2 — Claude AI 4 카드 narrative (caching 적용).
-            # Phase 3 PR 2 — Claude AI 4-card narrative (with caching).
-            insight = await dashboard_service.insight_narrative(db, days=days)
+            # Phase 3 PR 2 — Claude AI 4 카드 narrative (caching 적용) + PR 5 user_id 격리.
+            # Phase 3 PR 2 — Claude AI 4-card narrative (with caching) + PR 5 user_id isolation.
+            insight = await dashboard_service.insight_narrative(
+                db, days=days, user_id=current_user.id
+            )
             return templates.TemplateResponse(
                 request,
                 "dashboard.html",
@@ -109,14 +114,15 @@ async def dashboard(
                 },
             )
 
-        # effective_mode == "overview" — 기존 동작 보존
-        # effective_mode == "overview" — preserves prior behavior
-        kpi = dashboard_service.dashboard_kpi(db, days=days)
-        trend = dashboard_service.dashboard_trend(db, days=days)
-        frequent_issues = dashboard_service.frequent_issues_v2(db, days=days, n=5)
+        # effective_mode == "overview" — 기존 동작 보존 + PR 5 user_id 격리
+        # effective_mode == "overview" — preserves prior behavior + PR 5 user_id isolation
+        _uid = current_user.id
+        kpi = dashboard_service.dashboard_kpi(db, days=days, user_id=_uid)
+        trend = dashboard_service.dashboard_trend(db, days=days, user_id=_uid)
+        frequent_issues = dashboard_service.frequent_issues_v2(db, days=days, n=5, user_id=_uid)
         # Phase 2 PR 1: Auto-merge KPI + 실패 분포.
-        auto_merge = dashboard_service.auto_merge_kpi(db, days=days)
-        merge_failures = dashboard_service.merge_failure_distribution(db, days=days, n=5)
+        auto_merge = dashboard_service.auto_merge_kpi(db, days=days, user_id=_uid)
+        merge_failures = dashboard_service.merge_failure_distribution(db, days=days, n=5, user_id=_uid)
         # Phase 2 PR 2 (2026-05-02): feedback CTA — 운영 row=0 → 사용자 행동 유도.
         feedback = dashboard_service.feedback_status(db)
 

--- a/tests/unit/migrations/test_0026_rls_policies.py
+++ b/tests/unit/migrations/test_0026_rls_policies.py
@@ -1,0 +1,205 @@
+"""Phase 3 PR 5 — alembic 0026 RLS policy 회귀 가드 (TDD Red).
+
+Phase 3 PR 5 — alembic 0026 RLS policy regression guard (TDD Red).
+
+본 마이그레이션 (구현 미존재 단계 — Red):
+The migration verified by this module (implementation pending — Red phase):
+
+    alembic/versions/0026_*.py
+    - revision = "0026..."
+    - down_revision = "0025dropleaderboardoptin"
+
+upgrade() 동작 의도:
+upgrade() intent:
+    - PostgreSQL: repositories 테이블에 RLS 활성화 + policy 생성
+    - SQLite: 모든 op.execute 호출 skip (단위 테스트 환경)
+
+검증 3종:
+3 tests:
+    C.1 — revision 메타데이터 (revision/down_revision 정확성)
+    C.2 — postgresql dialect 시 ENABLE ROW LEVEL SECURITY + CREATE POLICY 호출
+    C.3 — sqlite dialect 시 op.execute 호출 0회 (skip 검증)
+
+dialect 분기는 `op.get_context().dialect.name` 분기 패턴 사용:
+The dialect branch uses the `op.get_context().dialect.name` check pattern:
+
+    def upgrade():
+        if op.get_context().dialect.name == 'postgresql':
+            op.execute("ALTER TABLE repositories ENABLE ROW LEVEL SECURITY;")
+            op.execute("CREATE POLICY repositories_user_isolation ON repositories ...")
+        # SQLite skip — 단위 테스트 환경
+
+회귀 가드 — RLS policy 가 SQLite 환경에서 실행되면 syntax error 발생.
+Regression guard — RLS policy execution on SQLite raises syntax error.
+"""
+# pylint: disable=wrong-import-position
+import os
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+
+# ─── C.1 — revision 메타데이터 ─────────────────────────────────────────────
+
+
+def test_alembic_0026_revision_metadata():
+    """C.1 — alembic 0026 revision = "0026..." + down_revision == "0025...".
+
+    C.1 — alembic 0026 revision starts with "0026", down_revision matches "0025...".
+
+    체인 정합성 검증 — 0025 (drop leaderboard_opt_in) → 0026 (RLS policies).
+    Chain integrity — 0025 (drop leaderboard_opt_in) → 0026 (RLS policies).
+    """
+    # 모듈 import 자체가 ImportError → Red 신호 (파일 미존재)
+    # Module import itself raises ImportError → Red signal (file missing)
+    import importlib
+
+    # 모듈명 패턴: 0026_*.py — glob 으로 찾기보다는 명시적 파일명 패턴 사용.
+    # File-name pattern: 0026_*.py — use glob-based discovery for flexibility.
+    import pathlib
+
+    versions_dir = pathlib.Path(__file__).resolve().parents[3] / "alembic" / "versions"
+    candidates = sorted(versions_dir.glob("0026_*.py"))
+    assert len(candidates) >= 1, (
+        f"alembic/versions/0026_*.py 파일 미존재 — Red 단계 정상 신호. "
+        f"검색 경로: {versions_dir}"
+    )
+
+    # 모듈 동적 import — 파일명에서 .py 제거 + alembic.versions 접두사 모듈 로드
+    # Dynamic module import — strip .py suffix, load via spec
+    module_path = candidates[0]
+    spec = importlib.util.spec_from_file_location(
+        f"alembic_0026_{module_path.stem}", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # revision 메타데이터 검증
+    # Verify revision metadata
+    assert hasattr(module, "revision"), "0026 모듈에 revision 식별자 누락"
+    assert module.revision.startswith("0026"), (
+        f"revision = '0026...' 기대, 실제: {module.revision!r}"
+    )
+    assert hasattr(module, "down_revision"), "0026 모듈에 down_revision 누락"
+    assert module.down_revision is not None and module.down_revision.startswith("0025"), (
+        f"down_revision = '0025...' 기대, 실제: {module.down_revision!r}"
+    )
+
+
+# ─── C.2 — postgresql dialect: ENABLE RLS + CREATE POLICY ─────────────────
+
+
+def test_alembic_0026_postgresql_creates_rls_policies():
+    """C.2 — postgresql dialect 환경에서 ENABLE ROW LEVEL SECURITY + CREATE POLICY 호출.
+
+    C.2 — On postgresql dialect, calls ENABLE ROW LEVEL SECURITY + CREATE POLICY.
+
+    검증 키워드 (대소문자 무관):
+    - "ROW LEVEL SECURITY" (ENABLE 구문)
+    - "CREATE POLICY" (정책 생성 구문)
+    - "repositories" (대상 테이블)
+
+    op.get_context().dialect.name == "postgresql" mock + op.execute 캡처 → SQL 키워드 검증.
+    """
+    import importlib
+    import pathlib
+
+    versions_dir = pathlib.Path(__file__).resolve().parents[3] / "alembic" / "versions"
+    candidates = sorted(versions_dir.glob("0026_*.py"))
+    assert len(candidates) >= 1, "0026 파일 미존재 (Red 단계 신호)"
+
+    module_path = candidates[0]
+    spec = importlib.util.spec_from_file_location(
+        f"alembic_0026_{module_path.stem}", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # op 모듈 자체 mock — get_context() + execute 모두 가로챔
+    # Mock the op module itself — intercept get_context() + execute
+    fake_context = MagicMock()
+    fake_context.dialect.name = "postgresql"
+
+    captured_sql: list[str] = []
+
+    def _capture_execute(sql, *_args, **_kwargs):
+        captured_sql.append(str(sql))
+
+    with patch.object(module, "op") as mock_op:
+        mock_op.get_context.return_value = fake_context
+        mock_op.execute.side_effect = _capture_execute
+        module.upgrade()
+
+    # 1 회 이상 SQL 실행 (PG 분기 진입)
+    # SQL executed ≥ 1 time (PG branch entered)
+    assert len(captured_sql) >= 1, (
+        "PG dialect 시 op.execute 호출 0회 — RLS 분기 미진입 (Red 단계 정상)"
+    )
+
+    joined_sql = " ".join(captured_sql).upper()
+    # ENABLE ROW LEVEL SECURITY 호출 검증
+    # Verify ENABLE ROW LEVEL SECURITY call
+    assert "ROW LEVEL SECURITY" in joined_sql, (
+        f"PG 분기에서 'ROW LEVEL SECURITY' 키워드 누락. captured: {captured_sql}"
+    )
+    # CREATE POLICY 호출 검증
+    # Verify CREATE POLICY call
+    assert "CREATE POLICY" in joined_sql, (
+        f"PG 분기에서 'CREATE POLICY' 키워드 누락. captured: {captured_sql}"
+    )
+    # 대상 테이블 (repositories) 검증
+    # Verify target table (repositories)
+    assert "REPOSITORIES" in joined_sql, (
+        f"PG 분기에서 'repositories' 테이블 대상 누락. captured: {captured_sql}"
+    )
+
+
+# ─── C.3 — sqlite dialect: 모든 op.execute skip ────────────────────────────
+
+
+def test_alembic_0026_sqlite_skip():
+    """C.3 — sqlite dialect 시 op.execute 호출 0회 (RLS 미적용).
+
+    C.3 — On sqlite dialect, op.execute is called 0 times (RLS not applied).
+
+    SQLite 는 RLS 미지원 — 단위 테스트 환경 (in-memory SQLite) 에서 PG 전용 SQL
+    실행 시 syntax error 발생. dialect 분기로 skip 의무.
+
+    SQLite does not support RLS — running PG-only SQL in the unit test
+    environment (in-memory SQLite) raises a syntax error. Dialect branch
+    MUST skip these statements.
+    """
+    import importlib
+    import pathlib
+
+    versions_dir = pathlib.Path(__file__).resolve().parents[3] / "alembic" / "versions"
+    candidates = sorted(versions_dir.glob("0026_*.py"))
+    assert len(candidates) >= 1, "0026 파일 미존재 (Red 단계 신호)"
+
+    module_path = candidates[0]
+    spec = importlib.util.spec_from_file_location(
+        f"alembic_0026_{module_path.stem}", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    # SQLite dialect 시뮬레이션
+    # Simulate SQLite dialect
+    fake_context = MagicMock()
+    fake_context.dialect.name = "sqlite"
+
+    with patch.object(module, "op") as mock_op:
+        mock_op.get_context.return_value = fake_context
+        mock_op.execute = MagicMock()
+        module.upgrade()
+
+    # SQLite 분기 — op.execute 호출 0회 (모든 RLS SQL skip)
+    # SQLite branch — op.execute called 0 times (all RLS SQL skipped)
+    assert mock_op.execute.call_count == 0, (
+        f"SQLite dialect 시 op.execute 호출 0회 기대, 실제: {mock_op.execute.call_count}회. "
+        f"SQLite 환경에서 RLS SQL 실행 시 syntax error → 단위 테스트 깨짐."
+    )

--- a/tests/unit/services/test_dashboard_service_user_id_filter.py
+++ b/tests/unit/services/test_dashboard_service_user_id_filter.py
@@ -1,0 +1,505 @@
+"""dashboard_service 6 함수 user_id 필터링 단위 테스트 — Phase 3 PR 5 (TDD Red).
+
+dashboard_service 6 functions user_id filtering unit tests — Phase 3 PR 5 (TDD Red).
+
+Phase 3 PR 5 — Supabase RLS 권한 모델 (앱 filter + alembic policy 페어).
+Phase 3 PR 5 — Supabase RLS permission model (app filter + alembic policy pair).
+
+본 PR 의 시그니처 변경 (구현 미존재 — Red 단계):
+The signature change verified by this PR (implementation pending — Red phase):
+
+    def dashboard_kpi(db, days=7, *, now=None, user_id: int | None = None) -> dict:
+        # user_id 명시 시 Repository.user_id == user_id OR Repository.user_id IS NULL 필터
+        # user_id None 시 모든 리포 (legacy / admin 호환)
+        # When user_id is given, filter Repository.user_id == user_id OR IS NULL.
+        # When user_id is None, query across all repos (legacy / admin compat).
+
+동일 패턴 적용 함수: dashboard_kpi, dashboard_trend, frequent_issues_v2,
+auto_merge_kpi, merge_failure_distribution, insight_narrative (async).
+
+기존 패턴 참조 (`src/ui/routes/overview.py:29`):
+Reference pattern (`src/ui/routes/overview.py:29`):
+
+    (Repository.user_id == current_user.id) | (Repository.user_id.is_(None))
+
+검증 시드 (각 테스트 동일):
+Common seed (per test):
+- User A (id=1), User B (id=2)
+- Repo A1 (user_id=1), Repo B1 (user_id=2), Repo Legacy (user_id=NULL)
+- 각 repo 에 Analysis 1건 + (필요 시) MergeAttempt 1건 seed
+- One Analysis (and where applicable, one MergeAttempt) per repo.
+
+호출 시나리오 3종 (각 테스트):
+3 invocation scenarios (per test):
+1. user_id=1 → user A repos (A1) + Legacy 만 보임 (count=2)
+2. user_id=2 → user B repos (B1) + Legacy 만 보임 (count=2)
+3. user_id=None → 모든 리포 보임 (count=3) — legacy/admin 호환
+
+ORM import 모듈 최상단 의무 — auto-memory pytest-fixture-lazy-orm-import-trap.md
+참조 (Phase 3 PR 4 CI #428 사고). lazy import 는 tests/ 전체 실행 시 metadata 누락.
+ORM imports MUST be at module top — see auto-memory pytest-fixture-lazy-orm-import-trap.md
+(Phase 3 PR 4 CI #428 incident). Lazy imports inside fixtures cause metadata gaps.
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+# ORM 모델 import 는 모듈 최상단 — Base.metadata 등록 (lazy import 금지)
+# Top-level ORM imports register Base.metadata (no lazy imports allowed)
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.merge_attempt import MergeAttempt
+from src.models.repository import Repository
+from src.models.user import User
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션을 제공한다.
+
+    Provides an in-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def seeded_users_and_repos(db):
+    """User A/B + Repo A1/B1/Legacy seed.
+
+    Seeds two users + their repos + one legacy (NULL user_id) repo.
+
+    Returns:
+        dict {"user_a": User, "user_b": User, "repo_a1": Repository,
+              "repo_b1": Repository, "repo_legacy": Repository}
+    """
+    # User A + B
+    user_a = User(github_id=1, github_login="alice", email="a@x.com", display_name="Alice")
+    user_b = User(github_id=2, github_login="bob", email="b@x.com", display_name="Bob")
+    db.add_all([user_a, user_b])
+    db.commit()
+    db.refresh(user_a)
+    db.refresh(user_b)
+
+    # Repo A1 (user_a 소유) / Repo B1 (user_b 소유) / Repo Legacy (user_id=NULL)
+    # Repo A1 (user_a) / Repo B1 (user_b) / Repo Legacy (user_id=NULL)
+    repo_a1 = Repository(full_name="alice/api", user_id=user_a.id)
+    repo_b1 = Repository(full_name="bob/api", user_id=user_b.id)
+    repo_legacy = Repository(full_name="legacy/old", user_id=None)
+    db.add_all([repo_a1, repo_b1, repo_legacy])
+    db.commit()
+    for r in (repo_a1, repo_b1, repo_legacy):
+        db.refresh(r)
+
+    return {
+        "user_a": user_a,
+        "user_b": user_b,
+        "repo_a1": repo_a1,
+        "repo_b1": repo_b1,
+        "repo_legacy": repo_legacy,
+    }
+
+
+def _make_analysis(
+    db: Session,
+    repo_id: int,
+    *,
+    score: int = 80,
+    offset_hours: int = 1,
+    result: dict[str, Any] | None = None,
+) -> Analysis:
+    """Analysis 1건 seed — 윈도우 내 (1시간 전) 기본.
+
+    Insert one Analysis (default: 1 hour ago, within window).
+    """
+    a = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{uuid.uuid4().hex}",
+        score=score,
+        grade="B",
+        result=result,
+        created_at=datetime.now(timezone.utc) - timedelta(hours=offset_hours),
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def _make_merge_attempt(
+    db: Session,
+    *,
+    analysis_id: int,
+    repo_name: str,
+    pr_number: int = 1,
+    success: bool = False,
+    failure_reason: str | None = "unstable_ci",
+    offset_hours: int = 1,
+) -> MergeAttempt:
+    """MergeAttempt 1건 seed — 윈도우 내 (1시간 전) 기본.
+
+    Insert one MergeAttempt (default: 1 hour ago, within window).
+    """
+    m = MergeAttempt(
+        analysis_id=analysis_id,
+        repo_name=repo_name,
+        pr_number=pr_number,
+        score=85,
+        threshold=75,
+        success=success,
+        failure_reason=failure_reason,
+        attempted_at=datetime.now(timezone.utc) - timedelta(hours=offset_hours),
+    )
+    db.add(m)
+    db.commit()
+    db.refresh(m)
+    return m
+
+
+# ─── A.1 dashboard_kpi user_id 필터링 ──────────────────────────────────────
+
+
+def test_dashboard_kpi_filters_by_user_id(db, seeded_users_and_repos):
+    """A.1 — dashboard_kpi(user_id=N) 호출 시 user N 의 리포 + legacy 만 집계.
+
+    A.1 — dashboard_kpi(user_id=N) aggregates only user N's repos + legacy.
+
+    검증 시나리오:
+    - user_id=1 → Repo A1 + Legacy 분석만 카운트 (analysis_count.value == 2)
+    - user_id=2 → Repo B1 + Legacy 분석만 카운트 (analysis_count.value == 2)
+    - user_id=None → 모든 리포 (== 3) — admin/legacy 호환
+    """
+    repos = seeded_users_and_repos
+    # 각 리포에 Analysis 1건 seed (윈도우 내, 점수 80)
+    # Seed 1 Analysis per repo (within window, score=80)
+    _make_analysis(db, repos["repo_a1"].id, score=80)
+    _make_analysis(db, repos["repo_b1"].id, score=80)
+    _make_analysis(db, repos["repo_legacy"].id, score=80)
+
+    from src.services.dashboard_service import dashboard_kpi  # late import (TDD Red)
+
+    # user_id=1 → Repo A1 + Legacy
+    # user_id=1 → Repo A1 + Legacy only
+    result_a = dashboard_kpi(db, days=7, user_id=repos["user_a"].id)
+    assert result_a["analysis_count"]["value"] == 2, (
+        f"user_id=1 시 Repo A1 + Legacy = 2 기대, 실제: {result_a['analysis_count']['value']}"
+    )
+
+    # user_id=2 → Repo B1 + Legacy
+    # user_id=2 → Repo B1 + Legacy only
+    result_b = dashboard_kpi(db, days=7, user_id=repos["user_b"].id)
+    assert result_b["analysis_count"]["value"] == 2, (
+        f"user_id=2 시 Repo B1 + Legacy = 2 기대, 실제: {result_b['analysis_count']['value']}"
+    )
+
+    # user_id=None → 모든 리포 (admin/legacy)
+    # user_id=None → all repos (admin/legacy compat)
+    result_all = dashboard_kpi(db, days=7)
+    assert result_all["analysis_count"]["value"] == 3, (
+        f"user_id 미지정 시 전체 = 3 기대, 실제: {result_all['analysis_count']['value']}"
+    )
+
+
+# ─── A.2 dashboard_trend user_id 필터링 ────────────────────────────────────
+
+
+def test_dashboard_trend_filters_by_user_id(db, seeded_users_and_repos):
+    """A.2 — dashboard_trend(user_id=N) 호출 시 user N 의 분석만 추세에 포함.
+
+    A.2 — dashboard_trend(user_id=N) includes only user N's analyses in the trend.
+
+    검증 — 각 리포의 score 가 다르므로 평균이 user 별로 다르게 산출:
+    - Repo A1 (user 1): score=90, Repo B1 (user 2): score=70, Legacy: score=80
+    - user_id=1 결과 평균 = (90+80)/2 = 85
+    - user_id=2 결과 평균 = (70+80)/2 = 75
+    - user_id=None 평균 = (90+70+80)/3 ≈ 80
+    """
+    repos = seeded_users_and_repos
+    # 각 리포에 다른 점수 seed (필터링 효과를 평균값으로 간접 검증)
+    # Seed different scores per repo (filter effect verified via average)
+    _make_analysis(db, repos["repo_a1"].id, score=90)
+    _make_analysis(db, repos["repo_b1"].id, score=70)
+    _make_analysis(db, repos["repo_legacy"].id, score=80)
+
+    from src.services.dashboard_service import dashboard_trend  # late import (TDD Red)
+
+    # user_id=1 → A1 (90) + Legacy (80) 만 → 1 또는 N 일자 항목 + count 합 = 2
+    # user_id=1 → A1 (90) + Legacy (80) only → count sum == 2
+    result_a = dashboard_trend(db, days=7, user_id=repos["user_a"].id)
+    total_count_a = sum(entry["count"] for entry in result_a)
+    assert total_count_a == 2, (
+        f"user_id=1 추세 count 합 = 2 기대, 실제: {total_count_a}"
+    )
+
+    # user_id=2 → B1 (70) + Legacy (80) 만 → count 합 = 2
+    # user_id=2 → B1 (70) + Legacy (80) only → count sum == 2
+    result_b = dashboard_trend(db, days=7, user_id=repos["user_b"].id)
+    total_count_b = sum(entry["count"] for entry in result_b)
+    assert total_count_b == 2, (
+        f"user_id=2 추세 count 합 = 2 기대, 실제: {total_count_b}"
+    )
+
+    # user_id=None → 모든 리포 (count 합 = 3)
+    # user_id=None → all repos (count sum == 3)
+    result_all = dashboard_trend(db, days=7)
+    total_count_all = sum(entry["count"] for entry in result_all)
+    assert total_count_all == 3, (
+        f"user_id 미지정 시 count 합 = 3 기대, 실제: {total_count_all}"
+    )
+
+
+# ─── A.3 frequent_issues_v2 user_id 필터링 ─────────────────────────────────
+
+
+def test_frequent_issues_v2_filters_by_user_id(db, seeded_users_and_repos):
+    """A.3 — frequent_issues_v2(user_id=N) 호출 시 user N 의 이슈만 카운트.
+
+    A.3 — frequent_issues_v2(user_id=N) counts only user N's issues.
+
+    검증 — 각 리포에 다른 message 의 이슈 1건 seed:
+    - Repo A1: "issue-from-A"
+    - Repo B1: "issue-from-B"
+    - Repo Legacy: "issue-from-legacy"
+    - user_id=1 → "issue-from-A", "issue-from-legacy" 만
+    - user_id=2 → "issue-from-B", "issue-from-legacy" 만
+    """
+    repos = seeded_users_and_repos
+    issue_a = {"issues": [{"message": "issue-from-A", "category": "code_quality",
+                            "language": "python", "tool": "pylint"}]}
+    issue_b = {"issues": [{"message": "issue-from-B", "category": "code_quality",
+                            "language": "python", "tool": "pylint"}]}
+    issue_legacy = {"issues": [{"message": "issue-from-legacy", "category": "code_quality",
+                                 "language": "python", "tool": "pylint"}]}
+    _make_analysis(db, repos["repo_a1"].id, result=issue_a)
+    _make_analysis(db, repos["repo_b1"].id, result=issue_b)
+    _make_analysis(db, repos["repo_legacy"].id, result=issue_legacy)
+
+    from src.services.dashboard_service import frequent_issues_v2  # late import
+
+    # user_id=1 → A 의 이슈 + legacy 만
+    # user_id=1 → user A's issues + legacy only
+    result_a = frequent_issues_v2(db, days=7, user_id=repos["user_a"].id)
+    messages_a = {item["message"] for item in result_a}
+    assert messages_a == {"issue-from-A", "issue-from-legacy"}, (
+        f"user_id=1 메시지 셋 불일치 — 기대 {{A, legacy}}, 실제: {messages_a}"
+    )
+
+    # user_id=2 → B 의 이슈 + legacy 만
+    # user_id=2 → user B's issues + legacy only
+    result_b = frequent_issues_v2(db, days=7, user_id=repos["user_b"].id)
+    messages_b = {item["message"] for item in result_b}
+    assert messages_b == {"issue-from-B", "issue-from-legacy"}, (
+        f"user_id=2 메시지 셋 불일치 — 기대 {{B, legacy}}, 실제: {messages_b}"
+    )
+
+    # user_id=None → 전체 메시지 3종
+    # user_id=None → all 3 messages
+    result_all = frequent_issues_v2(db, days=7)
+    messages_all = {item["message"] for item in result_all}
+    assert messages_all == {"issue-from-A", "issue-from-B", "issue-from-legacy"}, (
+        f"user_id 미지정 시 전체 3 메시지 기대, 실제: {messages_all}"
+    )
+
+
+# ─── A.4 auto_merge_kpi user_id 필터링 ──────────────────────────────────────
+
+
+def test_auto_merge_kpi_filters_by_user_id(db, seeded_users_and_repos):
+    """A.4 — auto_merge_kpi(user_id=N) 호출 시 user N 의 MergeAttempt 만 집계.
+
+    A.4 — auto_merge_kpi(user_id=N) aggregates only user N's MergeAttempts.
+
+    검증 — 각 리포에 MergeAttempt 1건 seed (모두 success=False):
+    - user_id=1 → A1 + Legacy = 2 attempts
+    - user_id=2 → B1 + Legacy = 2 attempts
+    - user_id=None → 3 attempts
+    """
+    repos = seeded_users_and_repos
+    # Analysis 1건씩 + MergeAttempt 1건씩 (각 repo 의 full_name 사용)
+    # 1 Analysis per repo + 1 MergeAttempt (using each repo's full_name)
+    a1 = _make_analysis(db, repos["repo_a1"].id)
+    b1 = _make_analysis(db, repos["repo_b1"].id)
+    legacy = _make_analysis(db, repos["repo_legacy"].id)
+    _make_merge_attempt(db, analysis_id=a1.id, repo_name=repos["repo_a1"].full_name)
+    _make_merge_attempt(db, analysis_id=b1.id, repo_name=repos["repo_b1"].full_name)
+    _make_merge_attempt(db, analysis_id=legacy.id, repo_name=repos["repo_legacy"].full_name)
+
+    from src.services.dashboard_service import auto_merge_kpi  # late import
+
+    # user_id=1 → A1 + Legacy = 2 attempts
+    # user_id=1 → A1 + Legacy = 2 attempts
+    result_a = auto_merge_kpi(db, days=7, user_id=repos["user_a"].id)
+    assert result_a["total_attempts"] == 2, (
+        f"user_id=1 시도 = 2 기대, 실제: {result_a['total_attempts']}"
+    )
+
+    # user_id=2 → B1 + Legacy = 2 attempts
+    # user_id=2 → B1 + Legacy = 2 attempts
+    result_b = auto_merge_kpi(db, days=7, user_id=repos["user_b"].id)
+    assert result_b["total_attempts"] == 2, (
+        f"user_id=2 시도 = 2 기대, 실제: {result_b['total_attempts']}"
+    )
+
+    # user_id=None → 전체 = 3 attempts
+    # user_id=None → all = 3 attempts
+    result_all = auto_merge_kpi(db, days=7)
+    assert result_all["total_attempts"] == 3, (
+        f"user_id 미지정 시 전체 시도 = 3 기대, 실제: {result_all['total_attempts']}"
+    )
+
+
+# ─── A.5 merge_failure_distribution user_id 필터링 ────────────────────────
+
+
+def test_merge_failure_distribution_filters_by_user_id(db, seeded_users_and_repos):
+    """A.5 — merge_failure_distribution(user_id=N) 호출 시 user N 의 실패 사유만 집계.
+
+    A.5 — merge_failure_distribution(user_id=N) aggregates only user N's failures.
+
+    검증 — 각 리포에 실패 MergeAttempt 1건씩 (다른 reason):
+    - Repo A1: failure_reason = "unstable_ci"
+    - Repo B1: failure_reason = "branch_protection_blocked"
+    - Repo Legacy: failure_reason = "permission_denied"
+
+    필터링 결과:
+    - user_id=1 → unstable_ci + permission_denied 만
+    - user_id=2 → branch_protection_blocked + permission_denied 만
+    """
+    repos = seeded_users_and_repos
+    a1 = _make_analysis(db, repos["repo_a1"].id)
+    b1 = _make_analysis(db, repos["repo_b1"].id)
+    legacy = _make_analysis(db, repos["repo_legacy"].id)
+    _make_merge_attempt(db, analysis_id=a1.id, repo_name=repos["repo_a1"].full_name,
+                        success=False, failure_reason="unstable_ci")
+    _make_merge_attempt(db, analysis_id=b1.id, repo_name=repos["repo_b1"].full_name,
+                        success=False, failure_reason="branch_protection_blocked")
+    _make_merge_attempt(db, analysis_id=legacy.id, repo_name=repos["repo_legacy"].full_name,
+                        success=False, failure_reason="permission_denied")
+
+    from src.services.dashboard_service import merge_failure_distribution  # late import
+
+    # user_id=1 → unstable_ci + permission_denied
+    # user_id=1 → unstable_ci + permission_denied only
+    result_a = merge_failure_distribution(db, days=7, user_id=repos["user_a"].id)
+    reasons_a = {item["reason"] for item in result_a}
+    assert reasons_a == {"unstable_ci", "permission_denied"}, (
+        f"user_id=1 사유 셋 불일치 — 기대 {{unstable_ci, permission_denied}}, 실제: {reasons_a}"
+    )
+
+    # user_id=2 → branch_protection_blocked + permission_denied
+    # user_id=2 → branch_protection_blocked + permission_denied only
+    result_b = merge_failure_distribution(db, days=7, user_id=repos["user_b"].id)
+    reasons_b = {item["reason"] for item in result_b}
+    assert reasons_b == {"branch_protection_blocked", "permission_denied"}, (
+        f"user_id=2 사유 셋 불일치 — 기대 {{branch_protection_blocked, permission_denied}}, "
+        f"실제: {reasons_b}"
+    )
+
+    # user_id=None → 전체 3 사유
+    # user_id=None → all 3 reasons
+    result_all = merge_failure_distribution(db, days=7)
+    reasons_all = {item["reason"] for item in result_all}
+    assert reasons_all == {"unstable_ci", "branch_protection_blocked", "permission_denied"}, (
+        f"user_id 미지정 시 전체 3 사유 기대, 실제: {reasons_all}"
+    )
+
+
+# ─── A.6 insight_narrative user_id 필터링 (async) ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_insight_narrative_filters_by_user_id(db, seeded_users_and_repos):
+    """A.6 — insight_narrative(user_id=N, ...) async 호출 시 user N 의 컨텍스트만 Claude 에 전달.
+
+    A.6 — insight_narrative(user_id=N, ...) async passes only user N's context to Claude.
+
+    검증:
+    - user_id 인자 수용 (TypeError 발생 X)
+    - DB 데이터 존재 (analysis_count > 0) → status="success" 또는 "no_data" (분기 정상 진입)
+    - Claude API mock 호출 시 user 분리된 데이터 사용
+
+    각 리포에 Analysis seed (점수 다름) — 4 dashboard 헬퍼가 user_id 격리 결과 사용해야 함.
+    """
+    repos = seeded_users_and_repos
+    # 각 리포에 Analysis 1건씩 seed
+    # Seed 1 Analysis per repo
+    _make_analysis(db, repos["repo_a1"].id, score=90)
+    _make_analysis(db, repos["repo_b1"].id, score=70)
+    _make_analysis(db, repos["repo_legacy"].id, score=80)
+
+    # Claude API 응답 mock — valid JSON narrative
+    # Mock Claude API response — valid JSON narrative
+    valid_json = (
+        '{'
+        '"positive_highlights": ["A 점수 90"],'
+        '"focus_areas": ["pylint warnings"],'
+        '"key_metrics": ['
+        '{"label": "평균", "value": "85", "delta": "+5"},'
+        '{"label": "건수", "value": "2", "delta": "0"},'
+        '{"label": "보안", "value": "0", "delta": "0"},'
+        '{"label": "Auto-merge", "value": "0%", "delta": "0%"}'
+        '],'
+        '"next_actions": ["pylint 해소"]'
+        '}'
+    )
+    fake_msg = MagicMock()
+    text_block = MagicMock()
+    text_block.text = valid_json
+    fake_msg.content = [text_block]
+    fake_msg.usage = MagicMock(
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=100,
+    )
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=fake_msg)
+
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative  # late import (TDD Red)
+
+        # user_id=1 → user A 컨텍스트 (A1 + Legacy)
+        # user_id=1 → user A context (A1 + Legacy)
+        result_a = await insight_narrative(
+            db, days=7, user_id=repos["user_a"].id, api_key="sk-test"
+        )
+
+    # 시그니처 수용 검증 — 정상 분기 진입 (success or no_data, api_error 아님)
+    # Signature acceptance — proper branch entered (success or no_data, NOT api_error)
+    assert result_a["status"] in ("success", "no_data"), (
+        f"user_id 인자 수용 실패 또는 graceful 분기 — status={result_a['status']!r}"
+    )
+
+    # 데이터 2건 (A1 + Legacy) → no_data 아님 → success 기대
+    # Data exists (A1 + Legacy = 2 analyses) → not no_data → success expected
+    assert result_a["status"] == "success", (
+        f"user_id=1 데이터 2건 → success 기대, 실제: {result_a['status']!r}"
+    )
+
+    # Claude API 호출 시 user-격리된 컨텍스트 (A 평균 점수 = 85) 가 user_prompt 에 포함
+    # Claude API call should include user-isolated context (user A avg score = 85)
+    fake_client.messages.create.assert_awaited_once()
+    call_kwargs = fake_client.messages.create.call_args.kwargs
+    user_prompt = call_kwargs["messages"][0]["content"]
+    # B1 의 데이터 (점수 70 — bob/api) 가 prompt 에 누출되지 않아야 함
+    # B's data (score 70 — bob/api) must NOT leak into the prompt
+    assert "bob/api" not in user_prompt, (
+        f"user_id=1 호출에 bob/api 데이터 누출 — RLS 격리 실패. prompt: {user_prompt[:300]}"
+    )

--- a/tests/unit/ui/test_dashboard_route.py
+++ b/tests/unit/ui/test_dashboard_route.py
@@ -605,3 +605,80 @@ def test_dashboard_no_mode_param_uses_detection():
     # initial_mode key in context — for client-side JS data-initial-mode signal
     assert captured.get("initial_mode") == "insight", \
         f"context['initial_mode']='insight' 기대, 실제: {captured.get('initial_mode')!r}"
+
+
+# ─── Phase 3 PR 5 (2026-05-04) — user_id RLS 격리 ─────────────────────────
+# Phase 3 PR 5 (2026-05-04) — user_id RLS isolation.
+#
+# 라우트가 모든 dashboard_service 함수 호출 시 current_user.id 를 user_id 인자로
+# 전달해 user-scoped 데이터만 집계하도록 한다 (Supabase RLS 앱 filter 측).
+#
+# The route MUST forward current_user.id as the user_id kwarg to every
+# dashboard_service function so aggregation is scoped to the logged-in user
+# (the application-side filter half of the Supabase RLS pair).
+
+
+def test_dashboard_passes_current_user_id_to_service(mock_insight_success):
+    """B.1 — GET /dashboard 호출 시 모든 service 함수에 user_id=current_user.id 전달.
+
+    B.1 — GET /dashboard MUST pass user_id=current_user.id to every service function.
+
+    검증 — overview 분기 (5 동기 함수) + insight 분기 (1 async) 양쪽 모두 user_id 전달:
+    - dashboard_kpi
+    - dashboard_trend
+    - frequent_issues_v2
+    - auto_merge_kpi
+    - merge_failure_distribution
+    - insight_narrative
+
+    user_id 인자 미전달 시 mock.call_args.kwargs.get("user_id") == None → fail (Red).
+
+    feedback_status 는 사용자 무관 global CTA 카드이므로 검증 대상 외.
+    feedback_status is a global CTA, not user-scoped — out of scope.
+    """
+    client = TestClient(app)
+    mock_db = MagicMock()
+
+    # overview 분기 — 5 동기 service 함수 호출 검증
+    # Overview branch — verify 5 sync service function calls
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_kpi", return_value={}) as mock_kpi, \
+         patch("src.ui.routes.dashboard.dashboard_service.dashboard_trend", return_value=[]) as mock_trend, \
+         patch("src.ui.routes.dashboard.dashboard_service.frequent_issues_v2", return_value=[]) as mock_freq, \
+         patch("src.ui.routes.dashboard.dashboard_service.auto_merge_kpi", return_value={}) as mock_am, \
+         patch("src.ui.routes.dashboard.dashboard_service.merge_failure_distribution", return_value=[]) as mock_mfd, \
+         patch("src.ui.routes.dashboard.dashboard_service.feedback_status",
+               return_value={"show_cta": False, "count": 0, "recent_analysis": None}), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse") as mock_tr:
+        from fastapi.responses import HTMLResponse
+        mock_tr.return_value = HTMLResponse(content="<html>x</html>", status_code=200)
+        # mode=overview 명시 — 분기 안정 (server fallback 회피)
+        # Explicit mode=overview — stable branch (avoids server fallback)
+        client.get("/dashboard?mode=overview")
+
+    # 5 동기 함수 모두 user_id=_TEST_USER.id 전달 검증
+    # Verify all 5 sync functions receive user_id=_TEST_USER.id
+    for mock_fn in (mock_kpi, mock_trend, mock_freq, mock_am, mock_mfd):
+        assert mock_fn.called, f"{mock_fn} 호출 안 됨 (overview 분기 누락)"
+        kwargs = mock_fn.call_args.kwargs
+        assert kwargs.get("user_id") == _TEST_USER.id, (
+            f"{mock_fn._mock_name or mock_fn} user_id 인자 누락 또는 불일치 — "
+            f"기대: {_TEST_USER.id}, 실제: {kwargs.get('user_id')!r}"
+        )
+
+    # insight 분기 — async insight_narrative 도 user_id 전달 검증
+    # Insight branch — verify async insight_narrative also receives user_id
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse") as mock_tr:
+        from fastapi.responses import HTMLResponse
+        mock_tr.return_value = HTMLResponse(content="<html>x</html>", status_code=200)
+        client.get("/dashboard?mode=insight")
+
+    # mock_insight_success fixture 가 patch 한 insight_narrative 호출 인자 검증
+    # Verify the insight_narrative invocation captured by the mock_insight_success fixture
+    assert mock_insight_success.await_count >= 1, "insight_narrative 호출 누락"
+    insight_kwargs = mock_insight_success.call_args.kwargs
+    assert insight_kwargs.get("user_id") == _TEST_USER.id, (
+        f"insight_narrative user_id 인자 누락 또는 불일치 — "
+        f"기대: {_TEST_USER.id}, 실제: {insight_kwargs.get('user_id')!r}"
+    )


### PR DESCRIPTION
…26 페어)

Phase 3 PR 5 — SaaS 전환 토대 + caching 6 PR 분할 안의 다섯 번째 PR. **사용자 결정 단일 PR (큰 응집 단위 우선)** — 앱 레벨 filter + DB 레벨 RLS policy 페어.

## 🚨 Claude 시각 검증 불가 — 사용자 의무 (정책 11)

본 PR 은 dashboard 데이터 격리 변경 — 시각 자체 변경 0이지만 표시 데이터 변동. 8 조합 시각 정합성은 정책 11 default — 다음 사항 직접 확인:
- [ ] 4 테마 × 데스크탑/모바일 dashboard 정상 렌더 (격리 후 빈 상태 fallback 포함)
- [ ] 신규 사용자 로그인 → 본인 리포 + legacy NULL 리포만 표시 (다른 사용자 데이터 누출 X)
- [ ] Insight 모드 4 카드 narrative 도 사용자별 격리 컨텍스트

## 사용자 결정 정합 (Phase 3 진입 의무 4건 중 4번 — 마지막)
**4️⃣ RLS 권한 모델: 🅐 Supabase RLS** ★ 권장 default 적용

## 변경 내역

### dashboard_service.py — 6 함수 user_id 인자 + 격리 헬퍼 2건
- 신규 헬퍼 `_apply_analysis_user_filter(query, user_id)` — Repository.user_id 기반 (legacy NULL 호환)
- 신규 헬퍼 `_apply_merge_attempt_user_filter(query, user_id)` — repo_name → Repository.full_name JOIN
- 6 함수 시그니처 `*, user_id: int | None = None` 추가:
  - `dashboard_kpi`, `dashboard_trend`, `frequent_issues_v2`, `auto_merge_kpi`, `merge_failure_distribution` (sync 5)
  - `insight_narrative` (async — 4 dashboard 헬퍼에 user_id 전파)
- user_id=None default — admin/legacy/단위 테스트 호환 (회귀 0)

### dashboard.py 라우트 — current_user.id 전달
- 모든 service 호출에 `user_id=current_user.id` 명시 전달
- `_detect_initial_dashboard_mode(db, user_id=...)` 도 동일 — 사용자별 분석 count 기준 default 모드 결정

### alembic 0026 — Supabase RLS policy (PostgreSQL 전용, SQLite skip)
- 3 테이블 RLS 활성화: `repositories`, `analyses`, `merge_attempts`
- 세션 컨텍스트 변수 `app.user_id` 패턴 (`SET LOCAL app.user_id = '<id>'` — Supabase Auth `auth.uid()` 미사용, GitHub OAuth 정합)
- USING 절: `user_id IS NULL OR user_id = NULLIF(current_setting('app.user_id', true), '')::integer`
- analyses/merge_attempts 는 repo_id/repo_name 통한 간접 격리 (subquery)
- SQLite 환경 (단위 테스트) 자동 skip — RLS 미지원

### 테스트 (신규 10건 + 기존 회귀 보존)
- `tests/unit/services/test_dashboard_service_user_id_filter.py` (신규 6건) — 6 함수 user_id 격리 검증
- `tests/unit/ui/test_dashboard_route.py` (+1) — `test_dashboard_passes_current_user_id_to_service`
- `tests/unit/migrations/test_0026_rls_policies.py` (신규 3건) — alembic 0026 dialect 분기 가드 (revision/PG/SQLite skip)

## 검증
- 신규 10 테스트: **10/10 PASS** (Green)
- 신규 + 기존 ui 통합: **24/24 PASS** (회귀 0)
- 전체 단위 (CI 명령): **2119 passed / 5 skipped / 0 failed**
- pylint dashboard_service + dashboard route: **10.00/10** (회귀 0; `dashboard_kpi`/`frequent_issues_v2` R0914 inline disable + 사유)
- flake8 / bandit: 0 issues

## 운영 적용 가이드
- **앱 레벨 filter** = 1차 안전망 (모든 환경 — SQLite/Postgres/Supabase 호환)
- **DB 레벨 RLS** = 2차 안전망 (Supabase / PostgreSQL 운영) — 앱 버그 시에도 데이터 누출 차단
- **세션 변수 설정 의무** (운영 환경): `SET LOCAL app.user_id = '<id>'` — request middleware 또는 SQLAlchemy event listener 시점 (별도 PR 권장)
- **legacy NULL user_id 리포** = 모든 사용자에게 노출 (admin 영역) — 향후 backfill 정책 별도 결정

## 향후 PR 호환성
- **PR 6** (Insight 회귀 가드 — 통합/E2E): mode=insight + caching mock + 4 카드 시각 + localStorage persist + first-visit detection + **본 PR user_id 격리 e2e 가드**
- **별도 PR (권장)**: SQLAlchemy event listener 또는 middleware — request 처리 시점에 `SET LOCAL app.user_id = current_user.id` 자동 주입 (운영 RLS 활성화 의무 페어)

## 자율 판단 보고 (정책 3) — 최상단 강조 5건

⚠️ 이의 시 알려주세요:

1. **legacy NULL user_id 리포 = 모든 사용자에게 노출** — 기존 `overview.py:29` 패턴 일치. SaaS 시점 backfill 정책 별도 결정 (본 PR scope 외).
2. **세션 변수 자동 주입 = 본 PR scope 외** — RLS 본문은 `SET LOCAL app.user_id` 의존. 운영 환경에서 미들웨어/listener 별도 신설 의무 (별도 PR 권장).
3. **앱 filter + DB RLS 페어 = "hybrid" 의미 X** — 단일 RLS only 는 SQLite 단위 테스트 미지원 → 페어 필연. 사용자 결정 🅐 (Supabase RLS) 정신 보존.
4. **insight_narrative 4 헬퍼 호출에 user_id 전파** — Claude API 컨텍스트도 격리. PR 2 의 prompt caching 은 user_id 별 cache key 분리 가능성 있음 (운영 비용 영향 — 다음 사이클 모니터링).
5. **R0914 inline disable** (`dashboard_kpi`, `frequent_issues_v2`) — user_id 필터 추가로 16/15. 사유 주석 명시 + 헬퍼 분리는 응집 단위 깨짐 (각 함수의 단일 책임 보호).

## 🔍 사용자 검증 필요 (정책 2 + 정책 11)
- [ ] PR 머지 + Railway 재배포 후 `/dashboard` (overview/insight 양 모드) 테스트 사용자 2명 이상으로 격리 검증
- [ ] alembic 0026 마이그레이션 자동 실행 (lifespan) 후 Supabase Dashboard / SQL editor 에서 `SELECT * FROM pg_policies WHERE tablename IN ('repositories', 'analyses', 'merge_attempts')` 실행하여 정책 3건 확인
- [ ] 운영 세션 컨텍스트 (`SET LOCAL app.user_id`) 미들웨어 신설 시점에 PR 5 RLS 효과 활성화 (현 PR 만으로는 RLS policy 정의만 — 활성화는 후속 PR)

## Code Scanning open alert (정책 14)
- ✅ open 0건 (다음 세션 시작 시 GitHub Security 탭 재확인)

## 운영 smoke check (정책 13)
- ✅ /health 200 + /auth/github redirect_uri 정합 + /login 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
