### PR TITLE
refactor(gate): enable_or_fallback legacy → enable_or_fallback_with_p…

### DIFF
--- a/src/gate/native_automerge.py
+++ b/src/gate/native_automerge.py
@@ -90,88 +90,19 @@ async def enable_or_fallback(
     expected_sha: str | None = None,
     merge_method: str = "SQUASH",
 ) -> tuple[bool, str | None, str]:
-    """Native auto-merge enable 시도 후 필요 시 폴백.
-    Try native auto-merge enable, falling back when appropriate.
+    """Legacy thin wrapper around `enable_or_fallback_with_path()` — backwards compat.
 
-    `merge_pr()` 와 동일한 시그니처/반환 형식 — 호출자(engine.py)가 그대로 교체 가능.
-    Same signature/return shape as `merge_pr()` so the caller can drop-in replace.
+    `merge_pr()` 와 동일한 (ok, reason, head_sha) 튜플 반환. 신규 코드는
+    `enable_or_fallback_with_path()` 직접 사용 권장 (`MergeOutcome.path` 활용).
 
-    Args:
-        expected_sha: PR head SHA — 호출자가 이미 조회했다면 전달해 중복 GET 회피.
-                      None 이면 본 함수가 직접 조회.
-                      Pass to skip duplicate GET when caller already fetched it.
-
-    Returns:
-        (True, None, head_sha) — enable 성공 (GitHub 가 머지 책임 인수)
-                                 또는 폴백 머지 즉시 성공
-        (False, reason, head_sha) — enable 실패 + 폴백도 실패 / 폴백 미시도
-        Caller should branch on ok and inspect reason for failure tag.
-
-    참고: enable 성공 시 GitHub 가 비동기로 머지를 수행 — 실제 머지 commit 발생은
-    `pull_request.closed merged=true` webhook 으로 별도 추적해야 한다 (PR-B 범위).
-    Note: on enable success, GitHub will merge asynchronously; the actual merge
-    commit must be tracked via the `pull_request.closed merged=true` webhook (PR-B).
+    Returns the legacy (ok, reason, head_sha) tuple. New callers should use
+    `enable_or_fallback_with_path()` directly to access `MergeOutcome.path`.
     """
-    # 1. PR head SHA — 호출자가 전달했으면 재사용, 아니면 조회
-    # 1. PR head SHA — reuse if caller passed, otherwise fetch
-    head_sha = expected_sha or ""
-    if not head_sha:
-        try:
-            _state, head_sha = await get_pr_mergeable_state(
-                github_token, repo_full_name, pr_number,
-            )
-        except httpx.HTTPError as exc:
-            logger.warning("get_pr_mergeable_state 실패 (pr=%d): %s", pr_number, exc)
-
-    # 2. PR node_id 조회 — GraphQL mutation 의 첫 번째 인자
-    # 2. Fetch PR node_id — first argument of the GraphQL mutation
-    pr_node_id = await get_pr_node_id(github_token, repo_full_name, pr_number)
-    if pr_node_id is None:
-        # node_id 조회 실패 — GraphQL 시도 자체 불가, 즉시 폴백
-        # node_id lookup failed — can't try GraphQL, fall back immediately
-        logger.warning(
-            "PR node_id 조회 실패, REST merge_pr 폴백 (repo=%s, pr=%d)",
-            repo_full_name, pr_number,
-        )
-        return await merge_pr(
-            github_token, repo_full_name, pr_number,
-            expected_sha=head_sha or None,
-        )
-
-    # 3. enablePullRequestAutoMerge 시도
-    # 3. Try enablePullRequestAutoMerge
-    result = await enable_pull_request_auto_merge(
-        github_token,
-        pr_node_id,
-        expected_head_oid=head_sha or None,
-        merge_method=merge_method,
-    )
-
-    # 4. 성공 — GitHub 가 머지 책임 인수
-    # 4. Success — GitHub now owns the merge
-    if result.status == ENABLE_OK:
-        logger.info(
-            "PR #%d native auto-merge enabled: %s (head=%s)",
-            pr_number, repo_full_name, head_sha[:7] if head_sha else "?",
-        )
-        return (True, None, head_sha)
-
-    # 5. 폴백 부적합 (force-push 등) — 즉시 실패 보고
-    # 5. Not fallback-eligible (force-push etc.) — return failure immediately
-    if result.status in _NO_FALLBACK_STATUSES:
-        reason = f"{result.status}: {result.detail or ''}".rstrip(": ")
-        return (False, reason, head_sha)
-
-    # 6. 폴백 시도 — _NO_FALLBACK_STATUSES 외 모든 status 가 REST merge_pr 폴백
-    # 6. Try fallback — every status outside _NO_FALLBACK_STATUSES falls back to REST merge_pr
-    logger.info(
-        "PR #%d native enable=%s 폴백 (REST merge_pr): %s",
-        pr_number, result.status, result.detail or "-",
-    )
-    return await merge_pr(
+    outcome = await enable_or_fallback_with_path(
         github_token, repo_full_name, pr_number,
-        expected_sha=head_sha or None,
+        expected_sha=expected_sha, merge_method=merge_method,
     )
+    return (outcome.ok, outcome.reason, outcome.head_sha)
 
 
 async def enable_or_fallback_with_path(


### PR DESCRIPTION
…ath thin wrapper (-90 LOC)

사이클 71 PR 4/3 (옵션 🅓). 정책 16 단순화 default 적용 — 분기 로직 100% 중복 제거.

## 변경 1건 (회귀 위험 Low — 회귀 가드 209 gate 단위 테스트 통과)

**src/gate/native_automerge.py** `enable_or_fallback` (legacy):
- 변경 전: 90 LOC 분기 로직 (head_sha → node_id → mutation → 분류 → 폴백) — `enable_or_fallback_with_path` 와 100% 동일
- 변경 후: 7 LOC thin wrapper — `enable_or_fallback_with_path` 호출 후 `(outcome.ok, outcome.reason, outcome.head_sha)` 반환
- 시그니처 + 반환 형식 100% 보존 (legacy compat)
- production caller = 0건 (engine.py 는 이미 `_with_path` 사용) — wrapper 는 단위 테스트 16 호출 호환만

## 자율 판단 보고 (정책 3 + 정책 15) — 사용자 검토 의무

본 PR 은 cross-verify 권장 (옵션 🅐 = 16 호출 마이그레이션 + legacy 완전 폐기) 와 **다른 옵션 🅑 (wrapper 보존)** 선택. 사유:

**정책 16 default 자문 = "이 변경이 가장 단순한 형태인가?"**:
| 옵션 | LOC 변경 | 테스트 reshape | 회귀 위험 | 정책 16 부합 |
|------|---------|--------------|---------|------------| | 🅐 (cross-verify 권장) | -90 (legacy) +0 (wrapper) +250 (테스트 16건 reshape) | 16 호출 마이그레이션 의무 | Low-Medium | △ (테스트 reshape 비용) | | 🅑 (Claude 채택) | -83 (90→7 wrapper) | 0 | Low | ★ (가장 단순) |

옵션 🅑 의 wrapper 자체는 추가 추상이지만, 90 LOC 분기 로직 중복 제거 = 순 단순화 ↑↑. 정책 16 원칙 4 (최소 추상화 = 사용처 ≥ 3) 와 부합 — wrapper 사용처 = 16 (테스트).

**사용자 이의 가능성 ⚠️**: cross-verify 권장 (🅐) 와 다른 결정. 이의 시 알려주세요.
- 🅐 추가 진행 시: 16 호출 reshape PR 별도 진행 가능 (본 PR 머지 후)

## 회귀 가드

- pytest unit gate (전체) = **209 passed / 0 failed**
- 16 테스트 호출 (test_native_automerge.py 10 + test_pr_a_scenarios.py 6) 모두 동일 결과 (wrapper 경유)
- Tier 3 PR-A 검증 영역 = `enable_or_fallback_with_path` 분기 로직 100% 보존

## 운영 smoke check (정책 13)
- code only — 운영 endpoint 무영향 (engine.py 는 _with_path 직접 사용 — 본 PR 무관)

## Code Scanning open alert (정책 14)
- legacy 함수 본문 -90 LOC = open alert 영향 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
