### PR TITLE
feat(cycle-81-prd): add_repo / login 모바일 form sweep — WCAG 2.5.5 ≥44/…

### DIFF
--- a/src/templates/add_repo.html
+++ b/src/templates/add_repo.html
@@ -61,6 +61,21 @@
     color: var(--text-muted);
     margin-top: .5rem;
   }
+
+  /* Cycle 81 PR-D — add_repo 모바일 768px↓ 분기 신설 (5+1 cross-verify 관점 🅑)
+     카드 padding 축소 + WCAG 2.5.5 ≥44px 가드 + 저장 버튼 ≥48px (settings PR-C 패턴 차용)
+     Cycle 81 PR-D — add_repo mobile 768px↓ branch (5+1 cross-verify 🅑)
+     Card padding shrink + WCAG 2.5.5 ≥44px guards + submit btn ≥48px (PR-C pattern) */
+  @media (max-width: 768px) {
+    .add-repo-card { margin: 1rem auto; }
+    .form-select { min-height: 44px; padding: .75rem 1rem; padding-right: 36px; }
+    .btn-primary { min-height: 48px; }
+    .back-btn { min-height: 44px; padding: .5rem .85rem; }
+    .form-group { margin-bottom: 1rem; }
+  }
+  @media (max-width: 480px) {
+    .add-repo-card { padding: 0 .5rem; }
+  }
 </style>
 
 <div class="toast" id="errorToast"></div>

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -26,6 +26,12 @@
     .login-wrap { padding: var(--space-4) 0; }
     .login-card { padding: 2rem 1.5rem; max-width: 100%; }
   }
