### PR TITLE
feat(i18n-phase1-pr1c): alembic 0030 + ORM 확장 (User + RepoConfig + In…

### DIFF
--- a/alembic/versions/0030_add_i18n_columns.py
+++ b/alembic/versions/0030_add_i18n_columns.py
@@ -1,0 +1,112 @@
+"""Phase 1 PR-1c (사이클 84) — 다국어 지원 i18n 컬럼 3건 + composite index 갱신
+
+Revision ID: 0030i18ncolumns
+Revises: 0029rls5missing
+Create Date: 2026-05-05
+
+Phase 1 PR-1c — i18n 다국어 지원 (영어/한국어/일본어) 인프라 DB 영역.
+
+신규 3 컬럼:
+1. users.preferred_language (String(5), NOT NULL, server_default="en")
+   — 사용자 선호 언어 (User.preferred_language — Phase 2 PR-4 헤더 dropdown 영역)
+2. repo_configs.notification_language (String(5), nullable=True)
+   — 리포별 알림 언어 override (NULL = 사용자 preferred_language fallback)
+3. insight_narrative_cache.language (String(5), NOT NULL, server_default="en")
+   — 캐시 키 분리 (composite index (user_id, days, language))
+
+Composite index 갱신:
+- 신규: ix_insight_cache_user_days_language (user_id, days, language)
+- 동일 사용자 다른 언어 transition 시 잘못된 캐시 hit 차단 (cross-verify 6차 §3.1)
+
+RLS 호환:
+- alembic 0026 + 0029 RLS policy 변화 0 (신규 컬럼 = user_id 격리 직교 속성)
+- 기존 RLS policy = user_id 기반 격리 유지
+
+backfill 전략:
+- server_default 의존 (앱 로직 0 + 모든 환경 호환)
+- 기존 행 → DB 단계 자동 default 삽입 (수작업 누락 위험 0)
+
+회귀 가드: tests/unit/migrations/test_0030_add_i18n_columns.py
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0030i18ncolumns"
+down_revision = "0029rls5missing"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """3 컬럼 추가 + composite index 갱신.
+
+    Add 3 i18n columns + composite index for cache key separation.
+    """
+    # 1. users.preferred_language
+    # 1. users.preferred_language
+    op.add_column(
+        "users",
+        sa.Column(
+            "preferred_language",
+            sa.String(5),
+            nullable=False,
+            server_default="en",
+        ),
+    )
+
+    # 2. repo_configs.notification_language (override, nullable)
+    # 2. repo_configs.notification_language (override, nullable)
+    op.add_column(
+        "repo_configs",
+        sa.Column(
+            "notification_language",
+            sa.String(5),
+            nullable=True,
+        ),
+    )
+
+    # 3. insight_narrative_cache.language
+    # 3. insight_narrative_cache.language
+    op.add_column(
+        "insight_narrative_cache",
+        sa.Column(
+            "language",
+            sa.String(5),
+            nullable=False,
+            server_default="en",
+        ),
+    )
+
+    # 4. composite index (user_id, days, language) — 캐시 키 분리 의무
+    # 4. composite index (user_id, days, language) — multilingual cache key separation
+    op.create_index(
+        "ix_insight_cache_user_days_language",
+        "insight_narrative_cache",
+        ["user_id", "days", "language"],
+    )
+
+
+def downgrade() -> None:
+    """역순 정확 복구 — composite index → 3 컬럼.
+
+    Reverse exact recovery — composite index → 3 columns.
+    """
+    # 1. composite index 삭제
+    # 1. Drop composite index
+    op.drop_index(
+        "ix_insight_cache_user_days_language",
+        table_name="insight_narrative_cache",
+    )
+
+    # 2. insight_narrative_cache.language 컬럼 삭제
+    # 2. Drop insight_narrative_cache.language
+    op.drop_column("insight_narrative_cache", "language")
+
+    # 3. repo_configs.notification_language 컬럼 삭제
+    # 3. Drop repo_configs.notification_language
+    op.drop_column("repo_configs", "notification_language")
+
+    # 4. users.preferred_language 컬럼 삭제
+    # 4. Drop users.preferred_language
+    op.drop_column("users", "preferred_language")

--- a/src/api/repos.py
+++ b/src/api/repos.py
@@ -33,6 +33,9 @@ class RepoConfigUpdate(BaseModel):
     create_issue: bool = False
     railway_deploy_alerts: bool = False
     auto_merge_issue_on_failure: bool = False
+    # Phase 1 PR-1c (사이클 84) — 다국어 지원 리포별 알림 언어 override
+    # NULL = 사용자 preferred_language fallback (Phase 3 PR-9~11 알림 채널 영역)
+    notification_language: str | None = None
     # leaderboard_opt_in 폐기 (그룹 60 사용자 결정 정정 — alembic 0025)
 
     @model_validator(mode="after")

--- a/src/config_manager/manager.py
+++ b/src/config_manager/manager.py
@@ -25,6 +25,9 @@ class RepoConfigData:  # pylint: disable=too-many-instance-attributes
     create_issue: bool = False
     railway_deploy_alerts: bool = False
     auto_merge_issue_on_failure: bool = False
+    # Phase 1 PR-1c (사이클 84) — 다국어 지원 리포별 알림 언어 override
+    # NULL = 사용자 preferred_language fallback (Phase 3 PR-9~11 알림 채널 영역)
+    notification_language: str | None = None
     # leaderboard_opt_in 폐기 (그룹 60 사용자 결정 정정 — alembic 0025)
 
 

--- a/src/models/insight_narrative_cache.py
+++ b/src/models/insight_narrative_cache.py
@@ -3,12 +3,17 @@
 Cycle 74 PR-B Phase 2-B 🅑 — UX 영향 최소 + 60% Anthropic API 비용 절감.
 Cycle 74 PR-B Phase 2-B 🅑 — minimum UX impact + 60% Anthropic API cost reduction.
 
-Key = (user_id, days) — 사용자별 + 윈도우별 격리.
-TTL 만료만 무효화 (자동 invalidate 미적용 — MVP 단순화 default).
+Phase 1 PR-1c (사이클 84) — 다국어 지원 캐시 키 분리:
+- language 컬럼 추가 + composite index (user_id, days, language) 갱신
+- 동일 사용자 다른 언어 transition 시 잘못된 캐시 hit 차단 (cross-verify 6차 §3.1 발견)
+
+Phase 1 PR-1c (Cycle 84) — multilingual cache key separation:
+- Add language column + composite index (user_id, days, language)
+- Prevents stale cache hits when same user transitions languages
 """
 from datetime import datetime, timezone
 
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Integer, UniqueConstraint
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
 
 from src.database import Base
 
@@ -23,6 +28,12 @@ class InsightNarrativeCache(Base):
     __tablename__ = "insight_narrative_cache"
     __table_args__ = (
         UniqueConstraint("user_id", "days", name="uq_insight_cache_user_days"),
+        # Phase 1 PR-1c — composite index (user_id, days, language) 캐시 키 분리
+        # Phase 1 PR-1c — composite index for multilingual cache key separation
+        Index(
+            "ix_insight_cache_user_days_language",
+            "user_id", "days", "language",
+        ),
     )
 
     id = Column(Integer, primary_key=True, index=True)
@@ -31,6 +42,9 @@ class InsightNarrativeCache(Base):
         nullable=False, index=True,
     )
     days = Column(Integer, nullable=False)  # 윈도우 (1/7/30/90)
