### PR TITLE
fix(cycle-78-pr2): 🅒 P0-1 — Telegram 403 (봇 차단) silent skip + streak …

### DIFF
--- a/src/notifier/telegram.py
+++ b/src/notifier/telegram.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 # single retry only to avoid infinite loop. Critical C4 from 2026-04-30 audit.
 TELEGRAM_RETRY_AFTER_MAX_SECONDS = 30
 
+# Cycle 78 PR 2 — 봇 차단 silent skip + streak guard (5+1 NEW-P0 — 🅒 P0-1).
+# Telegram 403 = bot blocked by user / kicked from group → cron 누적 사고 차단.
+# silent skip + WARNING (단발) + 5회 연속 시 streak WARNING (운영자 인지).
+# Cycle 78 PR 2 — bot blocked silent skip + streak guard (5+1 NEW-P0 — 🅒 P0-1).
+TELEGRAM_BOT_BLOCKED_STREAK_THRESHOLD = 5
+_telegram_bot_blocked_streak: int = 0  # process restart 시 reset (정책 16 단순화)
+
 
 async def telegram_post_message(bot_token: str, chat_id: str, payload: dict) -> None:
     """Telegram Bot API sendMessage 엔드포인트에 JSON 페이로드를 POST한다.
@@ -26,11 +33,16 @@ async def telegram_post_message(bot_token: str, chat_id: str, payload: dict) -> 
     429 Too Many Requests 응답 시 `parameters.retry_after` 만큼 sleep 후 1회 재시도.
     cap 30s — 악의적 응답으로 인한 무기한 sleep 방지.
 
+    403 Forbidden (bot blocked by user / kicked from group) 시 silent skip + WARNING.
+    5회 연속 403 시 추가 streak WARNING — 운영자 인지 의무.
+    Cycle 78 PR 2 — bot blocked guard (Phase 9 silent fallback streak 패턴 차용).
+
     Args:
         bot_token: Telegram Bot API 토큰
         chat_id:   대상 채팅 ID (사용자·그룹·채널)
         payload:   sendMessage JSON 페이로드 (text, parse_mode 등)
     """
+    global _telegram_bot_blocked_streak  # pylint: disable=global-statement
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
     client = get_http_client()  # 싱글톤
     body = {"chat_id": chat_id, **payload}
@@ -45,6 +57,33 @@ async def telegram_post_message(bot_token: str, chat_id: str, payload: dict) -> 
         )
         await asyncio.sleep(retry_after)
         r = await client.post(url, json=body)
+
+    # defensive int coercion — mock-safety + 정책 16 1번 원칙 정확성
+    # (메모리 `feedback-defensive-coercion-mock-safety.md` 패턴)
+    # defensive int coercion — mock-safety + Policy 16 #1 accuracy
+    try:
+        status = int(r.status_code or 0)
+    except (TypeError, ValueError):
+        status = 0
+
+    # 403 봇 차단 silent skip + streak guard (Cycle 78 PR 2 — 🅒 P0-1)
+    # 403 bot blocked silent skip + streak guard
+    if status == 403:
+        _telegram_bot_blocked_streak += 1
+        logger.warning(
+            "Telegram 403 (bot blocked or kicked) chat_id=%s — silent skip", chat_id,
+        )
+        if _telegram_bot_blocked_streak >= TELEGRAM_BOT_BLOCKED_STREAK_THRESHOLD:
+            logger.warning(
+                "Telegram bot_blocked streak=%d — 운영자 검토 의무 (token revoke 또는 chat 정리)",
+                _telegram_bot_blocked_streak,
+            )
+            _telegram_bot_blocked_streak = 0  # reset (재 alert 방지)
+        return
+
+    # 정상 응답 — streak reset
+    if status and status < 400:
+        _telegram_bot_blocked_streak = 0
 
     r.raise_for_status()
 