+  /* Cycle 81 PR-D — 모바일 768px↓ 분기 신설 (5+1 cross-verify 관점 🅑)
+     btn-github ≥48px (WCAG 의무 액션 권장) — 모바일 OAuth 버튼 클릭 영역 ↑
+     Cycle 81 PR-D — mobile 768px↓ branch — btn-github ≥48px (WCAG required action) */
+  @media (max-width: 768px) {
+    .btn-github { min-height: 48px; }
+  }
   .login-logo {
     width: 60px;
     height: 60px;

--- a/tests/integration/test_form_mobile_sweep.py
+++ b/tests/integration/test_form_mobile_sweep.py
@@ -1,0 +1,112 @@
+"""add_repo / login 모바일 form sweep 회귀 가드 (Cycle 81 PR-D — 영역 🅑 종결).
+
+5+1 cross-verify (관점 🅑) PR-D 의무:
+- add_repo.html 모바일 768px↓ + 480px↓ 분기 신설
+- login.html 모바일 768px↓ 분기 강화 (기존 480px↓ 보존)
+- WCAG 2.5.5 ≥44px (form-select / back-btn) + ≥48px (btn-primary / btn-github)
+- iOS Safari focus zoom 회피 (form-select font-size 16px — 이미 적용 보존 검증)
+
+Cycle 81 PR-A fix-up 학습 — HTML 정적 검증 (CSS string in) — 운영 endpoint 무관.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def add_repo_html() -> str:
+    return (Path(__file__).resolve().parents[2] / "src" / "templates" / "add_repo.html").read_text()
+
+
+@pytest.fixture(scope="module")
+def login_html() -> str:
+    return (Path(__file__).resolve().parents[2] / "src" / "templates" / "login.html").read_text()
+
+
+# ─── add_repo.html 모바일 분기 신설 ──────────────────────────────
+
+
+def test_add_repo_mobile_768px_branch_exists(add_repo_html):
+    """add_repo.html 모바일 768px↓ 분기 신설 (Cycle 81 PR-D)."""
+    assert "@media (max-width: 768px)" in add_repo_html
+
+
+def test_add_repo_mobile_480px_branch_exists(add_repo_html):
+    """add_repo.html 모바일 480px↓ 분기 신설 (PR-D 신규)."""
+    assert "@media (max-width: 480px)" in add_repo_html
+
+
+def test_add_repo_form_select_wcag_44px(add_repo_html):
+    """`.form-select` 모바일 ≥44px (WCAG 2.5.5)."""
+    idx = add_repo_html.find("@media (max-width: 768px)")
+    block = add_repo_html[idx:idx + 800]
+    assert ".form-select { min-height: 44px;" in block
+
+
+def test_add_repo_btn_primary_wcag_48px(add_repo_html):
+    """`.btn-primary` 모바일 ≥48px (의무 액션)."""
+    idx = add_repo_html.find("@media (max-width: 768px)")
+    block = add_repo_html[idx:idx + 800]
+    assert ".btn-primary { min-height: 48px; }" in block
+
+
+def test_add_repo_back_btn_wcag_44px(add_repo_html):
+    """`.back-btn` 모바일 ≥44px."""
+    idx = add_repo_html.find("@media (max-width: 768px)")
+    block = add_repo_html[idx:idx + 800]
+    assert ".back-btn { min-height: 44px;" in block
+
+
+def test_add_repo_form_select_ios_focus_zoom_preserved(add_repo_html):
+    """`.form-select` font-size 16px (iOS focus zoom 회피) 보존 검증."""
+    # 기존 line 43 = font-size 16px (PR-D 변경 무관)
+    assert "font-size: 16px;" in add_repo_html
+
+
+# ─── login.html 모바일 분기 강화 ────────────────────────────────
+
+
+def test_login_mobile_768px_branch_exists(login_html):
+    """login.html 모바일 768px↓ 분기 신설 (PR-D)."""
+    assert "@media (max-width: 768px)" in login_html
+
+
+def test_login_btn_github_wcag_48px(login_html):
+    """`.btn-github` 모바일 ≥48px (OAuth 의무 액션 — WCAG 권장)."""
+    idx = login_html.find("@media (max-width: 768px)")
+    block = login_html[idx:idx + 500]
+    assert ".btn-github { min-height: 48px; }" in block
+
+
+def test_login_existing_480px_branch_preserved(login_html):
+    """기존 login 480px↓ 분기 보존 (회귀 0)."""
+    assert "@media (max-width: 480px)" in login_html
+    # 기존 분기 영역 = .login-wrap + .login-card padding
+    idx = login_html.find("@media (max-width: 480px)")
+    block = login_html[idx:idx + 300]
+    assert ".login-wrap" in block
+    assert ".login-card" in block
+
+
+# ─── 회귀 가드 (PR-A/B/C 영역 무영향) ──────────────────────────
+
+
+def test_pwa_manifest_unchanged():
+    """PR-A PWA manifest = 본 PR 무영향."""
+    manifest = (Path(__file__).resolve().parents[2] / "src" / "static" / "manifest.json").read_text()
+    assert '"display": "standalone"' in manifest
+
+
+def test_dashboard_mobile_priority_unchanged():
+    """PR-B dashboard 모바일 KPI 우선순위 = 본 PR 무영향."""
+    dashboard_html = (Path(__file__).resolve().parents[2] / "src" / "templates" / "dashboard.html").read_text()
+    assert ".dash-kpi:nth-child(3) { order: 1;" in dashboard_html
+
+
+def test_settings_mobile_768px_unchanged():
+    """PR-C settings 모바일 768px↓ = 본 PR 무영향."""
+    settings_html = (Path(__file__).resolve().parents[2] / "src" / "templates" / "settings.html").read_text()
+    assert "@media (max-width: 768px)" in settings_html
+    assert ".s-card-body { padding: 0.85rem; }" in settings_html


### PR DESCRIPTION
…48px 가드 (영역 🅑 종결)

## Summary
사이클 81 영역 🅑 모바일 종결 PR — 5+1 cross-verify (관점 🅑) Phase 1 MVP 4 PR 분할 마지막 PR-D. add_repo / login form 모바일 768px↓ 분기 신설/강화 + WCAG 2.5.5 ≥44px (form-select/back-btn) + ≥48px (btn-primary/btn-github 의무 액션).

## 검증 (사이클 81 PR-D sync 실측)
- 통합 (신규) = 12 collected / 12 passed (test_form_mobile_sweep.py)
- 단위 (전체 회귀) = 2328 passed / 5 skipped / 0 failed (이전 2316 + 12)
- E2E = 변경 0

## 변경 영역 (3 파일)
- `src/templates/add_repo.html` — 모바일 768px↓ + 480px↓ 분기 신설 (form-select ≥44px / btn-primary ≥48px / back-btn ≥44px / 카드 padding 축소)
- `src/templates/login.html` — 모바일 768px↓ 분기 신설 (btn-github ≥48px) + 기존 480px↓ 분기 보존
- `tests/integration/test_form_mobile_sweep.py` 신규 — 회귀 가드 12건

## WCAG 2.5.5 가드 영역
| 셀렉터 | 모바일 ≥px | 사유 |
|--------|----------|------|
| `.form-select` (add_repo) | 44px | input/select 일반 영역 | | `.btn-primary` (add_repo) | 48px | 의무 액션 (저장) — WCAG 권장 | | `.back-btn` (add_repo) | 44px | 네비 영역 |
| `.btn-github` (login) | 48px | 의무 액션 (OAuth) — WCAG 권장 |

## iOS Safari focus zoom 회피 보존
- `.form-select` font-size 16px (기존 line 43 보존 검증) — PR-D 변경 무관

## 회귀 가드 12건
- add_repo 768px↓ + 480px↓ 분기 신설 검증
- WCAG 가드 4종 (form-select / btn-primary / back-btn + ios font-size)
- login 768px↓ 분기 신설 + 기존 480px↓ 보존
- 회귀 가드 (PR-A PWA / PR-B dashboard / PR-C settings) 무영향 검증 3건

## 자율 판단 보고 (정책 3)
1. **PR-C 패턴 차용** = `.btn-primary` 48px + `.form-select` 44px (settings 패턴 일관)
2. **iOS focus zoom 회피 보존** = add_repo 기존 `font-size: 16px` (line 43 default)
3. **CSS only** = HTML 구조 보존 + 회귀 0
4. **사이클 81 영역 🅑 종결** = PR-A (PWA manifest) + PR-B (dashboard 모바일) + PR-C (settings 모바일) + PR-D (add_repo/login form sweep) 4 PR 모두 진입

## 🚨 Claude 시각 검증 불가 — 사용자 의무 (정책 11)
모바일 form 시각 검증:
- [ ] iPhone 12 (390x844) — add_repo select tap 영역 ≥44px + btn-primary ≥48px
- [ ] iPhone SE (375x667) — login OAuth 버튼 ≥48px
- [ ] Android Pixel (393x851) — back-btn 클릭 영역 ≥44px
- [ ] iOS Safari select focus 시 zoom 미발생 (font-size ≥16px)

## 운영 smoke check (정책 13)
CSS only — 운영 endpoint 무영향. add_repo / login 폼 동작 100% 보존

## Code Scanning open alert (정책 14)
본 PR 작업 직전 = 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
