### PR TITLE
fix(conftest): pre-existing 5 fail 완전 해소 — setdefault → 직접 set (.env …

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,16 +2,22 @@ import os
 import pytest
 from fastapi.testclient import TestClient
 
-# Set required env vars before any src.* imports that trigger Settings() loading
-os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
-os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
-os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
-os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
-os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
-os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-key")
-os.environ.setdefault("GITHUB_CLIENT_ID", "test-github-client-id")
-os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-github-client-secret")
-os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+# 사이클 65 fix — pre-existing 5 fail (사이클 62~64 누적 보류) 정밀 조사 결과:
+# `.env` 가 셸 환경에 export 된 환경 (예: direnv, 또는 사용자 셸 config) 에서는
+# `os.environ.setdefault` 가 무시되어 운영 토큰 (TELEGRAM_BOT_TOKEN 등) 이 settings 로 들어감.
+# 단위 테스트의 하드코딩 HMAC 토큰 ("123:ABC" 기반) 과 mismatch → 5 fail.
+# 직접 set 으로 변경 — 모든 환경에서 일관 (CI 도 동일 값 명시 — `.github/workflows/ci.yml` L51).
+# Fix for cycle 65: replaced setdefault with direct assignment so test env vars always win
+# over .env exports — prevents 5 pre-existing flaky fails caused by HMAC token mismatch.
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["GITHUB_WEBHOOK_SECRET"] = "test_secret"
+os.environ["GITHUB_TOKEN"] = "ghp_test"
+os.environ["TELEGRAM_BOT_TOKEN"] = "123:ABC"
+os.environ["TELEGRAM_CHAT_ID"] = "-100123"
+os.environ["ANTHROPIC_API_KEY"] = "sk-test-key"
+os.environ["GITHUB_CLIENT_ID"] = "test-github-client-id"
+os.environ["GITHUB_CLIENT_SECRET"] = "test-github-client-secret"
+os.environ["SESSION_SECRET"] = "test-session-secret-32-chars-long!"
 
 from src.main import app
 from src.webhook import router as webhook_router


### PR DESCRIPTION
…override 트랩 차단)

사용자 발화 (2026-05-04): *"잔여 작업중에 가장 오래된 작업부터 수행합니다"* — 사이클 62~65 4 사이클 누적 보류된 pre-existing 5 fail 정밀 조사.

## 원인 (정밀 진단 결과)

5 fail 모두 동일 root cause = `tests/conftest.py:9` 의 `os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")`:

- `setdefault` = 환경변수에 이미 값이 있으면 무시
- `.env` 파일 = `TELEGRAM_BOT_TOKEN=***REMOVED-TELEGRAM-TOKEN***` (실제 운영 토큰)
- `make test` 시 어떤 mechanism (셸 config / direnv / pytest dotenv 등) 으로 `.env` 가 셸 환경에 export → conftest setdefault 무시 → settings 가 운영 토큰 로드
- 단위 테스트의 하드코딩 HMAC 토큰 = `hmac("123:ABC", "gate:42", sha256).hexdigest()[:32]` (test_telegram_provider.py L17~L20) ↔ 운영 토큰 mismatch → 401 거부 → 5 fail

### 재현 매트릭스
| 명령 | 결과 |
|------|------|
| `pytest tests/unit/gate/test_engine.py::<fail_test>` (단독) | PASS | | `pytest tests/` (env vars 명시) | 0 fail |
| `pytest tests/` (env vars 미명시, 셸 unset) | 0 fail (재현 X) | | **`make test`** (셸이 .env load 시점) | **5 fail 결정적 재현 (3/3)** |

### 누적 사이클 보류 추적
- 사이클 62 commit body: "5 pre-existing fail 모두 본 환경에서 PASS — 다음 사이클 재검증 필요"
- 사이클 63 commit body: 동일 보류
- 사이클 64 회고 §1 P1-2: "보류 ≥ 2 사이클 차단 — 정밀 조사 PR 1건 분리 의무"
- 사이클 65 commit body: "본 PR scope 외 — 다음 사이클 분리 PR"
- **사이클 66 (본 PR)**: 정밀 조사 + fix 적용

## Fix (1 파일 / 14+ / 9-)

`tests/conftest.py:6~14` — 9개 환경변수 모두 `setdefault` → 직접 set (`os.environ["..."] = "..."`):
- `.env` 가 셸에 export 됐어도 conftest 가 항상 우선 (override)
- CI 환경 (`.github/workflows/ci.yml` L51 = `TELEGRAM_BOT_TOKEN: "123:ABC"`) 영향 X (동일 값 명시)
- 사유 주석 추가 (한국어 + 영어 병행 — CLAUDE.md L8~L18)

## 검증
- `make test` 3회 반복: **3/3 모두 2121 passed / 5 skipped / 0 failed** (시도 1: 116s, 시도 2: 112s, 시도 3: 135s)
- 5 fail 영역 (gate/engine 2 + telegram_provider 3) 모두 PASS

## 자율 판단 보고 (정책 3)
- 본 PR scope = conftest 1 파일만 (정책 7 강화 응집 단위 — "환경변수 격리 fix" 단일 관심사)
- 메모리 추가 의무 = `feedback-conftest-direct-env-set.md` 신설 권장 (별도 PR 또는 다음 sync 묶음)
- 다른 영향 가능성 = `.env` 의 다른 환경변수 의존 unit 테스트 = 0건 (단위 테스트 isolation 의무)

## Code Scanning open alert (정책 14)
- ✅ open 0건 (마지막 확인 시점: 사이클 65 종료, 2026-05-04)

## 운영 smoke check (정책 13)
- ✅ /health 200 + /auth/github redirect_uri 정합 + /login 200 (PR #226 머지 직후 실행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신