### PR TITLE
feat(cycle-79-pr2): SaaS admin allow-list + require_admin Depends + S…

### DIFF
--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -1,8 +1,10 @@
 """Session helpers — get_current_user() and require_login Depends."""
 from dataclasses import dataclass, field
 from fastapi import Request, HTTPException
+from src.config import settings
 from src.database import SessionLocal
 from src.repositories import user_repo
+from src.shared.feature_kill_switch import is_disabled
 
 
 @dataclass
@@ -51,4 +53,43 @@ def require_login(request: Request) -> CurrentUser:
     user = get_current_user(request)
     if not user:
         raise HTTPException(status_code=302, headers={"Location": "/login"})
+    return user
+
+
+def _parse_admin_emails(raw: str) -> set[str]:
+    """CSV 형식 admin email allow-list 파싱 — 공백 trim + lowercase 정규화.
+
+    Parse CSV admin email allow-list — strip + lowercase.
+    """
+    return {e.strip().lower() for e in (raw or "").split(",") if e.strip()}
+
+
+def require_admin(request: Request) -> CurrentUser:
+    """SaaS admin 영역 접근 필수 의존성 (Cycle 79 PR 2 신설).
+
+    SaaS admin area access dependency (Cycle 79 PR 2).
+
+    3 layer 검증:
+    1. kill-switch (`SAAS_MULTITENANT_DISABLED=1`) → 503 (멀티 테넌트 영역 비활성)
+    2. require_login → 401 (비로그인)
+    3. user.email in `SAAS_ADMIN_EMAILS` → 403 (admin 부재)
+    """
+    # Layer 1: kill-switch (Phase 9 패턴 — feature_kill_switch helper 활용)
+    # Layer 1: kill-switch (Phase 9 pattern — feature_kill_switch helper)
+    if is_disabled("SAAS_MULTITENANT"):
+        raise HTTPException(status_code=503, detail="SaaS admin area disabled")
+
+    # Layer 2: require_login (기존 패턴 차용)
+    # Layer 2: require_login (existing pattern)
+    user = require_login(request)
+
+    # Layer 3: admin email allow-list 검증
+    # Layer 3: admin email allow-list check
+    allowed = _parse_admin_emails(settings.saas_admin_emails)
+    if not allowed:
+        # Allow-list 미설정 = 모든 사용자 차단 (silent open access 회피)
+        # Allow-list unset = block all (avoid silent open access)
+        raise HTTPException(status_code=503, detail="SAAS_ADMIN_EMAILS unset")
+    if (user.email or "").lower() not in allowed:
+        raise HTTPException(status_code=403, detail="admin access required")
     return user

--- a/src/config.py
+++ b/src/config.py
@@ -66,6 +66,13 @@ class Settings(BaseSettings):
     # 자기 분석 무한 루프 킬 스위치 — True 시 모든 webhook 분석 skip (Phase 9)
     # Kill-switch to disable self-analysis entirely — skips all webhook pipeline (Phase 9)
     scamanager_self_analysis_disabled: bool = False
+    # Cycle 79 PR 2 — SaaS admin allow-list (CSV email 형식)
+    # 빈 문자열 = admin 영역 비활성 (모든 admin 엔드포인트 503 반환)
+    # 명시 = ',' 분리 email allow-list — `current_user.email in saas_admin_emails`
+    # Cycle 79 PR 2 — SaaS admin allow-list (CSV email format)
+    # Empty = admin area disabled (all admin endpoints return 503)
+    # Set = comma-separated email allow-list — `current_user.email in saas_admin_emails`
+    saas_admin_emails: str = ""
     # Phase 12: CI-aware Auto Merge 재시도 설정
     # Phase 12: CI-aware Auto Merge retry configuration
     merge_retry_enabled: bool = True           # False 시 레거시 단일 시도 동작

