### PR TITLE
feat(cycle-81-prc): settings 모바일 768px↓ 분기 + WCAG 2.5.5 ≥44px 가드 + iO…

### DIFF
--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -464,6 +464,38 @@
       .alert .ms-auto { margin-left: 0; width: 100%; }
       .alert .btn { width: 100%; }
     }
+
+    /* Cycle 81 PR-C — settings 모바일 768px↓ 분기 (mobile portrait 호환)
+       5+1 cross-verify 관점 🅑 — 카드 padding 축소 + WCAG 2.5.5 ≥44px 가드 + 헤더 폰트 축소.
+       Progressive Disclosure (`<details>` wrap) 는 5-way sync 영향 위험 = Phase 2 영역 보류.
+       Cycle 81 PR-C — settings mobile 768px↓ branch (mobile portrait compat)
+       Cards padding shrink + WCAG 2.5.5 ≥44px guards + header font shrink.
+       `<details>` Progressive Disclosure deferred to Phase 2 (5-way sync risk). */
+    @media (max-width: 768px) {
+      /* 카드 padding 축소 — 모바일 가독성 + 스크롤 부담 ↓ */
+      .s-card-body { padding: 0.85rem; }
+      .s-card-hdr { padding: 0.6rem 0.85rem; }
+      .s-card-hdr .hdr-title { font-size: 12.5px; }
+      .s-card-hdr .hdr-icon { font-size: 14px; }
+
+      /* WCAG 2.5.5 모바일 ≥44px 클릭 영역 가드 (정책 11 페어) */
+      .gate-mode-btn { min-height: 44px; }
+      select, input[type=text], input[type=url], input[type=email], input[type=password] {
+        min-height: 44px;
+        font-size: 16px;  /* iOS Safari focus zoom 회피 (≥16px 의무) */
+      }
+      input[type=number] {
+        min-height: 44px;
+        font-size: 16px;
+      }
+      .save-btn, button[type=submit] { min-height: 48px; }
+
+      /* 위험 구역 (`.danger-summary-wrap`) 모바일 접근성 ↑ — 접힘 default 보존 + summary 클릭 영역 확대 */
+      .danger-summary-wrap summary {
+        min-height: 44px;
+        padding: 0.5rem;
+      }
+    }
   </style>
 
   <form id="settingsForm" method="post" action="/repos/{{ repo_name }}/settings">

