### PR TITLE
feat(i18n-phase2-pr4): 언어 선택 UI — 헤더 dropdown + /settings 언어 카드 + API…

### DIFF
--- a/src/api/users.py
+++ b/src/api/users.py
@@ -1,5 +1,5 @@
-"""사용자 계정 API — Telegram 연동 OTP 발급 등.
-User account API — Telegram link OTP issuance, etc.
+"""사용자 계정 API — Telegram 연동 OTP 발급 + 선호 언어 설정 등.
+User account API — Telegram link OTP issuance + preferred language settings, etc.
 """
 from __future__ import annotations
 
@@ -8,10 +8,12 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Response
+from pydantic import BaseModel, field_validator
 from sqlalchemy import update
 
 from src.auth.session import CurrentUser, require_login
+from src.config import settings
 from src.database import SessionLocal
 from src.models.user import User
 
@@ -55,4 +57,93 @@ async def issue_telegram_otp(
         "otp": otp,
         "expires_at": expires_at.isoformat(),
         "ttl_minutes": _OTP_TTL_MINUTES,
+    }
+
+
+# Phase 2 PR-4 (사이클 84 — 다국어 i18n) — 사용자 선호 언어 설정 API
+# Phase 2 PR-4 (Cycle 84 — i18n) — User preferred language settings API
+
+
+class PreferredLanguageUpdate(BaseModel):
+    """선호 언어 변경 요청 본문 (POST /api/users/me/preferred-language).
+
+    Body for POST /api/users/me/preferred-language.
+    """
+
+    language: str
+
+    @field_validator("language")
+    @classmethod
+    def validate_language(cls, v: str) -> str:
+        """SUPPORTED_LOCALES 영역 검증 + 정규화.
+
+        Validate against SUPPORTED_LOCALES + normalize.
+        """
+        v = v.strip().lower() if v else ""
+        if not v:
+            raise ValueError("language must not be empty")
+        supported = {lang.strip() for lang in settings.supported_locales.split(",")}
+        if v not in supported:
+            raise ValueError(
+                f"language '{v}' not in SUPPORTED_LOCALES "
+                f"({settings.supported_locales})"
+            )
+        return v
+
+
+@router.post("/me/preferred-language", status_code=200)
+async def update_preferred_language(
+    body: PreferredLanguageUpdate,
+    response: Response,
+    current_user: Annotated[CurrentUser, Depends(require_login)],
+) -> dict:
+    """사용자 선호 언어 변경 — DB + Cookie 동시 갱신 (LocaleMiddleware 페어).
+
+    Update user preferred language — sync DB + Cookie (pairs with LocaleMiddleware).
+
+    DB 갱신 의무 + Cookie `preferred_language` 1년 만료 설정 의무 (LocaleMiddleware
+    가 매 request 시 Cookie 우선 감지 — Cookie + DB 동시 갱신으로 즉시 반영).
+
+    Updates User.preferred_language in DB + sets Cookie with 1-year expiry
+    (LocaleMiddleware checks Cookie first per request — sync ensures immediate effect).
+    """
+    if settings.i18n_disabled:
+        # kill-switch 활성 시 = 변경 차단 (영문 hardcoded fallback 강제)
+        # When kill-switch enabled = block change (force English hardcoded fallback)
+        raise HTTPException(
+            status_code=503,
+            detail="i18n feature is disabled (I18N_DISABLED=1)",
+        )
+
+    with SessionLocal() as db:
+        db.execute(
+            update(User)
+            .where(User.id == current_user.id)
+            .values(preferred_language=body.language)
+        )
+        db.commit()
+
+    # Cookie 동기화 — LocaleMiddleware 가 매 request 시 우선 감지
+    # Cookie sync — LocaleMiddleware checks Cookie first per request
+    # 만료 = 1년 (사용자 명시 변경 시까지 유지)
+    # max-age = 1 year (until user explicitly changes)
+    is_prod = settings.app_base_url.startswith("https")
+    response.set_cookie(
+        key="preferred_language",
+        value=body.language,
+        max_age=60 * 60 * 24 * 365,  # 1 year
+        httponly=False,  # JavaScript 읽기 가능 (헤더 dropdown 표시 영역)
+        secure=is_prod,
+        samesite="lax",
+        path="/",
+    )
+
+    logger.info(
+        "preferred_language updated for user_id=%d → '%s'",
+        current_user.id,
+        body.language,
+    )
+    return {
+        "language": body.language,
+        "message": "preferred language updated",
     }

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -145,10 +145,11 @@ async def update_preferred_language(
         path="/",
     )
 
+    safe_language_for_log = language.replace("\r", "").replace("\n", "")
     logger.info(
         "preferred_language updated for user_id=%d → '%s'",
         current_user.id,
-        language,
+        safe_language_for_log,
     )
     return {
         "language": language,

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -91,7 +91,24 @@ class PreferredLanguageUpdate(BaseModel):
         return v
 
 
-@router.post("/me/preferred-language", status_code=200)
+@router.post(
+    "/me/preferred-language",
+    status_code=200,
+    responses={
+        # Pydantic body validator 가 SUPPORTED_LOCALES 미지원 / 빈 문자열 시 발화
+        # FastAPI auto-422 from Pydantic body validator (unsupported locale / empty)
+        422: {
+            "description": (
+                "Validation error — language not in SUPPORTED_LOCALES or empty"
+            ),
+        },
+        # I18N_DISABLED=1 kill-switch 활성 시 503 (사이클 78 NEW-P0-2 패턴 페어)
+        # 503 when I18N_DISABLED=1 kill-switch active (Cycle 78 NEW-P0-2 pair)
+        503: {
+            "description": "i18n feature is disabled (I18N_DISABLED=1)",
+        },
+    },
+)
 async def update_preferred_language(
     body: PreferredLanguageUpdate,
     response: Response,

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -115,11 +115,18 @@ async def update_preferred_language(
             detail="i18n feature is disabled (I18N_DISABLED=1)",
         )
 
+    # Sink 직전 방어: 허용된 locale만 쿠키/DB 반영
+    # Sink-adjacent guard: only allow configured locales for cookie/DB
+    supported = {lang.strip().lower() for lang in settings.supported_locales.split(",")}
+    language = body.language.strip().lower() if body.language else ""
+    if language not in supported:
+        raise HTTPException(status_code=400, detail="invalid language")
+
     with SessionLocal() as db:
         db.execute(
             update(User)
             .where(User.id == current_user.id)
-            .values(preferred_language=body.language)
+            .values(preferred_language=language)
         )
         db.commit()
 
@@ -130,7 +137,7 @@ async def update_preferred_language(
     is_prod = settings.app_base_url.startswith("https")
     response.set_cookie(
         key="preferred_language",
-        value=body.language,
+        value=language,
         max_age=60 * 60 * 24 * 365,  # 1 year
         httponly=False,  # JavaScript 읽기 가능 (헤더 dropdown 표시 영역)
         secure=is_prod,
@@ -141,9 +148,9 @@ async def update_preferred_language(
     logger.info(
         "preferred_language updated for user_id=%d → '%s'",
         current_user.id,
-        body.language,
+        language,
     )
     return {
-        "language": body.language,
+        "language": language,
         "message": "preferred language updated",
     }

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -16,6 +16,7 @@ from src.auth.session import CurrentUser, require_login
 from src.config import settings
 from src.database import SessionLocal
 from src.models.user import User
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +96,16 @@ class PreferredLanguageUpdate(BaseModel):
     "/me/preferred-language",
     status_code=200,
     responses={
+        # Defense-in-depth sink-adjacent guard (사실상 도달 불가 — Pydantic validator 가 422 먼저 발화)
+        # Defense-in-depth sink-adjacent guard (effectively unreachable — Pydantic validator returns 422 first)
+        # Copilot Autofix CodeQL "Construction of a cookie using user-supplied input" 페어
+        # Pairs with Copilot Autofix CodeQL "Construction of a cookie using user-supplied input"
+        400: {
+            "description": (
+                "Sink-adjacent guard: invalid locale "
+                "(defense-in-depth, normally caught by 422)"
+            ),
+        },
         # Pydantic body validator 가 SUPPORTED_LOCALES 미지원 / 빈 문자열 시 발화
         # FastAPI auto-422 from Pydantic body validator (unsupported locale / empty)
         422: {
@@ -162,11 +173,12 @@ async def update_preferred_language(
         path="/",
     )
 
-    safe_language_for_log = language.replace("\r", "").replace("\n", "")
+    # CLAUDE.md L893 정합 — sanitize_for_log helper 사용 의무 (CR/LF/TAB/NUL 제거 + 길이 제한)
+    # CLAUDE.md L893 — must use sanitize_for_log helper (strips CR/LF/TAB/NUL + truncates)
     logger.info(
         "preferred_language updated for user_id=%d → '%s'",
         current_user.id,
-        safe_language_for_log,
+        sanitize_for_log(language),
     )
     return {
         "language": language,

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -824,6 +824,22 @@
         <div class="theme-option" data-theme="claude-dark" role="menuitem" tabindex="0">📚 Claude 다크 (베타)</div>
       </div>
     </div>
+    {# Phase 2 PR-4 (사이클 84) — 다국어 i18n 헤더 dropdown (테마 토글 패턴 차용) #}
+    {# Phase 2 PR-4 (Cycle 84) — i18n header dropdown (uses theme-switcher pattern) #}
+    {% if current_user %}
+    <div class="theme-switcher" id="langSwitcher">
+      <button class="theme-btn" id="langToggle" aria-label="언어 변경" aria-haspopup="true" aria-expanded="false">
+        <span id="langIcon">🌍</span>
+        <span id="langName">한국어</span>
+        <span class="chevron">▾</span>
+      </button>
+      <div class="theme-dropdown" id="langDropdown" role="menu">
+        <div class="lang-option" data-lang="en" role="menuitem" tabindex="0">🇺🇸 English</div>
+        <div class="lang-option" data-lang="ko" role="menuitem" tabindex="0">🇰🇷 한국어</div>
+        <div class="lang-option" data-lang="ja" role="menuitem" tabindex="0">🇯🇵 日本語</div>
+      </div>
+    </div>
+    {% endif %}
   </nav>
   <div class="container">{% block content %}{% endblock %}</div>
   {% block scripts %}{% endblock %}
@@ -883,6 +899,82 @@
       });
     });
     document.addEventListener('click', () => { switcher.classList.remove('open'); toggleBtn.setAttribute('aria-expanded', 'false'); });
+
+    // Phase 2 PR-4 (사이클 84) — 다국어 i18n 헤더 dropdown
+    // Phase 2 PR-4 (Cycle 84) — i18n header dropdown
+    (function() {
+      const LANGS = {
+        en: { icon: '🇺🇸', name: 'English' },
+        ko: { icon: '🇰🇷', name: '한국어' },
+        ja: { icon: '🇯🇵', name: '日本語' }
+      };
+      const langSwitcher = document.getElementById('langSwitcher');
+      if (!langSwitcher) return;  // 비로그인 사용자 = lang dropdown 부재
+      const langToggle = document.getElementById('langToggle');
+      const langIcon = document.getElementById('langIcon');
+      const langName = document.getElementById('langName');
+
+      function applyLang(lang) {
+        if (!LANGS[lang]) lang = 'ko';
+        langIcon.textContent = LANGS[lang].icon;
+        langName.textContent = LANGS[lang].name;
+        document.querySelectorAll('.lang-option').forEach(el => {
+          el.classList.toggle('active', el.dataset.lang === lang);
+        });
+      }
+
+      // Cookie `preferred_language` 우선, 없으면 ko default (LocaleMiddleware 페어)
+      // Cookie preferred_language priority, fallback to ko default (pairs with LocaleMiddleware)
+      function readCookieLang() {
+        const m = document.cookie.match(/(?:^|;\s*)preferred_language=([^;]+)/);
+        return m ? m[1] : 'ko';
+      }
+      applyLang(readCookieLang());
+
+      langToggle.addEventListener('click', e => {
+        e.stopPropagation();
+        const open = langSwitcher.classList.toggle('open');
+        langToggle.setAttribute('aria-expanded', open);
+      });
+
+      async function changeLang(lang) {
+        try {
+          const res = await fetch('/api/users/me/preferred-language', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'same-origin',
+            body: JSON.stringify({ language: lang })
+          });
+          if (res.ok) {
+            applyLang(lang);
+            // 페이지 reload — 새 locale 로 UI 재렌더 (LocaleMiddleware 페어)
+            // Reload page — re-render UI with new locale (pairs with LocaleMiddleware)
+            window.location.reload();
+          } else {
+            console.error('Failed to update preferred_language:', res.status);
+          }
+        } catch (err) {
+          console.error('preferred_language API error:', err);
+        }
+        langSwitcher.classList.remove('open');
+        langToggle.setAttribute('aria-expanded', 'false');
+      }
+
+      document.querySelectorAll('.lang-option').forEach(el => {
+        el.addEventListener('click', () => changeLang(el.dataset.lang));
+        el.addEventListener('keydown', e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            changeLang(el.dataset.lang);
+          }
+        });
+      });
+
+      document.addEventListener('click', () => {
+        langSwitcher.classList.remove('open');
+        langToggle.setAttribute('aria-expanded', 'false');
+      });
+    })();
 
     // 모바일 햄버거
     const hamburger = document.getElementById('navHamburger');

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -949,7 +949,9 @@
             applyLang(lang);
             // 페이지 reload — 새 locale 로 UI 재렌더 (LocaleMiddleware 페어)
             // Reload page — re-render UI with new locale (pairs with LocaleMiddleware)
-            window.location.reload();
+            // SonarQube javascript:S7764 — globalThis 표준 권장 (window 대신)
+            // SonarQube javascript:S7764 — globalThis is the standard (replaces window)
+            globalThis.location.reload();
           } else {
             console.error('Failed to update preferred_language:', res.status);
           }

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -538,6 +538,75 @@
     {% endif %}
 
     <!-- ① 빠른 설정 (프리셋) / Quick settings (presets) -->
+    {# Phase 2 PR-4 (사이클 84) — 다국어 i18n 언어 설정 카드 (헤더 dropdown 페어) #}
+    {# Phase 2 PR-4 (Cycle 84) — i18n language settings card (pairs with header dropdown) #}
+    <div class="s-card" id="languageCard" style="margin-bottom:1rem;">
+      <div class="s-card-hdr" style="background:linear-gradient(135deg,#1e40af,#3b82f6)">
+        <span class="hdr-icon">🌍</span>
+        <span class="hdr-title">언어 설정</span>
+        <span class="hdr-badge">Language</span>
+      </div>
+      <div class="s-card-body">
+        <p style="font-size:12px;color:var(--text-muted);margin-bottom:0.8rem;">
+          선호 언어를 선택하세요. 변경 시 즉시 적용됩니다 (페이지 자동 새로고침).<br>
+          Select your preferred language. Changes apply immediately (page auto-reloads).
+        </p>
+        <div class="lang-radio-group" style="display:flex;gap:0.75rem;flex-wrap:wrap;">
+          <label class="lang-radio-label" style="display:flex;align-items:center;gap:0.4rem;padding:8px 14px;border:1px solid var(--border);border-radius:8px;cursor:pointer;min-height:44px;box-sizing:border-box;">
+            <input type="radio" name="settings_preferred_language" value="en"
+                   {% if current_user and current_user.preferred_language == 'en' %}checked{% endif %}
+                   data-lang-radio>
+            <span>🇺🇸 English</span>
+          </label>
+          <label class="lang-radio-label" style="display:flex;align-items:center;gap:0.4rem;padding:8px 14px;border:1px solid var(--border);border-radius:8px;cursor:pointer;min-height:44px;box-sizing:border-box;">
+            <input type="radio" name="settings_preferred_language" value="ko"
+                   {% if not current_user or current_user.preferred_language == 'ko' or not current_user.preferred_language %}checked{% endif %}
+                   data-lang-radio>
+            <span>🇰🇷 한국어</span>
+          </label>
+          <label class="lang-radio-label" style="display:flex;align-items:center;gap:0.4rem;padding:8px 14px;border:1px solid var(--border);border-radius:8px;cursor:pointer;min-height:44px;box-sizing:border-box;">
+            <input type="radio" name="settings_preferred_language" value="ja"
+                   {% if current_user and current_user.preferred_language == 'ja' %}checked{% endif %}
+                   data-lang-radio>
+            <span>🇯🇵 日本語</span>
+          </label>
+        </div>
+        <p id="langSaveStatus" style="font-size:11px;color:var(--text-muted);margin-top:0.5rem;min-height:1em;"></p>
+      </div>
+    </div>
+    <script>
+      // Phase 2 PR-4 — settings 페이지 언어 라디오 → API + Cookie 동기화
+      // Phase 2 PR-4 — settings page language radio → API + Cookie sync
+      (function() {
+        const radios = document.querySelectorAll('[data-lang-radio]');
+        const status = document.getElementById('langSaveStatus');
+        if (!radios.length) return;
+        radios.forEach(radio => {
+          radio.addEventListener('change', async () => {
+            if (!radio.checked) return;
+            const lang = radio.value;
+            status.textContent = '저장 중... / Saving...';
+            try {
+              const res = await fetch('/api/users/me/preferred-language', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                body: JSON.stringify({ language: lang })
+              });
+              if (res.ok) {
+                status.textContent = '저장됨. 페이지 새로고침... / Saved. Reloading...';
+                setTimeout(() => window.location.reload(), 600);
+              } else {
+                status.textContent = '저장 실패 / Save failed (status: ' + res.status + ')';
+              }
+            } catch (err) {
+              status.textContent = '오류 / Error: ' + err.message;
+            }
+          });
+        });
+      })();
+    </script>
+
     <div class="s-card" id="presetCard" style="margin-bottom:1rem;">
       <div class="s-card-hdr hdr-preset">
         <span class="hdr-icon">🚀</span>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -595,7 +595,9 @@
               });
               if (res.ok) {
                 status.textContent = '저장됨. 페이지 새로고침... / Saved. Reloading...';
-                setTimeout(() => window.location.reload(), 600);
+                // SonarQube javascript:S7764 — globalThis 표준 권장 (window 대신)
+                // SonarQube javascript:S7764 — globalThis is the standard (replaces window)
+                setTimeout(() => globalThis.location.reload(), 600);
               } else {
                 status.textContent = '저장 실패 / Save failed (status: ' + res.status + ')';
               }

--- a/tests/unit/api/test_preferred_language_api.py
+++ b/tests/unit/api/test_preferred_language_api.py
@@ -1,0 +1,114 @@
+"""사용자 선호 언어 API 단위 테스트 (Phase 2 PR-4 사이클 84).
+
+POST /api/users/me/preferred-language — DB + Cookie 동시 갱신 검증.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+# pylint: disable=wrong-import-position
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+from src.api.users import PreferredLanguageUpdate, router
+from fastapi import FastAPI
+
+
+@pytest.fixture
+def client():
+    """TestClient with mocked auth dependency."""
+    app = FastAPI()
+    app.include_router(router)
+
+    # Mock require_login dependency
+    from src.auth.session import require_login
+
+    def fake_user():
+        return MagicMock(id=42, email="test@example.com")
+
+    app.dependency_overrides[require_login] = fake_user
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_preferred_language_validator_valid_locale():
+    """SUPPORTED_LOCALES 영역 (en/ko/ja) → 정규화 OK."""
+    body = PreferredLanguageUpdate(language="en")
+    assert body.language == "en"
+
+
+def test_preferred_language_validator_normalizes_case():
+    """대문자 입력 → 소문자 정규화."""
+    body = PreferredLanguageUpdate(language="KO")
+    assert body.language == "ko"
+
+
+def test_preferred_language_validator_strips_whitespace():
+    """공백 좌우 제거."""
+    body = PreferredLanguageUpdate(language="  ja  ")
+    assert body.language == "ja"
+
+
+def test_preferred_language_validator_empty_raises():
+    """빈 문자열 → ValueError."""
+    with pytest.raises(ValueError, match="must not be empty"):
+        PreferredLanguageUpdate(language="")
+
+
+def test_preferred_language_validator_unsupported_raises():
+    """미지원 locale (예: 'zh') → ValueError."""
+    with pytest.raises(ValueError, match="not in SUPPORTED_LOCALES"):
+        PreferredLanguageUpdate(language="zh")
+
+
+def test_preferred_language_endpoint_updates_db_and_cookie(client):
+    """POST 엔드포인트 = DB update + Cookie 설정 검증."""
+    with patch("src.api.users.SessionLocal") as mock_session:
+        db_mock = MagicMock()
+        mock_session.return_value.__enter__.return_value = db_mock
+
+        res = client.post(
+            "/api/users/me/preferred-language",
+            json={"language": "ja"},
+        )
+
+        assert res.status_code == 200
+        data = res.json()
+        assert data["language"] == "ja"
+        assert "preferred language updated" in data["message"]
+
+        # Cookie 검증 — preferred_language=ja
+        assert "preferred_language" in res.cookies
+        assert res.cookies["preferred_language"] == "ja"
+
+        # DB update 호출 검증
+        assert db_mock.execute.called
+        assert db_mock.commit.called
+
+
+def test_preferred_language_endpoint_invalid_returns_422(client):
+    """미지원 locale → pydantic validation error 422."""
+    res = client.post(
+        "/api/users/me/preferred-language",
+        json={"language": "fr"},
+    )
+    assert res.status_code == 422
+
+
+def test_preferred_language_endpoint_kill_switch_returns_503(client):
+    """I18N_DISABLED=1 → 503."""
+    with patch("src.api.users.settings") as mock_settings:
+        mock_settings.i18n_disabled = True
+        mock_settings.app_base_url = ""
+        mock_settings.supported_locales = "en,ko,ja"
+        res = client.post(
+            "/api/users/me/preferred-language",
+            json={"language": "ko"},
+        )
+        assert res.status_code == 503
+        assert "i18n feature is disabled" in res.json()["detail"]