--- a/tests/unit/auth/test_require_admin.py
+++ b/tests/unit/auth/test_require_admin.py
@@ -1,0 +1,131 @@
+"""Cycle 79 PR 2 — require_admin Depends + admin allow-list 회귀 가드.
+
+3 layer 검증:
+- kill-switch (`SAAS_MULTITENANT_DISABLED=1`) → 503
+- require_login → 302 (비로그인)
+- admin email allow-list → 403 (admin 부재) 또는 503 (allow-list 미설정)
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from src.auth.session import (
+    CurrentUser,
+    _parse_admin_emails,
+    require_admin,
+)
+
+
+# ─── _parse_admin_emails ──────────────────────────────────────────────
+
+
+class TestParseAdminEmails:
+    def test_empty_returns_empty_set(self):
+        assert _parse_admin_emails("") == set()
+
+    def test_single_email(self):
+        assert _parse_admin_emails("alice@example.com") == {"alice@example.com"}
+
+    def test_csv_strips_whitespace(self):
+        result = _parse_admin_emails("  alice@example.com , bob@example.com  ")
+        assert result == {"alice@example.com", "bob@example.com"}
+
+    def test_lowercase_normalized(self):
+        result = _parse_admin_emails("Alice@Example.COM, BOB@example.com")
+        assert result == {"alice@example.com", "bob@example.com"}
+
+    def test_skips_blank_entries(self):
+        result = _parse_admin_emails("alice@example.com,,,bob@example.com,")
+        assert result == {"alice@example.com", "bob@example.com"}
+
+
+# ─── require_admin (kill-switch layer) ──────────────────────────────
+
+
+def _make_request_with_user(user_id: int = 1) -> MagicMock:
+    """세션 사용자 mock — request.session.get('user_id') 응답."""
+    req = MagicMock()
+    req.session.get.return_value = user_id
+    return req
+
+
+def _make_user(email: str = "alice@example.com") -> CurrentUser:
+    return CurrentUser(
+        id=1,
+        github_login="alice",
+        email=email,
+        display_name="Alice",
+        plaintext_token="ghp_test",
+    )
+
+
+def test_require_admin_kill_switch_returns_503(monkeypatch):
+    """kill-switch 활성 시 503 반환 (Layer 1)."""
+    monkeypatch.setenv("SAAS_MULTITENANT_DISABLED", "1")
+    req = _make_request_with_user()
+    with pytest.raises(HTTPException) as exc_info:
+        require_admin(req)
+    assert exc_info.value.status_code == 503
+    assert "disabled" in exc_info.value.detail.lower()
+
+
+def test_require_admin_not_logged_in_redirects(monkeypatch):
+    """비로그인 시 302 redirect (Layer 2 — require_login 위임)."""
+    monkeypatch.delenv("SAAS_MULTITENANT_DISABLED", raising=False)
+    monkeypatch.setattr("src.config.settings.saas_admin_emails", "alice@example.com")
+    req = MagicMock()
+    req.session.get.return_value = None  # 비로그인
+    with pytest.raises(HTTPException) as exc_info:
+        require_admin(req)
+    assert exc_info.value.status_code == 302
+
+
+def test_require_admin_allowlist_unset_returns_503(monkeypatch):
+    """allow-list 미설정 시 503 (silent open access 회피 — Layer 3a)."""
+    monkeypatch.delenv("SAAS_MULTITENANT_DISABLED", raising=False)
+    monkeypatch.setattr("src.config.settings.saas_admin_emails", "")
+    req = _make_request_with_user()
+    user = _make_user()
+    with patch("src.auth.session.require_login", return_value=user):
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin(req)
+    assert exc_info.value.status_code == 503
+    assert "unset" in exc_info.value.detail.lower()
+
+
+def test_require_admin_user_not_in_allowlist_returns_403(monkeypatch):
+    """admin allow-list 부재 시 403 (Layer 3b)."""
+    monkeypatch.delenv("SAAS_MULTITENANT_DISABLED", raising=False)
+    monkeypatch.setattr("src.config.settings.saas_admin_emails", "admin@example.com")
+    req = _make_request_with_user()
+    user = _make_user(email="alice@example.com")  # admin allow-list 외
+    with patch("src.auth.session.require_login", return_value=user):
+        with pytest.raises(HTTPException) as exc_info:
+            require_admin(req)
+    assert exc_info.value.status_code == 403
+
+
+def test_require_admin_user_in_allowlist_returns_user(monkeypatch):
+    """allow-list 명시 사용자 = 정상 반환."""
+    monkeypatch.delenv("SAAS_MULTITENANT_DISABLED", raising=False)
+    monkeypatch.setattr("src.config.settings.saas_admin_emails", "alice@example.com,bob@example.com")
+    req = _make_request_with_user()
+    user = _make_user(email="alice@example.com")
+    with patch("src.auth.session.require_login", return_value=user):
+        result = require_admin(req)
+    assert result is user
+    assert result.email == "alice@example.com"
+
+
+def test_require_admin_email_case_insensitive(monkeypatch):
+    """email 대소문자 무관 — Alice@Example.COM matches alice@example.com allow-list."""
+    monkeypatch.delenv("SAAS_MULTITENANT_DISABLED", raising=False)
+    monkeypatch.setattr("src.config.settings.saas_admin_emails", "Alice@Example.COM")
+    req = _make_request_with_user()
+    user = _make_user(email="alice@example.com")
+    with patch("src.auth.session.require_login", return_value=user):
+        result = require_admin(req)
+    assert result is user


### PR DESCRIPTION
…AAS_MULTITENANT kill-switch

## Summary
사이클 79 🅐 SaaS 영역 진입 PR 2 — 5+1 cross-verify 결과 NEW-P0-2 (kill-switch helper PR 1 #253) + cross-verify 보고 P0 #4 (admin allow-list 부재) 처리. 3-layer 검증 (kill-switch → require_login → email allow-list).

## 검증 (사이클 79 PR 2 sync 실측)
- 단위 (신규) = 11 collected / 11 passed (test_require_admin.py)
- 단위 (회귀 가드) = 38 passed (tests/unit/auth — `require_login` 외)
- 통합 = 변경 0
- E2E = 변경 0

## 변경 영역
- `src/config.py` — `saas_admin_emails: str = ""` 신규 (CSV email 형식)
- `src/auth/session.py` — `_parse_admin_emails` + `require_admin` Depends 신설
- `tests/unit/auth/test_require_admin.py` — 회귀 가드 11건
- `tests/unit/auth/__init__.py` — 디렉토리 마커 (신규)

## 3-layer 검증 (정책 12 정합 — silent open access 차단)
- **Layer 1 kill-switch** = `SAAS_MULTITENANT_DISABLED=1` → 503 (사이클 78 PR 1 helper 활용)
- **Layer 2 require_login** = 비로그인 → 302 redirect (기존 패턴 차용)
- **Layer 3a allow-list 미설정** = `SAAS_ADMIN_EMAILS=""` → 503 (silent open access 회피)
- **Layer 3b allow-list 부재 사용자** = email not in allow-list → 403

## 자율 판단 보고 (정책 3)
1. PR 1 helper (`feature_kill_switch.is_disabled`) 활용 — 사용처 +1 (총 3건 — 임계 ≥3 정합)
2. CSV 파싱 = 공백 trim + lowercase 정규화 (사용자 email 입력 변형 호환)
3. allow-list 미설정 시 503 (silent open access 회피) — 정책 12 부합 (안전 default)
4. require_admin = require_login 위임 (3-layer 분리 — 응집 단위 부합)
5. 단위 테스트 = `monkeypatch.setattr` 패턴 (settings 직접 mock — 메모리 `test-env-setup.md` 정합)

## 운영 smoke check (정책 13)
신규 endpoint 부재 — `require_admin` Depends 만 신설. PR 3 (admin UI + usage tab) 머지 후 endpoint 적용. 운영 endpoint 무영향

## Code Scanning open alert (정책 14)
본 PR 작업 직전 = 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