--- a/tests/unit/notifier/test_telegram_bot_blocked_skip.py
+++ b/tests/unit/notifier/test_telegram_bot_blocked_skip.py
@@ -1,0 +1,145 @@
+"""telegram_post_message — 봇 차단 silent skip + streak guard 회귀 가드.
+
+Cycle 78 PR 2 — 🅒 P0-1 (5+1 cross-verify 결과).
+봇 차단 (403 Forbidden) 시 silent skip + WARNING + 5회 연속 시 streak WARNING.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.notifier import telegram as telegram_module
+
+
+@pytest.fixture(autouse=True)
+def _reset_streak():
+    """테스트 격리 — 모듈 레벨 streak 카운터 reset."""
+    telegram_module._telegram_bot_blocked_streak = 0
+    yield
+    telegram_module._telegram_bot_blocked_streak = 0
+
+
+def _make_response(status_code: int):
+    """httpx Response mock — status_code + raise_for_status no-op."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_403_silent_skip_no_raise(caplog):
+    """403 Forbidden 응답 시 silent skip — raise_for_status X + WARNING 로그."""
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_response(403))
+    with patch("src.notifier.telegram.get_http_client", return_value=fake_client):
+        with caplog.at_level(logging.WARNING, logger="src.notifier.telegram"):
+            # raise X — silent skip
+            await telegram_module.telegram_post_message(
+                bot_token="fake-token", chat_id="123", payload={"text": "hi"},
+            )
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("403" in m and "silent skip" in m for m in msgs), \
+        "403 silent skip WARNING 의무"
+
+
+@pytest.mark.asyncio
+async def test_403_increments_streak(caplog):
+    """403 응답 1회 = streak +1. threshold 미만 = streak WARNING X."""
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_response(403))
+    with patch("src.notifier.telegram.get_http_client", return_value=fake_client):
+        with caplog.at_level(logging.WARNING, logger="src.notifier.telegram"):
+            await telegram_module.telegram_post_message(
+                bot_token="fake-token", chat_id="123", payload={"text": "hi"},
+            )
+    assert telegram_module._telegram_bot_blocked_streak == 1
+    msgs = [r.getMessage() for r in caplog.records]
+    # streak WARNING (5회 연속) 미발화
+    assert not any("streak=" in m for m in msgs)
+
+
+@pytest.mark.asyncio
+async def test_403_streak_threshold_emits_warning_and_resets(caplog):
+    """403 5회 연속 = streak WARNING + reset (재 alert 방지)."""
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_response(403))
+    with patch("src.notifier.telegram.get_http_client", return_value=fake_client):
+        with caplog.at_level(logging.WARNING, logger="src.notifier.telegram"):
+            for _ in range(5):
+                await telegram_module.telegram_post_message(
+                    bot_token="fake-token", chat_id="123", payload={"text": "hi"},
+                )
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("streak=5" in m for m in msgs), \
+        "5회 연속 403 시 streak=5 WARNING 의무"
+    # reset (재 alert 방지)
+    assert telegram_module._telegram_bot_blocked_streak == 0
+
+
+@pytest.mark.asyncio
+async def test_200_resets_streak():
+    """정상 응답 (200) 시 streak reset."""
+    telegram_module._telegram_bot_blocked_streak = 3  # 사전 누적
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=_make_response(200))
+    with patch("src.notifier.telegram.get_http_client", return_value=fake_client):
+        await telegram_module.telegram_post_message(
+            bot_token="fake-token", chat_id="123", payload={"text": "hi"},
+        )
+    assert telegram_module._telegram_bot_blocked_streak == 0
+
+
+@pytest.mark.asyncio
+async def test_200_no_warning(caplog):
+    """정상 응답 (200) 시 WARNING 없음 + raise_for_status no-op."""
+    fake_client = MagicMock()
+    fake_resp = _make_response(200)
+    fake_client.post = AsyncMock(return_value=fake_resp)
+    with patch("src.notifier.telegram.get_http_client", return_value=fake_client):
+        with caplog.at_level(logging.WARNING, logger="src.notifier.telegram"):
+            await telegram_module.telegram_post_message(
+                bot_token="fake-token", chat_id="123", payload={"text": "hi"},
+            )
+    msgs = [r.getMessage() for r in caplog.records]
+    assert not any("403" in m for m in msgs)
+    fake_resp.raise_for_status.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_500_still_raises(caplog):
+    """500 Internal Server Error = silent skip 영역 X — raise_for_status 발화."""
+    fake_client = MagicMock()
+    fake_resp = _make_response(500)
+    fake_resp.raise_for_status.side_effect = Exception("500 server error")
+    fake_client.post = AsyncMock(return_value=fake_resp)
+    with patch("src.notifier.telegram.get_http_client", return_value=fake_client):
+        with pytest.raises(Exception, match="500"):
+            await telegram_module.telegram_post_message(
+                bot_token="fake-token", chat_id="123", payload={"text": "hi"},
+            )
+    # 500 = streak 미증가 (403 만 카운트)
+    assert telegram_module._telegram_bot_blocked_streak == 0
+
+
+@pytest.mark.asyncio
+async def test_403_then_200_resets_streak(caplog):
+    """403 후 200 = streak reset (정상 복구)."""
+    fake_client = MagicMock()
+    # 첫 호출 403, 두 번째 호출 200
+    responses = [_make_response(403), _make_response(200)]
+    fake_client.post = AsyncMock(side_effect=responses)
+    with patch("src.notifier.telegram.get_http_client", return_value=fake_client):
+        with caplog.at_level(logging.WARNING, logger="src.notifier.telegram"):
+            # 첫 호출 = 403 silent skip
+            await telegram_module.telegram_post_message(
+                bot_token="fake-token", chat_id="123", payload={"text": "hi"},
+            )
+            assert telegram_module._telegram_bot_blocked_streak == 1
+            # 두 번째 호출 = 200 정상 → streak reset
+            await telegram_module.telegram_post_message(
+                bot_token="fake-token", chat_id="123", payload={"text": "hi"},
+            )
+    assert telegram_module._telegram_bot_blocked_streak == 0


