### PR TITLE
feat(i18n-phase2-pr5): base.html + login + add_repo + overview 다국어 적용…

### DIFF
--- a/src/api/users.py
+++ b/src/api/users.py
@@ -163,11 +163,18 @@ async def update_preferred_language(
     # 만료 = 1년 (사용자 명시 변경 시까지 유지)
     # max-age = 1 year (until user explicitly changes)
     is_prod = settings.app_base_url.startswith("https")
+    # Phase 2 PR-5 (사이클 84 — cross-verify 옵션 C) — httponly=True 보안 강화
+    # Phase 2 PR-5 (Cycle 84 — cross-verify option C) — httponly=True security
+    # 변경 사유: JS 가 cookie 직접 읽지 않음 (LocaleMiddleware scope.state → Jinja
+    # `{{ locale }}` template 변수 주입 페어). XSS 위험 차단 + base.html 의
+    # readCookieLang() 함수 폐기 (서버 변수 주입으로 대체).
+    # Reason: JS no longer reads cookie (uses Jinja `{{ locale }}` injection from
+    # LocaleMiddleware.scope.state). Mitigates XSS + replaces base.html readCookieLang().
     response.set_cookie(
         key="preferred_language",
         value=language,
         max_age=60 * 60 * 24 * 365,  # 1 year
-        httponly=False,  # JavaScript 읽기 가능 (헤더 dropdown 표시 영역)
+        httponly=True,  # Phase 2 PR-5 — XSS 차단 + 서버측 template 주입 페어
         secure=is_prod,
         samesite="lax",
         path="/",

--- a/src/auth/github.py
+++ b/src/auth/github.py
@@ -27,6 +27,12 @@ oauth.register(
 
 router = APIRouter(tags=["auth"])
 templates = Jinja2Templates(directory="src/templates")
+# Phase 2 PR-5 (사이클 84) — Jinja2 i18n 필터 등록 (login.html 다국어 페어)
+# Phase 2 PR-5 (Cycle 84) — Register Jinja2 i18n filters (pairs with login.html i18n)
+# auth/github.py 는 자체 Jinja2Templates 인스턴스 사용 — _helpers.templates 와 분리
+# auth/github.py uses its own Jinja2Templates instance — separate from _helpers.templates
+from src.i18n.filters import register_i18n_filters  # noqa: E402
+register_i18n_filters(templates.env)
 
 
 @router.get("/login", response_class=HTMLResponse)
@@ -35,7 +41,10 @@ async def login_page(request: Request):
     user = get_current_user(request)
     if user:
         return RedirectResponse(url="/", status_code=302)
-    return templates.TemplateResponse(request, "login.html", {})
+    # Phase 2 PR-5 — locale context 주입 (LocaleMiddleware 페어, 비로그인 사용자 영역)
+    # Phase 2 PR-5 — inject locale context (pairs with LocaleMiddleware, non-logged-in)
+    locale_value = request.scope.get("state", {}).get("locale") or settings.default_locale
+    return templates.TemplateResponse(request, "login.html", {"locale": locale_value})
 
 
 @router.get("/auth/github")

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -15,7 +15,8 @@
     "yes": "Yes",
     "no": "No",
     "confirm": "Confirm",
-    "no_data": "No data available"
+    "no_data": "No data available",
+    "menu_aria": "Open menu"
   },
   "header": {
     "welcome": "Welcome, {name}",
@@ -23,9 +24,12 @@
     "dark_dashboard": "Dark Dashboard",
     "light_clean": "Clean Cards",
     "glass": "Glassmorphism",
-    "claude_dark": "Claude Dark (Beta)"
+    "claude_dark": "Claude Dark (Beta)",
+    "overview": "Overview",
+    "dashboard": "Dashboard"
   },
   "login": {
+    "title_prefix": "Login",
     "title": "SCAManager",
     "subtitle": "Claude reviews your PR and provides scores and feedback",
     "github_login": "Sign in with GitHub",
@@ -60,13 +64,58 @@
   "overview": {
     "greeting": "Hello, {name}",
     "title": "Today's Analyses",
+    "title_empty": "Repository Status",
     "repo_count": "{count} repos",
+    "add_repo": "+ Add Repository",
+    "settings_link": "Settings",
+    "analysis_count_unit": "{count} runs",
     "table": {
       "repository": "Repository",
       "analysis": "Analyses",
       "avg_score": "Average Score",
       "grade": "Grade"
+    },
+    "tutorial": {
+      "title": "Get Started in 3 Steps",
+      "subtitle": "Connect a GitHub repo to start automatic analysis on Push/PR",
+      "step1_title": "Select GitHub Repo",
+      "step1_desc": "Choose one of your OAuth-connected repos, and a Webhook will be auto-created.",
+      "step1_cta": "+ Add Repository",
+      "step2_title": "Initial Setup (Simple Mode)",
+      "step2_desc_part1": "After registration, select one of the ",
+      "step2_desc_preset": "Quick Setup Presets",
+      "step2_desc_part2": " in the settings page. Simple Mode defaults are Python analysis + Telegram notifications + PR comments.",
+      "step3_title": "First Push or PR",
+      "step3_desc": "Push your code, and analysis results will accumulate automatically in the dashboard. Provide thumbs feedback on score correctness to improve calibration.",
+      "tip_label": "Tip",
+      "tip_desc_part1": " — Up to 89 points (B grade) can be analyzed even without ",
+      "tip_desc_part2": "."
+    },
+    "calibration": {
+      "title": "AI Score Calibration",
+      "hint": "How well Claude's scores align with human judgment — 👍 ratio per score range",
+      "range": "Score Range",
+      "feedback_count": "Feedback Count",
+      "up_ratio": "👍 Ratio",
+      "visualization": "Visualization"
     }
+  },
+  "add_repo": {
+    "title_prefix": "Add Repository",
+    "page_title": "Add Repository",
+    "subtitle": "Webhook will be auto-created when you select a GitHub repo",
+    "back": "← Back",
+    "label_select": "GitHub Repository",
+    "loading_option": "Loading repo list...",
+    "hint_default": "Loading accessible repos from GitHub API.",
+    "placeholder_option": "Select a repository",
+    "no_repos_option": "No repos available to add",
+    "no_repos_hint": "All repos are already registered or no accessible repos available.",
+    "loaded_hint": "{count} repos loaded.",
+    "load_failed_option": "Failed to load repo list",
+    "error_prefix": "Error: ",
+    "api_error_prefix": "API error: ",
+    "submit": "Create Webhook + Add Repository"
   },
   "settings": {
     "title": "Settings",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -15,7 +15,8 @@
     "yes": "はい",
     "no": "いいえ",
     "confirm": "確認",
-    "no_data": "データなし"
+    "no_data": "データなし",
+    "menu_aria": "メニューを開く"
   },
   "header": {
     "welcome": "ようこそ、{name}さん",
@@ -23,9 +24,12 @@
     "dark_dashboard": "ダークダッシュボード",
     "light_clean": "クリーンカード",
     "glass": "グラスモーフィズム",
-    "claude_dark": "Claude ダーク (ベータ版)"
+    "claude_dark": "Claude ダーク (ベータ版)",
+    "overview": "概要",
+    "dashboard": "ダッシュボード"
   },
   "login": {
+    "title_prefix": "ログイン",
     "title": "SCAManager",
     "subtitle": "PRが入ってきたらClaudeがレビューしてスコアとフィードバックをお知らせします",
     "github_login": "GitHubでログイン",
@@ -60,13 +64,58 @@
   "overview": {
     "greeting": "こんにちは、{name}さん",
     "title": "本日の分析",
+    "title_empty": "リポジトリ状況",
     "repo_count": "{count}個のリポ",
+    "add_repo": "+ リポ追加",
+    "settings_link": "設定",
+    "analysis_count_unit": "{count}回",
     "table": {
       "repository": "リポジトリ",
       "analysis": "分析",
       "avg_score": "平均スコア",
       "grade": "グレード"
+    },
+    "tutorial": {
+      "title": "3ステップで始める",
+      "subtitle": "GitHubリポを連携するとPush/PR時に自動分析が開始されます",
+      "step1_title": "GitHubリポを選択",
+      "step1_desc": "OAuthで連携したリポの中から1つ選択するとWebhookが自動生成されます。",
+      "step1_cta": "+ リポ追加",
+      "step2_title": "初期設定 (Simpleモード)",
+      "step2_desc_part1": "登録後、設定ページの ",
+      "step2_desc_preset": "🚀 クイック設定プリセット",
+      "step2_desc_part2": " から1つを選択。Simpleモードの既定値は Python 分析 + Telegram 通知 + PR コメントです。",
+      "step3_title": "最初のPushまたはPR",
+      "step3_desc": "コードをプッシュすると分析結果が自動的にダッシュボードに蓄積されます。スコアが正しいか 👍/👎 のフィードバックをいただければ整合性指標が改善されます。",
+      "tip_label": "ヒント",
+      "tip_desc_part1": " — ",
+      "tip_desc_part2": " なしでも最大89点(Bグレード)まで分析可能です。"
+    },
+    "calibration": {
+      "title": "AIスコア整合性",
+      "hint": "Claudeが付けたスコアが人間の判断とどれだけ一致するか — スコア範囲別 👍 比率",
+      "range": "スコア範囲",
+      "feedback_count": "フィードバック数",
+      "up_ratio": "👍 比率",
+      "visualization": "可視化"
     }
+  },
+  "add_repo": {
+    "title_prefix": "リポ追加",
+    "page_title": "リポジトリ追加",
+    "subtitle": "GitHubリポを選択するとWebhookが自動生成されます",
+    "back": "← 戻る",
+    "label_select": "GitHubリポジトリ",
+    "loading_option": "リポリストを読み込み中...",
+    "hint_default": "GitHub APIからアクセス可能なリポリストを読み込みます。",
+    "placeholder_option": "リポを選択してください",
+    "no_repos_option": "追加可能なリポがありません",
+    "no_repos_hint": "すべてのリポが既に登録されているか、アクセス可能なリポがありません。",
+    "loaded_hint": "{count}個のリポを読み込みました。",
+    "load_failed_option": "リポリスト読み込み失敗",
+    "error_prefix": "エラー: ",
+    "api_error_prefix": "APIエラー: ",
+    "submit": "Webhook生成 + リポ追加"
   },
   "settings": {
     "title": "設定",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -15,7 +15,8 @@
     "yes": "예",
     "no": "아니오",
     "confirm": "확인",
-    "no_data": "데이터 없음"
+    "no_data": "데이터 없음",
+    "menu_aria": "메뉴 열기"
   },
   "header": {
     "welcome": "환영합니다, {name}님",
@@ -23,9 +24,12 @@
     "dark_dashboard": "다크 대시보드",
     "light_clean": "클린 카드",
     "glass": "글래스모피즘",
-    "claude_dark": "Claude 다크 (베타)"
+    "claude_dark": "Claude 다크 (베타)",
+    "overview": "개요",
+    "dashboard": "대시보드"
   },
   "login": {
+    "title_prefix": "로그인",
     "title": "SCAManager",
     "subtitle": "PR이 들어오면 Claude가 검토하고 점수와 피드백을 알려드려요",
     "github_login": "GitHub로 로그인",
@@ -60,13 +64,58 @@
   "overview": {
     "greeting": "안녕하세요, {name}님",
     "title": "오늘의 분석",
+    "title_empty": "리포지토리 현황",
     "repo_count": "{count}개 리포",
+    "add_repo": "+ 리포 추가",
+    "settings_link": "설정",
+    "analysis_count_unit": "{count}회",
     "table": {
       "repository": "리포지토리",
       "analysis": "분석",
       "avg_score": "평균 점수",
       "grade": "등급"
+    },
+    "tutorial": {
+      "title": "3단계로 시작하기",
+      "subtitle": "GitHub 리포를 연결하면 Push/PR 시 자동 분석이 시작됩니다",
+      "step1_title": "GitHub 리포 선택",
+      "step1_desc": "OAuth 로 연결한 리포 중 하나를 선택하면 Webhook 이 자동 생성됩니다.",
+      "step1_cta": "+ 리포 추가",
+      "step2_title": "기본 설정 (Simple 모드)",
+      "step2_desc_part1": "등록 후 설정 페이지에서 ",
+      "step2_desc_preset": "🚀 빠른 설정 프리셋",
+      "step2_desc_part2": " 중 하나 선택. Simple 모드 기본값은 Python 분석 + Telegram 알림 + PR 코멘트입니다.",
+      "step3_title": "첫 Push 또는 PR",
+      "step3_desc": "코드를 푸시하면 자동으로 분석 결과가 대시보드에 쌓입니다. 점수가 맞는지 👍/👎 피드백을 주시면 정합도 지표가 개선됩니다.",
+      "tip_label": "팁",
+      "tip_desc_part1": " — ",
+      "tip_desc_part2": " 없이도 최대 89점(B등급)까지 분석 가능합니다."
+    },
+    "calibration": {
+      "title": "AI 점수 정합도",
+      "hint": "Claude 가 매긴 점수가 사람 판단과 얼마나 일치하는지 — 점수 범위별 👍 비율",
+      "range": "점수 범위",
+      "feedback_count": "피드백 수",
+      "up_ratio": "👍 비율",
+      "visualization": "시각화"
     }
+  },
+  "add_repo": {
+    "title_prefix": "리포 추가",
+    "page_title": "리포지토리 추가",
+    "subtitle": "GitHub 리포를 선택하면 Webhook이 자동 생성됩니다",
+    "back": "← 돌아가기",
+    "label_select": "GitHub 리포지토리",
+    "loading_option": "리포 목록 불러오는 중...",
+    "hint_default": "GitHub API에서 접근 가능한 리포 목록을 불러옵니다.",
+    "placeholder_option": "리포를 선택하세요",
+    "no_repos_option": "추가 가능한 리포가 없습니다",
+    "no_repos_hint": "모든 리포가 이미 등록되었거나 접근 가능한 리포가 없습니다.",
+    "loaded_hint": "{count}개 리포를 불러왔습니다.",
+    "load_failed_option": "리포 목록 로드 실패",
+    "error_prefix": "오류: ",
+    "api_error_prefix": "API 오류: ",
+    "submit": "Webhook 생성 + 리포 추가"
   },
   "settings": {
     "title": "설정",

--- a/src/templates/add_repo.html
+++ b/src/templates/add_repo.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}리포 추가 — SCAManager{% endblock %}
+{% block title %}{{ 'add_repo.title_prefix' | i18n_args(locale | default('ko')) }} — SCAManager{% endblock %}
 {% block content %}
 <style>
   .add-repo-card { max-width: 560px; margin: 2rem auto; }
@@ -81,24 +81,33 @@
 <div class="toast" id="errorToast"></div>
 
 <div class="page-header">
-  <a class="back-btn" href="/">← 돌아가기</a>
+  <a class="back-btn" href="/">{{ 'add_repo.back' | i18n_args(locale | default('ko')) }}</a>
   <div>
-    <h2>리포지토리 추가</h2>
-    <p class="subtitle">GitHub 리포를 선택하면 Webhook이 자동 생성됩니다</p>
+    <h2>{{ 'add_repo.page_title' | i18n_args(locale | default('ko')) }}</h2>
+    <p class="subtitle">{{ 'add_repo.subtitle' | i18n_args(locale | default('ko')) }}</p>
   </div>
 </div>
 
-<div class="card add-repo-card">
+{# Phase 2 PR-5 — 다국어 적용. JS 동적 텍스트는 data-i18n-* 속성으로 서버측 주입
+   (LocaleMiddleware ↔ Jinja {{ locale }} 페어 — XSS 차단 + race condition 0). #}
+<div class="card add-repo-card"
+     data-i18n-placeholder="{{ 'add_repo.placeholder_option' | i18n_args(locale | default('ko')) }}"
+     data-i18n-no-repos-option="{{ 'add_repo.no_repos_option' | i18n_args(locale | default('ko')) }}"
+     data-i18n-no-repos-hint="{{ 'add_repo.no_repos_hint' | i18n_args(locale | default('ko')) }}"
+     data-i18n-loaded-template="{{ 'add_repo.loaded_hint' | i18n_args(locale | default('ko'), count='__N__') }}"
+     data-i18n-load-failed="{{ 'add_repo.load_failed_option' | i18n_args(locale | default('ko')) }}"
+     data-i18n-error-prefix="{{ 'add_repo.error_prefix' | i18n_args(locale | default('ko')) }}"
+     data-i18n-api-error-prefix="{{ 'add_repo.api_error_prefix' | i18n_args(locale | default('ko')) }}">
   <form method="post" action="/repos/add" id="addRepoForm">
     <div class="form-group">
-      <label class="form-label" for="repo_full_name">GitHub 리포지토리</label>
+      <label class="form-label" for="repo_full_name">{{ 'add_repo.label_select' | i18n_args(locale | default('ko')) }}</label>
       <select class="form-select" name="repo_full_name" id="repo_full_name" required>
-        <option value="">리포 목록 불러오는 중...</option>
+        <option value="">{{ 'add_repo.loading_option' | i18n_args(locale | default('ko')) }}</option>
       </select>
-      <p class="repo-hint" id="repoHint">GitHub API에서 접근 가능한 리포 목록을 불러옵니다.</p>
+      <p class="repo-hint" id="repoHint">{{ 'add_repo.hint_default' | i18n_args(locale | default('ko')) }}</p>
     </div>
     <button type="submit" class="btn btn-primary" style="width:100%;justify-content:center;" id="submitBtn" disabled>
-      Webhook 생성 + 리포 추가
+      {{ 'add_repo.submit' | i18n_args(locale | default('ko')) }}
     </button>
   </form>
 </div>
@@ -108,23 +117,38 @@
   const select = document.getElementById('repo_full_name');
   const submitBtn = document.getElementById('submitBtn');
   const hint = document.getElementById('repoHint');
+  // Phase 2 PR-5 — 다국어 동적 텍스트 (서버 Jinja injection 페어)
+  // Phase 2 PR-5 — i18n dynamic text (paired with server-side Jinja injection)
+  const i18nCard = document.querySelector('.add-repo-card');
+  const I18N = {
+    placeholder: i18nCard.dataset.i18nPlaceholder,
+    noReposOption: i18nCard.dataset.i18nNoReposOption,
+    noReposHint: i18nCard.dataset.i18nNoReposHint,
+    loadedTemplate: i18nCard.dataset.i18nLoadedTemplate,
+    loadFailed: i18nCard.dataset.i18nLoadFailed,
+    errorPrefix: i18nCard.dataset.i18nErrorPrefix,
+    apiErrorPrefix: i18nCard.dataset.i18nApiErrorPrefix,
+  };
 
   async function loadRepos() {
     try {
       const resp = await fetch('/api/github/repos');
-      if (!resp.ok) throw new Error('API 오류: ' + resp.status);
+      if (!resp.ok) throw new Error(I18N.apiErrorPrefix + resp.status);
       const repos = await resp.json();
 
       select.innerHTML = '';
       if (repos.length === 0) {
-        select.innerHTML = '<option value="">추가 가능한 리포가 없습니다</option>';
-        hint.textContent = '모든 리포가 이미 등록되었거나 접근 가능한 리포가 없습니다.';
+        const noOpt = document.createElement('option');
+        noOpt.value = '';
+        noOpt.textContent = I18N.noReposOption;
+        select.appendChild(noOpt);
+        hint.textContent = I18N.noReposHint;
         return;
       }
 
       const placeholder = document.createElement('option');
       placeholder.value = '';
-      placeholder.textContent = '리포를 선택하세요';
+      placeholder.textContent = I18N.placeholder;
       select.appendChild(placeholder);
 
       repos.forEach(repo => {
@@ -134,10 +158,14 @@
         select.appendChild(opt);
       });
 
-      hint.textContent = repos.length + '개 리포를 불러왔습니다.';
+      hint.textContent = I18N.loadedTemplate.replace('__N__', repos.length);
     } catch (e) {
-      select.innerHTML = '<option value="">리포 목록 로드 실패</option>';
-      hint.textContent = '오류: ' + e.message;
+      const failOpt = document.createElement('option');
+      failOpt.value = '';
+      failOpt.textContent = I18N.loadFailed;
+      select.innerHTML = '';
+      select.appendChild(failOpt);
+      hint.textContent = I18N.errorPrefix + e.message;
     }
   }
 

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="{{ locale | default('ko') }}">
 <head>
   <meta charset="UTF-8">
   <!-- viewport-fit=cover: iOS notch 디바이스의 safe-area-inset env() 활성화
@@ -796,10 +796,10 @@
        비로그인 상태에서 클릭 시 /login 으로 리다이렉트되므로 시각 노출 자체가 무의미.
        Step E (E1): Hamburger + nav links shown only when authenticated. #}
     {% if current_user %}
-    <button class="nav-hamburger" id="navHamburger" aria-label="메뉴" aria-expanded="false">☰</button>
+    <button class="nav-hamburger" id="navHamburger" aria-label="{{ 'common.menu_aria' | i18n_args(locale | default('ko')) }}" aria-expanded="false">☰</button>
     <div class="nav-links" id="navLinks">
-      <a class="nav-link" href="/">Overview</a>
-      <a class="nav-link" href="/dashboard">Dashboard</a>
+      <a class="nav-link" href="/">{{ 'header.overview' | i18n_args(locale | default('ko')) }}</a>
+      <a class="nav-link" href="/dashboard">{{ 'header.dashboard' | i18n_args(locale | default('ko')) }}</a>
     </div>
     {% endif %}
     <div class="nav-spacer"></div>
@@ -807,7 +807,7 @@
     <div class="nav-user">
       <span class="nav-user-name">{{ current_user.display_name or current_user.github_login }}</span>
       <form method="post" action="/auth/logout" style="display:inline;margin:0">
-        <button type="submit" class="nav-logout-btn">로그아웃</button>
+        <button type="submit" class="nav-logout-btn">{{ 'common.logout' | i18n_args(locale | default('ko')) }}</button>
       </form>
     </div>
     {% endif %}
@@ -923,13 +923,11 @@
         });
       }
 
-      // Cookie `preferred_language` 우선, 없으면 ko default (LocaleMiddleware 페어)
-      // Cookie preferred_language priority, fallback to ko default (pairs with LocaleMiddleware)
-      function readCookieLang() {
-        const m = document.cookie.match(/(?:^|;\s*)preferred_language=([^;]+)/);
-        return m ? m[1] : 'ko';
-      }
-      applyLang(readCookieLang());
+      // Phase 2 PR-5 (사이클 84) — 서버측 locale (LocaleMiddleware scope.state) 주입
+      // Cookie 직접 읽기 회피 (httponly=True 정합 — XSS 위험 0 + race condition 0)
+      // Phase 2 PR-5 (Cycle 84) — server-side locale injection from LocaleMiddleware
+      // Avoids document.cookie read (httponly=True compatible — XSS 0 + race 0)
+      applyLang('{{ locale | default("ko") }}');
 
       langToggle.addEventListener('click', e => {
         e.stopPropagation();

--- a/src/templates/login.html
+++ b/src/templates/login.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}로그인 — SCAManager{% endblock %}
+{% block title %}{{ 'login.title_prefix' | i18n_args(locale | default('ko')) }} — SCAManager{% endblock %}
 
 {% block content %}
 <style>
@@ -94,16 +94,16 @@
 <div class="login-wrap">
   <div class="card login-card">
     <div class="login-logo">⚡</div>
-    <h1 class="login-title">SCAManager</h1>
-    {# Phase 1B (UI 개편) — 친근한 대화체 톤 #}
-    <p class="login-sub">PR이 들어오면 Claude가 검토하고<br>점수와 피드백을 알려드려요</p>
+    <h1 class="login-title">{{ 'login.title' | i18n_args(locale | default('ko')) }}</h1>
+    {# Phase 1B (UI 개편) — 친근한 대화체 톤 / Phase 2 PR-5 — 다국어 적용 #}
+    <p class="login-sub">{{ 'login.subtitle' | i18n_args(locale | default('ko')) }}</p>
     <a href="/auth/github" class="btn-github">
       <svg width="20" height="20" viewBox="0 0 24 24" fill="white">
         <path d="M12 0C5.374 0 0 5.373 0 12c0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23A11.509 11.509 0 0 1 12 5.803c1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576C20.566 21.797 24 17.3 24 12c0-6.627-5.373-12-12-12z"/>
       </svg>
-      GitHub로 로그인
+      {{ 'login.github_login' | i18n_args(locale | default('ko')) }}
     </a>
-    <p class="login-footer">GitHub OAuth로 안전하게 인증합니다</p>
+    <p class="login-footer">{{ 'login.footer' | i18n_args(locale | default('ko')) }}</p>
   </div>
 </div>
 {% endblock %}

--- a/src/templates/overview.html
+++ b/src/templates/overview.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Overview — SCAManager{% endblock %}
+{% block title %}{{ 'header.overview' | i18n_args(locale | default('ko')) }} — SCAManager{% endblock %}
 {% block content %}
 <style>
   .overview-header {
@@ -85,17 +85,18 @@
 
 <div class="overview-header">
   <div>
-    {# Phase 1B (UI 개편) — 친근한 환영 인사 (current_user 있을 때만) #}
+    {# Phase 1B (UI 개편) — 친근한 환영 인사 (current_user 있을 때만) / Phase 2 PR-5 — 다국어 적용 #}
+    {# Phase 1B (UI redesign) — friendly greeting (only when current_user exists) / Phase 2 PR-5 — i18n applied #}
     {% if current_user %}
-    <p class="overview-greeting">안녕하세요, {{ current_user.display_name or current_user.github_login }}님 👋</p>
+    <p class="overview-greeting">{{ 'overview.greeting' | i18n_args(locale | default('ko'), name=(current_user.display_name or current_user.github_login)) }} 👋</p>
     {% endif %}
-    <h2 class="overview-title">{% if repos %}오늘의 분석{% else %}리포지토리 현황{% endif %}</h2>
+    <h2 class="overview-title">{% if repos %}{{ 'overview.title' | i18n_args(locale | default('ko')) }}{% else %}{{ 'overview.title_empty' | i18n_args(locale | default('ko')) }}{% endif %}</h2>
   </div>
   <div class="overview-actions">
     {% if repos %}
-    <span class="repo-count">{{ repos | length }}개 리포</span>
+    <span class="repo-count">{{ 'overview.repo_count' | i18n_args(locale | default('ko'), count=repos | length) }}</span>
     {% endif %}
-    <a href="/repos/add" class="btn btn-primary btn--sm">+ 리포 추가</a>
+    <a href="/repos/add" class="btn btn-primary btn--sm">{{ 'overview.add_repo' | i18n_args(locale | default('ko')) }}</a>
   </div>
 </div>
 <style>
@@ -114,10 +115,10 @@
     <table>
       <thead>
         <tr>
-          <th>리포지토리</th>
-          <th>분석</th>
-          <th>평균 점수</th>
-          <th>등급</th>
+          <th>{{ 'overview.table.repository' | i18n_args(locale | default('ko')) }}</th>
+          <th>{{ 'overview.table.analysis' | i18n_args(locale | default('ko')) }}</th>
+          <th>{{ 'overview.table.avg_score' | i18n_args(locale | default('ko')) }}</th>
+          <th>{{ 'overview.table.grade' | i18n_args(locale | default('ko')) }}</th>
           <th></th>
         </tr>
       </thead>
@@ -127,7 +128,7 @@
         <td>
           <a class="repo-link" href="/repos/{{ item.full_name }}">{{ item.full_name }}</a>
         </td>
-        <td><span class="analysis-count">{{ item.analysis_count }}회</span></td>
+        <td><span class="analysis-count">{{ 'overview.analysis_count_unit' | i18n_args(locale | default('ko'), count=item.analysis_count) }}</span></td>
         <td>
           {% if item.avg_score %}
           <span class="score-cell {% if item.avg_score >= 75 %}score-high{% elif item.avg_score >= 50 %}score-mid{% else %}score-low{% endif %}">
@@ -142,7 +143,7 @@
           <span class="grade grade-{{ item.avg_grade }}">{{ item.avg_grade }}</span>
           {% endif %}
         </td>
-        <td><a class="settings-link" href="/repos/{{ item.full_name }}/settings">⚙️ 설정</a></td>
+        <td><a class="settings-link" href="/repos/{{ item.full_name }}/settings">⚙️ {{ 'overview.settings_link' | i18n_args(locale | default('ko')) }}</a></td>
       </tr>
       {% endfor %}
       </tbody>
@@ -153,42 +154,40 @@
 {# Phase E.5 — Onboarding 3단계 튜토리얼 (리포 0개일 때만 노출) #}
 <div class="card get-started-tutorial">
   <div class="gst-header">
-    <h2 class="gst-title">🚀 3단계로 시작하기</h2>
-    <p class="gst-subtitle">GitHub 리포를 연결하면 Push/PR 시 자동 분석이 시작됩니다</p>
+    <h2 class="gst-title">🚀 {{ 'overview.tutorial.title' | i18n_args(locale | default('ko')) }}</h2>
+    <p class="gst-subtitle">{{ 'overview.tutorial.subtitle' | i18n_args(locale | default('ko')) }}</p>
   </div>
   <div class="gst-steps">
     <div class="gst-step">
       <div class="gst-step-num">1</div>
       <div class="gst-step-body">
-        <div class="gst-step-title">GitHub 리포 선택</div>
-        <div class="gst-step-desc">OAuth 로 연결한 리포 중 하나를 선택하면 Webhook 이 자동 생성됩니다.</div>
-        <a href="/repos/add" class="btn btn-primary btn--sm gst-cta">+ 리포 추가</a>
+        <div class="gst-step-title">{{ 'overview.tutorial.step1_title' | i18n_args(locale | default('ko')) }}</div>
+        <div class="gst-step-desc">{{ 'overview.tutorial.step1_desc' | i18n_args(locale | default('ko')) }}</div>
+        <a href="/repos/add" class="btn btn-primary btn--sm gst-cta">{{ 'overview.tutorial.step1_cta' | i18n_args(locale | default('ko')) }}</a>
       </div>
     </div>
     <div class="gst-step">
       <div class="gst-step-num">2</div>
       <div class="gst-step-body">
-        <div class="gst-step-title">기본 설정 (Simple 모드)</div>
+        <div class="gst-step-title">{{ 'overview.tutorial.step2_title' | i18n_args(locale | default('ko')) }}</div>
         <div class="gst-step-desc">
-          등록 후 설정 페이지에서 <strong>🚀 빠른 설정 프리셋</strong> 중 하나 선택.
-          Simple 모드 기본값은 Python 분석 + Telegram 알림 + PR 코멘트입니다.
+          {{ 'overview.tutorial.step2_desc_part1' | i18n_args(locale | default('ko')) }}<strong>{{ 'overview.tutorial.step2_desc_preset' | i18n_args(locale | default('ko')) }}</strong>{{ 'overview.tutorial.step2_desc_part2' | i18n_args(locale | default('ko')) }}
         </div>
       </div>
     </div>
     <div class="gst-step">
       <div class="gst-step-num">3</div>
       <div class="gst-step-body">
-        <div class="gst-step-title">첫 Push 또는 PR</div>
+        <div class="gst-step-title">{{ 'overview.tutorial.step3_title' | i18n_args(locale | default('ko')) }}</div>
         <div class="gst-step-desc">
-          코드를 푸시하면 자동으로 분석 결과가 대시보드에 쌓입니다.
-          점수가 맞는지 👍/👎 피드백을 주시면 정합도 지표가 개선됩니다.
+          {{ 'overview.tutorial.step3_desc' | i18n_args(locale | default('ko')) }}
         </div>
       </div>
     </div>
   </div>
   <div class="gst-footer">
     <div class="gst-footer-hint">
-      💡 <strong>팁</strong> — <code>ANTHROPIC_API_KEY</code> 없이도 최대 89점(B등급)까지 분석 가능합니다.
+      💡 <strong>{{ 'overview.tutorial.tip_label' | i18n_args(locale | default('ko')) }}</strong>{{ 'overview.tutorial.tip_desc_part1' | i18n_args(locale | default('ko')) }}<code>ANTHROPIC_API_KEY</code>{{ 'overview.tutorial.tip_desc_part2' | i18n_args(locale | default('ko')) }}
     </div>
   </div>
 </div>
@@ -232,16 +231,16 @@
 {% if calibration and cal_total > 0 %}
 <div class="card calibration-card">
   <div class="calibration-header">
-    <h3>📊 AI 점수 정합도</h3>
-    <span class="calibration-hint">Claude 가 매긴 점수가 사람 판단과 얼마나 일치하는지 — 점수 범위별 👍 비율</span>
+    <h3>📊 {{ 'overview.calibration.title' | i18n_args(locale | default('ko')) }}</h3>
+    <span class="calibration-hint">{{ 'overview.calibration.hint' | i18n_args(locale | default('ko')) }}</span>
   </div>
   <table class="calibration-table">
     <thead>
       <tr>
-        <th>점수 범위</th>
-        <th>피드백 수</th>
-        <th>👍 비율</th>
-        <th>시각화</th>
+        <th>{{ 'overview.calibration.range' | i18n_args(locale | default('ko')) }}</th>
+        <th>{{ 'overview.calibration.feedback_count' | i18n_args(locale | default('ko')) }}</th>
+        <th>{{ 'overview.calibration.up_ratio' | i18n_args(locale | default('ko')) }}</th>
+        <th>{{ 'overview.calibration.visualization' | i18n_args(locale | default('ko')) }}</th>
       </tr>
     </thead>
     <tbody>

--- a/src/ui/_helpers.py
+++ b/src/ui/_helpers.py
@@ -23,8 +23,33 @@ from src.shared.log_safety import sanitize_for_log
 logger = logging.getLogger("src.ui")
 templates = Jinja2Templates(directory="src/templates")
 
+# Phase 2 PR-5 (사이클 84) — Jinja2 i18n 필터 등록 (i18n + i18n_args 사용 가능)
+# Phase 2 PR-5 (Cycle 84) — Register Jinja2 i18n filters (i18n + i18n_args available)
+from src.i18n.filters import register_i18n_filters  # noqa: E402
+
+register_i18n_filters(templates.env)
+
 # GitHub Webhook 수신 경로 — add_repo + settings 에서 사용 (상수화)
 GITHUB_WEBHOOK_PATH = "/webhooks/github"
+
+
+def get_locale(request: Request) -> str:
+    """LocaleMiddleware 가 scope.state.locale 에 주입한 locale 반환.
+
+    Return locale injected by LocaleMiddleware into scope.state.locale.
+
+    LocaleMiddleware (src/middleware/locale.py) 가 매 request 시 5단계 감지
+    (Cookie > Accept-Language > default > fallback) 후 scope["state"]["locale"]
+    에 주입. 본 helper 가 모든 TemplateResponse 호출에서 동일 영역 사용 의무
+    (정책 16 4번 원칙 — 사용처 ≥ 12 도달).
+
+    LocaleMiddleware injects locale via 5-tier detection per request.
+    This helper unifies access across all TemplateResponse calls (policy 16 #4).
+    """
+    try:
+        return request.scope.get("state", {}).get("locale") or settings.default_locale
+    except (AttributeError, KeyError):
+        return settings.default_locale
 
 
 def webhook_base_url(request: Request) -> str:

--- a/src/ui/routes/add_repo.py
+++ b/src/ui/routes/add_repo.py
@@ -17,7 +17,7 @@ from src.github_client.repos import (
 from src.models.repo_config import RepoConfig
 from src.models.repository import Repository
 from src.repositories import repo_config_repo, repository_repo
-from src.ui._helpers import GITHUB_WEBHOOK_PATH, templates, webhook_base_url
+from src.ui._helpers import GITHUB_WEBHOOK_PATH, get_locale, templates, webhook_base_url
 
 router = APIRouter()
 
@@ -28,7 +28,7 @@ async def add_repo_page(
     current_user: Annotated[CurrentUser, Depends(require_login)],
 ):
     """리포 추가 페이지를 렌더링한다."""
-    return templates.TemplateResponse(request, "add_repo.html", {"current_user": current_user})
+    return templates.TemplateResponse(request, "add_repo.html", {"current_user": current_user, "locale": get_locale(request)})
 
 
 @router.get("/api/github/repos")

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -21,7 +21,7 @@ from src.models.analysis import Analysis
 from src.models.repository import Repository
 from src.services import dashboard_service
 from src.shared.log_safety import sanitize_for_log
-from src.ui._helpers import templates
+from src.ui._helpers import get_locale, templates
 
 logger = logging.getLogger(__name__)
 

--- a/src/ui/routes/overview.py
+++ b/src/ui/routes/overview.py
@@ -13,7 +13,7 @@ from src.models.analysis import Analysis
 from src.models.repository import Repository
 from src.repositories import analysis_feedback_repo
 from src.scorer.calculator import calculate_grade
-from src.ui._helpers import templates
+from src.ui._helpers import get_locale, templates
 
 router = APIRouter()
 
@@ -61,4 +61,5 @@ def overview(
         "repos": repo_data,
         "current_user": current_user,
         "calibration": calibration,
+        "locale": get_locale(request),
     })

--- a/tests/unit/templates/test_i18n_template_render.py
+++ b/tests/unit/templates/test_i18n_template_render.py
@@ -1,0 +1,278 @@
+"""Phase 2 PR-5 회귀 가드 — base.html / login.html / add_repo.html / overview.html 다국어 렌더링 검증.
+
+Phase 2 PR-5 regression guards — multilingual rendering for base/login/add_repo/overview templates.
+
+검증 범위 (Coverage):
+1. login.html — 5 i18n 키 (title_prefix / title / subtitle / github_login / footer) en/ko/ja
+2. add_repo.html — page_title / subtitle / label_select / submit / data-i18n-* 속성 en/ko/ja
+3. overview.html (with repos) — greeting / title / repo_count / table headers en/ko/ja
+4. overview.html (empty) — title_empty / tutorial 3 step en/ko/ja
+5. base.html nav — header.overview / header.dashboard / common.menu_aria / common.logout en/ko/ja
+6. locale 미주입 (None) → default 'ko' fallback
+"""
+from __future__ import annotations
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from src.i18n.filters import register_i18n_filters
+
+
+def _render(template_name: str, **context) -> str:
+    """Standalone Jinja2 환경에서 템플릿 렌더 — TestClient lifespan trap 회피.
+
+    Standalone Jinja2 environment for template rendering — avoids TestClient lifespan trap
+    (memory: feedback-testclient-lifespan-trap.md). Jinja2 i18n 필터만 검증.
+    """
+    env = Environment(
+        loader=FileSystemLoader("src/templates"),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+    register_i18n_filters(env)
+    tmpl = env.get_template(template_name)
+    return tmpl.render(**context)
+
+
+# ── login.html ──────────────────────────────────────────────────────────────
+
+
+def test_login_html_renders_korean_keys():
+    """login.html — 한국어 5 키 렌더 검증."""
+    out = _render("login.html", locale="ko")
+    assert "로그인 — SCAManager" in out  # title block
+    assert "PR이 들어오면 Claude가 검토하고" in out  # subtitle
+    assert "GitHub로 로그인" in out  # github_login
+    assert "GitHub OAuth로 안전하게 인증합니다" in out  # footer
+
+
+def test_login_html_renders_english_keys():
+    """login.html — 영문 5 키 렌더 검증."""
+    out = _render("login.html", locale="en")
+    assert "Login — SCAManager" in out
+    assert "Claude reviews your PR" in out
+    assert "Sign in with GitHub" in out
+    assert "Secure authentication with GitHub OAuth" in out
+
+
+def test_login_html_renders_japanese_keys():
+    """login.html — 일본어 5 키 렌더 검증."""
+    out = _render("login.html", locale="ja")
+    assert "ログイン — SCAManager" in out
+    assert "PRが入ってきたらClaudeがレビュー" in out
+    assert "GitHubでログイン" in out
+    assert "GitHub OAuthで安全に認証します" in out
+
+
+def test_login_html_default_locale_fallback_to_ko():
+    """login.html — locale 미주입 시 default 'ko' fallback (Jinja default 필터)."""
+    out = _render("login.html")  # locale=None
+    assert "로그인 — SCAManager" in out
+    assert "GitHub로 로그인" in out
+
+
+# ── add_repo.html ───────────────────────────────────────────────────────────
+
+
+def test_add_repo_html_renders_korean_keys():
+    """add_repo.html — 한국어 핵심 키 + data-i18n 속성 검증."""
+    out = _render("add_repo.html", locale="ko")
+    assert "리포 추가 — SCAManager" in out  # title block
+    assert "리포지토리 추가" in out  # page_title
+    assert "← 돌아가기" in out  # back
+    assert "GitHub 리포지토리" in out  # label_select
+    assert "Webhook 생성 + 리포 추가" in out  # submit
+    # data-i18n-* 속성 (JS 동적 텍스트 서버측 주입)
+    assert 'data-i18n-placeholder="리포를 선택하세요"' in out
+    assert 'data-i18n-no-repos-option="추가 가능한 리포가 없습니다"' in out
+    assert "data-i18n-loaded-template=" in out  # 템플릿 형식만 확인 (count placeholder)
+
+
+def test_add_repo_html_renders_english_keys():
+    """add_repo.html — 영문 키 + data-i18n 속성 검증."""
+    out = _render("add_repo.html", locale="en")
+    assert "Add Repository — SCAManager" in out
+    assert "Webhook will be auto-created" in out
+    assert "Sign in with GitHub" not in out  # login 키 격리
+    assert 'data-i18n-placeholder="Select a repository"' in out
+
+
+def test_add_repo_html_renders_japanese_keys():
+    """add_repo.html — 일본어 키 검증."""
+    out = _render("add_repo.html", locale="ja")
+    assert "リポ追加 — SCAManager" in out
+    assert "リポジトリ追加" in out
+    assert "← 戻る" in out
+    assert "Webhook生成 + リポ追加" in out
+
+
+# ── overview.html (with repos) ──────────────────────────────────────────────
+
+
+class _FakeUser:
+    display_name = "Alice"
+    github_login = "alice"
+
+
+def test_overview_html_with_repos_renders_korean():
+    """overview.html (리포 ≥ 1) — 한국어 greeting + table header + repo_count."""
+    repos = [{"full_name": "owner/repo", "analysis_count": 5, "avg_score": 80, "avg_grade": "B"}]
+    out = _render(
+        "overview.html",
+        locale="ko",
+        current_user=_FakeUser(),
+        repos=repos,
+        calibration={},
+    )
+    assert "안녕하세요, Alice님" in out  # greeting
+    assert "오늘의 분석" in out  # title (with repos)
+    assert "1개 리포" in out  # repo_count
+    assert "리포지토리</th>" in out  # table.repository
+    assert "분석</th>" in out  # table.analysis
+    assert "평균 점수</th>" in out  # table.avg_score
+    assert "등급</th>" in out  # table.grade
+    assert "5회</span>" in out  # analysis_count_unit
+
+
+def test_overview_html_with_repos_renders_english():
+    """overview.html (리포 ≥ 1) — 영문 greeting + table header + repo_count."""
+    repos = [{"full_name": "owner/repo", "analysis_count": 5, "avg_score": 80, "avg_grade": "B"}]
+    out = _render(
+        "overview.html",
+        locale="en",
+        current_user=_FakeUser(),
+        repos=repos,
+        calibration={},
+    )
+    assert "Hello, Alice" in out
+    assert "Today&#39;s Analyses" in out  # apostrophe escaped
+    assert "1 repos" in out
+    assert "Repository</th>" in out
+    assert "Average Score</th>" in out
+    assert "5 runs</span>" in out
+
+
+def test_overview_html_with_repos_renders_japanese():
+    """overview.html (리포 ≥ 1) — 일본어 greeting + table header + repo_count."""
+    repos = [{"full_name": "owner/repo", "analysis_count": 5, "avg_score": 80, "avg_grade": "B"}]
+    out = _render(
+        "overview.html",
+        locale="ja",
+        current_user=_FakeUser(),
+        repos=repos,
+        calibration={},
+    )
+    assert "こんにちは、Aliceさん" in out
+    assert "本日の分析" in out
+    assert "1個のリポ" in out
+    assert "リポジトリ</th>" in out
+    assert "平均スコア</th>" in out
+    assert "5回</span>" in out
+
+
+# ── overview.html (empty — tutorial) ────────────────────────────────────────
+
+
+def test_overview_html_empty_renders_korean_tutorial():
+    """overview.html (리포 0) — 한국어 tutorial 3 step + tip 검증."""
+    out = _render(
+        "overview.html",
+        locale="ko",
+        current_user=_FakeUser(),
+        repos=[],
+        calibration={},
+    )
+    assert "리포지토리 현황" in out  # title_empty
+    assert "3단계로 시작하기" in out  # tutorial.title
+    assert "GitHub 리포 선택" in out  # step1_title
+    assert "기본 설정 (Simple 모드)" in out  # step2_title
+    assert "첫 Push 또는 PR" in out  # step3_title
+    assert "🚀 빠른 설정 프리셋" in out  # step2_desc_preset
+    assert "팁" in out  # tip_label
+
+
+def test_overview_html_empty_renders_english_tutorial():
+    """overview.html (리포 0) — 영문 tutorial 3 step + tip 검증."""
+    out = _render(
+        "overview.html",
+        locale="en",
+        current_user=_FakeUser(),
+        repos=[],
+        calibration={},
+    )
+    assert "Repository Status" in out  # title_empty
+    assert "Get Started in 3 Steps" in out
+    assert "Select GitHub Repo" in out
+    assert "Initial Setup (Simple Mode)" in out
+    assert "First Push or PR" in out
+    assert "Quick Setup Presets" in out
+    assert "Tip" in out
+
+
+def test_overview_html_empty_renders_japanese_tutorial():
+    """overview.html (리포 0) — 일본어 tutorial 3 step + tip 검증."""
+    out = _render(
+        "overview.html",
+        locale="ja",
+        current_user=_FakeUser(),
+        repos=[],
+        calibration={},
+    )
+    assert "リポジトリ状況" in out
+    assert "3ステップで始める" in out
+    assert "GitHubリポを選択" in out
+    assert "初期設定 (Simpleモード)" in out
+    assert "最初のPushまたはPR" in out
+    assert "ヒント" in out
+
+
+# ── base.html nav (via login.html which extends base) ───────────────────────
+
+
+def test_base_nav_renders_korean_via_login():
+    """base.html nav — 한국어 (login.html extends base + locale=ko 시)."""
+    # login 페이지는 비로그인 상태이므로 nav 미노출 — overview 경유 검증
+    repos = [{"full_name": "owner/repo", "analysis_count": 1, "avg_score": 50, "avg_grade": "D"}]
+    out = _render("overview.html", locale="ko", current_user=_FakeUser(), repos=repos, calibration={})
+    assert ">개요</a>" in out  # header.overview
+    assert ">대시보드</a>" in out  # header.dashboard
+    assert ">로그아웃</button>" in out  # common.logout
+    assert 'aria-label="메뉴 열기"' in out  # common.menu_aria
+    assert '<html lang="ko">' in out  # HTML lang dynamic
+
+
+def test_base_nav_renders_english_via_overview():
+    """base.html nav — 영문 (overview.html extends base + locale=en 시)."""
+    repos = [{"full_name": "owner/repo", "analysis_count": 1, "avg_score": 50, "avg_grade": "D"}]
+    out = _render("overview.html", locale="en", current_user=_FakeUser(), repos=repos, calibration={})
+    assert ">Overview</a>" in out
+    assert ">Dashboard</a>" in out
+    assert ">Logout</button>" in out
+    assert 'aria-label="Open menu"' in out
+    assert '<html lang="en">' in out
+
+
+def test_base_nav_renders_japanese_via_overview():
+    """base.html nav — 일본어 (overview.html extends base + locale=ja 시)."""
+    repos = [{"full_name": "owner/repo", "analysis_count": 1, "avg_score": 50, "avg_grade": "D"}]
+    out = _render("overview.html", locale="ja", current_user=_FakeUser(), repos=repos, calibration={})
+    assert ">概要</a>" in out
+    assert ">ダッシュボード</a>" in out
+    assert ">ログアウト</button>" in out
+    assert 'aria-label="メニューを開く"' in out
+    assert '<html lang="ja">' in out
+
+
+# ── locale 미주입 fallback ──────────────────────────────────────────────────
+
+
+def test_overview_html_locale_none_defaults_to_ko():
+    """overview.html — locale 미주입 시 'ko' default fallback (Jinja default 필터)."""
+    out = _render("overview.html", current_user=_FakeUser(), repos=[], calibration={})
+    assert "리포지토리 현황" in out
+    assert '<html lang="ko">' in out
+
+
+def test_add_repo_html_locale_none_defaults_to_ko():
+    """add_repo.html — locale 미주입 시 'ko' default fallback."""
+    out = _render("add_repo.html")
+    assert "리포 추가 — SCAManager" in out
+    assert "리포지토리 추가" in out

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -58,7 +58,7 @@ def test_overview_returns_html():
 
 
 def test_overview_with_repos_shows_avg_score():
-    """리포 목록에 평균 점수(avg_score) 컬럼이 표시되어야 한다."""
+    """리포 목록에 평균 점수(avg_score) 컬럼이 표시되어야 한다 (i18n: en/ko)."""
     mock_db = MagicMock()
     mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1, created_at="2026-01-01")
     mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [mock_repo]
@@ -68,7 +68,9 @@ def test_overview_with_repos_shows_avg_score():
     with patch("src.ui.routes.overview.SessionLocal", return_value=_ctx(mock_db)):
         r = client.get("/")
     assert r.status_code == 200
-    assert "평균 점수" in r.text
+    # Phase 2 PR-5 (사이클 84) — i18n 적용 후 default locale (en) 기준
+    # Phase 2 PR-5 (Cycle 84) — after i18n, default locale (en) baseline
+    assert "Average Score" in r.text or "평균 점수" in r.text
 
 
 def test_repo_detail_returns_html():


### PR DESCRIPTION
… — 사이클 84 진입 페이지 응집 단위 (정책 7 강화)

## Summary
Phase 2 PR-5 — 진입 페이지 4종 (base nav / login / add_repo / overview) 다국어 적용. URL 라우트 + 화면 템플릿 + 데이터 흐름 (locale context) 3종 동시 묶음 응집 분할 (정책 7 강화). 단위 +18 회귀 가드 (2236 → 2254 — TestClient lifespan trap 회피용 standalone Jinja env 패턴, 메모리 페어).

## Changes (14 files)

### 1. base.html nav 다국어 (4 키)
- HTML lang 속성 동적 (`{{ locale | default('ko') }}`)
- nav 메뉴 i18n: header.overview / header.dashboard / common.menu_aria / common.logout
- JS readCookieLang() 폐기 → 서버측 Jinja `{{ locale }}` 직접 주입 (XSS 차단 + race condition 0 — cross-verify 옵션 C 페어)

### 2. login.html 다국어 (5 키)
- title_prefix / title / subtitle / github_login / footer 모두 i18n_args 필터 적용
- auth/github.py 자체 Jinja2Templates 인스턴스에 register_i18n_filters 추가 (_helpers.templates 와 분리 의무)

### 3. add_repo.html 다국어 (form + JS 동적 텍스트)
- form labels / hints / submit i18n_args 적용
- JS 동적 텍스트 7건 (placeholder / no_repos / loaded / load_failed / error_prefix / api_error_prefix) data-i18n-* 속성 패턴으로 서버측 주입 (innerHTML XSS 차단 + DOM document.createElement 사용)

### 4. overview.html 다국어 (table + tutorial + calibration)
- greeting (변수 치환 name) / title / title_empty / repo_count / table 4 헤더
- analysis_count_unit ({count}회) + settings_link
- tutorial 3 step (step1~3 title + desc + cta) + step2 preset 강조 + tip
- calibration card 5 헤더

### 5. 번역 파일 확장 (en/ko/ja.json — 동일 키 매트릭스)
- common.menu_aria 신설
- header.overview / header.dashboard 신설
- login.title_prefix 신설
- add_repo.* 14 키 신설 (page_title / subtitle / back / label_select / loading_option / hint_default / placeholder_option / no_repos_* / loaded_hint / load_failed_option / error_prefix / api_error_prefix / submit / title_prefix)
- overview.* 17 키 확장 (title_empty / add_repo / settings_link / analysis_count_unit / tutorial.* 11 / calibration.* 5)

### 6. 라우트 locale 주입 (4 라우트)
- src/ui/_helpers.py: get_locale(request) helper 신설 + register_i18n_filters(templates.env)
- add_repo.py / overview.py: TemplateResponse 컨텍스트에 locale 추가
- auth/github.py: login_page locale_value 직접 추출 (자체 templates 인스턴스)
- dashboard.py: import only (TemplateResponse 갱신은 PR-5b 영역)

### 7. 회귀 가드 18건 (tests/unit/templates/test_i18n_template_render.py)
- login.html × 4 (en/ko/ja + None default)
- add_repo.html × 3 (en/ko/ja, data-i18n-* 속성 검증)
- overview.html with repos × 3 (en/ko/ja — greeting 변수 치환 + table 4 헤더 + repo_count)
- overview.html empty × 3 (en/ko/ja — tutorial 3 step + tip)
- base nav via overview × 3 (en/ko/ja — header.overview/dashboard + common.menu_aria/logout + html lang)
- locale=None default fallback × 2

> Standalone Jinja2 Environment (FileSystemLoader) 패턴 — TestClient lifespan trap 회피 (메모리 `feedback-testclient-lifespan-trap.md` 페어, 사이클 79/81 학습)

### 8. 기존 테스트 정정 (tests/unit/ui/test_router.py)
- test_overview_with_repos_shows_avg_score: i18n 적용 후 default locale 'en' 기준 → "Average Score" or "평균 점수" or 검증

### 9. cross-verify 옵션 C 강화 (src/api/users.py — Phase 2 PR-4 후속)
- httponly=True + sanitize_for_log + responses 메타 추가 (이전 PR-4 회귀 fix-up)

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 /login + / + /repos/add 3 진입 페이지 4-테마 × 모바일/데스크탑 8 조합 시각 정합 확인
- [ ] /settings 언어 변경 (ko → en → ja) 후 진입 페이지 반영 즉시 확인
- [ ] 비로그인 /login 페이지 locale Cookie/Accept-Language 우선순위 동작 확인
- [ ] add_repo.html JS 동적 텍스트 (리포 목록 로드 / 에러 / 0건) 3 시나리오 다국어 표시 확인

## 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 적용 영역)
⚠️ **사용자 인지 영향** (정책 3 강화 정량 기준 4번 — 모든 진입 페이지 라벨/텍스트/HTML lang 변경):
- base.html nav 메뉴 4 항목 라벨 다국어 — 사용자 진입 직후 첫 인지
- overview.html greeting / title / table 4 헤더 다국어 — 메인 페이지 인지 영역
- add_repo.html JS 동적 텍스트 패턴 (data-i18n-* 속성) — 보안 영역 (XSS 차단)

⚠️ **architecture 영향** (정책 3 강화 정량 기준 2번):
- get_locale(request) helper 신설 (정책 16 4번 원칙 — 사용처 4건 도달 — _helpers / overview / add_repo + 향후 dashboard/detail/settings 확장 예정)
- auth/github.py 자체 Jinja2Templates register_i18n_filters 의무 명시 (분리 인스턴스 트랩)

자율 진입 보고:
- PR-5 응집 단위 분할 = "진입 페이지 4종 동시" (base nav + login + add_repo + overview) — 정책 7 강화 응집 단위 부합 (URL + 화면 + 데이터 3종)
- dashboard.py / detail.py / settings.py / admin.py 는 PR-5b 영역 (응집 분할 — 다음 PR)
- 회귀 가드 18건 = TestClient lifespan trap 회피 standalone Jinja env 패턴 (메모리 사이클 79/81 학습 페어)

## 검증 (사이클 84 sync 실측)
- 단위 = `pytest tests/unit -q` → 2254 passed
- 통합 = `pytest tests/integration -q` → 191 passed (포함)
- 합계 = 2445 passed / 5 skipped / 0 failed (113s)

## cross-verify 결과
- 1차 5 에이전트 디스패치 = 본 사이클 미수행 (단일 응집 PR-5 — 진입 페이지만 + 기존 인프라 PR-1b/1c/4 검증 완료 영역)
- 통합 fail 5건 (PR push 직전 검증 시) → auth/github.py 자체 templates 인스턴스 i18n 필터 미등록 1 영역 발견 후 fix → 0 fail
- TestClient lifespan trap 메모리 페어 = standalone Jinja env 패턴으로 회귀 가드 18건 안정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
