### PR TITLE
feat(cycle-81-pra): PWA manifest + SVG icon (192/512) + theme-color +…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,12 @@ make run               # 개발 서버 (port 8000, DB 마이그레이션 자동)
 src/
 ├── main.py                     # FastAPI 앱, lifespan(DB 마이그레이션 + http_client), 전체 라우터 등록 + StaticFiles `/static` mount (UI 감사 Step C) + 미들웨어 LIFO 등록 (SecurityHeaders → RLSSessionMiddleware → SessionMiddleware — RLS inner / Session outer 보장, Phase 3 postlude #228)
 ├── static/
-│   └── vendor/
-│       └── chart.umd.min.js    # Chart.js 4.4.0 UMD min vendoring — CDN 차단/오프라인 환경 호환 (UI 감사 Step C). 사용처: repo_detail / analysis_detail / dashboard
+│   ├── vendor/
+│   │   └── chart.umd.min.js    # Chart.js 4.4.0 UMD min vendoring — CDN 차단/오프라인 환경 호환 (UI 감사 Step C). 사용처: repo_detail / analysis_detail / dashboard
+│   ├── manifest.json           # PWA manifest (Cycle 81 PR-A — 홈 화면 추가 + iOS PWA standalone 호환)
+│   └── icons/
+│       ├── icon-192.svg        # PWA maskable icon 192x192 (Cycle 81 PR-A — apple-touch-icon)
+│       └── icon-512.svg        # PWA maskable icon 512x512 (PWA splash screen)
 ├── config.py                   # pydantic-settings 환경변수 관리, postgres:// URL 자동 변환
 ├── constants.py                # 전역 상수 단일 출처 — 점수배점/감점가중치/AI기본값/등급/알림한도/HTTP타임아웃/캐시TTL
 ├── crypto.py                   # encrypt_token()/decrypt_token() — TOKEN_ENCRYPTION_KEY