### PR DESCRIPTION
…guard (NEW-P0-1 페어)

## Summary
사이클 78 5+1 cross-verify 결과 = 🅒 영역 P0-1 (`telegram_post_message:49 r.raise_for_status()` → 403 시 raise → cron 누적 사고). 봇 차단 시 silent skip + WARNING + 5회 연속 streak guard 적용.

## 검증 (사이클 78 PR 2 sync 실측)
- 단위 (신규) = 7 collected / 7 passed (test_telegram_bot_blocked_skip.py)
- 단위 (회귀 가드) = 12 passed (기존 test_telegram.py)
- 통합 = 변경 0
- E2E = 변경 0

## 변경 영역
- `src/notifier/telegram.py` — 403 silent skip + streak guard + defensive int coercion
- `tests/unit/notifier/test_telegram_bot_blocked_skip.py` — 회귀 가드 7건

## 자율 판단 보고 (정책 3)
1. 정책 16 1번 원칙 (정확성) + 메모리 `feedback-defensive-coercion-mock-safety.md` 페어 = `int(r.status_code or 0)` 의무 적용 (mock 회귀 차단)
2. silent fallback streak threshold = 5회 (사이클 72 #242 cache streak 와 동일 default 정합)
3. 사용처 +1 (claude_metrics 1 → 2). NEW-P0-2 (helper 추출 임계 ≥3) 도달 임박 — 추가 사용처 1건 시 helper 추출 결정 시점
4. 500 server error 는 silent skip 영역 X — `raise_for_status` 발화 보존 (회귀 가드 페어)
5. 200 정상 응답 시 streak reset (정상 복구 패턴 — silent fallback 누적 방지)

## 운영 smoke check (정책 13)
code 변경 = telegram.py only — 운영 endpoint 무영향 + 회귀 가드 19 PASS 검증 (silent skip = 운영 cron 안정화 페어)

## Code Scanning open alert (정책 14)
본 PR 작업 직전 = 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
