### PR TITLE
feat(cycle-81-prb): dashboard 모바일 KPI 우선순위 재배치 (보안 HIGH + 자동 머지 first…

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -309,6 +309,16 @@
   @media (max-width: 480px) {
     .dash-kpi-grid { grid-template-columns: 1fr; }
     .dash-range-toggle a { min-height: 44px; }
+    /* Cycle 81 PR-B — 모바일 first-fold 우선순위 재배치 (5+1 cross-verify 관점 🅑)
+       데스크탑 = 평균/분석/보안/활성/자동머지 (HTML 순서) 보존
+       모바일 = 운영 위험/사용자 가치 우선 (보안 HIGH + 자동 머지 = first-fold)
+       Cycle 81 PR-B — mobile first-fold priority re-order (5+1 cross-verify 🅑)
+       Desktop = HTML order preserved; mobile = security HIGH + auto-merge first-fold */
+    .dash-kpi:nth-child(3) { order: 1; }  /* 🛡️ 보안 HIGH = 1 (운영 위험 신호) */
+    .dash-kpi:nth-child(5) { order: 2; }  /* 🔀 자동 머지 = 2 (PR 결과 사용자 가치) */
+    .dash-kpi:nth-child(1) { order: 3; }  /* ⭐ 평균 점수 = 3 (overall 건강도) */
+    .dash-kpi:nth-child(2) { order: 4; }  /* 📊 분석 건수 = 4 (활동량) */
+    .dash-kpi:nth-child(4) { order: 5; }  /* 📁 활성 리포 = 5 (확산) */
   }
 </style>
 

--- a/tests/integration/test_dashboard_mobile_priority.py
+++ b/tests/integration/test_dashboard_mobile_priority.py
@@ -1,0 +1,85 @@
+"""dashboard 모바일 KPI 우선순위 재배치 회귀 가드 (Cycle 81 PR-B).
+
+5+1 cross-verify (관점 🅑) PR-B 의무:
+- 모바일 480px↓ first-fold 우선순위 = 보안 HIGH + 자동 머지 (사용자 가치 ↑)
+- 데스크탑 HTML 순서 보존 (CSS order 만 모바일 분기)
+- 운영 위험 신호 (보안 HIGH) + PR 결과 (자동 머지) 우선 인지
+
+Cycle 81 PR-A fix-up 학습 (TestClient lifespan 비활성):
+- `c = TestClient(app)` 직접 (lifespan 진입 X — 후속 unit test 영향 차단)
+- `/login` route 응답 검증 (DB/lifespan 무관)
+"""
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from src.main import app
+
+
+def test_dashboard_html_includes_mobile_order_css():
+    """dashboard.html 응답에 모바일 KPI order CSS 포함.
+
+    /login 페이지 = base.html 상속 but dashboard CSS 미포함 — dashboard 페이지 직접 검증
+    필요. 단 require_login 의무 = 비로그인 시 302 → CSS 직접 검증 불가.
+    대신 dashboard.html 정적 파일 본문 직접 검증 (templates 영역).
+    """
+    # dashboard.html 본문 직접 read (templates 정적 자원)
+    from pathlib import Path
+    dashboard_html = Path(__file__).resolve().parents[2] / "src" / "templates" / "dashboard.html"
+    content = dashboard_html.read_text()
+
+    # 모바일 480px↓ 분기 안 order CSS 포함 검증
+    assert "@media (max-width: 480px)" in content
+    # CSS order 5건 (1~5) 모두 포함
+    for order_n in range(1, 6):
+        assert f"order: {order_n};" in content, f"CSS order: {order_n} 누락"
+
+
+def test_dashboard_html_security_kpi_first_in_mobile_order():
+    """모바일 first-fold = 보안 HIGH (3rd HTML child) → order: 1 의무."""
+    from pathlib import Path
+    dashboard_html = Path(__file__).resolve().parents[2] / "src" / "templates" / "dashboard.html"
+    content = dashboard_html.read_text()
+    # nth-child(3) = 보안 HIGH (HTML 순서) — order: 1 (모바일 first)
+    assert ".dash-kpi:nth-child(3) { order: 1;" in content, \
+        "모바일 보안 HIGH first-fold 우선순위 누락"
+
+
+def test_dashboard_html_auto_merge_kpi_second_in_mobile_order():
+    """모바일 second = 자동 머지 (5th HTML child) → order: 2 의무."""
+    from pathlib import Path
+    dashboard_html = Path(__file__).resolve().parents[2] / "src" / "templates" / "dashboard.html"
+    content = dashboard_html.read_text()
+    # nth-child(5) = 자동 머지 (HTML 순서) — order: 2 (모바일 second)
+    assert ".dash-kpi:nth-child(5) { order: 2;" in content, \
+        "모바일 자동 머지 second-fold 우선순위 누락"
+
+
+def test_dashboard_html_desktop_order_preserved():
+    """데스크탑 = HTML 순서 보존 (CSS order 비활성).
+
+    데스크탑 = 5 컬럼 grid + nth-child order 무관 (HTML 순서 표시).
+    모바일 480px↓ 분기 안에만 order 적용 = 데스크탑 영향 0.
+    """
+    from pathlib import Path
+    dashboard_html = Path(__file__).resolve().parents[2] / "src" / "templates" / "dashboard.html"
+    content = dashboard_html.read_text()
+    # order CSS 가 모바일 분기 안에만 위치 검증 (전역 X)
+    # 단순 검증 = order CSS 직전 line 에 480px media query 포함
+    lines = content.split("\n")
+    for i, line in enumerate(lines):
+        if ".dash-kpi:nth-child" in line and "order:" in line:
+            # 전 5 line 안 480px media query 포함 의무
+            preceding = "\n".join(lines[max(0, i-15):i])
+            assert "max-width: 480px" in preceding, \
+                f"order CSS 가 모바일 분기 외부에 있음 — line {i}: {line.strip()}"
+
+
+def test_dashboard_html_login_response_includes_pwa_headers():
+    """기존 PR-A 회귀 가드 — /login = base.html PWA 헤더 보존."""
+    c = TestClient(app)
+    response = c.get("/login")
+    assert response.status_code == 200
+    # PR-A PWA 헤더 = PR-B 무관 = 회귀 0 검증
+    assert '<link rel="manifest" href="/static/manifest.json">' in response.text
+    assert 'theme-color' in response.text


### PR DESCRIPTION
…-fold)

