### PR TITLE
refactor(simplify): pure cleanup 5건 — deprecated 상수/미사용 헬퍼/불필요 분기 제거

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ src/
 │   └── _merge_attempt_states.py # MergeAttempt.state lifecycle 정규 상수 (LEGACY/ENABLED_PENDING_MERGE/ACTUALLY_MERGED/DISABLED_EXTERNALLY) — Phase 3 PR-B1 도입
 ├── notifier/                   # `__init__.py` 가 import 시 각 채널 모듈 자동 로드 → REGISTRY 등록 (Phase S.3-E)
 │   ├── __init__.py             # 8개 notifier 모듈 import (등록 순서 = 발송 우선순위)
-│   ├── _common.py              # 공통 헬퍼 — format_ref, get_all_issues, get_issue_samples, truncate_message, truncate_issue_msg
+│   ├── _common.py              # 공통 헬퍼 — format_ref, get_all_issues (호출자 캐시 권장), truncate_message, truncate_issue_msg
 │   ├── telegram_commands.py    # Telegram 인라인 명령 처리 — /stats, /settings, /connect OTP 흐름
 │   ├── _http.py                # build_safe_client() — HTTP_CLIENT_TIMEOUT + follow_redirects=False (SSRF 방어)
 │   ├── registry.py             # NotifyContext + Notifier Protocol + REGISTRY + register() (채널 확장)
@@ -1082,7 +1082,7 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 - **auto_merge GitHub 권한**: `merge_pr()`은 `repo` 스코프 또는 Fine-grained `pull_requests: write` 권한 필요 — 권한 부족 시 False 반환(파이프라인 미중단). Branch Protection Rules가 있으면 APPROVE 후에도 Merge 실패 가능.
 - **http_client 싱글톤 원칙**: 신뢰 API (GitHub/Telegram/Railway) 호출은 `src/shared/http_client.py::get_http_client()` 를 통해 연결 풀 재사용. 외부 untrusted URL (Discord/Slack/custom_webhook/n8n) 은 `src/notifier/_http.py::build_safe_client()` 사용. `async with httpx.AsyncClient()` 매번 생성 금지 (2026-04-24 P1-3).
 - **MergeAttempt 관측 (Phase F.1+F.2)**: `src/gate/engine.py::_run_auto_merge`(자동) 및 `src/webhook/providers/telegram.py::handle_gate_callback`(반자동) 양쪽에서 `merge_pr` 직후 `log_merge_attempt()`(`src/shared/merge_metrics.py`)로 모든 시도(성공·실패)를 DB에 기록. `failure_reason`은 `src/gate/merge_reasons.py`의 정규 태그(`branch_protection_blocked`, `unstable_ci`, `permission_denied` 등). 관측 실패는 notify 경로를 막지 않도록 nested try/except로 격리 — DB 오류 시 rollback 후 WARNING + None. **Phase F.3**: `engine.py::_run_auto_merge` 실패 시 `get_advice(reason)` + 조건부 `create_merge_failure_issue()` 호출 — `auto_merge_issue_on_failure` 필드(5-way sync 적용)로 Issue 생성 제어.