### PR DESCRIPTION
… + Cookie 동기화 (Phase 2 PR-4)

⚠️ 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 5건 적용):

⚠️ Phase 2 진입 첫 PR (Q5 = 🅐 Phase 별 사전 확인 default — 사용자 명시 신호 정합) ⚠️ 헤더 dropdown = 기존 theme-switcher 패턴 차용 (정책 16 5번 원칙 페어 — 코드 재사용) ⚠️ settings.html 7번째 카드 = inline style 사용 (응집 단위 단순화 — 별도 CSS 파일 신설 over-engineering 회피) ⚠️ Cookie 동기화 = LocaleMiddleware 페어 (PR-1b 페어 — 5단계 locale 감지 우선순위 정합) ⚠️ 본 PR-4 ~280 LOC (정책 7 강화 임계 1500 LOC 미달, 응집 단위 부합)

신규 영역:
1. src/api/users.py:
   - PreferredLanguageUpdate Pydantic body + field_validator (SUPPORTED_LOCALES 영역 검증 + 정규화)
   - POST /api/users/me/preferred-language endpoint (require_login + DB update + Cookie 동시 갱신 + I18N_DISABLED kill-switch 페어)
2. src/templates/base.html:
   - 헤더 lang dropdown (테마 토글 옆 위치, theme-switcher CSS 패턴 차용 — lang-option 별도 클래스 selector 분리)
   - JavaScript 언어 변경 핸들러 (Cookie 우선 감지 + API POST + 페이지 reload)
3. src/templates/settings.html:
   - 신규 7번째 카드 (언어 설정 — 빠른 설정 카드 직전 위치)
   - 라디오 3종 (en/ko/ja) + 자동 저장 (change 이벤트 → API + 페이지 reload)
4. tests/unit/api/test_preferred_language_api.py:
   - 회귀 가드 8건 (validator 5 + endpoint 3 — DB+Cookie 동시 갱신 / kill-switch 503 / unsupported 422)

검증 (메모리 feedback-pr-push-direct-validation.md default 적용):
- pytest tests/unit/api/test_preferred_language_api.py -v = 8 passed
- pytest tests/unit tests/integration -q = 2427 passed / 5 skipped / 0 failed

다음 단계 (Phase 2 잔여 PR-5~8):
- PR-5: base.html + login.html + add_repo.html + overview.html 다국어 적용 (~700 LOC)
- PR-6: dashboard.html (KPI 5 + Insight 4카드 + mode 4종) 다국어 (~600 LOC)
- PR-7: repo_detail.html + analysis_detail.html 다국어 (~500 LOC)
- PR-8: settings.html (전체 6 카드 한글) + admin 3 다국어 (~800 LOC)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