+    # Phase 1 PR-1c — 다국어 캐시 키 (default "en", server_default 의존)
+    # Phase 1 PR-1c — multilingual cache key (default "en", relies on server_default)
+    language = Column(String(5), nullable=False, default="en", server_default="en")
     response_json = Column(JSON, nullable=False)
     # 4 카드 narrative + status + generated_at 통합 dict
     created_at = Column(

--- a/src/models/repo_config.py
+++ b/src/models/repo_config.py
@@ -32,6 +32,12 @@ class RepoConfig(Base):
     auto_merge_issue_on_failure = Column(Boolean, default=False, nullable=False)
     # leaderboard_opt_in 컬럼 — 그룹 60 사용자 결정 정정 (2026-05-02) 으로 폐기.
     # alembic 0025 에서 컬럼 drop. 회귀 가드: tests/unit/services/test_analytics_service_deprecations.py
+
+    # Phase 1 PR-1c (사이클 84) — 다국어 지원 리포별 알림 언어 override
+    # Per-repo notification language override (Phase 1 PR-1c).
+    # Nullable=True (NULL = 사용자 preferred_language fallback / NULL = fallback to user)
+    notification_language = Column(String(5), nullable=True)
+
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc),
                         onupdate=lambda: datetime.now(timezone.utc))

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -35,6 +35,11 @@ class User(Base):
     # telegram_otp_expires_at: OTP expiry timestamp with timezone.
     telegram_otp_expires_at = Column(DateTime(timezone=True), nullable=True)
 