--- a/tests/integration/test_settings_mobile.py
+++ b/tests/integration/test_settings_mobile.py
@@ -1,0 +1,116 @@
+"""settings 모바일 768px↓ 분기 회귀 가드 (Cycle 81 PR-C — 영역 🅑 모바일).
+
+5+1 cross-verify (관점 🅑) PR-C 의무:
+- 768px↓ 분기 신설 (mobile portrait 호환)
+- 카드 padding 축소 (`.s-card-body` 1.1rem → 0.85rem)
+- 카드 헤더 폰트 축소 (`.s-card-hdr .hdr-title` 13px → 12.5px)
+- WCAG 2.5.5 ≥44px 가드 (button + select + input)
+- iOS Safari focus zoom 회피 (font-size ≥16px)
+
+Progressive Disclosure (`<details>` wrap) 는 Phase 2 영역 보류 (5-way sync 영향 위험).
+
+Cycle 81 PR-A fix-up 학습 (TestClient lifespan 비활성):
+- HTML 정적 검증 (CSS string in) — 운영 endpoint 무관
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def settings_html() -> str:
+    """settings.html 본문 read (templates 정적 자원)."""
+    return (Path(__file__).resolve().parents[2] / "src" / "templates" / "settings.html").read_text()
+
+
+# ─── 768px↓ 분기 신설 ────────────────────────────────────────────
+
+
+def test_settings_mobile_768px_branch_exists(settings_html):
+    """모바일 768px↓ 분기 신설 (Cycle 81 PR-C 신규)."""
+    assert "@media (max-width: 768px)" in settings_html
+
+
+def test_settings_card_body_padding_shrink(settings_html):
+    """카드 padding 축소 — 모바일 가독성 + 스크롤 부담 ↓."""
+    # 모바일 분기 안 .s-card-body padding 축소 검증
+    # Find the 768px branch and verify card body padding shrink
+    idx = settings_html.find("@media (max-width: 768px)")
+    assert idx > 0
+    # 768px↓ 분기 안 (다음 800자 이내) 카드 padding 축소
+    block = settings_html[idx:idx + 1500]
+    assert ".s-card-body { padding: 0.85rem; }" in block
+    assert ".s-card-hdr { padding: 0.6rem 0.85rem; }" in block
+
+
+def test_settings_card_header_font_shrink(settings_html):
+    """카드 헤더 폰트 축소 (모바일)."""
+    idx = settings_html.find("@media (max-width: 768px)")
+    block = settings_html[idx:idx + 1500]
+    assert ".s-card-hdr .hdr-title { font-size: 12.5px; }" in block
+
+
+# ─── WCAG 2.5.5 ≥44px 가드 ────────────────────────────────────────
+
+
+def test_settings_mobile_wcag_gate_mode_btn(settings_html):
+    """`.gate-mode-btn` 모바일 ≥44px (WCAG 2.5.5)."""
+    idx = settings_html.find("@media (max-width: 768px)")
+    block = settings_html[idx:idx + 1500]
+    assert ".gate-mode-btn { min-height: 44px; }" in block
+
+
+def test_settings_mobile_wcag_input_select(settings_html):
+    """select + input 모바일 ≥44px + ≥16px (iOS Safari focus zoom 회피)."""
+    idx = settings_html.find("@media (max-width: 768px)")
+    block = settings_html[idx:idx + 1500]
+    assert "select, input[type=text]" in block
+    assert "min-height: 44px;" in block
+    assert "font-size: 16px;" in block
+
+
+def test_settings_mobile_wcag_save_btn(settings_html):
+    """저장 버튼 모바일 ≥48px (의무 액션 — WCAG ≥48px 권장)."""
+    idx = settings_html.find("@media (max-width: 768px)")
+    block = settings_html[idx:idx + 1500]
+    assert ".save-btn, button[type=submit] { min-height: 48px; }" in block
+
+
+def test_settings_mobile_danger_summary_wrap(settings_html):
+    """위험 구역 summary 모바일 ≥44px 가드."""
+    idx = settings_html.find("@media (max-width: 768px)")
+    block = settings_html[idx:idx + 1500]
+    assert ".danger-summary-wrap summary" in block
+
+
+# ─── 기존 480px↓ 분기 회귀 0 ──────────────────────────────────────
+
+
+def test_existing_480px_branches_preserved(settings_html):
+    """기존 480px↓ 분기 4 위치 모두 보존 (회귀 0)."""
+    count = settings_html.count("@media (max-width: 480px)")
+    assert count == 4, f"480px↓ 분기 4 위치 보존 의무 — 실측: {count}"
+
+
+# ─── Progressive Disclosure 보류 검증 (Phase 2) ──────────────────
+
+
+def test_existing_details_preserved(settings_html):
+    """기존 `<details>` 영역 (preset 3 + 위험 구역) 보존 — Phase 2 추가 wrap X."""
+    # preset 3건 = preset-minimal / preset-standard / preset-strict
+    assert "preset-minimal" in settings_html
+    assert "preset-standard" in settings_html
+    assert "preset-strict" in settings_html
+    # 위험 구역 = danger-summary-wrap
+    assert "danger-summary-wrap" in settings_html
+
+
+# ─── 회귀 가드 (PR-A + PR-B 영역 무영향) ──────────────────────
+
+
+def test_pwa_manifest_unchanged():
+    """PR-A PWA manifest = settings 변경 무영향."""
+    manifest = (Path(__file__).resolve().parents[2] / "src" / "static" / "manifest.json").read_text()
+    assert '"display": "standalone"' in manifest


### PR DESCRIPTION
…S Safari focus zoom 회피

## Summary
사이클 81 영역 🅑 모바일 PR-C — 5+1 cross-verify (관점 🅑) Phase 1 MVP 4 PR 분할의 PR-C. settings.html 모바일 768px↓ 분기 신설 (mobile portrait 호환) + 카드 padding 축소 + 헤더 폰트 축소 + WCAG 2.5.5 ≥44px 가드 + iOS focus zoom 회피.

## 검증 (사이클 81 PR-C sync 실측)
- 통합 (신규) = 10 collected / 10 passed (test_settings_mobile.py)
- 단위 (전체 회귀) = 2316 passed / 5 skipped / 0 failed (이전 2306 + 10)
- E2E = 변경 0

## 변경 영역 (2 파일)
- `src/templates/settings.html` — `@media (max-width: 768px)` 분기 신설 + 카드 padding 축소 + 헤더 폰트 축소 + WCAG ≥44px 가드 + iOS focus zoom 회피
- `tests/integration/test_settings_mobile.py` 신규 — 회귀 가드 10건

## 모바일 768px↓ 분기 신설 영역
- `.s-card-body` padding 1.1rem → 0.85rem (가독성 ↑)
- `.s-card-hdr` padding + 폰트 12.5px (모바일 헤더 축소)
- `.gate-mode-btn` ≥44px (WCAG 2.5.5)
- `select` + `input[type=text/url/email/password/number]` ≥44px + ≥16px (iOS Safari focus zoom 회피)
- `.save-btn` + `button[type=submit]` ≥48px (의무 액션 — WCAG 권장)
- `.danger-summary-wrap summary` ≥44px (위험 구역 모바일 접근성 ↑)

## 회귀 가드 10건
- 768px↓ 분기 신설 + 카드 padding/헤더 폰트 축소 검증
- WCAG ≥44px 가드 4종 (gate-mode-btn / input/select / save-btn / danger summary)
- iOS focus zoom 회피 (≥16px) 검증
- 기존 480px↓ 분기 4 위치 보존 (회귀 0)
- `<details>` Progressive Disclosure 보존 (preset 3 + 위험 구역)
- PR-A PWA manifest 무영향

## 자율 판단 보고 (정책 3)
1. **`<details>` Progressive Disclosure 보류** = 5-way sync 영향 위험 (HTML 구조 변경 — Phase 2 영역). 정책 16 4번 원칙 + 사용자 명시 결정 의무 (High tier — `feedback-architecture-decision-pre-confirm.md`)
2. **CSS 만 변경 default** (정책 16 단순화) — HTML 구조 변경 0 + 회귀 위험 0
3. **WCAG 2.5.5 + iOS focus zoom 회피** = 메모리 영역 정합 (CLAUDE.md UI/템플릿 §) — 사용처 +1 누적 (480px↓ + 768px↓)
4. **위험 구역 (`danger-summary-wrap`)** = 기존 접힘 default 보존 + summary 클릭 영역 ≥44px 가드 추가 (모바일 접근성 ↑)
5. **PR-A fix-up 학습 적용** = HTML 정적 검증 (CSS string in) — 운영 endpoint 무관

## 🚨 Claude 시각 검증 불가 — 사용자 의무 (정책 11)
settings 모바일 768px↓ 시각 검증:
- [ ] iPhone 12 (390x844) viewport — 6 카드 padding 축소 정합 (가독성 ↑)
- [ ] iPhone SE (375x667) viewport — 카드 헤더 폰트 12.5px 가독성
- [ ] Android Pixel (393x851) viewport — input/select ≥44px + ≥16px (focus zoom 회피)
- [ ] 위험 구역 summary 클릭 영역 ≥44px + 접힘 default
- [ ] 데스크탑 1440px viewport = 768px↑ 분기 미진입 (회귀 0)

## 운영 smoke check (정책 13)
CSS only — 운영 endpoint 무영향. settings 폼 5-way sync 영역 무영향 (HTML 구조 보존)

## Code Scanning open alert (정책 14)
본 PR 작업 직전 = 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
