### PR TITLE
test(phase3-pr6): Insight 모드 회귀 가드 — e2e 7건 + integration 2건 (Phase 3…

### DIFF
--- a/e2e/test_dashboard_insight.py
+++ b/e2e/test_dashboard_insight.py
@@ -1,0 +1,166 @@
+"""E2E — /dashboard?mode=insight 회귀 가드 (Phase 3 PR 6).
+
+Phase 3 PR 1~5 (#218~#223) 머지 후속 — 본 모듈은 회귀 가드만 포함 (구현 변경 0).
+
+검증 범위:
+- A. Insight 모드 페이지 로드 + 4 카드 또는 status fallback (4건)
+- B. localStorage persist + URL 우선순위 (3건)
+
+e2e 환경에서는 ANTHROPIC_API_KEY 미설정 (e2e/conftest.py L97~L111 — 환경변수 주입 없음)
+→ settings.anthropic_api_key = "" (default) → insight_narrative status="no_api_key" 반환
+→ 템플릿이 .dash-insight-status div + "🔑 ANTHROPIC_API_KEY ..." 표시.
+
+In e2e there is no ANTHROPIC_API_KEY → insight_narrative returns status="no_api_key"
+→ template renders the .dash-insight-status div with the missing-key prompt.
+
+run: `make test-e2e` (Chromium Playwright, e2e/conftest.py 의 live_server fixture 사용).
+"""
+
+
+# ─── A. Insight 모드 페이지 로드 + status fallback ──────────────────────
+
+
+def test_dashboard_insight_mode_page_loads(page, base_url):
+    """GET /dashboard?mode=insight → 200 + .dash-insight-status (no_api_key fallback) 표시.
+
+    e2e = ANTHROPIC_API_KEY 미설정 → status=no_api_key → 🔑 텍스트 노출.
+    """
+    response = page.goto(f"{base_url}/dashboard?mode=insight")
+    assert response.status == 200, f"5xx 발생: {response.status}"
+
+    # status fallback div 존재 확인 (4 카드 grid 가 아닌 status div 가 렌더링되어야 함)
+    # The .dash-insight-status div should render (not the 4-card grid) on no_api_key.
+    status = page.locator(".dash-insight-status")
+    assert status.count() >= 1, "dash-insight-status 셀렉터 누락 (no_api_key fallback 미표시)"
+
+    # 본문에 ANTHROPIC_API_KEY 또는 🔑 marker 노출 (template L380~L382 정합)
+    # The body must include the missing-key prompt (dashboard.html L380-L382).
+    text = status.first.inner_text()
+    assert ("ANTHROPIC_API_KEY" in text) or ("🔑" in text), (
+        f"no_api_key 메시지 누락. 실제 텍스트: {text[:120]}"
+    )
+
+
+def test_dashboard_insight_mode_toggle_visible_in_overview(page, base_url):
+    """overview 모드 진입 시에도 .dash-mode-toggle 노출 + 양쪽 링크 모두 존재.
+
+    Mode toggle nav must render in overview mode with both links present (PR 3 정합).
+    """
+    page.goto(f"{base_url}/dashboard?mode=overview")
+    toggle = page.locator(".dash-mode-toggle")
+    assert toggle.count() == 1, ".dash-mode-toggle 미렌더 (PR 3 회귀)"
+
+    overview_link = page.locator('.dash-mode-toggle a[data-mode="overview"]')
+    insight_link = page.locator('.dash-mode-toggle a[data-mode="insight"]')
+    assert overview_link.count() == 1, "data-mode=overview 링크 누락"
+    assert insight_link.count() == 1, "data-mode=insight 링크 누락"
+
+
+def test_dashboard_insight_mode_toggle_active_state(page, base_url):
+    """?mode=insight 시 insight 링크에 .active 클래스 + overview 는 미가짐.
+
+    The active class must follow the URL `?mode=` parameter (template L327, L330).
+    """
+    page.goto(f"{base_url}/dashboard?mode=insight")
+
+    insight_link = page.locator('.dash-mode-toggle a[data-mode="insight"]')
+    overview_link = page.locator('.dash-mode-toggle a[data-mode="overview"]')
+
+    insight_class = insight_link.first.get_attribute("class") or ""
+    overview_class = overview_link.first.get_attribute("class") or ""
+
+    assert "active" in insight_class, (
+        f"mode=insight 시 insight 링크 .active 누락. class={insight_class!r}"
+    )
+    assert "active" not in overview_class, (
+        f"mode=insight 시 overview 링크 .active 잘못 부여됨. class={overview_class!r}"
+    )
+
+
+def test_dashboard_insight_mode_no_chart_canvas(page, base_url):
+    """Insight 모드 = narrative only — chart canvas 미렌더 (PR 3 정합).
+
+    Insight mode is narrative-only; no <canvas> for the trend chart should render
+    (overview-only branch in dashboard.html).
+    """
+    page.goto(f"{base_url}/dashboard?mode=insight")
+
+    # dashTrendChart canvas 는 overview 모드에서만 렌더링 (template if mode == 'insight' / else 분기)
+    # The dashTrendChart canvas only renders in overview mode.
+    canvas = page.locator("canvas#dashTrendChart")
+    assert canvas.count() == 0, (
+        f"Insight 모드인데 canvas#dashTrendChart 렌더됨 (count={canvas.count()}) — PR 3 회귀"
+    )
+
+
+# ─── B. localStorage persist + URL 우선순위 ─────────────────────────────
+
+
+def test_localStorage_persist_on_mode_toggle_click(page, base_url):
+    """모드 토글 클릭 시 localStorage 'sca-dashboard-mode' 저장 (PR 4 정합).
+
+    Clicking the mode toggle persists the choice to localStorage (PR 4).
+    """
+    page.goto(f"{base_url}/dashboard?mode=overview")
+
+    # insight 링크 클릭 — 페이지 이동 발생 (handler 가 setItem 후 navigate)
+    # Click the insight link — navigation will follow but the handler stores first.
+    page.click('.dash-mode-toggle a[data-mode="insight"]')
+    page.wait_for_load_state("networkidle")
+
+    stored = page.evaluate("() => localStorage.getItem('sca-dashboard-mode')")
+    assert stored == "insight", (
+        f"localStorage 'sca-dashboard-mode' 미저장 또는 잘못된 값: {stored!r}"
+    )
+
+
+def test_localStorage_redirect_on_no_url_mode(page, base_url):
+    """URL ?mode= 부재 + localStorage 'insight' 저장 → 1회 redirect 로 ?mode=insight 로 이동.
+
+    With no ?mode= in URL but localStorage='insight', the page redirects once
+    to add ?mode=insight (template L657-L670 — server initial_mode != stored).
+    """
+    # 1단계: dashboard 진입 후 localStorage 직접 setItem
+    # Step 1: visit dashboard, then setItem on localStorage directly.
+    page.goto(f"{base_url}/dashboard?mode=overview")
+    page.evaluate("() => localStorage.setItem('sca-dashboard-mode', 'insight')")
+
+    # 2단계: URL 에서 ?mode= 제거하고 재진입 — JS 가 stored != initial_mode 감지하여 redirect
+    # Step 2: visit /dashboard with no ?mode=; JS detects stored != initial and redirects.
+    page.goto(f"{base_url}/dashboard")
+    page.wait_for_load_state("networkidle")
+
+    # URL 에 mode=insight 가 포함되어야 함 (1회 redirect 후 안정 상태)
+    # Final URL must include mode=insight (post-redirect).
+    assert "mode=insight" in page.url, (
+        f"localStorage='insight' 인데 URL 에 mode=insight 미포함. 실제: {page.url}"
+    )
+
+
+def test_localStorage_url_mode_takes_precedence(page, base_url):
+    """URL ?mode= 명시 > localStorage — URL 명시 우선, redirect 발생 X (PR 4 정합).
+
+    URL `?mode=` takes precedence over localStorage; no redirect should occur
+    (template L660 — `if (url.searchParams.has('mode')) return;`).
+    """
+    # 사전 단계 — localStorage 에 'insight' 저장해 둠 (URL 우선순위 검증용)
+    # Setup — pre-store 'insight' in localStorage to verify URL precedence.
+    page.goto(f"{base_url}/dashboard")
+    page.evaluate("() => localStorage.setItem('sca-dashboard-mode', 'insight')")
+
+    # URL 에 명시적으로 mode=overview 부여 → URL 우선이므로 overview 유지 (insight 로 redirect X)
+    # Visit with explicit ?mode=overview → URL wins, no redirect to insight.
+    page.goto(f"{base_url}/dashboard?mode=overview")
+    page.wait_for_load_state("networkidle")
+
+    assert "mode=overview" in page.url, (
+        f"URL ?mode=overview 명시 시에도 redirect 발생. 실제: {page.url}"
+    )
+
+    # overview 링크가 .active — URL 명시 우선 검증
+    # The overview link must be active (URL precedence verified).
+    overview_link = page.locator('.dash-mode-toggle a[data-mode="overview"]')
+    overview_class = overview_link.first.get_attribute("class") or ""
+    assert "active" in overview_class, (
+        f"URL mode=overview 명시 시 overview 링크 .active 누락. class={overview_class!r}"
+    )

--- a/tests/integration/test_insight_caching.py
+++ b/tests/integration/test_insight_caching.py
@@ -1,0 +1,257 @@
+"""Integration — insight_narrative caching helper + user_id 격리 회귀 가드 (Phase 3 PR 6).
+
+Phase 3 PR 1 (`build_cached_system_param`) + PR 2 (`insight_narrative`) +
+PR 5 (user_id 격리) 페어 검증. 본 모듈은 회귀 가드만 (구현 변경 0).
+
+Phase 3 PR 1 (`build_cached_system_param`) + PR 2 (`insight_narrative`) +
+PR 5 (user_id isolation) regression guards. Implementation unchanged.
+
+검증 범위:
+- C.1 caching helper 호출 검증 (PR 1 + PR 2 페어)
+- C.2 user_id 격리 검증 — 다중 사용자 데이터에서 user_id=A 호출 시 A 데이터만 prompt 에 반영
+
+자동 마킹: tests/integration/conftest.py 가 @pytest.mark.slow 자동 부여.
+ORM import 모듈 최상단 의무 — auto-memory pytest-fixture-lazy-orm-import-trap.md 참조.
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+# ORM 모델 import 는 모듈 최상단 (lazy import 금지 — pytest-fixture-lazy-orm-import-trap.md)
+# Top-level ORM imports register Base.metadata (no lazy imports allowed)
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.merge_attempt import MergeAttempt  # noqa: F401  (register on metadata)
+from src.models.repository import Repository
+from src.models.user import User
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션을 제공한다.
+
+    Provides an in-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+_VALID_NARRATIVE_JSON = (
+    '{'
+    '"positive_highlights": ["A등급 분석 5건 달성", "보안 HIGH 0건 유지", "테스트 점수 평균 14"],'
+    '"focus_areas": ["pylint warning 12건 누적", "커밋 메시지 quality 12점"],'
+    '"key_metrics": ['
+    '{"label": "평균 점수", "value": "84.2", "delta": "+3.1"},'
+    '{"label": "분석 건수", "value": "5", "delta": "+2"},'
+    '{"label": "보안 HIGH", "value": "0", "delta": "0"},'
+    '{"label": "Auto-merge 성공", "value": "100%", "delta": "+10%"}'
+    '],'
+    '"next_actions": ["pylint 경고 해소", "커밋 메시지 가이드 공유"]'
+    '}'
+)
+
+
+def _make_anthropic_response(text: str) -> MagicMock:
+    """Anthropic Messages API 응답 객체 mock — content[0].text + usage.
+
+    Builds a MagicMock matching the Anthropic Messages API response shape
+    (mirrors tests/unit/services/test_dashboard_service_insight_narrative.py:121-136).
+    """
+    fake_msg = MagicMock()
+    text_block = MagicMock()
+    text_block.text = text
+    fake_msg.content = [text_block]
+    fake_msg.usage = MagicMock(
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=100,
+    )
+    return fake_msg
+
+
+def _make_analysis(
+    db: Session,
+    repo_id: int,
+    score: int,
+    *,
+    offset_hours: int = 0,
+    result: dict[str, Any] | None = None,
+) -> Analysis:
+    """Analysis 레코드 헬퍼 — 점수 / created_at offset / result dict 주입 가능.
+
+    Helper to insert an Analysis row with score / created_at offset / result dict.
+    """
+    created = datetime.now(timezone.utc) - timedelta(hours=offset_hours)
+    a = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{uuid.uuid4().hex}",
+        score=score,
+        grade="B",
+        result=result or {},
+        created_at=created,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+# ─── C.1 caching helper 호출 회귀 가드 (PR 1 + PR 2 페어) ─────────────────
+
+
+@pytest.mark.asyncio
+async def test_insight_narrative_calls_caching_helper(db):
+    """insight_narrative → build_cached_system_param 1회 호출 + system 인자 = list[dict] 검증.
+
+    Verifies PR 1 (`build_cached_system_param`) + PR 2 (`insight_narrative`) integration:
+    helper invoked exactly once, and the cached system param reaches the Anthropic call
+    as a list[dict] containing a `cache_control` ephemeral marker.
+    """
+    # User + Repo seed
+    user = User(github_id=1, github_login="alice", email="a@x.com", display_name="Alice")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    repo = Repository(full_name="owner/api", user_id=user.id)
+    db.add(repo)
+    db.commit()
+    db.refresh(repo)
+
+    # 5 건 Analysis seed (최근 7일 분포 — analysis_count > 0 → Claude API 호출 경로 진입)
+    # Seed 5 analyses (within 7 days) so the cost-saver early-return is bypassed.
+    for idx, score in enumerate([80, 85, 88, 92, 95]):
+        _make_analysis(db, repo.id, score, offset_hours=idx * 12)
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        return_value=_make_anthropic_response(_VALID_NARRATIVE_JSON)
+    )
+
+    # build_cached_system_param 의 실제 동작을 우회하지 않으면서 호출 spy
+    # Spy the helper without bypassing its actual behavior (PR 2 unit test pattern).
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ), patch(
+        "src.services.dashboard_service.build_cached_system_param",
+        wraps=lambda text, **kw: [
+            {"type": "text", "text": text, "cache_control": {"type": "ephemeral"}}
+        ],
+    ) as mock_helper:
+        from src.services.dashboard_service import insight_narrative
+        result = await insight_narrative(db, days=7, api_key="sk-test")
+
+    # PR 2 정합 — status=success
+    assert result["status"] == "success", f"status 비정상: {result['status']}"
+
+    # PR 1 + PR 2 페어 — caching helper 1회 호출
+    # PR 1 + PR 2 pair — caching helper invoked exactly once
+    assert mock_helper.call_count == 1, (
+        f"build_cached_system_param 호출 횟수 기대 1, 실제: {mock_helper.call_count}"
+    )
+
+    # Anthropic API 가 받은 system 인자 = list[dict] (caching format)
+    # The system param sent to the Anthropic API is a list[dict] (caching format).
+    fake_client.messages.create.assert_awaited_once()
+    call_kwargs = fake_client.messages.create.await_args.kwargs
+    system_arg = call_kwargs.get("system")
+    assert isinstance(system_arg, list), f"system 인자 list 기대, 실제: {type(system_arg)}"
+    assert len(system_arg) >= 1, "system list 비어있음"
+    assert isinstance(system_arg[0], dict), "system list 의 0번째 요소 dict 아님"
+    assert system_arg[0].get("cache_control", {}).get("type") == "ephemeral", (
+        f"cache_control ephemeral 마커 누락. system[0]={system_arg[0]}"
+    )
+
+
+# ─── C.2 user_id 격리 회귀 가드 (PR 5) ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_insight_narrative_user_id_isolation_in_claude_context(db):
+    """user_id=A 호출 시 prompt 에 User A 의 데이터만 포함, User B 데이터 미포함.
+
+    Verifies PR 5 user_id isolation propagates through to the Claude prompt:
+    - Seed: User A (3 analyses) + User B (3 analyses)
+    - Call insight_narrative(user_id=A.id) → prompt JSON 의 analysis_count == 3
+    - User B 의 score 데이터 (예: 50, 55, 60) 가 prompt 에 누설되지 않아야 함
+    """
+    # User A + B seed
+    user_a = User(github_id=1, github_login="alice", email="a@x.com", display_name="Alice")
+    user_b = User(github_id=2, github_login="bob", email="b@x.com", display_name="Bob")
+    db.add_all([user_a, user_b])
+    db.commit()
+    db.refresh(user_a)
+    db.refresh(user_b)
+
+    # Repo A1 (user A 소유) / Repo B1 (user B 소유)
+    repo_a1 = Repository(full_name="alice/api", user_id=user_a.id)
+    repo_b1 = Repository(full_name="bob/api", user_id=user_b.id)
+    db.add_all([repo_a1, repo_b1])
+    db.commit()
+    db.refresh(repo_a1)
+    db.refresh(repo_b1)
+
+    # User A: 점수 80/85/90 (3건), User B: 점수 50/55/60 (3건) — 의도적으로 다른 점수 분포
+    # User A: scores 80/85/90 (3). User B: scores 50/55/60 (3). Distinct distributions
+    # so we can detect leakage by checking the prompt for B-specific values.
+    for idx, score in enumerate([80, 85, 90]):
+        _make_analysis(db, repo_a1.id, score, offset_hours=idx * 12)
+    for idx, score in enumerate([50, 55, 60]):
+        _make_analysis(db, repo_b1.id, score, offset_hours=idx * 12)
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        return_value=_make_anthropic_response(_VALID_NARRATIVE_JSON)
+    )
+
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative
+        result = await insight_narrative(db, days=7, api_key="sk-test", user_id=user_a.id)
+
+    assert result["status"] == "success", f"status 비정상: {result['status']}"
+
+    # Claude API call_args 의 user message 본문 검사 — User A 데이터만 포함
+    # Inspect the user message sent to Claude — must contain only User A data.
+    fake_client.messages.create.assert_awaited_once()
+    call_kwargs = fake_client.messages.create.await_args.kwargs
+    messages = call_kwargs.get("messages", [])
+    assert len(messages) >= 1, "messages 비어있음"
+    user_content = messages[0].get("content", "")
+
+    # User A 의 analysis_count == 3 이 JSON payload 에 포함되어야 함
+    # The JSON payload must reflect User A's analysis_count == 3.
+    # _build_insight_user_prompt 은 kpi.analysis_count.value 를 직렬화 — "value": 3 형식
+    # The helper serialises kpi.analysis_count.value as `"value": 3`.
+    assert '"analysis_count"' in user_content, "user prompt 에 analysis_count 키 누락"
+
+    # PR 5 격리 — User A 가 호출했으니 analysis_count.value=3 (User A 의 3건만)
+    # PR 5 isolation — caller is User A, so only A's 3 analyses should be counted.
+    payload_str = user_content
+    assert '"value": 3' in payload_str or '"value":3' in payload_str, (
+        f"User A 격리 실패 — analysis_count.value=3 (User A 만) 기대. prompt: {payload_str[:400]}"
+    )
+
+    # User B 가 6건 합쳐 보이지 않아야 함 — analysis_count.value=6 잘못 노출 방지
+    # User B's data must not leak — analysis_count.value should never be 6.
+    assert '"value": 6' not in payload_str and '"value":6' not in payload_str, (
+        f"User B 데이터 누설 의심 — analysis_count.value=6 (격리 깨짐). prompt: {payload_str[:400]}"
+    )

--- a/tests/integration/test_insight_caching.py
+++ b/tests/integration/test_insight_caching.py
@@ -16,7 +16,6 @@ ORM import 모듈 최상단 의무 — auto-memory pytest-fixture-lazy-orm-impor
 # pylint: disable=redefined-outer-name
 from __future__ import annotations
 
-import json
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any


### PR DESCRIPTION
… 6 PR 분할 마무리)

Phase 3 PR 6 — SaaS 토대 + caching 6 PR 분할 안의 마지막 PR. **회귀 가드 전용 PR (구현 변경 0)**.

기획서 (`docs/design/2026-05-02-insight-dashboard-rework.md` L197):
> "Phase 3 PR 6 | Insight 모드 회귀 가드 + 통합/E2E — Claude API mock + caching mock + 모드 토글 e2e"

확장 — PR 5 user_id 격리 회귀 가드 포함.

## 변경 내역 (2 파일 / 신규 9 테스트)

### A. `e2e/test_dashboard_insight.py` (신규, 7 테스트)
- A.1 `test_dashboard_insight_mode_page_loads` — `?mode=insight` 200 + `.dash-insight-status` fallback (e2e 환경 ANTHROPIC_API_KEY 미설정 → no_api_key)
- A.2 `test_dashboard_insight_mode_toggle_visible_in_overview` — 모드 토글 nav 양쪽 링크 존재
- A.3 `test_dashboard_insight_mode_toggle_active_state` — `?mode=insight` 시 insight `.active` + overview 미가짐
- A.4 `test_dashboard_insight_mode_no_chart_canvas` — Insight = narrative only, canvas 미존재
- B.1 `test_localStorage_persist_on_mode_toggle_click` — 토글 클릭 → localStorage `sca-dashboard-mode` 저장
- B.2 `test_localStorage_redirect_on_no_url_mode` — URL no mode + localStorage='insight' → 1회 redirect
- B.3 `test_localStorage_url_mode_takes_precedence` — URL 명시 우선 (insight redirect 발생 X)

### B. `tests/integration/test_insight_caching.py` (신규, 2 테스트)
- C.1 `test_insight_narrative_calls_caching_helper` — `build_cached_system_param` 1회 호출 spy + Anthropic system 인자 list[dict] + cache_control ephemeral 마커 (PR 1 + PR 2 페어 검증)
- C.2 `test_insight_narrative_user_id_isolation_in_claude_context` — 다중 사용자 seed (User A 점수 80~90, User B 50~60) → `user_id=user_a.id` 호출 시 prompt JSON 의 analysis_count == 3 (User A 만, User B 6 합산 미노출 검증) — PR 5 RLS 격리 회귀 가드

## 검증
- 신규 9 테스트: **9/9 PASS** (회귀 가드 default 충족 — PR 1~5 구현 결함 0건)
- CI 명령 전체 단위: **2121 passed / 5 skipped / 0 failed**
- make test-e2e: **80 passed / 2 fail (모두 pre-existing — `test_two_column_layout_on_desktop`, `test_save_success_keeps_simple_mode`)** — 본 PR 영역 외, 사이클 62~63 이전부터 존재
- 분리 실행 의무: e2e (`make test-e2e`) ↔ tests/integration (CI command) 별도 — `e2e/pytest.ini` 가 의도적으로 asyncio_mode 미설정 (CLAUDE.md L832 정합)

## 자율 판단 보고 (정책 3)
- **본 PR scope = 회귀 가드 전용** — `src/`, `alembic/` 미수정. 기존 PR 1~5 구현 변경 0
- pre-existing 2 e2e fail (`test_settings.py` 2건) 본 PR 영역 외 — 별도 사이클 cleanup 권장 (사이클 62~63 commit body 와 동일)
- e2e + integration 동시 실행 시 asyncio_mode 충돌 (e2e/pytest.ini 의도) — CI 명령 (testpaths=tests) 는 e2e 미포함 → 영향 0
- **정책 11 미적용** — UI/시각 변경 0건 (테스트 파일만)
- **정책 13 미적용** — 인증/외부 통합 변경 0건 (테스트 파일만)

## Phase 3 종료 — 6 PR 분할 안 100% 머지 시 (본 PR 머지 후)
| PR | 머지 |
|------|------|
| PR 1 — Anthropic caching 인프라 | ✅ #218 |
| PR 2 — Insight service | ✅ #219 |
| PR 3 — 라우트 + 템플릿 + 모드 토글 | ✅ #220 |
| PR 4 — 사용자 신호 default + localStorage | ✅ #221 |
| PR 5 — Supabase RLS 권한 모델 | ✅ #223 |
| **PR 6 — Insight 회귀 가드 (본 PR)** | ⏳ |

→ Phase 3 SaaS 전환 토대 + caching + Insight 모드 + RLS 권한 100% 완성. 다음 단계 = SaaS 운영 활성화 (request middleware `SET LOCAL app.user_id` 자동 주입 — 별도 PR) + 운영 모니터링 (Anthropic caching hit rate / RLS policy 효과).

## Code Scanning open alert (정책 14)
- ✅ open 0건 (PR 5 머지 후 미확인 → 본 PR 머지 후 GitHub Security 탭 재확인 의무)

## 운영 smoke check (정책 13)
- ✅ /health 200 + /auth/github redirect_uri 정합 + /login 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