+    # Phase 1 PR-1c (사이클 84) — 다국어 지원 사용자 선호 언어
+    # User preferred language for multilingual support (Phase 1 PR-1c).
+    # Default = "en" (server_default 의존), LocaleMiddleware 가 Cookie 우선 시 override
+    preferred_language = Column(String(5), nullable=False, default="en", server_default="en")
+
     repositories = relationship("Repository", back_populates="owner")
 
     @property

--- a/tests/unit/migrations/test_0030_add_i18n_columns.py
+++ b/tests/unit/migrations/test_0030_add_i18n_columns.py
@@ -1,0 +1,194 @@
+"""Phase 1 PR-1c (사이클 84) — alembic 0030 i18n 컬럼 3건 + composite index 회귀 가드.
+
+신규 컬럼:
+1. users.preferred_language (String(5), NOT NULL, server_default="en")
+2. repo_configs.notification_language (String(5), nullable=True)
+3. insight_narrative_cache.language (String(5), NOT NULL, server_default="en")
+
+Composite index:
+- ix_insight_cache_user_days_language (user_id, days, language)
+
+회귀 가드 영역:
+- 컬럼 추가 검증 (type / nullable / default)
+- composite index 갱신 검증
+- backfill 검증 (server_default 의존 → 기존 사용자 "en" 자동 할당)
+- RLS 호환 (정책 변화 0)
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+# pylint: disable=wrong-import-position
+import pytest
+from sqlalchemy import create_engine, inspect, text
+
+from src.database import Base
+# 메모리 pytest-fixture-lazy-orm-import-trap.md 페어 — Base.metadata.create_all 전 명시 import 의무
+# Memory pytest-fixture-lazy-orm-import-trap.md pair — explicit import before create_all
+import src.models.user  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+import src.models.repo_config  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+import src.models.insight_narrative_cache  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+
+
+@pytest.fixture
+def engine():
+    """In-memory SQLite engine (Base.metadata.create_all 사용)."""
+    eng = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(eng)
+    yield eng
+    eng.dispose()
+
+
+def _column_info(engine_, table: str, column_name: str) -> dict | None:
+    """SQLAlchemy Inspector 로 컬럼 정보 조회. 미존재 시 None."""
+    inspector = inspect(engine_)
+    for col in inspector.get_columns(table):
+        if col["name"] == column_name:
+            return col
+    return None
+
+
+def _index_columns(engine_, table: str, index_name: str) -> list[str] | None:
+    """인덱스의 컬럼 목록 조회. 미존재 시 None."""
+    inspector = inspect(engine_)
+    for idx in inspector.get_indexes(table):
+        if idx["name"] == index_name:
+            return idx["column_names"]
+    return None
+
+
+def test_users_preferred_language_column_added(engine):
+    """users.preferred_language 컬럼 추가 검증."""
+    col = _column_info(engine, "users", "preferred_language")
+    assert col is not None, "users.preferred_language 컬럼 미추가"
+
+
+def test_users_preferred_language_not_nullable(engine):
+    """users.preferred_language NOT NULL 의무."""
+    col = _column_info(engine, "users", "preferred_language")
+    assert col["nullable"] is False, "preferred_language 는 NOT NULL 의무"
+
+
+def test_repo_configs_notification_language_column_added(engine):
+    """repo_configs.notification_language 컬럼 추가 검증."""
+    col = _column_info(engine, "repo_configs", "notification_language")
+    assert col is not None, "repo_configs.notification_language 컬럼 미추가"
+
+
+def test_repo_configs_notification_language_nullable(engine):
+    """repo_configs.notification_language nullable 의무 (override = NULL fallback)."""
+    col = _column_info(engine, "repo_configs", "notification_language")
+    assert col["nullable"] is True, "notification_language 는 nullable 의무 (NULL = fallback)"
+
+
+def test_insight_cache_language_column_added(engine):
+    """insight_narrative_cache.language 컬럼 추가 검증."""
+    col = _column_info(engine, "insight_narrative_cache", "language")
+    assert col is not None, "insight_narrative_cache.language 컬럼 미추가"
+
+
+def test_insight_cache_language_not_nullable(engine):
+    """insight_narrative_cache.language NOT NULL 의무."""
+    col = _column_info(engine, "insight_narrative_cache", "language")
+    assert col["nullable"] is False, "insight_narrative_cache.language 는 NOT NULL 의무"
+
+
+def test_insight_cache_composite_index_exists(engine):
+    """composite index (user_id, days, language) 존재 + 정확 컬럼 순서."""
+    cols = _index_columns(
+        engine,
+        "insight_narrative_cache",
+        "ix_insight_cache_user_days_language",
+    )
+    assert cols is not None, (
+        "composite index ix_insight_cache_user_days_language 미존재"
+    )
+    assert cols == ["user_id", "days", "language"], (
+        f"composite index 컬럼 순서 불일치: {cols}"
+    )
+
+
+def test_users_preferred_language_default_en(engine):
+    """server_default='en' 의존 — 신규 사용자 INSERT 시 자동 'en' 할당."""
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO users (github_id, email, display_name) "
+                "VALUES ('test-user-1', 'test1@example.com', 'Test User 1')"
+            )
+        )
+        conn.commit()
+        result = conn.execute(
+            text(
+                "SELECT preferred_language FROM users WHERE github_id = 'test-user-1'"
+            )
+        ).fetchone()
+        assert result[0] == "en", (
+            f"preferred_language default 'en' 미적용: {result[0]}"
+        )
+
+
+def test_insight_cache_language_default_en(engine):
+    """insight_narrative_cache.language server_default='en' 검증."""
+    from datetime import datetime, timezone
+
+    with engine.connect() as conn:
+        # 사용자 먼저 생성 (FK 의존)
+        conn.execute(
+            text(
+                "INSERT INTO users (github_id, email, display_name) "
+                "VALUES ('test-cache-user', 'cache@example.com', 'Cache User')"
+            )
+        )
+        user_id = conn.execute(
+            text("SELECT id FROM users WHERE github_id = 'test-cache-user'")
+        ).fetchone()[0]
+
+        # InsightNarrativeCache row 삽입 (language 컬럼 명시 X — server_default 검증)
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            text(
+                "INSERT INTO insight_narrative_cache "
+                "(user_id, days, response_json, created_at, expires_at) "
+                f"VALUES ({user_id}, 7, '{{}}', '{now}', '{now}')"
+            )
+        )
+        conn.commit()
+
+        result = conn.execute(
+            text(
+                f"SELECT language FROM insight_narrative_cache WHERE user_id = {user_id}"
+            )
+        ).fetchone()
+        assert result[0] == "en", (
+            f"insight_narrative_cache.language default 'en' 미적용: {result[0]}"
+        )
+
+
+def test_repo_configs_notification_language_nullable_default_none(engine):
+    """repo_configs.notification_language 미명시 시 NULL 자동 할당."""
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO repo_configs "
+                "(repo_full_name, pr_review_comment, approve_mode, "
+                "approve_threshold, reject_threshold, auto_merge, merge_threshold, "
+                "commit_comment, create_issue, railway_deploy_alerts, "
+                "auto_merge_issue_on_failure) "
+                "VALUES ('owner/test-repo', 1, 'disabled', 75, 50, 0, 75, 0, 0, 0, 0)"
+            )
+        )
+        conn.commit()
+        result = conn.execute(
+            text(
+                "SELECT notification_language FROM repo_configs "
+                "WHERE repo_full_name = 'owner/test-repo'"
+            )
+        ).fetchone()
+        assert result[0] is None, (
+            f"notification_language 기본값은 NULL 의무 (override 영역): {result[0]}"
+        )


### PR DESCRIPTION
…sightCache) + composite index 갱신 (Phase 1 PR-1c)

⚠️ 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 5건 적용):

⚠️ Q3 = 🅐 DB 컬럼 3개 모두 채택 (User.preferred_language + RepoConfig.notification_language + InsightCache.language)
   사유: cross-verify 6차 §3.1 InsightNarrativeCache 캐시 키 분리 의무 (잘못된 언어 hit 차단)
⚠️ alembic 0030 = is_postgresql 분기 미사용 (server_default 의존 default — SQLite + PostgreSQL 양 호환)
   사유: 컬럼 추가 + composite index = 양 dialect 표준 SQL (분기 불필요)
⚠️ RLS 호환 = alembic 0026 + 0029 RLS policy 변화 0 (신규 컬럼 = user_id 격리 직교 속성) ⚠️ 5-way sync 부분 적용:
   - ORM ✅ (User + RepoConfig + InsightCache)
   - RepoConfigData dataclass ✅
   - API body (RepoConfigUpdate) ✅
   - HTML 폼 = Phase 2 PR-4 (settings 다국어) 영역
   - PRESETS = Phase 2 PR-4 영역 ⚠️ 본 PR-1c = ~280 LOC (정책 7 강화 임계 1500 LOC 미달)

신규 영역 (사전 검토 관점 B 정합):
1. alembic/versions/0030_add_i18n_columns.py 신설:
   - 3 컬럼 추가 (preferred_language / notification_language / language)
   - composite index ix_insight_cache_user_days_language (user_id, days, language)
   - downgrade 역순 정확 복구
2. src/models/insight_narrative_cache.py 확장:
   - language 컬럼 + composite index __table_args__
   - server_default="en" 의존 (앱 로직 0)
3. src/models/user.py 확장:
   - preferred_language 컬럼 (NOT NULL, server_default="en")
4. src/models/repo_config.py 확장:
   - notification_language 컬럼 (nullable, NULL = fallback)
5. src/config_manager/manager.py 확장 (5-way sync):
   - RepoConfigData.notification_language 추가
6. src/api/repos.py 확장 (5-way sync):
   - RepoConfigUpdate.notification_language 추가
7. tests/unit/migrations/test_0030_add_i18n_columns.py 신설:
   - 회귀 가드 10건 (컬럼 추가 + composite index + server_default + nullable + ORM lazy import 트랩 차단)

검증 (메모리 feedback-pr-push-direct-validation.md default 적용):
- pytest tests/unit/migrations/test_0030_add_i18n_columns.py -v = 10 passed
- pytest tests/unit tests/integration -q = 2383 passed / 5 skipped / 0 failed
- 메모리 pytest-fixture-lazy-orm-import-trap.md 페어 적용 (test_0030 안 명시 import)

Phase 1 종결 (PR-1a/b/c 모두 머지 시):
- 환경변수 5건 + LocaleMiddleware ASGI + 번역 로더/필터 + en/ko/ja.json + alembic 0030 + ORM 3 모델 확장
- 다음 단계 = Phase 2 (UI 다국어 — PR-4~8) 사용자 명시 신호 의무 (정책 5 페어)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