--- a/src/static/icons/icon-192.svg
+++ b/src/static/icons/icon-192.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SCAManager PWA icon — 192x192 maskable (Cycle 81 PR-A 신설).
+  PWA maskable safe zone = center 80% (40% radius from center).
+  텍스트 "SCA" 중앙 + dark theme color (#0a0a0a) 배경 + accent (#60a5fa) 그라데이션.
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="100%" stop-color="#1f2937"/>
+    </linearGradient>
+    <linearGradient id="text" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#10b981"/>
+    </linearGradient>
+  </defs>
+  <!-- 배경 = 전체 영역 (maskable safe zone 외부 포함) -->
+  <rect width="192" height="192" fill="url(#bg)"/>
+  <!-- 중앙 "SCA" 텍스트 (safe zone 내부 — center 80%) -->
+  <text x="96" y="96"
+        text-anchor="middle"
+        dominant-baseline="central"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+        font-size="48"
+        font-weight="800"
+        fill="url(#text)">SCA</text>
+  <!-- 하단 검은색 마크 (sca + manager 의 ✓ 표식) -->
+  <text x="96" y="144"
+        text-anchor="middle"
+        dominant-baseline="central"
+        font-family="-apple-system, BlinkMacSystemFont, sans-serif"
+        font-size="14"
+        font-weight="500"
+        fill="#9ca3af">Manager</text>
+</svg>

--- a/src/static/icons/icon-512.svg
+++ b/src/static/icons/icon-512.svg
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  SCAManager PWA icon — 512x512 maskable (Cycle 81 PR-A 신설).
+  PWA maskable safe zone = center 80% (radius 205 from center 256).
+  192 동일 디자인 + 더 큰 폰트 (PWA splash screen 영역 호환).
+-->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0a0a0a"/>
+      <stop offset="100%" stop-color="#1f2937"/>
+    </linearGradient>
+    <linearGradient id="text" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#10b981"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#bg)"/>
+  <text x="256" y="240"
+        text-anchor="middle"
+        dominant-baseline="central"
+        font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+        font-size="140"
+        font-weight="800"
+        fill="url(#text)">SCA</text>
+  <text x="256" y="370"
+        text-anchor="middle"
+        dominant-baseline="central"
+        font-family="-apple-system, BlinkMacSystemFont, sans-serif"
+        font-size="40"
+        font-weight="500"
+        fill="#9ca3af">Manager</text>
+</svg>

--- a/src/static/manifest.json
+++ b/src/static/manifest.json
@@ -1,0 +1,27 @@
+{
+  "name": "SCAManager — Static Code Analysis Manager",
+  "short_name": "SCAManager",
+  "description": "GitHub Push/PR 정적 분석 + AI 코드 리뷰 + Auto-merge gate. 다중 채널 알림 (Telegram / Discord / Slack / Email / n8n).",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "theme_color": "#0a0a0a",
+  "background_color": "#0a0a0a",
+  "lang": "ko-KR",
+  "categories": ["developer", "productivity", "utilities"],
+  "icons": [
+    {
+      "src": "/static/icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/static/icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -5,6 +5,12 @@
   <!-- viewport-fit=cover: iOS notch 디바이스의 safe-area-inset env() 활성화
        viewport-fit=cover: enables safe-area-inset env() on iOS notch devices -->
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <!-- Cycle 81 PR-A — PWA manifest + theme-color + apple-touch-icon (홈 화면 추가 + iOS PWA standalone 호환) -->
+  <!-- Cycle 81 PR-A — PWA manifest + theme-color + apple-touch-icon (Add to Home Screen + iOS PWA standalone) -->
+  <link rel="manifest" href="/static/manifest.json">
+  <meta name="theme-color" content="#0a0a0a" id="theme-color-meta">
+  <link rel="apple-touch-icon" href="/static/icons/icon-192.svg">
+  <link rel="icon" type="image/svg+xml" href="/static/icons/icon-192.svg">
   <title>{% block title %}SCAManager{% endblock %}</title>
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pretendard@1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" crossorigin="anonymous">

--- a/tests/integration/test_pwa_manifest.py
+++ b/tests/integration/test_pwa_manifest.py
@@ -1,0 +1,91 @@
+"""PWA manifest + icon serving 회귀 가드 (Cycle 81 PR-A — 영역 🅑 모바일 진입).
+
+5+1 cross-verify (관점 🅑) PR-A 의무:
+- manifest.json 200 응답 + JSON valid
+- icon-192.svg + icon-512.svg 200 응답 + SVG valid
+- base.html PWA 헤더 (manifest link + theme-color + apple-touch-icon)
+- start_url + scope + display 정합성
+"""
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from src.main import app
+
+
+def test_manifest_serves_200():
+    """GET /static/manifest.json — 200 응답."""
+    with TestClient(app) as c:
+        response = c.get("/static/manifest.json")
+        assert response.status_code == 200
+
+
+def test_manifest_is_valid_json():
+    """manifest.json = valid JSON 구조 + 필수 필드 모두 존재."""
+    with TestClient(app) as c:
+        response = c.get("/static/manifest.json")
+        data = json.loads(response.text)
+        # PWA install criteria — 필수 필드
+        assert "name" in data
+        assert "short_name" in data
+        assert "start_url" in data
+        assert "display" in data
+        assert "icons" in data
+        # SCAManager 정합
+        assert data["name"].startswith("SCAManager")
+        assert data["start_url"] == "/"
+        assert data["display"] == "standalone"
+        assert data["scope"] == "/"
+
+
+def test_manifest_includes_192_and_512_icons():
+    """manifest.icons = 192 + 512 (PWA install 의무 사이즈)."""
+    with TestClient(app) as c:
+        data = json.loads(c.get("/static/manifest.json").text)
+        sizes = {icon["sizes"] for icon in data["icons"]}
+        assert "192x192" in sizes
+        assert "512x512" in sizes
+
+
+def test_manifest_icons_have_maskable_purpose():
+    """icons.purpose = "any maskable" (PWA maskable 호환)."""
+    with TestClient(app) as c:
+        data = json.loads(c.get("/static/manifest.json").text)
+        for icon in data["icons"]:
+            assert "maskable" in icon.get("purpose", ""), \
+                f"icon {icon['src']} maskable 부재"
+
+
+def test_icon_192_svg_serves_200():
+    """GET /static/icons/icon-192.svg — 200 응답 + SVG content."""
+    with TestClient(app) as c:
+        response = c.get("/static/icons/icon-192.svg")
+        assert response.status_code == 200
+        assert "<svg" in response.text
+        assert "viewBox" in response.text
+
+
+def test_icon_512_svg_serves_200():
+    """GET /static/icons/icon-512.svg — 200 응답 + SVG content."""
+    with TestClient(app) as c:
+        response = c.get("/static/icons/icon-512.svg")
+        assert response.status_code == 200
+        assert "<svg" in response.text
+        assert "viewBox" in response.text
+
+
+def test_base_html_includes_manifest_link():
+    """base.html (overview 페이지 응답) = manifest link + theme-color + apple-touch-icon 헤더 포함."""
+    with TestClient(app) as c:
+        response = c.get("/")
+        # 비로그인 시 /login redirect — login 페이지도 base.html 상속 = PWA 헤더 동일
+        # Follow redirects to ensure base.html headers present
+        if response.status_code == 302:
+            response = c.get(response.headers["location"])
+        assert response.status_code == 200
+        # PWA 핵심 헤더 3종
+        assert '<link rel="manifest" href="/static/manifest.json">' in response.text
+        assert 'theme-color' in response.text
+        assert '/static/icons/icon-192.svg' in response.text

--- a/tests/integration/test_pwa_manifest.py
+++ b/tests/integration/test_pwa_manifest.py
@@ -5,6 +5,12 @@
 - icon-192.svg + icon-512.svg 200 응답 + SVG valid
 - base.html PWA 헤더 (manifest link + theme-color + apple-touch-icon)
 - start_url + scope + display 정합성
+
+Cycle 81 PR-A fix-up: `with TestClient(app) as c:` lifespan 진입 → 후속 unit test
+caplog 깨짐 사고 (CI Run #522 fail 58 = test ordering 영향). 모든 test = lifespan
+비활성 (`TestClient(app)` 직접) — 정적 자원 + `/login` route 모두 lifespan/DB 무관.
+Cycle 81 PR-A fix-up: avoid lifespan via `TestClient(app)` direct (no `with` block)
+to prevent ordering side-effects on subsequent unit tests' caplog records.
 """
 from __future__ import annotations
 
@@ -17,75 +23,75 @@ from src.main import app
 
 def test_manifest_serves_200():
     """GET /static/manifest.json — 200 응답."""
-    with TestClient(app) as c:
-        response = c.get("/static/manifest.json")
-        assert response.status_code == 200
+    c = TestClient(app)
+    response = c.get("/static/manifest.json")
+    assert response.status_code == 200
 
 
 def test_manifest_is_valid_json():
     """manifest.json = valid JSON 구조 + 필수 필드 모두 존재."""
-    with TestClient(app) as c:
-        response = c.get("/static/manifest.json")
-        data = json.loads(response.text)
-        # PWA install criteria — 필수 필드
-        assert "name" in data
-        assert "short_name" in data
-        assert "start_url" in data
-        assert "display" in data
-        assert "icons" in data
-        # SCAManager 정합
-        assert data["name"].startswith("SCAManager")
-        assert data["start_url"] == "/"
-        assert data["display"] == "standalone"
-        assert data["scope"] == "/"
+    c = TestClient(app)
+    response = c.get("/static/manifest.json")
+    data = json.loads(response.text)
+    # PWA install criteria — 필수 필드
+    assert "name" in data
+    assert "short_name" in data
+    assert "start_url" in data
+    assert "display" in data
+    assert "icons" in data
+    # SCAManager 정합
+    assert data["name"].startswith("SCAManager")
+    assert data["start_url"] == "/"
+    assert data["display"] == "standalone"
+    assert data["scope"] == "/"
 
 
 def test_manifest_includes_192_and_512_icons():
     """manifest.icons = 192 + 512 (PWA install 의무 사이즈)."""
-    with TestClient(app) as c:
-        data = json.loads(c.get("/static/manifest.json").text)
-        sizes = {icon["sizes"] for icon in data["icons"]}
-        assert "192x192" in sizes
-        assert "512x512" in sizes
+    c = TestClient(app)
+    data = json.loads(c.get("/static/manifest.json").text)
+    sizes = {icon["sizes"] for icon in data["icons"]}
+    assert "192x192" in sizes
+    assert "512x512" in sizes
 
 
 def test_manifest_icons_have_maskable_purpose():
     """icons.purpose = "any maskable" (PWA maskable 호환)."""
-    with TestClient(app) as c:
-        data = json.loads(c.get("/static/manifest.json").text)
-        for icon in data["icons"]:
-            assert "maskable" in icon.get("purpose", ""), \
-                f"icon {icon['src']} maskable 부재"
+    c = TestClient(app)
+    data = json.loads(c.get("/static/manifest.json").text)
+    for icon in data["icons"]:
+        assert "maskable" in icon.get("purpose", ""), \
+            f"icon {icon['src']} maskable 부재"
 
 
 def test_icon_192_svg_serves_200():
     """GET /static/icons/icon-192.svg — 200 응답 + SVG content."""
-    with TestClient(app) as c:
-        response = c.get("/static/icons/icon-192.svg")
-        assert response.status_code == 200
-        assert "<svg" in response.text
-        assert "viewBox" in response.text
+    c = TestClient(app)
+    response = c.get("/static/icons/icon-192.svg")
+    assert response.status_code == 200
+    assert "<svg" in response.text
+    assert "viewBox" in response.text
 
 
 def test_icon_512_svg_serves_200():
     """GET /static/icons/icon-512.svg — 200 응답 + SVG content."""
-    with TestClient(app) as c:
-        response = c.get("/static/icons/icon-512.svg")
-        assert response.status_code == 200
-        assert "<svg" in response.text
-        assert "viewBox" in response.text
+    c = TestClient(app)
+    response = c.get("/static/icons/icon-512.svg")
+    assert response.status_code == 200
+    assert "<svg" in response.text
+    assert "viewBox" in response.text
 
 
 def test_base_html_includes_manifest_link():
-    """base.html (overview 페이지 응답) = manifest link + theme-color + apple-touch-icon 헤더 포함."""
-    with TestClient(app) as c:
-        response = c.get("/")
-        # 비로그인 시 /login redirect — login 페이지도 base.html 상속 = PWA 헤더 동일
-        # Follow redirects to ensure base.html headers present
-        if response.status_code == 302:
-            response = c.get(response.headers["location"])
-        assert response.status_code == 200
-        # PWA 핵심 헤더 3종
-        assert '<link rel="manifest" href="/static/manifest.json">' in response.text
-        assert 'theme-color' in response.text
-        assert '/static/icons/icon-192.svg' in response.text
+    """base.html (login 페이지 응답) = manifest link + theme-color + apple-touch-icon 헤더 포함.
+
+    /login route = `get_current_user` (request.session) 만 의존 — DB/lifespan 무관.
+    /login route = depends only on request.session — DB/lifespan independent.
+    """
+    c = TestClient(app)
+    response = c.get("/login")
+    assert response.status_code == 200
+    # PWA 핵심 헤더 3종
+    assert '<link rel="manifest" href="/static/manifest.json">' in response.text
+    assert 'theme-color' in response.text
+    assert '/static/icons/icon-192.svg' in response.text


### PR DESCRIPTION
… apple-touch-icon (영역 🅑 모바일 진입)

## Summary
사이클 81 영역 🅑 모바일 진입 첫 PR — 5+1 cross-verify (관점 🅑) 옵션 🅐 채택 = Phase 1 MVP 4 PR 분할의 PR-A. PWA manifest + SVG icon + base.html 헤더 = 홈 화면 추가 + iOS PWA standalone 호환.

## 검증 (사이클 81 PR-A sync 실측)
- 통합 (신규) = 7 collected / 7 passed (test_pwa_manifest.py)
- 단위 (회귀 가드) = 변경 0
- E2E = 변경 0

## 변경 영역 (5 파일)
- `src/static/manifest.json` 신규 — PWA manifest (name/short_name/start_url/scope/display=standalone/theme_color/background_color/icons 192+512)
- `src/static/icons/icon-192.svg` 신규 — maskable PWA icon (apple-touch-icon)
- `src/static/icons/icon-512.svg` 신규 — PWA splash screen icon
- `src/templates/base.html` — `<link rel="manifest">` + `<meta name="theme-color">` + `<link rel="apple-touch-icon">` + `<link rel="icon">` 4 PWA 헤더 추가
- `tests/integration/test_pwa_manifest.py` 신규 — 회귀 가드 7건
- CLAUDE.md src/ 트리 — `static/manifest.json` + `static/icons/` 추가

## SVG icon 설계
- 192x192 + 512x512 — maskable purpose (PWA install criteria)
- 디자인: dark gradient 배경 (#0a0a0a → #1f2937) + accent gradient 텍스트 "SCA" (#60a5fa → #10b981) + "Manager" 라벨
- safe zone 정합 (center 80% — PWA maskable 호환)
- SCAManager 로고 placeholder — Phase 2 (사용자 디자인 의무) 시 PNG 추가 가능

## 회귀 가드 7건
- manifest.json 200 응답 + JSON valid
- manifest 필수 필드 (name / short_name / start_url / display / icons)
- icons 192 + 512 사이즈 검증 + maskable purpose
- icon-192.svg + icon-512.svg 200 응답 + SVG valid
- base.html PWA 헤더 (manifest link + theme-color + apple-touch-icon)

## 자율 판단 보고 (정책 3)
1. **SVG icon default** = Chrome / Android PWA install 호환 + Apple iOS apple-touch-icon SVG 지원 (iOS 16+)
2. **PNG icon = Phase 2 영역** = 사용자 디자인 의무 (Claude 디자인 스킬 부재) — Apple 구버전 호환 필요 시 추가
3. **theme-color 정적 (#0a0a0a)** = dark default. 4 테마 themechange 동기화는 Phase 2 영역 (정책 16 4번 원칙 — 사용처 1)
4. **service worker 보류** = Phase 2 영역 (cache 정책 사용자 명시 결정 의무 — NEW-P0 cross-verify P0 영역)
5. **kill-switch 보류** = `MOBILE_PWA_DISABLED` 환경변수 추가는 Phase 2 영역 (정책 16 4번 원칙 — 사용처 1, manifest 정적 자원만 — kill-switch 효용 ↓)
6. **회귀 가드 = integration** = 정적 자원 serving 검증 (단위 영역 X)

## 🚨 Claude 시각 검증 불가 — 사용자 의무 (정책 11 강화 — 4 테마 × 모바일 16 조합) PWA manifest + icon = 사용자 시각 검증 의무:
- [ ] iOS Safari (iPhone 12+) "홈 화면에 추가" 시 icon 정상 표시
- [ ] Android Chrome PWA install prompt 동작
- [ ] icon-192.svg 시각 (dark 배경 + "SCA" 텍스트 + "Manager" 라벨)
- [ ] icon-512.svg PWA splash screen 정상 표시
- [ ] theme-color (#0a0a0a) = iOS PWA status bar dark 정합

## 운영 smoke check (정책 13)
신규 정적 자원 (manifest.json + icons) — `/static/manifest.json` + `/static/icons/icon-{192,512}.svg` 200 응답 검증 (회귀 가드 PASS)

## Code Scanning open alert (정책 14)
본 PR 작업 직전 = 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
