### PR TITLE
feat(backfill): legacy NULL Repository.user_id backfill 스크립트 — author…

### DIFF
--- a/scripts/backfill_repository_user_id.py
+++ b/scripts/backfill_repository_user_id.py
@@ -1,0 +1,171 @@
+"""Legacy NULL `Repository.user_id` backfill script — author_login JOIN 패턴 (옵션 🅐-2).
+
+Phase 3 postlude — 사이클 64 회고 P1 후속. SaaS 전환 시점 RLS 격리 정합성 보강.
+
+## 사용 방법
+
+```bash
+# Dry-run (default — 영향 row + SQL 출력만, DB 변경 X)
+python -m scripts.backfill_repository_user_id
+
+# 실제 적용 (사용자 명시 의무)
+python -m scripts.backfill_repository_user_id --apply
+```
+
+## 동작
+1. `Repository.user_id IS NULL` 조회
+2. 각 repo 의 첫 (created_at asc) `Analysis.author_login` 가져옴
+3. `users.github_login = author_login` 매칭 → user.id 발견
+4. dry-run = SQL UPDATE 출력만 / `--apply` = 실제 UPDATE
+5. 결과 보고: `resolved` (매칭 성공) + `skipped_no_analysis` + `skipped_no_author` + `skipped_no_user`
+
+## 사용자 결정 영역 (정책 3)
+실제 backfill 적용은 사용자 명시 의무 (`--apply`). dry-run 으로 영향 미리 확인 후 결정.
+
+Legacy NULL backfill — author_login JOIN pattern (option 🅐-2). User-explicit `--apply` only.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.database import SessionLocal  # pylint: disable=import-error
+from src.models.analysis import Analysis  # pylint: disable=import-error
+from src.models.repository import Repository  # pylint: disable=import-error
+from src.models.user import User  # pylint: disable=import-error
+
+logger = logging.getLogger(__name__)
+
+
+def _resolve_user_id_for_repo(db: Session, repo: Repository) -> Optional[int]:
+    """주어진 repository 의 첫 Analysis 의 author_login 으로 user_id 매칭.
+
+    Resolve user_id by joining the first Analysis's author_login to users.github_login.
+
+    None 반환 케이스:
+    1. repo 에 Analysis 0건
+    2. 첫 Analysis 의 author_login NULL/빈 문자열
+    3. users 테이블에 매칭 github_login 없음
+    """
+    # 첫 Analysis (created_at asc) 조회 — author_login 추출
+    # First Analysis chronologically — extract author_login
+    first_analysis = db.scalars(
+        select(Analysis)
+        .where(Analysis.repo_id == repo.id)
+        .order_by(Analysis.created_at.asc())
+    ).first()
+
+    if first_analysis is None:
+        return None
+
+    author_login = first_analysis.author_login
+    if not author_login:
+        return None
+
+    # users.github_login 매칭 user 검색
+    # Match users.github_login
+    user = db.scalars(
+        select(User).where(User.github_login == author_login)
+    ).first()
+
+    if user is None:
+        return None
+
+    return int(user.id)
+
+
+def _format_update_sql(repo_id: int, user_id: int) -> str:
+    """dry-run 출력용 SQL UPDATE 문 빌더 (실제 실행 X — 시각 출력 전용)."""
+    # SQL UPDATE statement builder for dry-run output (NOT executed — display only)
+    # Both args are int (caller responsibility — type hints) — no SQL injection vector.
+    return f"UPDATE repositories SET user_id = {user_id} WHERE id = {repo_id};"  # nosec B608
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Legacy NULL user_id backfill main — dry-run default, --apply 명시 시 실제 적용.
+
+    Returns: 0 = success, 1 = errors during apply.
+    """
+    parser = argparse.ArgumentParser(
+        description="Legacy NULL Repository.user_id backfill (author_login JOIN — 옵션 🅐-2)"
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="실제 DB UPDATE 실행 (default = dry-run only).",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    logger.info("=" * 60)
+    logger.info("Legacy NULL Repository.user_id backfill — mode=%s", mode)
+    logger.info("Pattern: 옵션 🅐-2 (author_login JOIN — Claude 권장 default)")
+    logger.info("=" * 60)
+
+    counters = {
+        "resolved": 0,
+        "skipped_no_analysis": 0,
+        "skipped_no_author": 0,
+        "skipped_no_user": 0,
+    }
+    sql_lines: list[str] = []
+
+    with SessionLocal() as db:
+        # Repository.user_id IS NULL 만 처리 — 이미 매칭된 row 변경 X
+        # Process only rows with NULL user_id — never touch already-mapped rows
+        legacy_repos = list(
+            db.scalars(select(Repository).where(Repository.user_id.is_(None))).all()
+        )
+        logger.info("Legacy NULL repositories: %d", len(legacy_repos))
+
+        for repo in legacy_repos:
+            resolved_user_id = _resolve_user_id_for_repo(db, repo)
+            if resolved_user_id is None:
+                # 세분 카운트 — 진단용
+                # Detailed counters for diagnostics
+                first = db.scalars(
+                    select(Analysis)
+                    .where(Analysis.repo_id == repo.id)
+                    .order_by(Analysis.created_at.asc())
+                ).first()
+                if first is None:
+                    counters["skipped_no_analysis"] += 1
+                elif not first.author_login:
+                    counters["skipped_no_author"] += 1
+                else:
+                    counters["skipped_no_user"] += 1
+                continue
+
+            counters["resolved"] += 1
+            sql_lines.append(_format_update_sql(repo.id, resolved_user_id))
+            if args.apply:
+                # 실제 UPDATE 실행 — Repository row 직접 수정
+                # Apply UPDATE — directly mutate the Repository row
+                repo.user_id = resolved_user_id
+
+        if args.apply:
+            db.commit()
+            logger.info("Applied %d UPDATE rows.", counters["resolved"])
+        else:
+            logger.info("Dry-run SQL (실제 실행 X — `--apply` 명시 의무):")
+            for sql in sql_lines:
+                logger.info("  %s", sql)
+
+    logger.info("-" * 60)
+    logger.info("Result counters:")
+    logger.info("  ✓ resolved (user_id 매칭 성공): %d", counters["resolved"])
+    logger.info("  ⊘ skipped_no_analysis (Analysis 0건): %d", counters["skipped_no_analysis"])
+    logger.info("  ⊘ skipped_no_author (author_login NULL): %d", counters["skipped_no_author"])
+    logger.info("  ⊘ skipped_no_user (users 매칭 없음): %d", counters["skipped_no_user"])
+    logger.info("=" * 60)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/scripts/test_backfill_repository_user_id.py
+++ b/tests/unit/scripts/test_backfill_repository_user_id.py
@@ -1,0 +1,213 @@
+"""scripts/backfill_repository_user_id.py `_resolve_user_id_for_repo` 단위 테스트
+— Phase 3 backfill (TDD Red).
+
+scripts/backfill_repository_user_id.py `_resolve_user_id_for_repo` unit tests
+— Phase 3 backfill (TDD Red).
+
+본 PR 의 신규 함수 (구현 미존재 — Red 단계):
+The new function this PR introduces (implementation pending — Red phase):
+
+    def _resolve_user_id_for_repo(db, repo) -> int | None:
+        # 주어진 repository 의 첫 Analysis 의 author_login 으로 user_id 매칭.
+        # 1. Analysis (repo_id == repo.id) 중 created_at asc 의 첫 row 의
+        #    author_login 가져옴
+        # 2. users.github_login = author_login 매칭
+        # 3. 매칭되면 user.id 반환 / 없으면 None
+        #
+        # Resolves user_id for a repository by joining the chronologically first
+        # Analysis.author_login against users.github_login.
+
+사용자 결정 옵션 🅐-2 (author_login JOIN — Claude 권장 default).
+User decision option 🅐-2 (author_login JOIN — Claude recommended default).
+
+ORM import 모듈 최상단 의무 — auto-memory pytest-fixture-lazy-orm-import-trap.md
+참조 (Phase 3 PR 4 CI #428 사고). lazy import 는 tests/ 전체 실행 시 metadata 누락.
+ORM imports MUST be at module top — see auto-memory pytest-fixture-lazy-orm-import-trap.md
+(Phase 3 PR 4 CI #428 incident). Lazy imports inside fixtures cause metadata gaps.
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+# ORM 모델 import 는 모듈 최상단 — Base.metadata 등록 (lazy import 금지)
+# Top-level ORM imports register Base.metadata (no lazy imports allowed)
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.repository import Repository
+from src.models.user import User
+
+# 구현 대상 함수 — Red 단계에서는 ModuleNotFoundError 발생 의도.
+# collection error 가 아닌 per-test fail 로 집계되도록 try/except 로 감싼다.
+# Function under test — ModuleNotFoundError expected during Red phase.
+# Wrapped in try/except so failures count per-test instead of as collection error.
+try:
+    from scripts.backfill_repository_user_id import (  # type: ignore[import-not-found]
+        _resolve_user_id_for_repo,
+    )
+except ModuleNotFoundError:  # pragma: no cover — Red 단계 전용 분기
+    _resolve_user_id_for_repo = None  # type: ignore[assignment]
+
+
+@pytest.fixture
+def db():
+    """in-memory SQLite + ORM 메타데이터 — 테스트 간 완전 격리.
+    in-memory SQLite + ORM metadata — full isolation between tests.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _make_user(db, *, github_login: str, user_id: int) -> User:
+    """User seed 헬퍼 — email/display_name nullable=False 충족.
+    User seed helper — satisfies nullable=False constraints on email/display_name.
+    """
+    user = User(
+        id=user_id,
+        github_id=f"gh-{user_id}",
+        github_login=github_login,
+        email=f"{github_login}@example.com",
+        display_name=github_login,
+    )
+    db.add(user)
+    db.commit()
+    return user
+
+
+def _make_repo(db, *, full_name: str = "owner/repo") -> Repository:
+    """Repository seed 헬퍼 — user_id NULL (legacy 시뮬레이션).
+    Repository seed helper — user_id NULL (legacy simulation).
+    """
+    repo = Repository(full_name=full_name, user_id=None)
+    db.add(repo)
+    db.commit()
+    return repo
+
+
+def _make_analysis(
+    db,
+    *,
+    repo_id: int,
+    author_login: str | None,
+    commit_sha: str,
+    created_at: datetime | None = None,
+) -> Analysis:
+    """Analysis seed 헬퍼 — repo_id + author_login + 명시적 created_at 지원.
+    Analysis seed helper — supports explicit created_at for chronological ordering.
+    """
+    analysis = Analysis(
+        repo_id=repo_id,
+        commit_sha=commit_sha,
+        author_login=author_login,
+        score=80,
+        grade="B",
+    )
+    if created_at is not None:
+        analysis.created_at = created_at
+    db.add(analysis)
+    db.commit()
+    return analysis
+
+
+# ───────────────────────── 테스트 5건 / 5 tests ─────────────────────────
+
+
+def test_resolve_returns_user_id_when_author_login_matches(db):
+    """첫 Analysis.author_login 이 users.github_login 매칭 시 user.id 반환.
+    Returns user.id when first Analysis.author_login matches users.github_login.
+    """
+    _make_user(db, github_login="alice", user_id=42)
+    repo = _make_repo(db, full_name="alice/repo")
+    _make_analysis(db, repo_id=repo.id, author_login="alice", commit_sha="sha1")
+
+    result = _resolve_user_id_for_repo(db, repo)
+
+    assert result == 42
+
+
+def test_resolve_returns_none_when_no_analysis(db):
+    """repo 에 Analysis 0건 시 None 반환.
+    Returns None when the repo has no Analysis rows.
+    """
+    repo = _make_repo(db, full_name="orphan/repo")
+
+    result = _resolve_user_id_for_repo(db, repo)
+
+    assert result is None
+
+
+def test_resolve_returns_none_when_author_login_null(db):
+    """첫 Analysis.author_login 이 NULL 인 경우 None 반환.
+    Returns None when first Analysis.author_login is NULL.
+    """
+    _make_user(db, github_login="alice", user_id=42)
+    repo = _make_repo(db, full_name="legacy/repo")
+    _make_analysis(db, repo_id=repo.id, author_login=None, commit_sha="sha1")
+
+    result = _resolve_user_id_for_repo(db, repo)
+
+    assert result is None
+
+
+def test_resolve_returns_none_when_no_matching_user(db):
+    """Analysis.author_login 에 매칭되는 users.github_login 없을 때 None.
+    Returns None when no user matches Analysis.author_login.
+    """
+    # alice 만 존재 — bob 미존재
+    # only alice exists — bob is absent
+    _make_user(db, github_login="alice", user_id=42)
+    repo = _make_repo(db, full_name="bob/repo")
+    _make_analysis(db, repo_id=repo.id, author_login="bob", commit_sha="sha1")
+
+    result = _resolve_user_id_for_repo(db, repo)
+
+    assert result is None
+
+
+def test_resolve_uses_first_analysis_chronologically(db):
+    """3 Analysis 시드 시 created_at asc 의 첫 row 의 author_login 사용.
+    Uses author_login of the chronologically first Analysis when 3 rows exist.
+    """
+    # User seed — first_user(99), second_user(88) 모두 존재
+    # User seed — first_user(99) and second_user(88) both exist
+    _make_user(db, github_login="first_user", user_id=99)
+    _make_user(db, github_login="second_user", user_id=88)
+    repo = _make_repo(db, full_name="multi/repo")
+
+    base = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    # 명시적 created_at 으로 순서 강제 (asc: first → second → third)
+    # Force ordering via explicit created_at (asc: first → second → third)
+    _make_analysis(
+        db,
+        repo_id=repo.id,
+        author_login="first_user",
+        commit_sha="sha-first",
+        created_at=base,
+    )
+    _make_analysis(
+        db,
+        repo_id=repo.id,
+        author_login="second_user",
+        commit_sha="sha-second",
+        created_at=base + timedelta(hours=1),
+    )
+    _make_analysis(
+        db,
+        repo_id=repo.id,
+        author_login="third_user",
+        commit_sha="sha-third",
+        created_at=base + timedelta(hours=2),
+    )
+
+    result = _resolve_user_id_for_repo(db, repo)
+
+    # first_user.id == 99 사용 (가장 오래된 Analysis 기준)
+    # Uses first_user.id == 99 (oldest Analysis takes precedence)
+    assert result == 99


### PR DESCRIPTION
…_login JOIN dry-run (옵션 🅐-2)

사용자 발화 (2026-05-04): *"A-2 진행해주세요"* — 옵션 🅐 (legacy NULL backfill) + sub-option 🅐-2 (author_login JOIN — Claude 권장 default).

사이클 64 회고 P1 후속. SaaS 전환 시점 RLS 격리 정합성 보강. **dry-run only (실제 backfill 미실행 — 사용자 결정 영역 보호)**.

## 변경 내역 (3 파일 신규 + 5 테스트)

### 신규 스크립트 (`scripts/backfill_repository_user_id.py`)
- `_resolve_user_id_for_repo(db, repo) -> int | None` pure 함수:
  1. `Analysis (repo_id == repo.id)` 의 `created_at asc` 첫 row 의 `author_login` 추출
  2. `users.github_login = author_login` 매칭 → `user.id` 반환
  3. None 반환 케이스: Analysis 0건 / author_login NULL / users 매칭 없음
- `_format_update_sql(repo_id, user_id) -> str` — dry-run 시각 출력 (실제 SQL 실행 X, int 인자 — `# nosec B608` 사유 주석)
- `main(argv=None) -> int`:
  - argparse: `--apply` (default = dry-run)
  - SessionLocal 사용 — `Repository.user_id IS NULL` 만 처리
  - 결과 카운터 4건: `resolved` / `skipped_no_analysis` / `skipped_no_author` / `skipped_no_user`
  - `--apply` 시 `db.commit()` 실행 / dry-run 시 SQL 출력만

### 신규 테스트 (`tests/unit/scripts/test_backfill_repository_user_id.py` 5건)
- T1 정상 매칭 (author_login → user.id)
- T2 Analysis 0건 → None
- T3 author_login NULL → None
- T4 users 매칭 없음 → None
- T5 첫 (chronological) Analysis 사용 검증

### 사용자 결정 보고 (정책 3 — 자율 판단)
- Sub-option 🅐-2 (author_login JOIN) = Claude 권장 default 적용 — 사용자 명시 OK
- 본 PR scope = **dry-run 스크립트 신설만** (실제 backfill 미실행)
- 실제 적용 = 사용자 명시 의무 (`python -m scripts.backfill_repository_user_id --apply` — 운영 환경 또는 Supabase MCP)
- 사용자가 dry-run 결과 본 후 sub-option 변경 / 실제 적용 결정

## 사용 방법
```bash
# Dry-run (default — 영향 row + SQL 출력만)
python -m scripts.backfill_repository_user_id

# 실제 적용 (사용자 명시)
python -m scripts.backfill_repository_user_id --apply
```

## 결과 카운터 분류
| 카운터 | 의미 | 다음 결정 |
|------|------|---------|
| ✓ `resolved` | author_login 매칭 → user_id 매핑 가능 | dry-run 결과 확인 후 `--apply` | | ⊘ `skipped_no_analysis` | repo 에 Analysis 0건 | 별도 정책 (admin user 폴백 등) | | ⊘ `skipped_no_author` | author_login NULL | author backfill 선행 (`scripts/backfill_author.py` 신설 필요?) | | ⊘ `skipped_no_user` | github_login 매칭 user 없음 | 사용자 OAuth 가입 후 재실행 |

## 검증
- 신규 5 테스트: **5/5 PASS** (Green) — TDD Red 5 fail → Green 5/5
- `make test` 전체 회귀: **2135 passed (+5 신규) / 5 skipped / 0 failed** (회귀 0)
- pylint: **10.00/10** (E0401 import-error inline disable — sys.path false positive)
- flake8: 0 issues
- bandit: 0 issues (B608 hardcoded SQL = `# nosec` 사유 주석 — int 인자만 사용 + dry-run 출력 전용)

## 자율 판단 보고 (정책 3 — PR 본문 최상단 3건)

⚠️ 이의 시 알려주세요:

1. **dry-run only PR scope** — 사용자 결정 영역 보호 (실제 backfill 적용은 사용자 명시 `--apply`)
2. **첫 Analysis (created_at asc) author 사용** — 가장 오래된 contributor = 리포 originator 가정. 다른 정책 (예: 가장 활발한 contributor) 선호 시 sub-option 변경 가능
3. **users 매칭 없음 → NULL 유지** — RLS USING 절의 `user_id IS NULL` 분기 (admin scope) 활용. backfill 후에도 일부 NULL 잔존 = 의도된 동작

## 🔍 사용자 검증 의무 (정책 2)
- [ ] PR 머지 후 dry-run 실행 (운영 또는 Supabase MCP) → 결과 카운터 4건 확인
- [ ] resolved 카운트 검토 후 `--apply` 결정 의무
- [ ] skipped_no_analysis / skipped_no_author / skipped_no_user 잔존 case 처리 정책 결정

## Code Scanning open alert (정책 14)
- ✅ open 0건 (마지막 확인 시점: 사이클 65 종료, 2026-05-04)

## 운영 smoke check (정책 13)
- ✅ /health 200 + /auth/github redirect_uri 정합 + /login 200 (PR #228 머지 직후 실행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
