### PR TITLE
refactor(simplify): 응집 헬퍼 3건 — chat_id 3중복 → 헬퍼 + Webhook 실패 로깅 + red…

### DIFF
--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -317,11 +317,20 @@ async def _get_ci_status_safe(
         return "unknown"
 
 
+def _resolve_retry_chat_id(row: MergeRetryQueue, cfg: RepoConfigData) -> str | None:
+    """retry worker 알림 chat_id 3-tier fallback (config → row 스냅샷 → global).
+
+    Resolve retry worker notification chat_id (3-tier fallback).
+    `analytics_service.resolve_chat_id` 와 분리: row.notify_chat_id 단계 추가.
+    """
+    return cfg.notify_chat_id or row.notify_chat_id or settings.telegram_chat_id
+
+
 async def _notify_config_changed(row: MergeRetryQueue, cfg: RepoConfigData) -> None:
     """설정 변경으로 재시도가 중단됐음을 알린다.
     Notify user that retry was stopped due to config change.
     """
-    chat_id = cfg.notify_chat_id or row.notify_chat_id or settings.telegram_chat_id
+    chat_id = _resolve_retry_chat_id(row, cfg)
     if not chat_id or not settings.telegram_bot_token:
         return
     msg = (
@@ -342,7 +351,7 @@ async def _notify_merge_succeeded(row: MergeRetryQueue, cfg: RepoConfigData) -> 
     """재시도 후 머지 성공을 알린다 (시도 횟수 포함).
     Notify user of successful merge after retries (includes attempt count).
     """
-    chat_id = cfg.notify_chat_id or row.notify_chat_id or settings.telegram_chat_id
+    chat_id = _resolve_retry_chat_id(row, cfg)
     if not chat_id or not settings.telegram_bot_token:
         return
     pr_url = f"https://github.com/{row.repo_full_name}/pull/{row.pr_number}"
@@ -369,7 +378,7 @@ async def _notify_merge_terminal(
     """최종 머지 실패를 알린다.
     Notify user of terminal merge failure.
     """
-    chat_id = cfg.notify_chat_id or row.notify_chat_id or settings.telegram_chat_id
+    chat_id = _resolve_retry_chat_id(row, cfg)
     if not chat_id or not settings.telegram_bot_token:
         return
     advice = get_advice(reason_tag)

--- a/src/ui/_helpers.py
+++ b/src/ui/_helpers.py
@@ -18,6 +18,7 @@ from src.models.analysis import Analysis
 from src.models.gate_decision import GateDecision
 from src.models.repository import Repository
 from src.repositories import repo_config_repo, repository_repo
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger("src.ui")
 templates = Jinja2Templates(directory="src/templates")
@@ -51,8 +52,13 @@ async def delete_repo_cascade(db: Session, repo: Repository, github_token: str) 
     if repo.webhook_id:
         try:
             await delete_webhook(github_token, repo.full_name, repo.webhook_id)
-        except Exception:  # nosec B110  # pylint: disable=broad-except
-            pass
+        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
+            # best-effort: GitHub API 실패 시 운영 관측 위해 logger.warning (Sentry 송출)
+            # best-effort: log warning on GitHub API failure for observability (Sentry)
+            logger.warning(
+                "delete_repo_cascade: webhook delete failed for %s: %s",
+                sanitize_for_log(repo.full_name), type(exc).__name__,
+            )
 
     analysis_ids = [
         row.id for row in db.query(Analysis.id).filter(Analysis.repo_id == repo.id).all()

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -149,17 +149,23 @@ async def dashboard(
 # Permanent redirect for users with bookmarks of the deprecated URLs.
 
 
-@router.get("/insights")
-def redirect_insights(request: Request) -> RedirectResponse:
-    """GET /insights → 301 /dashboard (쿼리 파라미터 보존)."""
+def _redirect_to_dashboard(request: Request) -> RedirectResponse:
+    """폐기 URL → 301 /dashboard (쿼리 파라미터 보존).
+
+    Permanent (301) redirect to /dashboard, preserving query string.
+    """
     qs = request.url.query
     target = f"/dashboard?{qs}" if qs else "/dashboard"
     return RedirectResponse(url=target, status_code=301)
+
+
+@router.get("/insights")
+def redirect_insights(request: Request) -> RedirectResponse:
+    """GET /insights → 301 /dashboard."""
+    return _redirect_to_dashboard(request)
 
 
 @router.get("/insights/me")
 def redirect_insights_me(request: Request) -> RedirectResponse:
-    """GET /insights/me → 301 /dashboard (쿼리 파라미터 보존)."""
-    qs = request.url.query
-    target = f"/dashboard?{qs}" if qs else "/dashboard"
-    return RedirectResponse(url=target, status_code=301)
+    """GET /insights/me → 301 /dashboard."""
+    return _redirect_to_dashboard(request)


### PR DESCRIPTION
…irect 통합

사이클 71 PR 2/3 (옵션 🅓). 정책 16 단순화 default 적용 + 사용처 ≥ 3 헬퍼 추출.

## 변경 3건 (회귀 위험 모두 Low)

1. **services/merge_retry_service.py** — `_resolve_retry_chat_id` 헬퍼 추출
   - `cfg.notify_chat_id or row.notify_chat_id or settings.telegram_chat_id` 3 함수 중복 제거
   - 사용처 = 3 (`_notify_config_changed` / `_notify_merge_succeeded` / `_notify_merge_terminal`)
   - 정책 16 원칙 4 (사용처 ≥ 3 도달 = 추상화 가치 ↑) 충족
   - `analytics_service.resolve_chat_id` 와 분리 의도 docstring 명시 (row 스냅샷 추가)

2. **ui/_helpers.py** `delete_repo_cascade` Webhook 실패 로깅 추가
   - 변경 전: `except Exception: pass` (silent — 운영 사고 원인 추적 불가)
   - 변경 후: `logger.warning("delete_repo_cascade: webhook delete failed for %s: %s", ...)`
   - `sanitize_for_log(repo.full_name)` 사용 (로그 인젝션 방어)
   - best-effort 정책 보존 (raise X — DB 정리 계속 진행)

3. **ui/routes/dashboard.py** `_redirect_to_dashboard` 헬퍼 추출
   - `redirect_insights` (L153) ↔ `redirect_insights_me` (L161) 본문 100% 동일
   - 단일 헬퍼 추출 후 두 라우트 핸들러는 `return _redirect_to_dashboard(request)` 1줄

## 자율 판단 보고 (정책 3 + 정책 15)

- **정책 15 사전 사고**: 3 영역 모두 grep 으로 사용처/패턴 검증 완료 (영향 범위 인지)
- **정책 16 4 원칙 부합**:
  - 정확성 ✓ (동일 동작, regression 0)
  - 성능 ✓ (영향 0)
  - 가독성 ↑ (3중복 제거, silent → 관측 가능, redirect 통합)
  - 최소 추상화 ✓ (사용처 = 3 충족 시점에 추출)
- **응집 단위**: "헬퍼 추출 + 운영 관측성 ↑" — 정책 7 강화 부합

## 회귀 가드

- pytest unit (services + ui) = **234 passed / 0 failed**

## 운영 smoke check (정책 13)
- code only — auth/외부 통합 변경 X (3 endpoint smoke 무영향)
- `delete_repo_cascade` = best-effort 정책 보존 + 로깅만 추가

## Code Scanning open alert (정책 14)
- `bare except` → `except Exception as exc` + `# noqa: BLE001` (의도 명시)
- 영향 추가 alert 0건 예상

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
