### PR TITLE
feat(phase3-postlude): RLS 운영 활성화 미들웨어 — alembic 0026 SET LOCAL app.u…

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -6,10 +6,11 @@ import threading
 import time
 from urllib.parse import urlparse, parse_qs
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, event, text
 from sqlalchemy.exc import OperationalError
 from sqlalchemy.orm import sessionmaker, DeclarativeBase, Session
 from src.config import settings
+from src.shared.rls_context import get_rls_user_id
 
 logger = logging.getLogger(__name__)
 
@@ -228,6 +229,37 @@ class FailoverSessionFactory:  # pylint: disable=too-many-instance-attributes
 _FALLBACK_URL = settings.database_url_fallback or None
 SessionLocal = FailoverSessionFactory(settings.database_url, _FALLBACK_URL)
 engine = SessionLocal._primary_engine  # pylint: disable=protected-access  # alembic/env.py 호환
+
+
+# Phase 3 postlude — RLS 운영 활성화 미들웨어 페어 (alembic 0026 USING 절 활성화).
+# 매 query 직전에 contextvars 의 user_id 를 읽고 SET LOCAL app.user_id 발화 (PG only).
+# RLSSessionMiddleware 가 request 시작 시 contextvars 설정 → 본 listener 가 query 마다 SET LOCAL → RLS USING 절 활성화.
+# Phase 3 postlude — pairs with RLSSessionMiddleware to activate alembic 0026 RLS USING clause.
+# Reads contextvars user_id and emits SET LOCAL app.user_id before every query (PG only).
+def _set_rls_user_id_per_query(  # pylint: disable=too-many-arguments,too-many-positional-arguments,unused-argument
+    conn, cursor, statement, params, context, executemany
+):
+    """SQLAlchemy before_cursor_execute hook — SET LOCAL app.user_id 발화.
+
+    SQLite dialect 또는 contextvars 조회 실패 시 graceful skip — query 차단 X.
+    SQLite dialect or contextvars failure → graceful skip (never break query).
+    """
+    if conn.dialect.name != "postgresql":
+        return
+    try:
+        user_id = get_rls_user_id()
+    except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        # contextvars 조회 자체가 깨져도 query 는 살려둠 (graceful)
+        # Even if contextvars introspection fails, keep the query path alive
+        return
+    val = str(user_id) if user_id else ""
+    cursor.execute(f"SET LOCAL app.user_id = '{val}'")
+
+
+# 운영 engine 에 listener 등록 — PG 환경에서만 실효 (SQLite skip 분기 내장)
+# Register on the production engine — only effective on PG (SQLite skip is built-in)
+if hasattr(engine, "dialect"):  # 정상 SQLAlchemy Engine 일 때만
+    event.listen(engine, "before_cursor_execute", _set_rls_user_id_per_query)
 
 
 def get_db():

--- a/src/main.py
+++ b/src/main.py
@@ -135,6 +135,17 @@ app = FastAPI(
     openapi_url=None if _is_prod else "/openapi.json",
 )
 app.add_middleware(SecurityHeadersMiddleware)