## Summary
사이클 81 영역 🅑 모바일 PR-B — 5+1 cross-verify (관점 🅑) 옵션 🅐 채택 = Phase 1 MVP 4 PR 분할의 PR-B. 모바일 480px↓ first-fold 우선순위 재배치 — 운영 위험 신호 (보안 HIGH) + PR 결과 (자동 머지) 우선 인지. CSS order 모바일 분기만 적용 (데스크탑 HTML 순서 보존).

## 검증 (사이클 81 PR-B sync 실측)
- 통합 (신규) = 5 collected / 5 passed (test_dashboard_mobile_priority.py)
- 단위 (전체 회귀) = 2306 passed / 5 skipped / 0 failed (이전 2301 + 5)
- E2E = 변경 0 (Playwright 환경 한계 — integration 가드 default)

## 변경 영역 (2 파일)
- `src/templates/dashboard.html` — `@media (max-width: 480px)` 안 CSS order 5건 추가 (nth-child 1~5 → order 3/4/1/5/2)
- `tests/integration/test_dashboard_mobile_priority.py` 신규 — 회귀 가드 5건

## 모바일 우선순위 재배치 (480px↓)
| HTML 순서 | 카드 | 모바일 order | 이유 |
|----------|------|------------|------|
| 1 | ⭐ 평균 점수 | 3 | overall 건강도 |
| 2 | 📊 분석 건수 | 4 | 활동량 |
| **3** | **🛡️ 보안 HIGH** | **1 (first-fold)** | **운영 위험 신호 — 즉시 인지 의무** | | 4 | 📁 활성 리포 | 5 | 확산 |
| **5** | **🔀 자동 머지** | **2 (second-fold)** | **PR 결과 — 사용자 가치 ↑** |

## 회귀 가드 5건
- 모바일 480px↓ 분기 + order 1~5 모두 포함 검증
- 보안 HIGH (3rd HTML child) → order 1 검증
- 자동 머지 (5th HTML child) → order 2 검증
- 데스크탑 = order CSS 모바일 분기 안에만 위치 (전역 X) 검증
- PR-A 회귀 가드 보존 = /login PWA 헤더 검증

## 자율 판단 보고 (정책 3)
1. **CSS order = HTML 순서 보존** — 데스크탑 5 컬럼 grid 영향 0 (정책 16 단순화 default)
2. **Insight 4 카드 carousel 보류** = 1열 stack 이미 적용 (line 305) — 추가 carousel 도입 = over-engineering (정책 16 4번 원칙)
3. **회귀 가드 = integration default** — Playwright e2e 환경 한계 (사용처 1 — 정책 16 4번 원칙 페어). HTML 정적 검증 (CSS string in) 으로 충분
4. **PR-A fix-up 학습 적용** — `c = TestClient(app)` 직접 (lifespan 비활성 — 후속 unit test 영향 0)
5. **사이클 78 PR 2/3/4 = 영구 보류** (사용자 명시 결정 정합 — GitHub PR 미생성)

## 🚨 Claude 시각 검증 불가 — 사용자 의무 (정책 11)
dashboard 모바일 480px↓ 시각 검증:
- [ ] iPhone 12 (390x844) viewport 시 보안 HIGH 카드 = first-fold (스크롤 0)
- [ ] iPhone SE (375x667) viewport 시 자동 머지 카드 = second-fold
- [ ] Android Pixel (393x851) viewport 시 동일 우선순위
- [ ] 데스크탑 1440px viewport = HTML 순서 정합 (회귀 0 검증)

## 운영 smoke check (정책 13)
CSS only — 운영 endpoint 무영향 (template 안 CSS 추가, HTML 응답 본문 동일)

## Code Scanning open alert (정책 14)
본 PR 작업 직전 = 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