-- **notifier 공통 헬퍼**: `src/notifier/_common.py`의 `format_ref()`, `get_all_issues()`, `get_issue_samples()`, `truncate_message()`, `truncate_issue_msg()`를 사용. 각 notifier 모듈에 이슈 수집 루프나 메시지 절단 로직 직접 작성 금지.
+- **notifier 공통 헬퍼**: `src/notifier/_common.py`의 `format_ref()`, `get_all_issues()` (호출자 캐시 권장 — hot path), `truncate_message()`, `truncate_issue_msg()`를 사용. 각 notifier 모듈에 이슈 수집 루프나 메시지 절단 로직 직접 작성 금지.
 - **webhook secret TTL 캐시**: `get_webhook_secret(full_name)` 함수가 `_webhook_secret_cache` dict에 5분(WEBHOOK_SECRET_CACHE_TTL=300초) TTL로 per-repo 시크릿을 캐시. 리포 시크릿 변경 후 최대 5분간 구 시크릿으로 검증 — 인지하고 있을 것.
 - **Telegram 콜백 도메인 분리**: `_make_callback_token(bot_token, scope, payload_id)`이 `scope ∈ {"gate","cmd"}`별 다른 HMAC 생성. 신규 명령 추가 시 `cmd:<verb>:<id>:<token>` 준수, 64-byte 한도 검증 (numeric id). `_gate_callback_token()`은 `_make_callback_token(..., "gate", analysis_id)` thin wrapper. `test_callback_data_within_64_bytes_all_commands` 단위 테스트 강제.
 - **Cron 엔드포인트 인증**: `POST /api/internal/cron/*`는 `INTERNAL_CRON_API_KEY` 전용 (admin key와 분리). Railway `[[deploy.cronJobs]]` 트리거. `hmac.compare_digest` 타이밍 안전 비교. `INTERNAL_CRON_API_KEY` 미설정 시 503 반환.

--- a/src/analyzer/pure/language.py
+++ b/src/analyzer/pure/language.py
@@ -95,11 +95,14 @@ _SHEBANG_RE = re.compile(r"^#!\s*(\S+)(?:\s+(\S+))?")
 
 
 def _parse_shebang(content: str) -> str:
-    """첫 줄의 shebang에서 인터프리터 basename을 추출해 언어를 반환. 실패 시 empty string."""
-    if not content:
+    """첫 줄의 shebang에서 인터프리터 basename을 추출해 언어를 반환. 실패 시 empty string.
+
+    Extract interpreter basename from first-line shebang. Returns "" on failure.
+    """
+    lines = content.splitlines() if content else []
+    if not lines:
         return ""
-    first_line = content.splitlines()[0] if "\n" in content else content
-    match = _SHEBANG_RE.match(first_line)
+    match = _SHEBANG_RE.match(lines[0])
     if not match:
         return ""
     interpreter, arg = match.group(1), match.group(2)
@@ -122,12 +125,12 @@ def _match_filename(basename: str) -> str:
 
 
 def _match_extension(basename: str) -> str:
-    """확장자 매핑. `.R` 같은 대소문자 구분 케이스 우선 조회 후 lowercase 조회. 실패 시 empty string."""
+    """확장자 매핑 (lowercase). 실패 시 empty string.
+
+    Extension mapping (lowercase). Returns "" on failure.
+    """
     _, ext = os.path.splitext(basename)
-    if not ext:
-        return ""
-    # Check exact-case first (preserves `.R` vs `.r` if needed — both map to "r" here)
-    return _EXTENSION_MAP.get(ext) or _EXTENSION_MAP.get(ext.lower(), "")
+    return _EXTENSION_MAP.get(ext.lower(), "") if ext else ""
 
 
 def detect_language(filename: str, content: str | None = None) -> str:

--- a/src/constants.py
+++ b/src/constants.py
@@ -14,10 +14,7 @@ TEST_COVERAGE_MAX = 15      # Claude AI 0-10 → 0-15 스케일링
 # ── Static analysis deduction weights ────────────────────────────────────
 PYLINT_ERROR_PENALTY = 3    # code_quality error 1건당 감점
 PYLINT_WARNING_PENALTY = 1  # code_quality warning 1건당 감점
-PYLINT_WARNING_CAP = 15     # (deprecated) 구 pylint warning 상한 — CQ_WARNING_CAP 사용 권장
-FLAKE8_WARNING_PENALTY = 1  # (deprecated) 구 flake8 경고 감점 — PYLINT_WARNING_PENALTY와 동일
-FLAKE8_WARNING_CAP = 10     # (deprecated) 구 flake8 상한 — CQ_WARNING_CAP 사용 권장
-CQ_WARNING_CAP = 25         # code_quality warning 감점 상한 (PYLINT_WARNING_CAP+FLAKE8_WARNING_CAP 합산)
+CQ_WARNING_CAP = 25         # code_quality warning 감점 상한 (구 PYLINT+FLAKE8 합산)
 BANDIT_HIGH_PENALTY = 7     # security error 1건당 감점
 BANDIT_LOW_PENALTY = 2      # security warning 1건당 감점
 

