### PR TITLE
feat(cycle-80-pr1): Sentry PII 스크러빙 강화 + runbook (5+1 cross-verify P0…

### DIFF
--- a/docs/runbooks/sentry-activation.md
+++ b/docs/runbooks/sentry-activation.md
@@ -1,0 +1,138 @@
+# Sentry 운영 활성화 — 사이클 80 PR 1
+
+> **작업일**: 2026-05-05 (사이클 80 영역 🅔 운영 모니터링 묶음 PR 1)
+> **5+1 cross-verify P0-1**: Sentry PII 노출 위험 — 신규 헤더 스크러빙 candidate 검증 의무
+
+---
+
+## 1. 배경
+
+**Phase 1 baseline (사이클 72 PR 2 #242)** = Sentry SDK 인프라 구현 (`src/shared/observability.py`) — `SENTRY_DSN` 미설정 시 silent skip. 운영 활성화 = Railway 환경변수 등록 의무.
+
+**Phase 2 진입 (사이클 80 PR 1)** = PII 스크러빙 검증 + 운영 활성화 가이드.
+
+---
+
+## 2. PII 스크러빙 사양 (Cycle 80 PR 1 강화)
+
+### 2-1. 헤더 화이트리스트 (10건)
+
+| 헤더 | 사유 |
+|------|------|
+| `Authorization` | Bearer / Basic 토큰 |
+| `X-API-Key` | admin API key |
+| `X-Hub-Signature` | 구 GitHub HMAC 서명 |
+| `X-Hub-Signature-256` | GitHub HMAC SHA-256 서명 |
+| `X-GitHub-Token` | GitHub API 호출 헤더 |
+| `X-Telegram-Bot-Api-Secret-Token` | Telegram webhook secret_token |
+| `X-Webhook-Token` | custom webhook 인증 |
+| `X-Forwarded-For` | 사용자 IP — PII |
+| `X-Real-IP` | 사용자 IP — PII |
+| `Cookie` | 세션 쿠키 |
+
+→ Sentry 이벤트 본문에서 `[Filtered]` 로 치환 (대소문자 무관).
+
+### 2-2. URL 스크러빙
+
+- query string 제거: `?token=xxx` → 제거
+- fragment 제거: `#token=xxx` → 제거 (사이클 80 신규)
+
+### 2-3. body data + cookies
+
+- `request["data"]` → `[Filtered]` 명시
+- `request["cookies"]` → `{}` 비움
+- `send_default_pii=False` SDK 옵션 (기본값 + 명시 방어)
+
+---
+
+## 3. Railway 운영 활성화 절차
+
+### 3-1. Sentry 프로젝트 생성
+
+1. [sentry.io](https://sentry.io) 가입 + 프로젝트 신설
+2. Project Type = `Python` 선택
+3. DSN 발급 = `https://<key>@<org>.ingest.sentry.io/<project_id>` 형식
+
+### 3-2. Railway 환경변수 등록
+
+Railway dashboard → SCAManager service → Variables 탭:
+
+```
+SENTRY_DSN=https://<key>@<org>.ingest.sentry.io/<project_id>
+SENTRY_ENVIRONMENT=production
+SENTRY_TRACES_SAMPLE_RATE=0.1
+```
+
+→ 변경 즉시 Railway 자동 재배포.
+
+### 3-3. 활성화 검증 (정책 13 smoke check 페어)
+
+배포 완료 후 manual 검증:
+
+```bash
+# 1. 로그 확인 — "Sentry initialized (env=production)" INFO 메시지
+curl -sf https://<APP_BASE_URL>/health
+# Railway logs 에서 `Sentry initialized` 검색
+
+# 2. test event 발사 (수동 — 운영 실수 회피)
+# Sentry dashboard → Settings → Projects → SCAManager → Test Notification
+# → 이벤트 수신 확인 (수 분 내)
+
+# 3. 운영 endpoint 1회 의도적 fail 테스트 (admin only)
+# → Sentry dashboard 이벤트 본문에서 [Filtered] 확인 의무
+```
+
+### 3-4. PII 스크러빙 운영 검증 (의무)
+
+Sentry dashboard 첫 이벤트 수신 시:
+
+- [ ] `request.url` 에 `?token=`, `#token=` 부재 검증
+- [ ] `request.headers.Authorization` = `[Filtered]` 검증
+- [ ] `request.cookies` = `{}` 검증
+- [ ] `request.data` = `[Filtered]` 검증
+- [ ] 사용자 IP (`X-Forwarded-For` / `X-Real-IP`) = `[Filtered]` 검증
+
+**누설 발견 시**: `_SENSITIVE_HEADERS` 추가 + 회귀 가드 추가 (`tests/unit/shared/test_observability_before_send.py` 패턴) + 후속 PR 진행.
+
+---
+
+## 4. 운영 사용량 baseline (사이클 81+ 의무)
+
+### 4-1. Sentry SaaS free tier 한계
+
+- **5,000 events / 월** (free tier — 2026-05 기준)
+- `traces_sample_rate=0.1` (10% 샘플링) default — 운영 트래픽 ↑ 시 한계 도달
+
+### 4-2. 1주 baseline 측정 (사이클 81+ 진행)
+
+PR 1 머지 + Sentry 활성화 후 1주 운영 시점:
+
+```bash
+# Sentry dashboard → Projects → SCAManager → Stats
+# 7-day total events 측정 + 월간 추정 (× 4.3) + free tier 5K 대비 검증
+```
+
+**임계 도달 시 결정**:
+- 임계 80% 도달 = `traces_sample_rate=0.05` (5%) 조정
+- 임계 100% 도달 = team plan 업그레이드 또는 self-hosted Sentry 고려
+
+---
+
+## 5. 관련 문서
+
+- `src/shared/observability.py` (Phase E.2a + 사이클 80 PR 1 강화)
+- `tests/unit/shared/test_observability_before_send.py` (Cycle 80 PR 1 신규 회귀 가드 23건)
+- `tests/unit/shared/test_observability.py` (Phase E.2a 기존 9건)
+- 메모리 `feedback-phase4-area-entry-pattern.md` Phase 4 영역 진입 패턴 (안전 default 4건)
+- 정책 13 운영 smoke check (사이클 62 신설)
+- 사이클 78 PR 1 helper 모듈 (kill-switch 패턴 페어)
+
+---
+
+## 6. 자율 판단 보고 (정책 3)
+
+1. **`_before_send` = sentry-sdk 의존 0** (단순 dict 변환) → 회귀 가드 importorskip 제거 (devcontainer 도 PASS — 23/23)
+2. **헤더 화이트리스트 frozenset** = O(1) lookup + immutable (정책 16 단순화 default — 추상화 0)
+3. **body data 영구 필터** = SDK 기본값 + 명시 방어 (defence in depth)
+4. **운영 적용 시점** = 사용자 명시 (Railway 환경변수 등록 — Claude 진입 X)
+5. **Phase 2 baseline 측정** = 사이클 81+ 1주 운영 후 별도 사이클 진행 default

--- a/src/shared/observability.py
+++ b/src/shared/observability.py
@@ -20,26 +20,50 @@ except ImportError:  # pragma: no cover — DNS 제약 dev env 전용 경로
     _SENTRY_AVAILABLE = False
 
 
+# Cycle 80 PR 1 — PII/secret 스크러빙 헤더 화이트리스트 확장 (5+1 cross-verify P0-1)
+# Cycle 80 PR 1 — PII/secret scrubbing header allowlist expansion
+_SENSITIVE_HEADERS = frozenset({
+    "authorization",                    # Bearer / Basic 토큰
+    "x-api-key",                        # admin API key
+    "x-hub-signature",                  # 구 GitHub HMAC 서명
+    "x-hub-signature-256",              # GitHub HMAC SHA-256 서명
+    "x-github-token",                   # GitHub API 호출 헤더
+    "x-telegram-bot-api-secret-token",  # Telegram webhook secret_token
+    "x-webhook-token",                  # custom webhook 인증
+    "x-forwarded-for",                  # 사용자 IP — PII
+    "x-real-ip",                        # 사용자 IP — PII
+    "cookie",                           # 세션 쿠키
+})
+
+
 def _before_send(event: dict, _hint: dict) -> dict:
     """Sentry 이벤트 전송 전 민감 데이터 스크러빙 — PII/secret 누수 방어.
 
     GitHub webhook 처리 중 발생한 예외는 request body·URL query·headers 에
     토큰/시크릿/사용자 입력이 포함될 수 있다. Sentry 기본 수집 범위를 명시적으로
     제한해 외부 SaaS 에 민감 정보가 유출되지 않도록 한다.
+
+    Cycle 80 PR 1 — 헤더 화이트리스트 확장 (4 → 10) + URL fragment 제거 추가.
     """
     request = event.get("request") or {}
-    # URL query string 제거 — ?token=xxx, ?api_key=yyy 등 유출 방지
+    # URL query string + fragment 제거 — ?token=xxx, #token=yyy 등 유출 방지
+    # URL query + fragment removal — defends ?token=xxx, #token=yyy
     url = request.get("url")
-    if isinstance(url, str) and "?" in url:
-        request["url"] = url.split("?", 1)[0]
+    if isinstance(url, str):
+        if "?" in url:
+            url = url.split("?", 1)[0]
+        if "#" in url:
+            url = url.split("#", 1)[0]
+        request["url"] = url
     # Cookies 제거 — 세션 쿠키가 그대로 Sentry 에 가는 것 방어
     if "cookies" in request:
         request["cookies"] = {}
-    # Authorization 헤더 등 민감 헤더 제거
+    # 민감 헤더 화이트리스트 기반 스크러빙 (Cycle 80 PR 1 — 10 헤더)
+    # Sensitive header allowlist scrubbing (Cycle 80 PR 1 — 10 headers)
     headers = request.get("headers") or {}
     if isinstance(headers, dict):
         for key in list(headers.keys()):
-            if key.lower() in ("authorization", "x-api-key", "x-hub-signature-256", "cookie"):
+            if key.lower() in _SENSITIVE_HEADERS:
                 headers[key] = "[Filtered]"
     event["request"] = request
     # body 는 Sentry 기본값이 이미 제외하지만 명시적으로 제거

--- a/tests/unit/shared/test_observability_before_send.py
+++ b/tests/unit/shared/test_observability_before_send.py
@@ -1,0 +1,154 @@
+"""observability._before_send PII 스크러빙 회귀 가드 (Cycle 80 PR 1).
+
+5+1 cross-verify P0-1 처리 — 신규 헤더 5건 추가 + URL fragment 제거 추가.
+
+검증 영역:
+- URL query string + fragment 제거
+- 민감 헤더 10건 (authorization / x-api-key / x-hub-signature[/-256] /
+  x-github-token / x-telegram-bot-api-secret-token / x-webhook-token /
+  x-forwarded-for / x-real-ip / cookie)
+- Cookies + body data scrubbing
+- 정상 헤더 (Content-Type 등) 통과 검증
+"""
+from __future__ import annotations
+
+import os
+
+# conftest.py 가 실행되기 전에 필수 env var 주입
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+import pytest
+
+# `_before_send` 함수 = sentry-sdk 의존 X (단순 dict 변환) — devcontainer 도 직접 검증 가능
+# `_before_send` is sentry-sdk independent (pure dict transform) — runs everywhere
+from src.shared import observability  # noqa: E402
+
+
+# ─── URL query/fragment 제거 ────────────────────────────────────────
+
+
+class TestUrlScrub:
+    def test_query_string_removed(self):
+        event = {"request": {"url": "https://app/auth/callback?token=secret&state=xyz"}}
+        result = observability._before_send(event, {})
+        assert result["request"]["url"] == "https://app/auth/callback"
+
+    def test_fragment_removed(self):
+        event = {"request": {"url": "https://app/dashboard#token=abc"}}
+        result = observability._before_send(event, {})
+        assert result["request"]["url"] == "https://app/dashboard"
+
+    def test_query_and_fragment_removed(self):
+        event = {"request": {"url": "https://app/r?a=1#b=2"}}
+        result = observability._before_send(event, {})
+        assert result["request"]["url"] == "https://app/r"
+
+    def test_clean_url_unchanged(self):
+        event = {"request": {"url": "https://app/health"}}
+        result = observability._before_send(event, {})
+        assert result["request"]["url"] == "https://app/health"
+
+    def test_no_url_field_no_crash(self):
+        event = {"request": {}}
+        result = observability._before_send(event, {})
+        assert "url" not in result["request"]
+
+
+# ─── 민감 헤더 10건 스크러빙 ────────────────────────────────────────
+
+
+class TestHeaderScrub:
+    @pytest.mark.parametrize("header_name", [
+        "Authorization",
+        "X-API-Key",
+        "X-Hub-Signature",
+        "X-Hub-Signature-256",
+        "X-GitHub-Token",
+        "X-Telegram-Bot-Api-Secret-Token",
+        "X-Webhook-Token",
+        "X-Forwarded-For",
+        "X-Real-IP",
+        "Cookie",
+    ])
+    def test_sensitive_headers_filtered(self, header_name):
+        event = {"request": {"headers": {header_name: "secret-value-12345"}}}
+        result = observability._before_send(event, {})
+        assert result["request"]["headers"][header_name] == "[Filtered]"
+
+    def test_lowercase_header_filtered(self):
+        """대소문자 무관 검증."""
+        event = {"request": {"headers": {"authorization": "Bearer xyz"}}}
+        result = observability._before_send(event, {})
+        assert result["request"]["headers"]["authorization"] == "[Filtered]"
+
+    def test_clean_headers_pass_through(self):
+        """정상 헤더 (Content-Type 등) 통과 검증."""
+        event = {"request": {"headers": {
+            "Content-Type": "application/json",
+            "User-Agent": "pytest",
+        }}}
+        result = observability._before_send(event, {})
+        assert result["request"]["headers"]["Content-Type"] == "application/json"
+        assert result["request"]["headers"]["User-Agent"] == "pytest"
+
+    def test_mixed_headers_only_sensitive_filtered(self):
+        """민감 + 정상 혼재 = 민감 만 filter."""
+        event = {"request": {"headers": {
+            "Authorization": "Bearer xyz",
+            "Content-Type": "application/json",
+            "X-Real-IP": "1.2.3.4",
+        }}}
+        result = observability._before_send(event, {})
+        assert result["request"]["headers"]["Authorization"] == "[Filtered]"
+        assert result["request"]["headers"]["X-Real-IP"] == "[Filtered]"
+        assert result["request"]["headers"]["Content-Type"] == "application/json"
+
+
+# ─── Cookies + body data 스크러빙 ────────────────────────────────────
+
+
+class TestCookieAndBodyScrub:
+    def test_cookies_cleared(self):
+        event = {"request": {"cookies": {"session": "secret-cookie", "csrf": "xyz"}}}
+        result = observability._before_send(event, {})
+        assert result["request"]["cookies"] == {}
+
+    def test_body_data_filtered(self):
+        event = {"request": {"data": {"username": "alice", "password": "secret"}}}
+        result = observability._before_send(event, {})
+        assert result["request"]["data"] == "[Filtered]"
+
+    def test_no_cookies_no_data_no_crash(self):
+        event = {"request": {"url": "https://app/health"}}
+        result = observability._before_send(event, {})
+        assert result is event
+
+
+# ─── 헤더 화이트리스트 상수 검증 ────────────────────────────────────
+
+
+class TestSensitiveHeadersConstant:
+    def test_all_lowercase(self):
+        """모든 헤더 이름 lowercase 의무 (대소문자 비교 안전)."""
+        for header in observability._SENSITIVE_HEADERS:
+            assert header == header.lower(), f"{header!r} 가 lowercase 가 아님"
+
+    def test_includes_10_headers(self):
+        """Cycle 80 PR 1 — 10 헤더 모두 포함."""
+        expected = {
+            "authorization",
+            "x-api-key",
+            "x-hub-signature",
+            "x-hub-signature-256",
+            "x-github-token",
+            "x-telegram-bot-api-secret-token",
+            "x-webhook-token",
+            "x-forwarded-for",
+            "x-real-ip",
+            "cookie",
+        }
+        assert observability._SENSITIVE_HEADERS == expected


### PR DESCRIPTION
…-1 처리)

## Summary
사이클 80 영역 🅔 운영 모니터링 Phase 2 첫 PR — 5+1 cross-verify P0-1 처리. Sentry `_before_send` PII 스크러빙 헤더 4 → 10 확장 + URL fragment 제거 + 회귀 가드 23건 + 운영 활성화 runbook.

## 검증 (사이클 80 PR 1 sync 실측)
- 단위 (신규) = 23 collected / 23 passed (test_observability_before_send.py)
- 단위 (전체 회귀) = 2200 passed / 2 skipped / 0 failed (이전 2178 + 23)
- 통합 = 변경 0
- E2E = 변경 0

## 변경 영역 (3 파일)
- `src/shared/observability.py` — `_SENSITIVE_HEADERS` frozenset 신설 (10건) + URL fragment 제거 추가
- `tests/unit/shared/test_observability_before_send.py` 신규 — 회귀 가드 23건 (URL 5 + 헤더 12 + cookies/body 3 + frozenset 검증 2 + 정상 헤더 통과)
- `docs/runbooks/sentry-activation.md` 신규 — 운영 활성화 절차 + PII 스크러빙 검증 의무 + 1주 baseline 측정 (사이클 81+)

## 신규 헤더 5건 (Cycle 80 PR 1)
- `X-Hub-Signature` (구 GitHub HMAC 서명)
- `X-GitHub-Token` (GitHub API 호출 헤더)
- `X-Telegram-Bot-Api-Secret-Token` (Telegram webhook secret_token)
- `X-Webhook-Token` (custom webhook 인증)
- `X-Forwarded-For` + `X-Real-IP` (사용자 IP — PII)

## URL fragment 제거 추가
`?token=xxx` (query) + `#token=xxx` (fragment) 둘 다 제거 — OAuth callback / hash routing 영역 PII 누설 차단

## 자율 판단 보고 (정책 3)
1. **`_before_send` = sentry-sdk 의존 0** (단순 dict 변환) → 회귀 가드 `importorskip` 제거 (devcontainer 도 PASS — 23/23)
2. **`_SENSITIVE_HEADERS` frozenset** = O(1) lookup + immutable (정책 16 단순화 default — 추상화 0)
3. **운영 적용 시점** = 사용자 명시 (Railway `SENTRY_DSN` 환경변수 등록 — Claude 진입 X)
4. **Phase 2 baseline 측정** = 사이클 81+ 1주 운영 후 별도 사이클 진행 default (옵션 🅒 — cross-verify 권장)
5. PR 2 (operations 모드) 후속 진입 의무

## 운영 smoke check (정책 13)
docs only + 회귀 가드 — 운영 endpoint 무영향. Sentry 활성화 시점 = 사용자 Railway 환경변수 등록 후 manual smoke check (runbook §3-3 명시)

## Code Scanning open alert (정책 14)
본 PR 작업 직전 = 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