+# Phase 3 postlude — RLS 운영 활성화 미들웨어. Starlette LIFO 미들웨어 스택:
+# add_middleware 마지막 호출이 outer (request 먼저 처리). 원하는 흐름 = SessionMiddleware → RLSSessionMiddleware → route
+# 따라서 RLS 먼저 등록 (inner), SessionMiddleware 나중 등록 (outer — RLS 보다 먼저 호출).
+# Phase 3 postlude — RLS runtime activation. Starlette LIFO middleware stack:
+# Last add_middleware becomes outer (called first). Desired flow: SessionMiddleware → RLSSessionMiddleware → route
+# Therefore register RLS first (inner) so that SessionMiddleware (outer) populates session before RLS reads it.
+# alembic 0026 RLS policy + database.py event listener 페어 — 본 미들웨어 부재 시
+# RLS = "deny-all + legacy admin only 모드" 동작 (운영 사고 위험).
+from src.middleware.rls_session import RLSSessionMiddleware  # noqa: E402  # pylint: disable=wrong-import-position
+
+app.add_middleware(RLSSessionMiddleware)
 app.add_middleware(
     SessionMiddleware,
     secret_key=settings.session_secret,

--- a/src/middleware/__init__.py
+++ b/src/middleware/__init__.py
@@ -1,0 +1,1 @@
+"""HTTP middleware modules (Phase 3 postlude — RLS 운영 활성화 패턴 시작)."""

--- a/src/middleware/rls_session.py
+++ b/src/middleware/rls_session.py
@@ -1,0 +1,56 @@
+"""RLS session middleware — request 시작 시 session.user_id 를 contextvars 로 전파.
+
+request 시작 시 session.user_id (Starlette SessionMiddleware 가 scope["session"] 에 채움)
+를 추출해 `src.shared.rls_context._RLS_USER_ID` 에 저장. request 종료 시 reset.
+
+SQLAlchemy event listener (`src/database.py::_set_rls_user_id_per_query`) 가
+매 query 직전에 본 contextvars 읽고 `SET LOCAL app.user_id = '<id>'` 발화 (PG only).
+
+Phase 3 postlude — alembic 0026 RLS policy (메모리 `phase3-rls-runtime-activation-pending.md`)
+운영 활성화. 본 미들웨어 부재 시 RLS = "deny-all + legacy admin only 모드" 동작 (운영 사고 위험).
+
+🔴 ASGI middleware 패턴 의무 (BaseHTTPMiddleware 우회):
+Starlette `BaseHTTPMiddleware.dispatch` 는 별도 anyio task 에서 `call_next` 호출 →
+contextvars 가 하위 라우트 핸들러에 전파 X. 본 미들웨어는 동일 task ASGI 패턴 사용.
+
+ASGI middleware (not BaseHTTPMiddleware) — same task ensures contextvars propagate to handlers.
+"""
+from src.shared.rls_context import reset_rls_user_id, set_rls_user_id
+
+
+class RLSSessionMiddleware:  # pylint: disable=too-few-public-methods
+    """ASGI middleware — request 시작 시 scope["session"]["user_id"] → contextvars.
+
+    ASGI 표준 = `__call__` 단일 method (pylint R0903 inline disable — 의도된 표준 패턴).
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        # HTTP scope 만 처리 (websocket / lifespan 무관)
+        # Only handle HTTP scope (websocket / lifespan are not affected)
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # session 에서 user_id 추출 — Starlette SessionMiddleware 가 먼저 등록되어야 함
+        # Extract user_id from session — Starlette SessionMiddleware must be registered first
+        user_id: int | None = None
+        try:
+            session = scope.get("session", {})
+            raw = session.get("user_id") if session else None
+            if raw is not None:
+                user_id = int(raw)
+        except (KeyError, ValueError, TypeError, AttributeError):
+            # session 부재 / 키 없음 / int 변환 실패 모두 graceful
+            # session missing / key absent / int conversion failure all graceful
+            user_id = None
+
+        token = set_rls_user_id(user_id)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            # request 종료 시 cleanup — cross-request 격리 보장
+            # Cleanup at request end — cross-request isolation guaranteed
+            reset_rls_user_id(token)

--- a/src/shared/rls_context.py
+++ b/src/shared/rls_context.py
@@ -1,0 +1,42 @@
+"""RLS user_id context — request scope (Phase 3 postlude).
+
+contextvars 기반 request scope user_id 컨텍스트.
+SQLAlchemy event listener 가 매 query 직전에 본 컨텍스트 읽고 `SET LOCAL app.user_id` 발화.
+
+Request-scoped user_id context for RLS. The SQLAlchemy event listener reads this
+on every query and emits `SET LOCAL app.user_id`. None = anonymous/unauthenticated.
+
+Phase 3 postlude — RLS 운영 활성화 미들웨어. alembic 0026 의 USING 절이
+`current_setting('app.user_id', true)` 의존 — 본 컨텍스트 미설정 시 RLS = "deny-all + legacy admin only" 동작.
+"""
+import contextvars
+
+# request scope user_id (None = 익명/미인증)
+# Request-scoped user_id (None = anonymous/unauthenticated)
+_RLS_USER_ID: contextvars.ContextVar[int | None] = contextvars.ContextVar(
+    "rls_user_id", default=None
+)
+
+
+def set_rls_user_id(user_id: int | None) -> contextvars.Token:
+    """user_id 를 contextvars 에 설정. 반환 token 은 reset 에 사용.
+
+    Set user_id in contextvars. Returned token is used for reset.
+    """
+    return _RLS_USER_ID.set(user_id)
+
+
+def get_rls_user_id() -> int | None:
+    """현재 request 의 user_id 반환 (None = 익명).
+
+    Return current request's user_id (None = anonymous).
+    """
+    return _RLS_USER_ID.get()
+
+
+def reset_rls_user_id(token: contextvars.Token) -> None:
+    """token 으로 contextvars reset (request scope cleanup).
+
+    Reset contextvars using token (request scope cleanup).
+    """
+    _RLS_USER_ID.reset(token)

--- a/tests/unit/middleware/test_rls_session.py
+++ b/tests/unit/middleware/test_rls_session.py
@@ -1,0 +1,147 @@
+"""RLSSessionMiddleware 단위 테스트 — Phase 3 RLS 운영 활성화.
+
+세션 user_id → contextvars 전파 + request 종료 시 cleanup 검증.
+RLSSessionMiddleware unit tests for Phase 3 RLS production enablement —
+verifies session.user_id propagation into contextvars and cleanup on
+request completion.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+from starlette.middleware.sessions import SessionMiddleware
+from starlette.requests import Request
+
+# Red 단계: 신규 모듈 미존재 → ImportError 발생 (의도된 fail).
+# Red phase: new modules do not exist yet, so these imports trigger
+# ImportError as the intended failure signal.
+from src.shared.rls_context import (  # noqa: E402
+    get_rls_user_id,
+    reset_rls_user_id,
+    set_rls_user_id,
+)
+from src.middleware.rls_session import RLSSessionMiddleware  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# A.1 — contextvars 초기값 검증
+# A.1 — verifies the initial contextvars value is None
+# ---------------------------------------------------------------------------
+def test_rls_context_initial_value_is_none():
+    # 어떤 set 호출도 없는 상태에서 default 가 None 이어야 함
+    # The default value must be None when no set has been performed yet.
+    # 격리: 다른 테스트가 set 한 뒤 reset 안 했을 가능성에 대비해 강제 None 으로 설정 후 측정
+    # Isolation guard: defensively force None in case a previous test left a stale value.
+    token = set_rls_user_id(None)
+    try:
+        assert get_rls_user_id() is None
+    finally:
+        reset_rls_user_id(token)
+
+
+# ---------------------------------------------------------------------------
+# A.2 — set/get/reset 사이클 검증
+# A.2 — verifies the full set/get/reset lifecycle
+# ---------------------------------------------------------------------------
+def test_rls_context_set_and_get():
+    # set 직후 동일 값을 get 해야 함 + reset 후 다시 None 으로 복귀해야 함
+    # After set, get must return the same value; after reset, it must revert to None.
+    token = set_rls_user_id(42)
+    assert get_rls_user_id() == 42
+    reset_rls_user_id(token)
+    assert get_rls_user_id() is None
+
+
+# ---------------------------------------------------------------------------
+# 공용 헬퍼 — RLSSessionMiddleware 단독 테스트 앱 (main.py 의존 회피)
+# Helper — standalone TestClient app for middleware-only assertions
+# (avoids depending on src.main wiring during the Red phase).
+# ---------------------------------------------------------------------------
+def _build_test_app() -> FastAPI:
+    """RLSSessionMiddleware 만 적용된 최소 FastAPI 앱.
+    Minimal FastAPI app wired with only RLSSessionMiddleware + SessionMiddleware,
+    exposing two endpoints used to introspect contextvars during a request.
+    """
+    test_app = FastAPI()
+    # Starlette LIFO: 마지막 add 가 outer → SessionMiddleware 가 RLS 보다 outer 가 되어야 함.
+    # Therefore RLS first (inner), SessionMiddleware last (outer) — request 흐름:
+    # SessionMiddleware → RLSSessionMiddleware → route (RLS 가 채워진 session 읽음).
+    test_app.add_middleware(RLSSessionMiddleware)
+    test_app.add_middleware(SessionMiddleware, secret_key="test-rls-secret-32-chars-long!!")
+
+    @test_app.get("/_set-session")
+    async def _set_session(request: Request, user_id: int):  # type: ignore[no-untyped-def]
+        # 세션에 user_id 주입 — 다음 요청에서 middleware 가 이를 contextvars 로 옮긴다
+        # Inject user_id into the session so subsequent requests propagate it via contextvars.
+        request.session["user_id"] = user_id
+        return JSONResponse({"ok": True})
+
+    @test_app.get("/_read-rls")
+    async def _read_rls():
+        # request 처리 중 contextvars 값을 그대로 응답
+        # Echo the contextvars value observed during request handling.
+        return JSONResponse({"user_id": get_rls_user_id()})
+
+    return test_app
+
+
+# ---------------------------------------------------------------------------
+# A.3 — middleware 가 session.user_id 를 contextvars 로 전파
+# A.3 — middleware copies session.user_id into contextvars during request handling
+# ---------------------------------------------------------------------------
+def test_rls_middleware_sets_contextvars_from_session():
+    # 1) 첫 요청으로 세션 쿠키 발급 + user_id=42 주입
+    # 1) First request issues a session cookie and stores user_id=42.
+    # 2) 두 번째 요청에서 middleware 가 contextvars 에 42 를 올려야 함
+    # 2) Second request should expose user_id=42 via contextvars.
+    client = TestClient(_build_test_app())
+    setup = client.get("/_set-session", params={"user_id": 42})
+    assert setup.status_code == 200
+
+    response = client.get("/_read-rls")
+    assert response.status_code == 200
+    assert response.json() == {"user_id": 42}
+
+
+# ---------------------------------------------------------------------------
+# A.4 — 세션 없는 요청은 contextvars 가 None 으로 유지
+# A.4 — anonymous request keeps contextvars at None
+# ---------------------------------------------------------------------------
+def test_rls_middleware_no_session_returns_none_user():
+    # 신규 client (쿠키 없음) → session.user_id 부재 → middleware 는 None 으로 처리
+    # A fresh client has no session cookie, so middleware must yield None.
+    client = TestClient(_build_test_app())
+    response = client.get("/_read-rls")
+    assert response.status_code == 200
+    assert response.json() == {"user_id": None}
+
+
+# ---------------------------------------------------------------------------
+# A.5 — request 완료 시 contextvars 가 cleanup + 다음 요청 격리 보장
+# A.5 — contextvars are cleaned up after each request, isolating later requests
+# ---------------------------------------------------------------------------
+def test_rls_middleware_cleans_up_after_request():
+    # 1) client A 요청으로 user_id=10 설정 후 read 검증
+    # 1) Client A sets user_id=10 and verifies the propagated value.
+    # 2) 동일 프로세스에서 client B (다른 세션) 요청이 None 으로 격리되어야 함
+    # 2) A separate Client B (different session) must observe None — no cross-talk.
+    # 3) request 종료 후 contextvars 가 None 으로 reset 되었는지 직접 확인
+    # 3) After requests complete, contextvars must reset to None at module scope.
+    app_a = _build_test_app()
+    client_a = TestClient(app_a)
+    client_a.get("/_set-session", params={"user_id": 10})
+    response_a = client_a.get("/_read-rls")
+    assert response_a.json() == {"user_id": 10}
+
+    # 새 client (별도 cookie jar) — session 없음 → contextvars cross-talk 가 있다면 10 이 새어 나옴
+    # Fresh client (separate cookie jar) with no session — if contextvars leaked,
+    # we would observe 10; the assertion guards against cross-request bleed.
+    client_b = TestClient(app_a)
+    response_b = client_b.get("/_read-rls")
+    assert response_b.json() == {"user_id": None}
+
+    # 모든 요청 종료 후 모듈 레벨에서 contextvars 는 None 이어야 함
+    # After all requests finish, the module-level contextvars must be None.
+    assert get_rls_user_id() is None

--- a/tests/unit/middleware/test_rls_session.py
+++ b/tests/unit/middleware/test_rls_session.py
@@ -7,7 +7,6 @@ request completion.
 """
 from __future__ import annotations
 
-import pytest
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient

--- a/tests/unit/test_rls_event_listener.py
+++ b/tests/unit/test_rls_event_listener.py
@@ -1,0 +1,124 @@
+"""RLS SQLAlchemy event listener 단위 테스트 — Phase 3 RLS 운영 활성화.
+
+`SET LOCAL app.user_id` 발화 조건과 graceful 동작 검증.
+SQLAlchemy event listener tests — verifies that `SET LOCAL app.user_id`
+is emitted only on PostgreSQL, falls back to empty string for anonymous
+requests, and never breaks query execution if contextvars introspection
+raises.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Red 단계: src.database._set_rls_user_id_per_query 미존재 → ImportError
+# Red phase: src.database._set_rls_user_id_per_query does not exist yet,
+# so this import is the intended failure signal.
+from src.database import _set_rls_user_id_per_query  # noqa: E402
+from src.shared.rls_context import (  # noqa: E402
+    reset_rls_user_id,
+    set_rls_user_id,
+)
+
+
+@pytest.fixture
+def mock_pg_conn():
+    """PostgreSQL dialect 를 흉내내는 mock connection.
+    Mock SQLAlchemy connection mimicking the PostgreSQL dialect.
+    """
+    conn = MagicMock()
+    conn.dialect.name = "postgresql"
+    return conn
+
+
+@pytest.fixture
+def mock_sqlite_conn():
+    """SQLite dialect 를 흉내내는 mock connection.
+    Mock SQLAlchemy connection mimicking the SQLite dialect.
+    """
+    conn = MagicMock()
+    conn.dialect.name = "sqlite"
+    return conn
+
+
+@pytest.fixture
+def mock_cursor():
+    """SET LOCAL 호출 발화 여부 검증용 mock cursor.
+    Mock cursor used to assert whether SET LOCAL was issued.
+    """
+    return MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def _reset_rls_context():
+    """각 테스트 직전/직후 contextvars 를 None 으로 초기화.
+    Reset contextvars to None around every test to keep cases isolated.
+    """
+    token = set_rls_user_id(None)
+    yield
+    reset_rls_user_id(token)
+
+
+# ---------------------------------------------------------------------------
+# B.1 — SQLite dialect 에서는 SQL 발화 X (개발/테스트 환경 호환)
+# B.1 — listener must skip SQL execution on SQLite to keep dev/test compatible
+# ---------------------------------------------------------------------------
+def test_listener_skips_on_sqlite_dialect(mock_sqlite_conn, mock_cursor):
+    # SQLite 에는 SET LOCAL 문법이 없으므로 listener 는 즉시 return 해야 함
+    # SQLite has no SET LOCAL syntax, so the listener must return immediately.
+    _set_rls_user_id_per_query(
+        mock_sqlite_conn, mock_cursor, "SELECT 1", {}, None, False
+    )
+    mock_cursor.execute.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# B.2 — PostgreSQL + user_id 설정 시 정확한 SET LOCAL SQL 발화
+# B.2 — emits the exact SET LOCAL statement on PostgreSQL with user_id
+# ---------------------------------------------------------------------------
+def test_listener_emits_set_local_on_postgresql_with_user_id(
+    mock_pg_conn, mock_cursor
+):
+    # contextvars 에 42 설정 후 listener 호출 → cursor.execute 인자 검증
+    # Set contextvars to 42, invoke listener, then assert the exact SQL emitted.
+    set_rls_user_id(42)
+    _set_rls_user_id_per_query(
+        mock_pg_conn, mock_cursor, "SELECT 1", {}, None, False
+    )
+    mock_cursor.execute.assert_called_once_with("SET LOCAL app.user_id = '42'")
+
+
+# ---------------------------------------------------------------------------
+# B.3 — PostgreSQL + user_id 미설정 시 빈 문자열로 발화 (RLS deny-all)
+# B.3 — anonymous PostgreSQL request emits empty string (RLS deny-all default)
+# ---------------------------------------------------------------------------
+def test_listener_emits_empty_on_postgresql_no_user(mock_pg_conn, mock_cursor):
+    # contextvars 가 None (anonymous) 일 때 SET LOCAL 의 값은 빈 문자열이어야 함
+    # When contextvars is None (anonymous), SET LOCAL must use an empty string.
+    # 기본값이 None — autouse fixture 가 보장하므로 별도 set 불필요
+    # Default is None — already enforced by the autouse fixture.
+    _set_rls_user_id_per_query(
+        mock_pg_conn, mock_cursor, "SELECT 1", {}, None, False
+    )
+    mock_cursor.execute.assert_called_once_with("SET LOCAL app.user_id = ''")
+
+
+# ---------------------------------------------------------------------------
+# B.4 — get_rls_user_id() 가 예외 raise 해도 listener 는 graceful (query 차단 X)
+# B.4 — listener stays graceful when get_rls_user_id() raises (no query break)
+# ---------------------------------------------------------------------------
+def test_listener_does_not_break_on_get_context_failure(mock_pg_conn, mock_cursor):
+    # contextvars 조회 자체가 실패해도 listener 는 예외를 propagate 하면 안 됨
+    # Even if contextvars introspection itself fails, the listener must not
+    # propagate the exception — query path stays intact.
+    with patch(
+        "src.database.get_rls_user_id",
+        side_effect=RuntimeError("contextvars broken"),
+    ):
+        # 예외가 propagate 되면 본 테스트는 fail (pytest.raises 미사용 = no-raise 검증)
+        # If the exception propagated, this test would fail — the absence of
+        # pytest.raises is the no-raise assertion.
+        _set_rls_user_id_per_query(
+            mock_pg_conn, mock_cursor, "SELECT 1", {}, None, False
+        )


### PR DESCRIPTION
…ser_id 자동 주입

사용자 발화 (2026-05-04): *"네 바로 수행 부탁드립니다"* — 옵션 🅐 (FastAPI middleware default).

Phase 3 postlude — alembic 0026 RLS policy (#223 머지) 운영 활성화. 본 PR 부재 시 RLS = "deny-all + legacy admin only 모드" 동작 (메모리 `phase3-rls-runtime-activation-pending.md` 운영 사고 위험).

## 변경 내역 (5 파일 + 2 신규 테스트)

### 신규 모듈 (3 파일)

#### `src/shared/rls_context.py`
- `contextvars.ContextVar` 기반 request scope user_id (None = 익명)
- `set_rls_user_id(user_id) -> Token` / `get_rls_user_id() -> int|None` / `reset_rls_user_id(token)` 3 함수

#### `src/middleware/__init__.py` + `src/middleware/rls_session.py`
- 신규 디렉토리 + 패키지 마커
- `RLSSessionMiddleware` (ASGI 표준) — request 시작 시 `scope["session"]["user_id"]` → contextvars 저장 + 종료 시 reset
- 🔴 **ASGI 패턴 의무** (BaseHTTPMiddleware 우회) — Starlette `BaseHTTPMiddleware.dispatch` 는 별도 anyio task 에서 `call_next` 호출 → contextvars 가 하위 라우트 핸들러에 전파 X. 본 미들웨어는 동일 task ASGI 패턴
- session 부재 / int 변환 실패 모두 graceful (KeyError, ValueError, TypeError, AttributeError)

### 변경

#### `src/database.py`
- import: `event` (sqlalchemy) + `get_rls_user_id` (rls_context)
- 신규 `_set_rls_user_id_per_query` 함수 — SQLAlchemy `before_cursor_execute` hook (PG only, SQLite skip)
- `cursor.execute(f"SET LOCAL app.user_id = '{val}'")` — contextvars 의 user_id (None = 빈 문자열)
- contextvars 조회 실패 시 graceful (broad-except)
- `event.listen(engine, "before_cursor_execute", ...)` — 운영 engine 등록

#### `src/main.py`
- import + 등록: `RLSSessionMiddleware` (Starlette LIFO 의무 — RLS 먼저 등록 = inner, SessionMiddleware 나중 = outer)
- 등록 순서 swap: SessionMiddleware → RLS (inner 가 session 채워진 상태에서 진입)

### 신규 테스트 (2 파일 / 9 테스트)

#### `tests/unit/middleware/__init__.py` + `test_rls_session.py` (5건)
- A.1 contextvars default = None
- A.2 set/get/reset 사이클
- A.3 middleware 가 session.user_id → contextvars 전파
- A.4 익명 request → contextvars None
- A.5 cleanup + cross-request 격리

#### `tests/unit/test_rls_event_listener.py` (4건)
- B.1 SQLite dialect skip
- B.2 PG + user_id=42 → `SET LOCAL app.user_id = '42'`
- B.3 PG + None → `SET LOCAL app.user_id = ''`
- B.4 contextvars 조회 실패 graceful

## 검증
- TDD 흐름: Red 9 fail → Green 9/9 PASS
- 인접 회귀: tests/unit/middleware + test_rls_event_listener + test_main + test_database = **30/30 PASS**
- `make test` 3회 반복: **3/3 모두 2130 passed (+9 신규) / 5 skipped / 0 failed** (이전 사이클 5 fail 재발 0)
- pylint: **10.00/10** (R0903 ASGI 표준 + W0613 SQLAlchemy hook 시그니처 inline disable 적용)
- flake8 / bandit: 0 issues

## 자율 판단 보고 (정책 3) — 최상단 강조 4건

⚠️ 이의 시 알려주세요:

1. **ASGI middleware 직접 작성** (BaseHTTPMiddleware 우회) — TDD 1차 시도에서 contextvars 전파 실패 후 즉시 ASGI 로 전환. Starlette 알려진 issue 정합. 이의 시 BaseHTTPMiddleware + `contextvars.copy_context()` 명시 전파 패턴 가능.
2. **middleware 등록 순서 LIFO** — SessionMiddleware (outer) → RLSSessionMiddleware (inner) → route. swap 의무.
3. **SET LOCAL 매 query 발화** — connection pool 환경에서 transaction 안 1회 set 만 필요할 수 있으나 안전성 우선 (transaction 시작 시점 추적 복잡). 운영 비용 = query 당 1 SQL → 무시 가능 (PG round-trip ↑1).
4. **legacy NULL user_id = 모든 사용자 노출** — alembic 0026 USING 절 `user_id IS NULL OR ...` 패턴. backfill 정책 별도 PR (메모리 `phase3-rls-runtime-activation-pending.md` 후속 작업).

## 운영 효과 (PR 머지 후)
- alembic 0026 RLS policy 가 비로소 효과 발휘 — `current_setting('app.user_id', true)` 가 매 query 마다 사용자별 값 반환
- repositories/analyses/merge_attempts 3 테이블에 자동 격리 적용
- 앱 레벨 filter (Phase 3 PR 5 — `_apply_*_user_filter`) = 1차 안전망 + DB RLS = 2차 안전망 = **2-layer 격리 완전 활성화**

## 🔍 사용자 검증 필요 (정책 2)
- [ ] PR 머지 + Railway 재배포 후 Supabase Dashboard SQL editor 에서 검증:
  - `SELECT current_setting('app.user_id', true);` 실행 (admin role) → 빈 문자열 (anonymous)
  - 운영 사용자 로그인 후 본인 dashboard 접속 → DB 로그에 `SET LOCAL app.user_id = '<id>'` 발화 확인
  - `SELECT * FROM repositories;` (앱 user 권한) → 본인 + legacy NULL 만 반환 검증
- [ ] (선택) Anthropic Sentry 로 query 빈도 증가 모니터링 (SET LOCAL = +1 round-trip per query)

## Code Scanning open alert (정책 14)
- ✅ open 0건 (마지막 확인 시점: 사이클 65 종료, 2026-05-04)

## 운영 smoke check (정책 13)
- ✅ /health 200 + /auth/github redirect_uri 정합 + /login 200 (PR #227 머지 직후 실행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
