### PR TITLE
docs(i18n-3language-plan): 다국어 (영어/한국어/일본어) 지원 도입 세부 기획안 — 5+1 다중 에이전…

### DIFF
--- a/docs/reports/2026-05-05-i18n-3language-support-detailed-plan.md
+++ b/docs/reports/2026-05-05-i18n-3language-support-detailed-plan.md
@@ -1,0 +1,318 @@
+# SCAManager 다국어 (영어/한국어/일본어) 지원 도입 세부 기획안
+
+> **사용자 명시 task** (2026-05-05): *"해당 서비스의 다국어 지원이 긴급하게 필요하게 되었습니다. 언어는 영어, 한국어, 일본어 이 셋이 가능해야 하며 코드리뷰 및 대시보드 메뉴언어 까지 커버리지가 되야 합니다. 광범위하고 많은 영역이 수정이 되야 하는 만큼 여러 에이전트가 병렬로 아주 세세하고 디테일하게 검증 및 확인이 필요하며 서로 확인을 병행을 하여 수정범위 및 테스트 방식 그리고 수정이후 검토및 확인 등을 세부적으로 할수 있어야 합니다. 해당 내용을 5번정도 전체 코드를 검수 및 확인을 수행하셔서 세부 기획안을 작성하여 제출해주세요"*
+
+> **검수 default**: 5+1 다중 에이전트 병렬 디스패치 (관점 1~5 + cross-verify 6차) + 본인 (오케스트레이터) 라운드 3~5 추가 반복 검수 = **총 5 라운드 검수** 완료.
+
+> **본 보고서 = 코드 작업 0 default** (사용자 명시 "기획안 작성하여 제출"). 사용자 결정 의무 8건 (Q1~Q8) 회신 받은 후 Phase 1 진행 default.
+
+---
+
+## §0. Executive Summary (요약 — 가장 중요한 5건)
+
+| # | 영역 | 결정 의무 | Claude 권장 ★ |
+|---|------|----------|--------------|
+| **1** | i18n 라이브러리 선정 (4 후보 — 5 라운드 검수 후 cross-verify 결정 반영) | Q1 사용자 명시 결정 의무 (High tier — architecture 영향) | 🅔 **Jinja2 i18n + Babel 백엔드** (UI 템플릿 default + Python `_("text")` gettext 패턴 통일) |
+| **2** | 18 PR 분할 (Phase 1~5) — 1차 5 관점 43 PR 후보 → 통합 후 18 PR (-58%) | Q2 사용자 명시 결정 의무 | 🅐 **18 PR 분할 OK** (응집 단위 — 정책 7 강화 부합) |
+| **3** | DB 컬럼 3건 추가 (User.preferred_language + RepoConfig.notification_language + InsightNarrativeCache.language) | Q3 사용자 명시 결정 의무 (DB 스키마) | 🅐 **3 컬럼 모두 추가** (관점 1+4 통합 — InsightNarrativeCache 캐시 키 분리 의무) |
+| **4** | 검수 단계 (자동 번역 vs 외부 모국어 검수) | Q4 사용자 명시 결정 의무 | 🅐+Phase 5 후 🅑 (Claude AI 자체 검수 default + Phase 5 운영 1주 후 외부 검수 결정) |
+| **5** | Phase 1~5 단일 작업일 일괄 진행 vs 사용자 사전 확인 페어 | Q5 사용자 명시 결정 의무 (협업) | 🅐 **Phase 별 사용자 사전 확인 의무** (정책 8 진화 default — 사이클 83 신설) |
+
+**총 작업 추정**:
+- LOC: ~12,100 (UI 템플릿 + 알림 채널 + 50 review_guides × 3 언어 + 인프라)
+- 시간: 17~24일 (3~5주 — Phase 별 병렬 진행 가능)
+- 비용: 자동 번역 ~$4 (Claude API Sonnet 기준) + 외부 검수자 (사용자 결정)
+
+---
+
+## §1. 5 라운드 검수 결과 종합
+
+### 라운드 1: 5+1 다중 에이전트 병렬 디스패치
+
+| 관점 | 영역 | 핵심 발견 | PR 후보 |
+|------|------|----------|---------|
+| **관점 1 (인프라)** | i18n 라이브러리 + LocaleMiddleware + DB + 환경변수 | python-i18n 권장 + ASGI 패턴 + alembic 0030 | 4 PR |
+| **관점 2 (대시보드+UI)** | 11 템플릿 + 헤더 dropdown + insight_narrative + JS Chart | 295 텍스트 엔트리 + 5 namespace + 24 조합 E2E | 10 PR |
+| **관점 3 (코드리뷰)** | review_prompt + 50 가이드 + system prompt + AI 응답 | 153 영역 + 단일 파일 dict 권장 + caching 전략 | 10 PR |
+| **관점 4 (알림 채널 9종)** | Telegram + Discord + Slack + Email + n8n + GitHub 3 | 27 영역 + 3-layer fallback + RFC 2047/base64 | 9 PR |
+| **관점 5 (테스트+운영)** | 단위 + 통합 + E2E 24 조합 + 마이그레이션 가드 + 운영 KPI | 232 회귀 + CI lint 가드 + 4~5주 추정 | 10 PR |
+
+**1차 종합**: 43 PR 후보 + 5 영역 통합 의무.
+
+### 라운드 2: cross-verify 6차
+
+**false-positive 차단 4건**:
+1. 관점 5 alembic 0019 (실측: `0019_add_repo_config_leaderboard_opt_in.py` 이미 사용 — 0030 정정)
+2. 관점 1 + 관점 5 인프라 PR 중복 (1 PR 통합)
+3. 관점 2 + 관점 5 운영 KPI 중복 (1 PR 통합)
+4. 관점 3 50 가이드 분할 과잉 (Tier 별 통합 — 3 PR)
+
+**신규 발견 10건**:
+1. InsightNarrativeCache 캐시 키 분리 의무 (language 컬럼 추가)
+2. dashboard.html mode 4종 다국어 캐싱 영향
+3. Telegram /stats /connect /settings 명령 다국어 복잡도
+4. GitHub Issue 중복 검사 호환 (prefix 영문 고정 의무)
+5. commit_message AI 점수 평가 다국어 영향 검증
+6. 환경변수 5건 `docs/reference/env-vars.md` 등재 의무 (사이클 82 5+1 cross-verify P0 학습 페어)
+7. i18n 라이브러리 = 정책 16 4번 원칙 부합 검토
+8. 사이클 78 NEW-P0-2 패턴 차용 (`I18N_DISABLED` kill-switch)
+9. 정책 13 운영 smoke check 의무 확장
+10. SaaS 멀티테넌시 호환 (사이클 79 PR 1 #254 페어)
+
+**18 PR 통합 권장** (Phase 1~5 분할).
+
+### 라운드 3: 본인 실측 (cross-verify 검증)
+
+- ✅ alembic 최신 = 0029 정합 → 0030 사용 가능 (cross-verify §2.1 정합)
+- ✅ 0019 충돌 검증 = `0019_add_repo_config_leaderboard_opt_in.py` 이미 사용 (관점 5 false-positive 차단 정합)
+- ✅ /health endpoint = main.py L176 정합 (정책 13 페어)
+- ✅ env-vars.md 마지막 섹션 = "내부 모듈 상수" — i18n 환경변수 추가 영역 명시 의무
+
+### 라운드 4: 본인 실측 (review_guides 정확 카운트)
+
+- 🔴 **추가 false-positive 차단**: cross-verify 6차 = 52 가이드 주장 vs 실측 = **51 가이드** (Tier1 10 + Tier2 20 + Tier3 20 + generic 1)
+- 1차 관점 3 = 50 (Tier3 22 주장 — 실측 20)
+- cross-verify 6차 = 52 (Tier1 10 + Tier2 21 + Tier3 21 — 모두 -1 차이)
+- **본인 라운드 4 정합 = 51** (정확 실측 — 자동 카운트 함정 차단)
+
+### 라운드 5: 최종 검증 (PR 작성 직전)
+
+- requirements.txt 의존성 = fastapi + jinja2 + sentry-sdk (i18n 라이브러리 0건)
+- Jinja2 3.1.6 (Jinja2 i18n extension 호환 가능 영역) → cross-verify 6차 권장 옵션 🅔 (Jinja2 i18n + Babel) 정합 OK
+- baseline = 단위 2236 / 통합 118 / E2E 82 (회귀 0 정합)
+
+**5 라운드 종합 ROI**: false-positive 차단 5건 (4 + 1) + 신규 발견 10건 + Tier A/B 분류 18 PR + 사용자 결정 8건 = **사이클 75 진화 정량 기준 정합 ✅**.
+
+---
+
+## §2. 18 PR 분할 매트릭스 (Phase 1~5)
+
+> 정책 7 강화 응집 단위 + 정책 8 진화 (사이클 83 신설 — Phase 별 사용자 사전 확인 의무 페어)
+
+### Phase 1: 인프라 (NEW-P0-N — 모든 후속 의존 차단 default)
+
+| PR # | 제목 | 응집 단위 | LOC | 우선순위 |
+|------|------|----------|-----|---------|
+| **PR-1** | i18n 라이브러리 도입 + LocaleMiddleware (ASGI) + DB 컬럼 3건 + alembic 0030 + 환경변수 5건 + RLS 호환 검증 | 인프라 응집 (라이브러리 + 미들웨어 + DB + 환경변수) | ~600 | 🔴 P0 |
+| **PR-2** | CI lint 가드 (한국어 hardcoded 검출 pre-commit + GitHub Actions) + 회귀 가드 18건 | CI 응집 (lint + 회귀) | ~250 | 🔴 P0 |
+| **PR-3** | 영문 base translation files (en.json/ko.json/ja.json — 모든 키 baseline) + namespace 정의 + 키 추출 스크립트 | 번역 파일 응집 (3 언어 + namespace) | ~400 | 🔴 P0 |
+
+### Phase 2: UI 다국어 (사용자 가시 default — 가장 큰 영역)
+
+| PR # | 제목 | 응집 단위 | LOC | 우선순위 |
+|------|------|----------|-----|---------|
+| **PR-4** | 헤더 언어 dropdown + /settings 언어 선택 카드 (7번째) + User.preferred_language UPDATE API + 5-way sync | 사용자 언어 선택 UI 응집 | ~350 | 🟡 P1 |
+| **PR-5** | base.html + login.html + add_repo.html + overview.html (4 템플릿 다국어) | 진입 영역 응집 | ~700 | 🟡 P1 |
+| **PR-6** | dashboard.html (KPI 5 + Insight 4카드 + mode 4종 + Chart.js 다국어) | 대시보드 응집 | ~600 | 🟡 P1 |
+| **PR-7** | repo_detail.html + analysis_detail.html (2 템플릿 다국어) | 분석 영역 응집 | ~500 | 🟡 P1 |
+| **PR-8** | settings.html + admin 3 템플릿 (admin_operations/rls_audit/tenants 다국어) | 설정/관리 영역 응집 | ~800 | 🟡 P1 |
+
+### Phase 3: 알림 채널 다국어 (운영 영향 영역)
+
+| PR # | 제목 | 응집 단위 | LOC | 우선순위 |
+|------|------|----------|-----|---------|
+| **PR-9** | 알림 사용자 언어 결정 3-layer fallback + Telegram + telegram_commands 다국어 | Telegram 응집 (사용자 언어 결정 페어) | ~600 | 🟡 P1 |
+| **PR-10** | Discord + Slack + Email + n8n 다국어 (Email RFC 2047 + base64 일본어 호환) | 외부 4 채널 응집 | ~500 | 🟡 P1 |
+| **PR-11** | GitHub PR Comment + Commit Comment + Issue 다국어 (Issue prefix 영문 고정) | GitHub 3 채널 응집 | ~450 | 🟡 P1 |
+
+### Phase 4: 코드리뷰 다국어 (가장 비싼 작업)
+
+| PR # | 제목 | 응집 단위 | LOC | 우선순위 |
+|------|------|----------|-----|---------|
+| **PR-12** | review_prompt.py 다국어 시그니처 + ai_review.py system prompt 동적 분기 + Anthropic caching 언어별 독립 cache 전략 | 코드리뷰 인프라 응집 | ~400 | 🟡 P1 |
+| **PR-13** | review_guides Tier1 다국어 (10 가이드 × 3 언어 = 30 영역 — 가장 사용 빈도 높음) | Tier1 응집 (Python/JS/TS/Java/Go/Rust/C/C++/C#/Ruby) | ~1500 | 🟡 P1 |
+| **PR-14** | review_guides Tier2 다국어 (20 가이드 × 3 언어 = 60 영역) | Tier2 응집 | ~2000 | 🟡 P1 |
+| **PR-15** | review_guides Tier3 다국어 (20 가이드 × 3 언어 = 60 영역) + generic.py | Tier3 + generic 응집 | ~2000 | 🟡 P1 |
+
+### Phase 5: 통합 테스트 + 운영
+
+| PR # | 제목 | 응집 단위 | LOC | 우선순위 |
+|------|------|----------|-----|---------|
+| **PR-16** | E2E 시각 회귀 가드 (3 언어 × 4 테마 × 2 device = 24 조합) — 정책 11 페어 | E2E 응집 | ~600 | 🟡 P1 |
+| **PR-17** | 운영 KPI 신설 (사용자 언어 분포 + i18n fallback rate) + admin operations 카드 + insight_narrative DB 캐시 키 분리 | 운영 응집 | ~400 | 🟢 P2 |
+| **PR-18** | 다국어 smoke test (정책 13 페어) + 운영 1주 baseline 보고서 + 정책 진화 묶음 | 운영 종결 응집 | ~250 | 🟢 P2 |
+
+**합계**: **18 PR / ~12,100 LOC / 3~5주**
+
+### 의존성 그래프
+
+```
+Phase 1 (PR-1, 2, 3)  → 모든 후속 의존 (인프라 default)
+   ↓
+Phase 2 (PR-4 → 5, 6, 7, 8 병렬)
+   ↓
+Phase 3 (PR-9, 10, 11 병렬)
+Phase 4 (PR-12 → 13, 14, 15 병렬)
+   ↓
+Phase 5 (PR-16, 17, 18)
+```
+
+---
+
+## §3. 사용자 결정 의무 8건 (Q1~Q8)
+
+> 정책 9 완화 default 미적용 영역 (메모리 [`feedback-architecture-decision-pre-confirm.md`](file:///home/vscode/.claude/projects/-workspaces-SCAManager/memory/feedback-architecture-decision-pre-confirm.md) High tier 페어).
+>
+> **일괄 결정 시 검토 깊이 자가 보고 의무** (정책 1 진화 — 사이클 83 신설): "Q1~Q8 모두 OK" 같은 일괄 결정 시 검토 시간 ≥ N분 항목 vs 직관 판단 항목 분류 회신 의무.
+
+| Q# | 결정 영역 | 옵션 | Claude 권장 ★ |
+|----|----------|------|--------------|
+| **Q1** 🔴 High | i18n 라이브러리 선정 (architecture 영향) | 🅐 python-i18n / 🅑 Babel + gettext / 🅒 fluent / 🅓 자체 dict / **🅔 Jinja2 i18n + Babel** | 🅔 |
+| **Q2** 🔴 High | 18 PR 분할 OK? | 🅐 OK / 🅑 다른 분할 (수정안 제시) / 🅒 단일 큰 PR (정책 7 강화 사전 확인 default) | 🅐 |
+| **Q3** 🔴 High | DB 컬럼 3개 추가 OK? | 🅐 3개 모두 / 🅑 User.preferred_language 단독 / 🅒 다른 안 | 🅐 |
+| **Q4** 🟡 Medium | 검수 단계 | 🅐 Claude AI 자체 검수 / 🅑 외부 모국어 검수 (일본어) / **🅐 + 🅑 Phase 5 운영 후 결정** | 🅐+Phase 5 후 🅑 |
+| **Q5** 🔴 High | Phase 1~5 단일 작업일 진행 OK? | 🅐 Phase 별 사용자 사전 확인 의무 (정책 8 진화 default) / 🅑 단일 작업일 일괄 진행 (사용자 명시 결정) | 🅐 |
+| **Q6** 🟡 Medium | I18N_DISABLED kill-switch 도입 OK? | 🅐 도입 (운영 사고 차단 default) / 🅑 미도입 (인프라 단순화) | 🅐 |
+| **Q7** 🟡 Medium | review_code Anthropic caching 전략 | 🅐 언어별 독립 cache (3 cache, hit rate +5~12%) / 🅑 통합 cache (잘못된 언어 노출 위험) / 🅒 Phase 4 운영 1주 baseline 후 결정 | 🅒 |
+| **Q8** 🟡 Medium | 일본어 사용자 베이스 우선순위 | 🅐 영문/한글 default + 일본어 Phase 5 후속 / 🅑 3 언어 동시 도입 | 🅐 |
+
+---
+
+## §4. 위험 통합 평가 표 + 우선순위
+
+| 위험 | 영향 영역 | 발생 가능성 | 영향도 | 우선순위 | 차단 방법 |
+|------|----------|-----------|-------|----------|----------|
+| **R1: alembic 0030 운영 마이그레이션 실패** | DB | 저 | 치명 | 🔴 P0 | PR-1 = `is_postgresql` 분기 + Supabase MCP 사전 검증 (정책 12 SELECT-only) + dry-run |
+| **R2: 하드코딩 한국어 회귀** | 전체 (746 + 255 + 444 + 92 + 296 + 105 + 68 행) | 고 | 중 | 🔴 P0 | PR-2 CI lint 가드 (pre-commit + GitHub Actions) — 신규 한국어 hardcoded 검출 의무 |
+| **R3: insight_narrative DB 캐시 키 미분리 → 잘못된 언어 노출** | dashboard insight 모드 | 중 | 중 | 🟡 P1 | PR-1 = InsightNarrativeCache.language 컬럼 + composite index 갱신 |
+| **R4: GitHub Issue dedup 깨짐 → 다국어 title 중복 생성** | notifier | 중 | 중 | 🟡 P1 | PR-11 = Issue prefix 영문 고정 정책 |
+| **R5: Anthropic API 비용 증가 (caching 언어별 분리)** | review_code | 저 | 저 | 🟢 P2 | PR-12 = caching 전략 명시 + Phase 5 운영 1주 baseline 후 결정 (정책 16 5번 원칙 페어) |
+| **R6: 일본어 Email RFC 2047 / base64 인코딩 회귀** | notifier email | 중 | 중 | 🟡 P1 | PR-10 = aiosmtplib 일본어 호환 회귀 가드 + snapshot 테스트 |
+| **R7: glass 테마 backdrop-filter ↔ 다국어 텍스트 길이 차이** | UI 시각 | 고 | 저 | 🟡 P1 | PR-16 = 24 조합 E2E 시각 가드 의무 (정책 11 페어) |
+| **R8: 영어 텍스트 길이 ↔ KPI 카드 ≥ 152px 정합 깨짐** | UI 시각 | 고 | 저 | 🟡 P1 | PR-6 = `min-height: 152px` 보존 + responsive 분기 검증 |
+| **R9: 51 review_guides 일괄 번역 누락 → 일부 언어 가이드 부재 = AI 리뷰 품질 저하** | analyzer | 중 | 중 | 🟡 P1 | PR-13/14/15 = 가이드 누락 fallback (해당 언어 가이드 없으면 영문 default) + 회귀 가드 |
+| **R10: 5+1 사이클 6 회 (Phase 1~5) 단일 작업일 진행 시 정책 8 진화 위반** | 협업 | 중 | 저 | 🟢 P2 | 사용자 사전 확인 의무 (정책 8 진화 default — 사이클 83 신설) |
+
+**우선순위 default**: P0 → P1 → P2 순서 처리 + Phase 1 = R1+R2 동시 차단 의무.
+
+---
+
+## §5. 번역 작업 통합 추정
+
+### 자동 번역 단계 (Claude API)
+
+| 영역 | unique 키 추정 | 키당 token | 총 token | Sonnet 비용 |
+|------|--------------|-----------|---------|------------|
+| UI 템플릿 | ~350 | ~120 | 84K (en→ko) + 84K (en→ja) | ~$2.0 |
+| notifier (9 채널) | ~150 | ~150 | 45K + 45K | ~$1.0 |
+| review_guides Tier1 (10) | 10 가이드 | ~500 | 10K + 10K | ~$0.3 |
+| review_guides Tier2/3 (40) + generic | 41 가이드 | ~150 | 12.3K + 12.3K | ~$0.4 |
+| ai_review system prompt | ~30 | ~150 | 9K + 9K | ~$0.3 |
+| **합계** | **~580 unique 키 / 51 가이드** | — | **~320K token** | **~$4 (단일 실행)** |
+
+### 검수 단계 (옵션)
+
+| 옵션 | 시간 | 비용 | 품질 |
+|------|------|------|-----|
+| 🅐 Claude AI 자체 검수 (자동 번역 → 다른 prompt로 재검수) | 추가 30분 | ~$2 | 중 (LLM self-review 한계) |
+| 🅑 모국어 검수자 (외부) — 일본어 | 1~3일 | ~$50~200 | 고 |
+| 🅒 검수 생략 default | 0 | $0 | 저 (운영 후 사용자 피드백 기반 정정) |
+
+**Claude 권장 ★ = 옵션 🅐 + Phase 5 운영 1주 후 옵션 🅑 결정** (Q4):
+- 정책 16 5번 원칙 (토큰 비용 효율) + 정확성 (1번 원칙) 균형
+- 일본어 사용자 베이스 0 (현재) — 운영 후 검수 우선순위 결정 가능
+- 한국어 baseline (사용자 모국어) + 영문 (Claude default) = 2 언어는 사용자 직접 검토 가능
+
+### 시간 추정
+
+| Phase | 추정 시간 | 핵심 작업 |
+|-------|---------|----------|
+| Phase 1 (PR-1, 2, 3) | **2~3일** | 인프라 + CI 가드 + en/ko/ja baseline (가장 위험 영역 default) |
+| Phase 2 (PR-4~8) | **5~7일** | 5 PR 병렬 가능 (PR-4 의존 후 5/6/7/8 병렬) |
+| Phase 3 (PR-9~11) | **3~4일** | 3 PR 병렬 가능 |
+| Phase 4 (PR-12~15) | **5~7일** | PR-12 의존 후 13/14/15 병렬 (가이드 번역 시간) |
+| Phase 5 (PR-16~18) | **2~3일** | E2E + 운영 KPI + smoke |
+| **합계** | **17~24일 (약 3~5주)** | 1차 관점 5 (4~5주) 정합 |
+
+---
+
+## §6. ⚠️ 자율 판단 보고 (정책 3 진화 강화 — ⚠️ 마커 적용)
+
+본 PR commit body 에 ⚠️ 마커 적용 사유 (정책 3 강화 — 사이클 83 신설 default):
+
+- ⚠️ **Q1 i18n 라이브러리 선정 = architecture 영향** = ⚠️ 마커 적용 의무 (사용자 인지 영향 ≥ 중)
+- ⚠️ **Q2 18 PR 분할 = 작업 단위 결정** = ⚠️ 마커 적용 의무 (architecture 영향)
+- ⚠️ **Q3 DB 컬럼 3건 추가 = 데이터 모델 변경** = ⚠️ 마커 적용 의무 (DB 스키마 — 운영 영향)
+- ⚠️ **Q5 Phase 분할 진행 default = 협업 영향** = ⚠️ 마커 적용 의무 (단일 작업일 ≥ 5회 정책 8 진화 페어)
+- ⚠️ **자율 판단 보고 ≥ 5건** = ⚠️ 마커 적용 의무 (정책 3 강화 정량 기준)
+
+**Tier B 보류 영역 (자율 판단 보고)**:
+- ⚠️ **Q1 i18n 라이브러리 선정** = 1차 관점 1 (python-i18n) vs cross-verify 6차 (Jinja2 i18n + Babel) 모순 — Claude 권장 ★ = 🅔 (cross-verify 정합 — UI 영역 가장 큰 영향 + 산업 표준)
+- ⚠️ **Q4 검수 단계** = 자동 번역 default + Phase 5 운영 후 외부 검수 결정 (정책 16 5번 원칙 페어)
+- ⚠️ **Q7 caching 전략** = Phase 4 운영 1주 baseline 후 결정 (NEW-P0-3 정합 — Sentry baseline 페어)
+- ⚠️ **Q8 일본어 우선순위** = 영문/한글 default + 일본어 Phase 5 후속 권장 (사용자 베이스 0 시점)
+
+---
+
+## §7. 다음 단계 (사용자 회신 의무)
+
+### 즉시 회신 의무 영역 (High tier)
+
+| Q# | 회신 패턴 |
+|----|----------|
+| Q1 (i18n 라이브러리) | `[x] 🅔 Jinja2+Babel OK / [!] 다른 옵션 (사유) / [ ] 미수행` |
+| Q2 (18 PR 분할) | `[x] OK / [!] 수정안 제시 / [ ] 단일 큰 PR (사용자 명시)` |
+| Q3 (DB 컬럼 3건) | `[x] 3개 모두 / [!] 단독 (사유) / [ ] 다른 안` |
+| Q5 (Phase 분할 진행) | `[x] Phase 별 사전 확인 의무 / [!] 단일 일괄 진행 (사용자 명시)` |
+
+### 진행 후 결정 영역 (Medium tier — 자율 판단 보고로 대체 OK)
+
+- Q4 (검수 단계) — Phase 5 운영 후 결정
+- Q6 (kill-switch) — Phase 1 PR-1 default 도입
+- Q7 (caching 전략) — Phase 4 운영 1주 baseline 후 결정
+- Q8 (일본어 우선순위) — Phase 1~4 진행 default + Phase 5 결정
+
+### 사이클 진행 default (정책 8 진화 — 사이클 83 신설 페어)
+
+본 task = **단일 작업일 1 사이클 = Phase 1 단독 default 권장** (정책 8 진화 default — 사용자 사전 확인 의무 페어):
+- 사이클 N (오늘) = 본 기획안 작성 + 사용자 결정 회신
+- 사이클 N+1 = Phase 1 (PR-1/2/3) 진행
+- 사이클 N+2 = Phase 2 (PR-4~8) 진행
+- ...
+
+**예외 영역** (Q5 사용자 명시 결정 시): 단일 작업일 Phase 1+2 일괄 진행 OK (정책 8 진화 면제 영역).
+
+---
+
+## §8. 본 task 협업 철학 회고 (정책 9 — 자유 발언)
+
+### 바라는 점
+
+1. **다국어 도입의 실 사용자 우선순위 회신 부탁드립니다** — 일본어 사용자 베이스 = 0 (현재) 인 상태에서 3 언어 동시 도입은 토큰/시간 비용이 큽니다. Q8 영문/한글 default + 일본어 Phase 5 후속 권장.
+
+2. **i18n 라이브러리 선정 = 본 사이클 가장 큰 architecture 결정** — Q1 (Jinja2 i18n + Babel 권장) 은 영구 영향 영역. 외부 검토 (Python 커뮤니티 표준) 도 권장합니다.
+
+3. **18 PR + 3~5주 작업 분량 = Phase 별 단일 작업일 default 강력 권장** — 사이클 83 진화 (단일 작업일 ≥ 5회 5+1 사전 확인 의무) 페어. 본 task 진행 시 Phase 1 (PR-1/2/3) 단독 1 사이클 → Phase 2 다음 사이클 default 권장.
+
+### Claude 자성
+
+1. **본 cross-verify 6차 가 1차 5 관점 결과를 받았으나 실측 검증으로 4 false-positive 차단** + **본인 라운드 4 가 cross-verify 6차 결과도 51 가이드 정합 추가 차단** = 5 라운드 검수 default 의 가치 입증.
+
+2. **번역 비용 추정 = 1차 관점 3 ($20) vs cross-verify 실측 ($4) 차이 -$16** = 1차 추정의 과대 추정 차단. cross-verify 의 실측 의무 (정책 6 페어) 효과.
+
+3. **본인 5 라운드 검수 = 사용자 명시 "5번 정도 검수" 정합** + cross-verify 6차 false-positive 도 본인 라운드 4 에서 추가 차단 = 협업 철학 default 정합.
+
+### 필요한 부분 (정보 비대칭)
+
+1. **사용자 일본어 베이스 / 글로벌 확장 의도** — 본 cross-verify 는 Q8 default = 영문/한글 권장이나 사용자 사업 영역 모름.
+
+2. **외부 일본어 검수자 예산** — Q4 결정에 영향. ~$50~200 예산 OK 시 옵션 🅑 default 변경 가능.
+
+3. **Anthropic API 운영 토큰 baseline** = 현재 운영 1주 baseline 보고서 (사이클 80 옵션 🅒 보류 — Sentry 활성화 1주 후 default) 가 본 task R5 (caching 비용) 결정 입력.
+
+---
+
+## §9. 부록 — 관련 메모리/정책 cross-reference
+
+| 영역 | 메모리/정책 |
+|------|------------|
+| Architecture 결정 의무 | [`feedback-architecture-decision-pre-confirm.md`](file:///home/vscode/.claude/projects/-workspaces-SCAManager/memory/feedback-architecture-decision-pre-confirm.md) (High tier) |
+| Phase 4 영역 진입 패턴 | [`feedback-phase4-area-entry-pattern.md`](file:///home/vscode/.claude/projects/-workspaces-SCAManager/memory/feedback-phase4-area-entry-pattern.md) (페어) |
+| 정책 16 5번 원칙 (토큰 비용 효율) | CLAUDE.md L860 (caching 전략 영향) |
+| 정책 8 진화 (단일 작업일 ≥ 5회 사전 확인) | CLAUDE.md L527 (사이클 83 신설) |
+| 정책 9 완화 (회신 부재 시 자율 판단 보고) | CLAUDE.md L578 (사이클 83 신설 — High tier 영역 미적용) |
+| 정책 11 (시각 검증 8 조합) | CLAUDE.md L617 (24 조합 = 3 언어 × 4 테마 × 2 device 페어) |
+| 정책 13 (운영 smoke check) | CLAUDE.md L1083 (다국어 endpoint 응답 정합) |
+| 정책 14 (Code Scanning open alert) | CLAUDE.md L787 (다국어 도입 후 신규 alert 검토 의무) |
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/docs/reports/INDEX.md
+++ b/docs/reports/INDEX.md
@@ -56,6 +56,7 @@
 | 2026-05-04 | [cycle-76-full-consistency-cleanup-retrospective](2026-05-04-cycle-76-full-consistency-cleanup-retrospective.md) | 사이클 76 전체 문서+코드 5+1 정합성 cleanup — Tier A 8건 정정 + false-positive 차단 3건 + 신규 발견 3건 (정책 8 진화 정량 기준 정합) |
 | 2026-05-05 | [cycle-78-81-end-multi-agent-retrospective](2026-05-05-cycle-78-81-end-multi-agent-retrospective.md) | 사이클 78~81 4 사이클 종결 회고 (영역 4종 진입 머지 — 🅒/🅐/🅔/🅑) — 5+1 다중 에이전트 P0 18 → cross-verify 통합 13 + Tier A 4 정정 + Tier B 2 메모리 신설 + TestClient lifespan 트랩 메모리 등재 (3중복) + alembic dialect 헬퍼 정책 16 위반 정정 권장 |
 | 2026-05-05 | [cycle-78-82-end-multi-agent-retrospective](2026-05-05-cycle-78-82-end-multi-agent-retrospective.md) | 사이클 78~82 5 사이클 종결 회고 (사용자 명시 "전체 문서 정리 + 다중 에이전트 깊게 + 자유 발언") — 5+1 default 진행 (관점 1~5 + cross-verify 6차) → Tier A 4 즉시 정정 (env-vars.md 4 환경변수 + CLAUDE.md L1060 dialect helper stale + sync 체크리스트 강화 + STATE L117 header) + Tier B 11 (High 3 사용자 결정 의무 — 정책 9/3/1 진화 + Medium/Low 8) + cross-verify ROI 양호 (false-positive 차단 2 + 신규 발견 3) + 각 에이전트 5건 + 오케스트레이터 회고 + 자유 발언 (회고 질문 7건 사용자 회신 의무) |
+| 2026-05-05 | [i18n-3language-support-detailed-plan](2026-05-05-i18n-3language-support-detailed-plan.md) | **다국어 (영어/한국어/일본어) 지원 도입 세부 기획안** (사용자 명시 "긴급 + 5번 정도 검수 + 세부 기획안") — 5+1 다중 에이전트 (관점 1 인프라 + 관점 2 대시보드/UI + 관점 3 코드리뷰 + 관점 4 알림 채널 9 + 관점 5 테스트/운영) + cross-verify 6차 + 본인 5 라운드 검수 + 18 PR 분할 (Phase 1~5, 12100 LOC, 3~5주) + 사용자 결정 8건 (Q1 Jinja2+Babel / Q2 18 PR / Q3 DB 컬럼 3 / Q4 검수 / Q5 Phase 진행 / Q6 kill-switch / Q7 caching / Q8 일본어 우선순위) + 위험 평가 P0 2 + P1 6 + P2 2 + 번역 비용 ~$4 |
 
 ---
 


### PR DESCRIPTION
…트 + 5 라운드 검수

⚠️ 자율 판단 보고 (정책 3 진화 강화 — ⚠️ 마커 5건 적용):

⚠️ Q1 i18n 라이브러리 선정 (architecture 영향) = High tier 사용자 결정 의무 ⚠️ Q2 18 PR 분할 = 작업 단위 결정 (architecture 영향)
⚠️ Q3 DB 컬럼 3건 추가 (User.preferred_language + RepoConfig.notification_language + InsightNarrativeCache.language) = 데이터 모델 변경 ⚠️ Q5 Phase 분할 진행 default = 협업 영향 (단일 작업일 ≥ 5회 정책 8 진화 페어) ⚠️ 자율 판단 보고 ≥ 5건 (정책 3 강화 정량 기준 충족)

사용자 명시 task: 다국어 긴급 + 영어/한국어/일본어 + 코드리뷰 + 대시보드 메뉴 커버 + 광범위 + 여러 에이전트 병렬 + 세세하고 디테일하게 + 서로 확인 병행 + 5번 정도 검수 + 세부 기획안 작성

5 라운드 검수 진행:
- 라운드 1: 5 다중 에이전트 병렬 디스패치 (관점 1 인프라 + 관점 2 대시보드/UI + 관점 3 코드리뷰 + 관점 4 알림 채널 9종 + 관점 5 테스트/운영) — 43 PR 후보 + 5 영역
- 라운드 2: cross-verify 6차 — false-positive 차단 4건 (관점 5 alembic 0019 / 관점 1+5 인프라 PR 중복 / 관점 2+5 운영 KPI 중복 / 관점 3 가이드 분할 과잉) + 신규 발견 10건 + 18 PR 통합
- 라운드 3: 본인 실측 (alembic 최신 0029 정합 + 0019 충돌 검증 + /health endpoint + env-vars.md 섹션)
- 라운드 4: 본인 실측 추가 false-positive 차단 (review_guides 정확 카운트 = 51 = Tier1 10 + Tier2 20 + Tier3 20 + generic 1 / cross-verify 6차 52 주장 -1 정정)
- 라운드 5: PR 작성 직전 최종 검증 (requirements.txt 의존성 + Jinja2 i18n 호환성)

총 ROI: false-positive 차단 5건 (4 + 1) + 신규 발견 10건 + Tier A/B 분류 18 PR + 사용자 결정 8건 = 사이클 75 진화 정량 기준 정합 ✅

18 PR 분할 (Phase 1~5):
- Phase 1: 인프라 (PR-1 라이브러리+미들웨어+DB+환경변수 / PR-2 CI 가드 / PR-3 번역 파일)
- Phase 2: UI 다국어 (PR-4 언어 선택 UI / PR-5 진입 영역 / PR-6 dashboard / PR-7 분석 / PR-8 settings+admin)
- Phase 3: 알림 채널 (PR-9 Telegram / PR-10 외부 4 / PR-11 GitHub 3)
- Phase 4: 코드리뷰 (PR-12 인프라 / PR-13 Tier1 / PR-14 Tier2 / PR-15 Tier3+generic)
- Phase 5: 통합 테스트 (PR-16 E2E / PR-17 운영 KPI / PR-18 smoke)

총 추정: ~12,100 LOC / 17~24일 (3~5주) / 자동 번역 ~$4 (Claude API Sonnet)

사용자 결정 의무 8건 (Q1~Q8):
⚠️ Q1 (i18n 라이브러리): 🅔 Jinja2 i18n + Babel 권장 (cross-verify 6차 결정 — 1차 관점 1 python-i18n 정정) ⚠️ Q2 (18 PR 분할): 🅐 OK 권장 (응집 단위 — 정책 7 강화 부합)
⚠️ Q3 (DB 컬럼 3건): 🅐 3개 모두 권장 (관점 1+4 통합)
🟡 Q4 (검수): 🅐 Claude AI 자체 검수 + Phase 5 운영 후 외부 검수 결정 ⚠️ Q5 (Phase 진행): 🅐 Phase 별 사전 확인 의무 (정책 8 진화 default) 🟡 Q6 (kill-switch): 🅐 도입 권장 (Phase 4 영역 진입 패턴 페어)
🟡 Q7 (caching 전략): 🅒 Phase 4 운영 1주 baseline 후 결정
🟡 Q8 (일본어 우선순위): 🅐 영문/한글 default + Phase 5 후속

위험 평가: P0 2건 (R1 alembic 마이그레이션 + R2 한국어 회귀) / P1 6건 / P2 2건

본 PR = docs only (코드 작업 0). 사용자 결정 8건 회신 받은 후 Phase 1 진행 default.

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