--- a/src/gate/native_automerge.py
+++ b/src/gate/native_automerge.py
@@ -75,14 +75,6 @@ class MergeOutcome:
 
 logger = logging.getLogger(__name__)
 
-# 폴백을 시도해야 하는 enable 실패 status 집합
-# Set of enable failure statuses where fallback to merge_pr() makes sense
-# - ENABLE_DISABLED_IN_REPO: 리포 settings 에 "Allow auto-merge" 미설정 — 직접 머지 시도
-# - ENABLE_PERMISSION_DENIED: GraphQL mutation 권한 없음 — REST 권한은 있을 수 있어 시도
-# - ENABLE_DISABLED_IN_REPO: repo settings has "Allow auto-merge" off — try direct merge
-# - ENABLE_PERMISSION_DENIED: no GraphQL permission — REST might still work
-_FALLBACK_STATUSES = frozenset({ENABLE_DISABLED_IN_REPO, ENABLE_PERMISSION_DENIED})
-
 # 폴백 없이 즉시 실패 처리해야 하는 status
 # Statuses that should be treated as immediate failure without fallback
 # - ENABLE_FORCE_PUSHED: head SHA 가 이미 변경됨 — REST 머지도 stale 상태로 실패
@@ -170,8 +162,8 @@ async def enable_or_fallback(
         reason = f"{result.status}: {result.detail or ''}".rstrip(": ")
         return (False, reason, head_sha)
 
-    # 6. 폴백 시도 — _FALLBACK_STATUSES 또는 분류 외 status 모두 폴백
-    # 6. Try fallback — both _FALLBACK_STATUSES and unclassified statuses fall back
+    # 6. 폴백 시도 — _NO_FALLBACK_STATUSES 외 모든 status 가 REST merge_pr 폴백
+    # 6. Try fallback — every status outside _NO_FALLBACK_STATUSES falls back to REST merge_pr
     logger.info(
         "PR #%d native enable=%s 폴백 (REST merge_pr): %s",
         pr_number, result.status, result.detail or "-",

--- a/src/notifier/_common.py
+++ b/src/notifier/_common.py
@@ -3,26 +3,26 @@ from __future__ import annotations
 
 from src.constants import (
     COMMIT_SHA_DISPLAY_LENGTH,
-    NOTIFIER_MAX_ISSUES_SHORT,
     NOTIFIER_MESSAGE_TRUNCATE,
 )
 
 
 def format_ref(commit_sha: str, pr_number: int | None) -> str:
-    """PR 번호 또는 단축 커밋 SHA 레퍼런스 문자열을 반환한다."""
+    """PR 번호 또는 단축 커밋 SHA 레퍼런스 문자열을 반환한다.
+
+    Format a PR number or short commit SHA reference string.
+    """
     if pr_number:
         return f"PR #{pr_number}"
     return f"커밋 {commit_sha[:COMMIT_SHA_DISPLAY_LENGTH]}"
 
 
 def get_all_issues(analysis_results: list) -> list:
-    """analysis_results에서 모든 AnalysisIssue를 평탄화해 반환한다."""
+    """analysis_results의 모든 AnalysisIssue를 평탄화한다 (호출자 캐시 권장 — hot path).
+
+    Flatten all AnalysisIssue from analysis_results (callers should cache — hot path).
+    """
     return [issue for r in analysis_results for issue in r.issues]
-
-
-def get_issue_samples(analysis_results: list, max_count: int = NOTIFIER_MAX_ISSUES_SHORT) -> list:
-    """분석 결과에서 상위 max_count개 이슈를 반환한다."""
-    return get_all_issues(analysis_results)[:max_count]
 
 
 def truncate_message(text: str, max_length: int, suffix: str = "...") -> str:


### PR DESCRIPTION
사이클 71 PR 1/3 (옵션 🅓 — 사용자 결정 옵션 선택). 정책 16 단순화 default 적용.

## 변경 5건 (회귀 위험 모두 Low — 사용처 0건 사전 검증)

1. **constants.py** — 3 deprecated 상수 제거
   - `PYLINT_WARNING_CAP` / `FLAKE8_WARNING_PENALTY` / `FLAKE8_WARNING_CAP`
   - 사용처 검증: `grep -rn ... src tests` = 정의 외 0건
   - `CQ_WARNING_CAP=25` 가 단일 출처 (구 두 상수 합산)

2. **analyzer/pure/language.py** `_match_extension` — 이중 dict 조회 제거
   - 변경 전: `_EXTENSION_MAP.get(ext) or _EXTENSION_MAP.get(ext.lower(), "")`
   - 변경 후: `_EXTENSION_MAP.get(ext.lower(), "") if ext else ""`
   - 사전 검증: `_EXTENSION_MAP` 대문자 키 0건 (`grep -E '"\.[A-Z]' = 0`)
   - 잘못된 주석 ("preserves `.R` vs `.r`") 제거 — 코드 ↔ 주석 정합 회복

3. **analyzer/pure/language.py** `_parse_shebang` — 불필요 분기 제거
   - 변경 전: `if "\n" in content` 분기 후 `splitlines()[0]`
   - 변경 후: `lines = content.splitlines() if content else []` 단일화
   - `splitlines()` 가 `\r`, `\r\n`, `\n` 모두 처리 — 분기 자체 dead branch
   - 한국어/영어 docstring 병행 (CLAUDE.md L7~)

4. **gate/native_automerge.py** — `_FALLBACK_STATUSES` 미사용 상수 제거
   - 사용처 검증: 정의 + stale 주석 외 0건 (실사용은 `_NO_FALLBACK_STATUSES` 만)
   - 주석 stale ("_FALLBACK_STATUSES 또는 분류 외") 도 함께 정리

5. **notifier/_common.py** — `get_issue_samples` 미사용 헬퍼 제거
   - 사용처 검증: src/ tests/ 모두 정의 외 0건
   - 8 채널 모두 `get_all_issues(...)[:NOTIFIER_MAX_ISSUES_SHORT]` inline 패턴 사용
   - `get_all_issues` docstring 에 "호출자 캐시 권장 — hot path" 명시

## 자율 판단 보고 (정책 3 + 정책 15)

- **정책 15 사전 사고 의무**: 5 항목 모두 Edit 직전 grep 사용처 검증 (영향 범위 인지) — 결과 = 4 항목 0건 + 1 항목 stale 주석 정리
- **정책 16 4 원칙 부합**: 정확성 (사용처 0 검증) + 성능 (영향 0) + 가독성 ↑↑ + 최소 추상화 (dead code 제거)
- **5 영역 묶음 응집 단위**: "deprecated/미사용 cleanup" 단일 의도 (정책 7 강화 부합)

## 회귀 가드

- pytest unit (scorer + analyzer + gate/native_automerge + notifier) = **784 passed / 0 failed**
- pylint 영향 0 (변경 영역 모두 단순화 — 신규 disable X)

## CLAUDE.md 동기화 (정책 15 영향 범위)

- L168 `_common.py` 트리: `get_issue_samples` 제거 + `get_all_issues` 캐시 권장 명시
- L1085 notifier 헬퍼 본문: 동일 갱신

## 운영 smoke check (정책 13)
- code only (analyzer + scorer + notifier 헬퍼) — 운영 endpoint 무영향 (3 endpoint smoke 무관)

## Code Scanning open alert (정책 14)
- 본 PR = pure cleanup (dead code 제거) → open alert 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
