### PR TITLE
feat(i18n-phase2-pr6): dashboard.html 다국어 — KPI 5 + mode 4종 + Insight…

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -37,29 +37,109 @@
   },
   "dashboard": {
     "title": "Dashboard",
+    "title_prefix": "Dashboard",
     "subtitle": "How is our code flowing?",
+    "mode_aria": "Dashboard mode",
+    "range_aria": "Period selector",
     "modes": {
       "overview": "Overview",
       "insight": "Insight",
       "security": "Security",
-      "usage": "Usage"
+      "usage": "Usage",
+      "security_tooltip": "GitHub Code Scanning + Secret Scanning alert audit (Cycle 73 F2 — read-only)",
+      "usage_tooltip": "Own usage (SaaS Phase 1 read-only — Cycle 79 PR 3b)"
     },
     "kpi": {
       "avg_score": "Average Score",
       "analysis_count": "Analyses",
       "high_security": "Security Issues (HIGH)",
       "active_repos": "Active Repos",
-      "auto_merge_success": "Auto-Merge Success Rate (PR-based)"
+      "auto_merge_success": "Auto-Merge Success Rate (PR-based)",
+      "auto_merge_tooltip": "PR-based final success rate (after retries). Simple-attempt success rate is shown in sub-text."
     },
     "delta": {
       "improvement": "improved",
       "decline": "declined",
       "no_change": "no change",
       "no_comparison": "no comparison data",
-      "vs_period": "vs previous {days} days"
+      "vs_period": "vs previous {days} days",
+      "attempts_vs_period": "attempts ▲ +{delta}% vs previous {days} days",
+      "attempts_vs_period_down": "attempts ▼ {delta}% vs previous {days} days",
+      "attempts_no_change": "attempts — no change",
+      "attempts_baseline": "attempt baseline {value}% ({success}/{total})"
     },
     "trend": "Score Trend ({days}d)",
-    "frequent_issues": "Frequent Issues (Last {days} days)"
+    "trend_chart_label": "Average Score",
+    "no_trend_data": "No analysis data in the last {days} days.",
+    "frequent_issues": "Frequent Issues (Last {days} days)",
+    "no_frequent_issues": "No issues found in the last {days} days.",
+    "merge_failures_title": "Auto-Merge Failure Reasons (Last {days} days)",
+    "merge_failure_meta": "share {pct}% · {count} cases",
+    "feedback_cta": {
+      "title": "📝 Please give feedback on AI scores",
+      "meta_zero": "Use the 👍 / 👎 buttons on the analysis result page to indicate score accuracy — this improves AI calibration.",
+      "meta_some": "{count} feedback items so far — leave more feedback to improve AI calibration accuracy.",
+      "btn_recent": "→ View recent analysis",
+      "aria": "Feedback request"
+    },
+    "security": {
+      "kill_switch_active": "🚫 Security auto-processing disabled (`SECURITY_AUTO_PROCESS_DISABLED=1`) — kill-switch is active. Unset the env var to resume cron polling.",
+      "empty_title": "✅ No alerts pending review.",
+      "empty_hint_part1": "A cron polls GitHub Code Scanning + Secret Scanning APIs every hour, and new alerts will appear here. ",
+      "empty_hint_link": "View directly on GitHub Security tab",
+      "empty_hint_part2": " is also available.",
+      "load_failed": "⚠️ Failed to load Security data — please try again later.",
+      "card_aria": "Security audit 4 cards",
+      "processed_title": "✨ Processed",
+      "processed_label": "User confirmed",
+      "total_label": "Total alerts (cumulative)",
+      "pending_title": "🔍 New pending",
+      "pending_label": "Awaiting user decision",
+      "pending_hint": "User 1-click confirm required (Phase 1 — no auto-dismiss)",
+      "classification_title": "📊 Classification distribution",
+      "recent_pending_title": "💬 Recent pending (Top 5)",
+      "recent_pending_empty": "No pending alerts."
+    },
+    "usage": {
+      "empty_title": "📭 No repositories registered.",
+      "empty_hint_part1": "Register a GitHub repo on the ",
+      "empty_hint_link": "Add Repository",
+      "empty_hint_part2": " page to see usage here.",
+      "load_failed": "⚠️ Failed to load Usage data — please try again later.",
+      "card_aria": "Own usage 4 cards",
+      "own_repos_title": "📁 Your Repos",
+      "repo_count_label": "Registered repo count",
+      "repo_count_hint": "Direct user_id isolation (RLS pair — alembic 0026/0029)",
+      "total_analyses_title": "📊 Total Analyses",
+      "total_analyses_label": "Cumulative total",
+      "last_analysis_label": "Last analysis",
+      "recent_period_title": "🕒 Last {days} days",
+      "recent_analyses_label": "Analysis count",
+      "recent_period_hint": "Period: last {days} days (range toggle pair)",
+      "avg_score_title": "⭐ Average Score",
+      "avg_score_label": "Last {days} days average",
+      "avg_score_unit": "{score} pts",
+      "avg_score_hint": "Shown as - when sample is insufficient",
+      "saas_info_title": "💡 SaaS Phase 1 Info",
+      "saas_info_li1_part1": "This area shows ",
+      "saas_info_li1_strong": "your data only",
+      "saas_info_li1_part2": " — direct user_id isolation via RLS (alembic 0026/0029)",
+      "saas_info_li2": "Token cost estimation = Phase 2 (after per-user cost tracking infrastructure)",
+      "saas_info_li3": "On SaaS transition (users ≥ 2), the same cards isolate per-user automatically"
+    },
+    "insight": {
+      "card_aria": "AI Insight 4 cards",
+      "generated_at_tooltip": "Cache generation time — 1h TTL",
+      "refresh": "🔄 Refresh",
+      "refresh_tooltip": "Force cache invalidation + generate new narrative (Anthropic API call)",
+      "positive_title": "✨ What went well",
+      "focus_title": "🔍 What to focus on",
+      "metrics_title": "📊 Numbers",
+      "next_title": "💬 Next",
+      "no_api_key": "🔑 ANTHROPIC_API_KEY not set — Insight mode requires AI analysis. Please set the key in Railway Variables.",
+      "no_data": "📭 Insufficient analysis data in the last {days} days — please try again after results accumulate.",
+      "load_failed": "⚠️ AI Insight generation failed ({status}) — please try again later."
+    }
   },
   "overview": {
     "greeting": "Hello, {name}",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -37,29 +37,109 @@
   },
   "dashboard": {
     "title": "ダッシュボード",
+    "title_prefix": "ダッシュボード",
     "subtitle": "私たちのコードはどのように流れていますか",
+    "mode_aria": "ダッシュボードモード",
+    "range_aria": "期間選択",
     "modes": {
       "overview": "概要",
       "insight": "インサイト",
       "security": "セキュリティ",
-      "usage": "使用量"
+      "usage": "使用量",
+      "security_tooltip": "GitHub Code Scanning + Secret Scanning alert audit (サイクル 73 F2 — read-only)",
+      "usage_tooltip": "本人の使用量 (SaaS Phase 1 read-only — サイクル 79 PR 3b)"
     },
     "kpi": {
       "avg_score": "平均スコア",
       "analysis_count": "分析数",
       "high_security": "セキュリティ問題 (HIGH)",
       "active_repos": "アクティブなリポ",
-      "auto_merge_success": "自動マージ成功率 (PR基準)"
+      "auto_merge_success": "自動マージ成功率 (PR基準)",
+      "auto_merge_tooltip": "PR基準の最終 success rate (リトライ後の結果)。単純試行 success rate は sub-text 参照。"
     },
     "delta": {
       "improvement": "改善",
       "decline": "低下",
       "no_change": "変動なし",
       "no_comparison": "比較データなし",
-      "vs_period": "前 {days} 日比"
+      "vs_period": "前 {days} 日比",
+      "attempts_vs_period": "試行 ▲ +{delta}% 前 {days} 日比",
+      "attempts_vs_period_down": "試行 ▼ {delta}% 前 {days} 日比",
+      "attempts_no_change": "試行 — 変動なし",
+      "attempts_baseline": "試行ベース {value}% ({success}/{total})"
     },
     "trend": "スコアトレンド ({days}日)",
-    "frequent_issues": "頻発する問題 (最近 {days} 日)"
+    "trend_chart_label": "平均スコア",
+    "no_trend_data": "最近 {days} 日間の分析データがありません。",
+    "frequent_issues": "頻発する問題 (最近 {days} 日)",
+    "no_frequent_issues": "最近 {days} 日間に発見された問題はありません。",
+    "merge_failures_title": "自動マージ失敗の理由 (最近 {days} 日)",
+    "merge_failure_meta": "比率 {pct}% · {count}件",
+    "feedback_cta": {
+      "title": "📝 AIスコアにフィードバックをお願いします",
+      "meta_zero": "分析結果ページの 👍 / 👎 ボタンでスコアの整合性を教えてくださると AI 精度が改善されます。",
+      "meta_some": "現在まで {count} 件のフィードバックがあります — より正確な AI 整合性測定のためフィードバックをお願いします。",
+      "btn_recent": "→ 最近の分析を見る",
+      "aria": "フィードバック要請"
+    },
+    "security": {
+      "kill_switch_active": "🚫 Security 自動処理が無効化されています (`SECURITY_AUTO_PROCESS_DISABLED=1`) — kill-switch がアクティブです。環境変数を解除すると cron ポーリングが再開されます。",
+      "empty_title": "✅ 処理待ちの alert はありません。",
+      "empty_hint_part1": "cron が GitHub Code Scanning + Secret Scanning API を1時間ごとにポーリングし、新規 alert を発見した際に本カードに表示されます。",
+      "empty_hint_link": "GitHub Security タブで直接確認",
+      "empty_hint_part2": " も可能です。",
+      "load_failed": "⚠️ Security データ読み込み失敗 — しばらくしてから再試行してください。",
+      "card_aria": "Security audit 4 カード",
+      "processed_title": "✨ 処理済み",
+      "processed_label": "ユーザー confirm 完了",
+      "total_label": "全 alert 累計",
+      "pending_title": "🔍 新規 pending",
+      "pending_label": "ユーザー決定待ち",
+      "pending_hint": "ユーザー 1-click confirm 必須 (Phase 1 — 自動 dismiss なし)",
+      "classification_title": "📊 分類分布",
+      "recent_pending_title": "💬 最近 pending (Top 5)",
+      "recent_pending_empty": "pending alert なし。"
+    },
+    "usage": {
+      "empty_title": "📭 登録されたリポジトリがありません。",
+      "empty_hint_part1": "Web UI の ",
+      "empty_hint_link": "リポ追加",
+      "empty_hint_part2": " ページから GitHub リポを登録すると、本カードに使用量が表示されます。",
+      "load_failed": "⚠️ Usage データ読み込み失敗 — しばらくしてから再試行してください。",
+      "card_aria": "本人使用量 4 カード",
+      "own_repos_title": "📁 本人のリポ",
+      "repo_count_label": "登録済みリポ数",
+      "repo_count_hint": "user_id 直接分離 (RLS ペア — alembic 0026/0029)",
+      "total_analyses_title": "📊 累計分析",
+      "total_analyses_label": "累計合計",
+      "last_analysis_label": "最終分析",
+      "recent_period_title": "🕒 最近 {days} 日",
+      "recent_analyses_label": "分析件数",
+      "recent_period_hint": "期間: 最近 {days} 日 (range toggle ペア)",
+      "avg_score_title": "⭐ 平均スコア",
+      "avg_score_label": "最近 {days} 日平均",
+      "avg_score_unit": "{score} 点",
+      "avg_score_hint": "サンプル不足時は - 表示",
+      "saas_info_title": "💡 SaaS Phase 1 案内",
+      "saas_info_li1_part1": "本領域は ",
+      "saas_info_li1_strong": "本人データのみ",
+      "saas_info_li1_part2": " 表示 — RLS user_id 直接分離 (alembic 0026/0029)",
+      "saas_info_li2": "トークン cost 推定領域 = Phase 2 (ユーザー別 cost トラッキングインフラ導入後)",
+      "saas_info_li3": "SaaS 移行時 (ユーザー ≥ 2)、同一カードはユーザー別自動分離"
+    },
+    "insight": {
+      "card_aria": "AI Insight 4 カード",
+      "generated_at_tooltip": "cache 生成時刻 — 1時間 TTL",
+      "refresh": "🔄 更新",
+      "refresh_tooltip": "cache 強制無効化 + 新規 narrative 生成 (Anthropic API コール)",
+      "positive_title": "✨ よかったこと",
+      "focus_title": "🔍 注力すべき点",
+      "metrics_title": "📊 数値",
+      "next_title": "💬 次",
+      "no_api_key": "🔑 ANTHROPIC_API_KEY 未設定 — Insight モードは AI 分析が必要です。Railway Variables で key を設定してください。",
+      "no_data": "📭 最近 {days} 日の分析データが不足しています — 分析結果が蓄積された後に再試行してください。",
+      "load_failed": "⚠️ AI Insight 生成失敗 ({status}) — しばらくしてから再試行してください。"
+    }
   },
   "overview": {
     "greeting": "こんにちは、{name}さん",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -37,29 +37,109 @@
   },
   "dashboard": {
     "title": "대시보드",
+    "title_prefix": "대시보드",
     "subtitle": "우리 코드는 어떻게 흘러가고 있나요",
+    "mode_aria": "대시보드 모드",
+    "range_aria": "기간 선택",
     "modes": {
       "overview": "개요",
       "insight": "인사이트",
       "security": "보안",
-      "usage": "사용량"
+      "usage": "사용량",
+      "security_tooltip": "GitHub Code Scanning + Secret Scanning alert audit (사이클 73 F2 — read-only)",
+      "usage_tooltip": "본인 사용량 (SaaS Phase 1 read-only — 사이클 79 PR 3b)"
     },
     "kpi": {
       "avg_score": "평균 점수",
       "analysis_count": "분석 건수",
       "high_security": "보안 이슈 (HIGH)",
       "active_repos": "활성 리포",
-      "auto_merge_success": "자동 머지 성공률 (PR 기준)"
+      "auto_merge_success": "자동 머지 성공률 (PR 기준)",
+      "auto_merge_tooltip": "PR 기준 최종 success rate (retry 후 결과). 단순 시도 success rate 는 sub-text 참고."
     },
     "delta": {
       "improvement": "개선",
       "decline": "악화",
       "no_change": "변동 없음",
       "no_comparison": "비교 데이터 없음",
-      "vs_period": "vs 직전 {days}일"
+      "vs_period": "vs 직전 {days}일",
+      "attempts_vs_period": "시도 ▲ +{delta}% vs 직전 {days}일",
+      "attempts_vs_period_down": "시도 ▼ {delta}% vs 직전 {days}일",
+      "attempts_no_change": "시도 — 변동 없음",
+      "attempts_baseline": "시도 기준 {value}% ({success}/{total})"
     },
     "trend": "점수 추세 ({days}일)",
-    "frequent_issues": "자주 발생 이슈 (최근 {days}일)"
+    "trend_chart_label": "평균 점수",
+    "no_trend_data": "최근 {days}일간 분석 데이터가 없습니다.",
+    "frequent_issues": "자주 발생 이슈 (최근 {days}일)",
+    "no_frequent_issues": "최근 {days}일간 발견된 이슈가 없습니다.",
+    "merge_failures_title": "자동 머지 실패 사유 (최근 {days}일)",
+    "merge_failure_meta": "비율 {pct}% · {count}건",
+    "feedback_cta": {
+      "title": "📝 AI 점수에 피드백을 남겨주세요",
+      "meta_zero": "분석 결과 페이지의 👍 / 👎 버튼으로 점수 정합도를 알려주시면 AI 정확도가 개선됩니다.",
+      "meta_some": "현재까지 {count}건의 피드백이 있습니다 — 더 정확한 AI 정합도 측정을 위해 피드백을 남겨주세요.",
+      "btn_recent": "→ 최근 분석 보기",
+      "aria": "피드백 요청"
+    },
+    "security": {
+      "kill_switch_active": "🚫 Security 자동 처리 비활성화 (`SECURITY_AUTO_PROCESS_DISABLED=1`) — kill-switch 가 활성 상태입니다. 환경변수를 해제하면 cron 폴링이 재개됩니다.",
+      "empty_title": "✅ 처리 대기 중인 alert 가 없습니다.",
+      "empty_hint_part1": "cron 이 GitHub Code Scanning + Secret Scanning API 를 1시간마다 폴링하며, 신규 alert 발견 시 본 카드에 표시됩니다. ",
+      "empty_hint_link": "GitHub Security 탭에서 직접 확인",
+      "empty_hint_part2": "도 가능합니다.",
+      "load_failed": "⚠️ Security 데이터 로딩 실패 — 잠시 후 다시 시도해주세요.",
+      "card_aria": "Security audit 4 카드",
+      "processed_title": "✨ 처리됨",
+      "processed_label": "사용자 confirm 완료",
+      "total_label": "전체 alert 누적",
+      "pending_title": "🔍 신규 pending",
+      "pending_label": "사용자 결정 대기",
+      "pending_hint": "사용자 1-click confirm 의무 (Phase 1 — 자동 dismiss X)",
+      "classification_title": "📊 분류 분포",
+      "recent_pending_title": "💬 최근 pending (Top 5)",
+      "recent_pending_empty": "pending alert 없음."
+    },
+    "usage": {
+      "empty_title": "📭 등록된 리포지토리가 없습니다.",
+      "empty_hint_part1": "웹 UI 의 ",
+      "empty_hint_link": "리포 추가",
+      "empty_hint_part2": " 페이지에서 GitHub 리포를 등록하면 본 카드에 사용량이 표시됩니다.",
+      "load_failed": "⚠️ Usage 데이터 로딩 실패 — 잠시 후 다시 시도해주세요.",
+      "card_aria": "본인 사용량 4 카드",
+      "own_repos_title": "📁 본인 리포",
+      "repo_count_label": "등록된 리포 수",
+      "repo_count_hint": "user_id 직접 격리 (RLS 페어 — alembic 0026/0029)",
+      "total_analyses_title": "📊 누적 분석",
+      "total_analyses_label": "전체 누적",
+      "last_analysis_label": "최종 분석",
+      "recent_period_title": "🕒 최근 {days}일",
+      "recent_analyses_label": "분석 건수",
+      "recent_period_hint": "기간: 최근 {days}일 (range toggle 페어)",
+      "avg_score_title": "⭐ 평균 점수",
+      "avg_score_label": "최근 {days}일 평균",
+      "avg_score_unit": "{score}점",
+      "avg_score_hint": "샘플 부족 시 - 표시",
+      "saas_info_title": "💡 SaaS Phase 1 안내",
+      "saas_info_li1_part1": "본 영역은 ",
+      "saas_info_li1_strong": "본인 데이터만",
+      "saas_info_li1_part2": " 표시 — RLS user_id 직접 격리 (alembic 0026/0029)",
+      "saas_info_li2": "토큰 cost 추정 영역 = Phase 2 (사용자별 cost 추적 인프라 도입 후)",
+      "saas_info_li3": "SaaS 전환 시 (사용자 ≥ 2) 동일 카드 = 사용자별 격리 자동 동작"
+    },
+    "insight": {
+      "card_aria": "AI Insight 4 카드",
+      "generated_at_tooltip": "cache 생성 시각 — 1시간 TTL",
+      "refresh": "🔄 새로 고침",
+      "refresh_tooltip": "cache 강제 무효화 + 신규 narrative 생성 (Anthropic API 호출)",
+      "positive_title": "✨ 잘한 것",
+      "focus_title": "🔍 신경 쓸 것",
+      "metrics_title": "📊 숫자",
+      "next_title": "💬 다음",
+      "no_api_key": "🔑 ANTHROPIC_API_KEY 미설정 — Insight 모드는 AI 분석이 필요합니다. Railway Variables 에서 키를 설정해주세요.",
+      "no_data": "📭 최근 {days}일 분석 데이터가 부족합니다 — 분석 결과가 누적된 후 다시 시도해주세요.",
+      "load_failed": "⚠️ AI Insight 생성 실패 ({status}) — 잠시 후 다시 시도해주세요."
+    }
   },
   "overview": {
     "greeting": "안녕하세요, {name}님",

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Dashboard · SCAManager{% endblock %}
+{% block title %}{{ 'dashboard.title_prefix' | i18n_args(locale | default('ko')) }} · SCAManager{% endblock %}
 
 {# Phase 1 PR 4 — MVP-B 신규 페이지. /insights (PR 1~3 폐기) 후속. #}
 {# Claude × Linear 디자인 시스템 부분 적용 (scoped — 다른 페이지 영향 0). #}
@@ -325,29 +325,29 @@
 <div class="dashboard-page" data-initial-mode="{{ initial_mode or 'overview' }}">
   <div class="dash-header">
     <div>
-      <h1 class="dash-title">Dashboard</h1>
-      <p class="dash-subtitle">우리 코드는 어떻게 흘러가고 있나요</p>
+      <h1 class="dash-title">{{ 'dashboard.title' | i18n_args(locale | default('ko')) }}</h1>
+      <p class="dash-subtitle">{{ 'dashboard.subtitle' | i18n_args(locale | default('ko')) }}</p>
     </div>
     <div style="display:flex; align-items:center; flex-wrap:wrap; gap:8px;">
-      {# Phase 3 PR 3 — 모드 토글 (Overview default + Insight 신규) #}
-      {# Phase 3 PR 3 — mode toggle (Overview default + Insight new) #}
-      <nav class="dash-mode-toggle" aria-label="대시보드 모드 / Dashboard mode">
+      {# Phase 3 PR 3 — 모드 토글 (Overview default + Insight 신규) / Phase 2 PR-6 — i18n #}
+      {# Phase 3 PR 3 — mode toggle (Overview default + Insight new) / Phase 2 PR-6 — i18n #}
+      <nav class="dash-mode-toggle" aria-label="{{ 'dashboard.mode_aria' | i18n_args(locale | default('ko')) }}">
         <a href="/dashboard?mode=overview&days={{ days }}"
            data-mode="overview"
-           {% if mode == 'overview' %}class="active"{% endif %}>📊 Overview</a>
+           {% if mode == 'overview' %}class="active"{% endif %}>📊 {{ 'dashboard.modes.overview' | i18n_args(locale | default('ko')) }}</a>
         <a href="/dashboard?mode=insight&days={{ days }}"
            data-mode="insight"
-           {% if mode == 'insight' %}class="active"{% endif %}>💬 Insight</a>
+           {% if mode == 'insight' %}class="active"{% endif %}>💬 {{ 'dashboard.modes.insight' | i18n_args(locale | default('ko')) }}</a>
         <a href="/dashboard?mode=security&days={{ days }}"
            data-mode="security"
-           title="GitHub Code Scanning + Secret Scanning alert audit (Cycle 73 F2 — read-only)"
-           {% if mode == 'security' %}class="active"{% endif %}>🛡️ Security</a>
+           title="{{ 'dashboard.modes.security_tooltip' | i18n_args(locale | default('ko')) }}"
+           {% if mode == 'security' %}class="active"{% endif %}>🛡️ {{ 'dashboard.modes.security' | i18n_args(locale | default('ko')) }}</a>
         <a href="/dashboard?mode=usage&days={{ days }}"
            data-mode="usage"
-           title="본인 사용량 (SaaS Phase 1 read-only — Cycle 79 PR 3b) / Own usage (read-only)"
-           {% if mode == 'usage' %}class="active"{% endif %}>📈 Usage</a>
+           title="{{ 'dashboard.modes.usage_tooltip' | i18n_args(locale | default('ko')) }}"
+           {% if mode == 'usage' %}class="active"{% endif %}>📈 {{ 'dashboard.modes.usage' | i18n_args(locale | default('ko')) }}</a>
       </nav>
-      <nav class="dash-range-toggle" aria-label="기간 선택 / Period selector">
+      <nav class="dash-range-toggle" aria-label="{{ 'dashboard.range_aria' | i18n_args(locale | default('ko')) }}">
         <a href="/dashboard?mode={{ mode }}&days=1" {% if days == 1 %}class="active"{% endif %}>1d</a>
         <a href="/dashboard?mode={{ mode }}&days=7" {% if days == 7 %}class="active"{% endif %}>7d</a>
         <a href="/dashboard?mode={{ mode }}&days=30" {% if days == 30 %}class="active"{% endif %}>30d</a>
@@ -361,37 +361,37 @@
   {% if mode == 'security' %}
     {% if security and security.kill_switch_active %}
     <div class="dash-insight-status">
-      🚫 Security 자동 처리 비활성화 (`SECURITY_AUTO_PROCESS_DISABLED=1`) — kill-switch 가 활성 상태입니다. 환경변수를 해제하면 cron 폴링이 재개됩니다.
+      {{ 'dashboard.security.kill_switch_active' | i18n_args(locale | default('ko')) }}
     </div>
     {% elif security and security.total_alerts == 0 %}
-    {# Empty State — onboarding tooltip + 가이드 #}
+    {# Empty State — onboarding tooltip + 가이드 / Phase 2 PR-6 — i18n #}
     <div class="dash-insight-status">
-      ✅ 처리 대기 중인 alert 가 없습니다. <br>
-      <small style="opacity:0.8;">cron 이 GitHub Code Scanning + Secret Scanning API 를 1시간마다 폴링하며, 신규 alert 발견 시 본 카드에 표시됩니다. <a href="https://github.com/{{ current_user.github_login }}?tab=security" target="_blank" rel="noopener">GitHub Security 탭에서 직접 확인</a>도 가능합니다.</small>
+      {{ 'dashboard.security.empty_title' | i18n_args(locale | default('ko')) }} <br>
+      <small style="opacity:0.8;">{{ 'dashboard.security.empty_hint_part1' | i18n_args(locale | default('ko')) }}<a href="https://github.com/{{ current_user.github_login }}?tab=security" target="_blank" rel="noopener">{{ 'dashboard.security.empty_hint_link' | i18n_args(locale | default('ko')) }}</a>{{ 'dashboard.security.empty_hint_part2' | i18n_args(locale | default('ko')) }}</small>
     </div>
     {% elif security %}
-    <div class="dash-insight-grid" role="region" aria-label="Security audit 4 카드">
+    <div class="dash-insight-grid" role="region" aria-label="{{ 'dashboard.security.card_aria' | i18n_args(locale | default('ko')) }}">
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">✨ 처리됨</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.security.processed_title' | i18n_args(locale | default('ko')) }}</h2>
         <div class="dash-insight-metric">
-          <span class="dash-insight-metric-label">사용자 confirm 완료</span>
+          <span class="dash-insight-metric-label">{{ 'dashboard.security.processed_label' | i18n_args(locale | default('ko')) }}</span>
           <span class="dash-insight-metric-value">{{ security.processed_count }}</span>
         </div>
         <div class="dash-insight-metric">
-          <span class="dash-insight-metric-label">전체 alert 누적</span>
+          <span class="dash-insight-metric-label">{{ 'dashboard.security.total_label' | i18n_args(locale | default('ko')) }}</span>
           <span class="dash-insight-metric-value">{{ security.total_alerts }}</span>
         </div>
       </div>
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">🔍 신규 pending</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.security.pending_title' | i18n_args(locale | default('ko')) }}</h2>
         <div class="dash-insight-metric">
-          <span class="dash-insight-metric-label">사용자 결정 대기</span>
+          <span class="dash-insight-metric-label">{{ 'dashboard.security.pending_label' | i18n_args(locale | default('ko')) }}</span>
           <span class="dash-insight-metric-value">{{ security.pending_count }}</span>
         </div>
-        <small style="opacity:0.7;">사용자 1-click confirm 의무 (Phase 1 — 자동 dismiss X)</small>
+        <small style="opacity:0.7;">{{ 'dashboard.security.pending_hint' | i18n_args(locale | default('ko')) }}</small>
       </div>
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">📊 분류 분포</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.security.classification_title' | i18n_args(locale | default('ko')) }}</h2>
         <div>
           {% for key, count in security.classification.items() %}
           <div class="dash-insight-metric">
@@ -402,7 +402,7 @@
         </div>
       </div>
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">💬 최근 pending (Top 5)</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.security.recent_pending_title' | i18n_args(locale | default('ko')) }}</h2>
         {% if security.recent_pending %}
         <ul class="dash-insight-list">
           {% for row in security.recent_pending %}
@@ -410,106 +410,106 @@
           {% endfor %}
         </ul>
         {% else %}
-        <small style="opacity:0.7;">pending alert 없음.</small>
+        <small style="opacity:0.7;">{{ 'dashboard.security.recent_pending_empty' | i18n_args(locale | default('ko')) }}</small>
         {% endif %}
       </div>
     </div>
     {% else %}
     <div class="dash-insight-status">
-      ⚠️ Security 데이터 로딩 실패 — 잠시 후 다시 시도해주세요.
+      {{ 'dashboard.security.load_failed' | i18n_args(locale | default('ko')) }}
     </div>
     {% endif %}
   {% elif mode == 'usage' %}
-    {# Cycle 79 PR 3b — SaaS Phase 1 본인 사용량 (read-only — user_id 직접 격리) #}
-    {# Cycle 79 PR 3b — SaaS Phase 1 own usage (read-only — user_id direct isolation) #}
+    {# Cycle 79 PR 3b — SaaS Phase 1 본인 사용량 (read-only — user_id 직접 격리) / Phase 2 PR-6 — i18n #}
+    {# Cycle 79 PR 3b — SaaS Phase 1 own usage (read-only — user_id direct isolation) / Phase 2 PR-6 — i18n #}
     {% if usage and usage.repo_count == 0 %}
     {# Empty State — onboarding tooltip #}
     <div class="dash-insight-status">
-      📭 등록된 리포지토리가 없습니다 / No repositories registered.<br>
-      <small style="opacity:0.8;">웹 UI 의 <a href="/repos/add">리포 추가</a> 페이지에서 GitHub 리포를 등록하면 본 카드에 사용량이 표시됩니다.</small>
+      {{ 'dashboard.usage.empty_title' | i18n_args(locale | default('ko')) }}<br>
+      <small style="opacity:0.8;">{{ 'dashboard.usage.empty_hint_part1' | i18n_args(locale | default('ko')) }}<a href="/repos/add">{{ 'dashboard.usage.empty_hint_link' | i18n_args(locale | default('ko')) }}</a>{{ 'dashboard.usage.empty_hint_part2' | i18n_args(locale | default('ko')) }}</small>
     </div>
     {% elif usage %}
-    <div class="dash-insight-grid" role="region" aria-label="본인 사용량 4 카드">
+    <div class="dash-insight-grid" role="region" aria-label="{{ 'dashboard.usage.card_aria' | i18n_args(locale | default('ko')) }}">
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">📁 본인 리포</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.usage.own_repos_title' | i18n_args(locale | default('ko')) }}</h2>
         <div class="dash-insight-metric">
-          <span class="dash-insight-metric-label">등록된 리포 수</span>
+          <span class="dash-insight-metric-label">{{ 'dashboard.usage.repo_count_label' | i18n_args(locale | default('ko')) }}</span>
           <span class="dash-insight-metric-value">{{ usage.repo_count }}</span>
         </div>
-        <small style="opacity:0.7;">user_id 직접 격리 (RLS 페어 — alembic 0026/0029)</small>
+        <small style="opacity:0.7;">{{ 'dashboard.usage.repo_count_hint' | i18n_args(locale | default('ko')) }}</small>
       </div>
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">📊 누적 분석</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.usage.total_analyses_title' | i18n_args(locale | default('ko')) }}</h2>
         <div class="dash-insight-metric">
-          <span class="dash-insight-metric-label">전체 누적</span>
+          <span class="dash-insight-metric-label">{{ 'dashboard.usage.total_analyses_label' | i18n_args(locale | default('ko')) }}</span>
           <span class="dash-insight-metric-value">{{ usage.total_analyses }}</span>
         </div>
         {% if usage.last_analysis_at %}
         <div class="dash-insight-metric">
-          <span class="dash-insight-metric-label">최종 분석</span>
+          <span class="dash-insight-metric-label">{{ 'dashboard.usage.last_analysis_label' | i18n_args(locale | default('ko')) }}</span>
           <span class="dash-insight-metric-value" style="font-size:0.85em;">{{ usage.last_analysis_at.strftime('%Y-%m-%d %H:%M') }}</span>
         </div>
         {% endif %}
       </div>
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">🕒 최근 {{ usage.days }}일</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.usage.recent_period_title' | i18n_args(locale | default('ko'), days=usage.days) }}</h2>
         <div class="dash-insight-metric">
-          <span class="dash-insight-metric-label">분석 건수</span>
+          <span class="dash-insight-metric-label">{{ 'dashboard.usage.recent_analyses_label' | i18n_args(locale | default('ko')) }}</span>
           <span class="dash-insight-metric-value">{{ usage.recent_analyses }}</span>
         </div>
-        <small style="opacity:0.7;">기간: 최근 {{ usage.days }}일 (range toggle 페어)</small>
+        <small style="opacity:0.7;">{{ 'dashboard.usage.recent_period_hint' | i18n_args(locale | default('ko'), days=usage.days) }}</small>
       </div>
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">⭐ 평균 점수</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.usage.avg_score_title' | i18n_args(locale | default('ko')) }}</h2>
         <div class="dash-insight-metric">
-          <span class="dash-insight-metric-label">최근 {{ usage.days }}일 평균</span>
+          <span class="dash-insight-metric-label">{{ 'dashboard.usage.avg_score_label' | i18n_args(locale | default('ko'), days=usage.days) }}</span>
           <span class="dash-insight-metric-value">
-            {% if usage.avg_score is not none %}{{ usage.avg_score }}점{% else %}-{% endif %}
+            {% if usage.avg_score is not none %}{{ 'dashboard.usage.avg_score_unit' | i18n_args(locale | default('ko'), score=usage.avg_score) }}{% else %}-{% endif %}
           </span>
         </div>
-        <small style="opacity:0.7;">샘플 부족 시 - 표시</small>
+        <small style="opacity:0.7;">{{ 'dashboard.usage.avg_score_hint' | i18n_args(locale | default('ko')) }}</small>
       </div>
     </div>
     <div style="margin-top: 1rem; padding: 1rem; background: var(--bg-card, #1f2937); border-radius: 8px;">
-      <h3 style="margin: 0 0 0.5rem; font-size: 1rem;">💡 SaaS Phase 1 안내</h3>
+      <h3 style="margin: 0 0 0.5rem; font-size: 1rem;">{{ 'dashboard.usage.saas_info_title' | i18n_args(locale | default('ko')) }}</h3>
       <ul style="margin: 0; padding-left: 1.25rem; color: var(--text-muted, #9ca3af); font-size: 0.9em;">
-        <li>본 영역은 <strong>본인 데이터만</strong> 표시 — RLS user_id 직접 격리 (alembic 0026/0029)</li>
-        <li>토큰 cost 추정 영역 = Phase 2 (사용자별 cost 추적 인프라 도입 후)</li>
-        <li>SaaS 전환 시 (사용자 ≥ 2) 동일 카드 = 사용자별 격리 자동 동작</li>
+        <li>{{ 'dashboard.usage.saas_info_li1_part1' | i18n_args(locale | default('ko')) }}<strong>{{ 'dashboard.usage.saas_info_li1_strong' | i18n_args(locale | default('ko')) }}</strong>{{ 'dashboard.usage.saas_info_li1_part2' | i18n_args(locale | default('ko')) }}</li>
+        <li>{{ 'dashboard.usage.saas_info_li2' | i18n_args(locale | default('ko')) }}</li>
+        <li>{{ 'dashboard.usage.saas_info_li3' | i18n_args(locale | default('ko')) }}</li>
       </ul>
     </div>
     {% else %}
     <div class="dash-insight-status">
-      ⚠️ Usage 데이터 로딩 실패 — 잠시 후 다시 시도해주세요.
+      {{ 'dashboard.usage.load_failed' | i18n_args(locale | default('ko')) }}
     </div>
     {% endif %}
   {% elif mode == 'insight' %}
-    {# Phase 2-B 🅑 (사이클 74 PR-B) — DB 캐싱 1h TTL + Refresh 버튼 + generated_at 표시 #}
-    {# Phase 2-B 🅑 (Cycle 74 PR-B) — DB cache 1h TTL + Refresh button + generated_at display #}
+    {# Phase 2-B 🅑 (사이클 74 PR-B) — DB 캐싱 1h TTL + Refresh 버튼 + generated_at 표시 / Phase 2 PR-6 — i18n #}
+    {# Phase 2-B 🅑 (Cycle 74 PR-B) — DB cache 1h TTL + Refresh button + generated_at display / Phase 2 PR-6 — i18n #}
     {% if insight and insight.status == 'success' %}
     <div style="display:flex; justify-content:flex-end; align-items:center; gap:12px; margin-bottom:8px; font-size:0.85em; opacity:0.8;">
       {% if insight.generated_at %}
-      <span title="cache 생성 시각 — 1시간 TTL">⏱ {{ insight.generated_at[:16].replace('T', ' ') }}</span>
+      <span title="{{ 'dashboard.insight.generated_at_tooltip' | i18n_args(locale | default('ko')) }}">⏱ {{ insight.generated_at[:16].replace('T', ' ') }}</span>
       {% endif %}
       <a href="/dashboard?mode=insight&days={{ days }}&refresh=1"
-         title="cache 강제 무효화 + 신규 narrative 생성 (Anthropic API 호출)"
-         style="text-decoration:none;">🔄 Refresh</a>
+         title="{{ 'dashboard.insight.refresh_tooltip' | i18n_args(locale | default('ko')) }}"
+         style="text-decoration:none;">{{ 'dashboard.insight.refresh' | i18n_args(locale | default('ko')) }}</a>
     </div>
-    <div class="dash-insight-grid" role="region" aria-label="AI Insight 4 카드">
+    <div class="dash-insight-grid" role="region" aria-label="{{ 'dashboard.insight.card_aria' | i18n_args(locale | default('ko')) }}">
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">✨ 잘한 것</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.insight.positive_title' | i18n_args(locale | default('ko')) }}</h2>
         <ul class="dash-insight-list">
           {% for item in insight.positive_highlights %}<li>{{ item }}</li>{% endfor %}
         </ul>
       </div>
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">🔍 신경 쓸 것</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.insight.focus_title' | i18n_args(locale | default('ko')) }}</h2>
         <ul class="dash-insight-list">
           {% for item in insight.focus_areas %}<li>{{ item }}</li>{% endfor %}
         </ul>
       </div>
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">📊 숫자</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.insight.metrics_title' | i18n_args(locale | default('ko')) }}</h2>
         <div>
           {% for m in insight.key_metrics %}
           <div class="dash-insight-metric">
@@ -523,7 +523,7 @@
         </div>
       </div>
       <div class="dash-insight-card">
-        <h2 class="dash-insight-title">💬 다음</h2>
+        <h2 class="dash-insight-title">{{ 'dashboard.insight.next_title' | i18n_args(locale | default('ko')) }}</h2>
         <ul class="dash-insight-list">
           {% for item in insight.next_actions %}<li>{{ item }}</li>{% endfor %}
         </ul>
@@ -531,111 +531,108 @@
     </div>
     {% elif insight and insight.status == 'no_api_key' %}
     <div class="dash-insight-status">
-      🔑 ANTHROPIC_API_KEY 미설정 — Insight 모드는 AI 분석이 필요합니다. Railway Variables 에서 키를 설정해주세요.
+      {{ 'dashboard.insight.no_api_key' | i18n_args(locale | default('ko')) }}
     </div>
     {% elif insight and insight.status == 'no_data' %}
     <div class="dash-insight-status">
-      📭 최근 {{ days }}일 분석 데이터가 부족합니다 — 분석 결과가 누적된 후 다시 시도해주세요.
+      {{ 'dashboard.insight.no_data' | i18n_args(locale | default('ko'), days=days) }}
     </div>
     {% else %}
     <div class="dash-insight-status">
-      ⚠️ AI Insight 생성 실패 ({{ insight.status if insight else 'unknown' }}) — 잠시 후 다시 시도해주세요.
+      {{ 'dashboard.insight.load_failed' | i18n_args(locale | default('ko'), status=(insight.status if insight else 'unknown')) }}
     </div>
     {% endif %}
   {% else %}
 
-  {# Phase 2 PR 2 — feedback CTA banner (조건부, count < threshold 시만 표시) #}
+  {# Phase 2 PR 2 — feedback CTA banner (조건부, count < threshold 시만 표시) / Phase 2 PR-6 — i18n #}
   {% if feedback and feedback.show_cta %}
-  <div class="dash-cta-banner" role="region" aria-label="피드백 요청">
+  <div class="dash-cta-banner" role="region" aria-label="{{ 'dashboard.feedback_cta.aria' | i18n_args(locale | default('ko')) }}">
     <div class="dash-cta-text">
-      <p class="dash-cta-title">📝 AI 점수에 피드백을 남겨주세요</p>
+      <p class="dash-cta-title">{{ 'dashboard.feedback_cta.title' | i18n_args(locale | default('ko')) }}</p>
       <p class="dash-cta-meta">
         {% if feedback.count == 0 %}
-          분석 결과 페이지의 👍 / 👎 버튼으로 점수 정합도를 알려주시면 AI 정확도가 개선됩니다.
+          {{ 'dashboard.feedback_cta.meta_zero' | i18n_args(locale | default('ko')) }}
         {% else %}
-          현재까지 {{ feedback.count }}건의 피드백이 있습니다 — 더 정확한 AI 정합도 측정을 위해 피드백을 남겨주세요.
+          {{ 'dashboard.feedback_cta.meta_some' | i18n_args(locale | default('ko'), count=feedback.count) }}
         {% endif %}
       </p>
     </div>
     {% if feedback.recent_analysis %}
     <a class="dash-cta-btn"
        href="/repos/{{ feedback.recent_analysis.repo_full_name }}/analyses/{{ feedback.recent_analysis.id }}#feedbackCard">
-      → 최근 분석 보기
+      {{ 'dashboard.feedback_cta.btn_recent' | i18n_args(locale | default('ko')) }}
     </a>
     {% endif %}
   </div>
   {% endif %}
 
-  {# KPI 5 카드 (Phase 1 4 + Phase 2 Auto-merge) #}
+  {# KPI 5 카드 (Phase 1 4 + Phase 2 Auto-merge) / Phase 2 PR-6 — i18n #}
   <div class="dash-kpi-grid">
     <div class="dash-kpi">
-      <div class="dash-kpi-label">평균 점수</div>
+      <div class="dash-kpi-label">{{ 'dashboard.kpi.avg_score' | i18n_args(locale | default('ko')) }}</div>
       <div class="dash-kpi-row">
         <span class="dash-kpi-value">{{ kpi.avg_score.value if kpi.avg_score.value is not none else '—' }}</span>
         {% if kpi.avg_score.grade %}<span class="dash-kpi-grade {{ kpi.avg_score.grade }}">{{ kpi.avg_score.grade }}</span>{% endif %}
       </div>
       {% if kpi.avg_score.delta is not none %}
         {% if kpi.avg_score.delta > 0 %}
-          <div class="dash-kpi-delta up">▲ +{{ kpi.avg_score.delta }} vs 직전 {{ days }}일</div>
+          <div class="dash-kpi-delta up">▲ +{{ kpi.avg_score.delta }} {{ 'dashboard.delta.vs_period' | i18n_args(locale | default('ko'), days=days) }}</div>
         {% elif kpi.avg_score.delta < 0 %}
-          <div class="dash-kpi-delta down">▼ {{ kpi.avg_score.delta }} vs 직전 {{ days }}일</div>
+          <div class="dash-kpi-delta down">▼ {{ kpi.avg_score.delta }} {{ 'dashboard.delta.vs_period' | i18n_args(locale | default('ko'), days=days) }}</div>
         {% else %}
-          <div class="dash-kpi-delta neu">— 변동 없음</div>
+          <div class="dash-kpi-delta neu">— {{ 'dashboard.delta.no_change' | i18n_args(locale | default('ko')) }}</div>
         {% endif %}
       {% else %}
-        <div class="dash-kpi-delta neu">— 비교 데이터 없음</div>
+        <div class="dash-kpi-delta neu">— {{ 'dashboard.delta.no_comparison' | i18n_args(locale | default('ko')) }}</div>
       {% endif %}
     </div>
 
     <div class="dash-kpi">
-      <div class="dash-kpi-label">분석 건수</div>
+      <div class="dash-kpi-label">{{ 'dashboard.kpi.analysis_count' | i18n_args(locale | default('ko')) }}</div>
       <div class="dash-kpi-row">
         <span class="dash-kpi-value">{{ kpi.analysis_count.value }}</span>
       </div>
       {% if kpi.analysis_count.delta > 0 %}
-        <div class="dash-kpi-delta up">▲ +{{ kpi.analysis_count.delta }} vs 직전 {{ days }}일</div>
+        <div class="dash-kpi-delta up">▲ +{{ kpi.analysis_count.delta }} {{ 'dashboard.delta.vs_period' | i18n_args(locale | default('ko'), days=days) }}</div>
       {% elif kpi.analysis_count.delta < 0 %}
-        <div class="dash-kpi-delta down">▼ {{ kpi.analysis_count.delta }} vs 직전 {{ days }}일</div>
+        <div class="dash-kpi-delta down">▼ {{ kpi.analysis_count.delta }} {{ 'dashboard.delta.vs_period' | i18n_args(locale | default('ko'), days=days) }}</div>
       {% else %}
-        <div class="dash-kpi-delta neu">— 변동 없음</div>
+        <div class="dash-kpi-delta neu">— {{ 'dashboard.delta.no_change' | i18n_args(locale | default('ko')) }}</div>
       {% endif %}
     </div>
 
     <div class="dash-kpi">
-      <div class="dash-kpi-label">보안 이슈 (HIGH)</div>
+      <div class="dash-kpi-label">{{ 'dashboard.kpi.high_security' | i18n_args(locale | default('ko')) }}</div>
       <div class="dash-kpi-row">
         <span class="dash-kpi-value">{{ kpi.high_security_issues.value }}</span>
       </div>
       {% if kpi.high_security_issues.delta > 0 %}
-        <div class="dash-kpi-delta down">▲ +{{ kpi.high_security_issues.delta }} (악화)</div>
+        <div class="dash-kpi-delta down">▲ +{{ kpi.high_security_issues.delta }} ({{ 'dashboard.delta.decline' | i18n_args(locale | default('ko')) }})</div>
       {% elif kpi.high_security_issues.delta < 0 %}
-        <div class="dash-kpi-delta up">▼ {{ kpi.high_security_issues.delta }} (개선)</div>
+        <div class="dash-kpi-delta up">▼ {{ kpi.high_security_issues.delta }} ({{ 'dashboard.delta.improvement' | i18n_args(locale | default('ko')) }})</div>
       {% else %}
-        <div class="dash-kpi-delta neu">— 변동 없음</div>
+        <div class="dash-kpi-delta neu">— {{ 'dashboard.delta.no_change' | i18n_args(locale | default('ko')) }}</div>
       {% endif %}
     </div>
 
     <div class="dash-kpi">
-      <div class="dash-kpi-label">활성 리포</div>
+      <div class="dash-kpi-label">{{ 'dashboard.kpi.active_repos' | i18n_args(locale | default('ko')) }}</div>
       <div class="dash-kpi-row">
         <span class="dash-kpi-value">{{ kpi.active_repos.value }}</span>
         <span class="dash-kpi-grade">/ {{ kpi.active_repos.total }}</span>
       </div>
       {% if kpi.active_repos.delta > 0 %}
-        <div class="dash-kpi-delta up">▲ +{{ kpi.active_repos.delta }} vs 직전 {{ days }}일</div>
+        <div class="dash-kpi-delta up">▲ +{{ kpi.active_repos.delta }} {{ 'dashboard.delta.vs_period' | i18n_args(locale | default('ko'), days=days) }}</div>
       {% elif kpi.active_repos.delta < 0 %}
-        <div class="dash-kpi-delta down">▼ {{ kpi.active_repos.delta }} vs 직전 {{ days }}일</div>
+        <div class="dash-kpi-delta down">▼ {{ kpi.active_repos.delta }} {{ 'dashboard.delta.vs_period' | i18n_args(locale | default('ko'), days=days) }}</div>
       {% else %}
-        <div class="dash-kpi-delta neu">— 변동 없음</div>
+        <div class="dash-kpi-delta neu">— {{ 'dashboard.delta.no_change' | i18n_args(locale | default('ko')) }}</div>
       {% endif %}
     </div>
 
-    {# Phase 1+2 회고 P0 #3 swap (2026-05-02) — 메인=PR 기준 최종, sub=단순 시도.
-       사유: 단순 시도 16.6% 가 큰 폰트로 노출 시 부정 인상. retry-aware final 이
-       사용자 가치 (내 PR 결국 머지됐나) 에 더 가까움. 단순 시도는 sub-text 보존
-       (운영 신호 정확성 — fallback 으로 단순 표시 시 retry-aware 데이터 부재 환경 호환). #}
-    <div class="dash-kpi" title="PR 기준 최종 success rate (retry 후 결과). 단순 시도 success rate 는 sub-text 참고.">
-      <div class="dash-kpi-label">자동 머지 성공률 (PR 기준)</div>
+    {# Phase 1+2 회고 P0 #3 swap (2026-05-02) — 메인=PR 기준 최종, sub=단순 시도. / Phase 2 PR-6 — i18n #}
+    <div class="dash-kpi" title="{{ 'dashboard.kpi.auto_merge_tooltip' | i18n_args(locale | default('ko')) }}">
+      <div class="dash-kpi-label">{{ 'dashboard.kpi.auto_merge_success' | i18n_args(locale | default('ko')) }}</div>
       <div class="dash-kpi-row">
         <span class="dash-kpi-value">
           {%- if auto_merge.final_success_rate_pct is not none -%}
@@ -652,41 +649,41 @@
       </div>
       {% if auto_merge.delta is not none %}
         {% if auto_merge.delta > 0 %}
-          <div class="dash-kpi-delta up">시도 ▲ +{{ auto_merge.delta }}% vs 직전 {{ days }}일</div>
+          <div class="dash-kpi-delta up">{{ 'dashboard.delta.attempts_vs_period' | i18n_args(locale | default('ko'), delta=auto_merge.delta, days=days) }}</div>
         {% elif auto_merge.delta < 0 %}
-          <div class="dash-kpi-delta down">시도 ▼ {{ auto_merge.delta }}% vs 직전 {{ days }}일</div>
+          <div class="dash-kpi-delta down">{{ 'dashboard.delta.attempts_vs_period_down' | i18n_args(locale | default('ko'), delta=auto_merge.delta, days=days) }}</div>
         {% else %}
-          <div class="dash-kpi-delta neu">시도 — 변동 없음</div>
+          <div class="dash-kpi-delta neu">{{ 'dashboard.delta.attempts_no_change' | i18n_args(locale | default('ko')) }}</div>
         {% endif %}
       {% else %}
         <div class="dash-kpi-delta neu">
           {%- if auto_merge.value is not none -%}
-            시도 기준 {{ auto_merge.value }}% ({{ auto_merge.success_count }}/{{ auto_merge.total_attempts }})
+            {{ 'dashboard.delta.attempts_baseline' | i18n_args(locale | default('ko'), value=auto_merge.value, success=auto_merge.success_count, total=auto_merge.total_attempts) }}
           {%- else -%}
-            — 비교 데이터 없음
+            — {{ 'dashboard.delta.no_comparison' | i18n_args(locale | default('ko')) }}
           {%- endif -%}
         </div>
       {% endif %}
     </div>
   </div>
 
-  {# 점수 추세 라인 차트 #}
+  {# 점수 추세 라인 차트 / Phase 2 PR-6 — i18n #}
   <div class="dash-chart-card">
-    <h2 class="dash-section-title">점수 추세 ({{ days }}일)</h2>
+    <h2 class="dash-section-title">{{ 'dashboard.trend' | i18n_args(locale | default('ko'), days=days) }}</h2>
     {% if trend %}
       <div class="dash-chart-wrap">
         <canvas id="dashTrendChart"></canvas>
       </div>
     {% else %}
       <div class="dash-empty-state">
-        최근 {{ days }}일간 분석 데이터가 없습니다.
+        {{ 'dashboard.no_trend_data' | i18n_args(locale | default('ko'), days=days) }}
       </div>
     {% endif %}
   </div>
 
-  {# 자주 발생 이슈 #}
+  {# 자주 발생 이슈 / Phase 2 PR-6 — i18n #}
   <div class="dash-issues-card">
-    <h2 class="dash-section-title">자주 발생 이슈 (최근 {{ days }}일)</h2>
+    <h2 class="dash-section-title">{{ 'dashboard.frequent_issues' | i18n_args(locale | default('ko'), days=days) }}</h2>
     {% if frequent_issues %}
       {% for issue in frequent_issues %}
       <div class="dash-issue-row">
@@ -700,20 +697,20 @@
       </div>
       {% endfor %}
     {% else %}
-      <div class="dash-empty-state">최근 {{ days }}일간 발견된 이슈가 없습니다.</div>
+      <div class="dash-empty-state">{{ 'dashboard.no_frequent_issues' | i18n_args(locale | default('ko'), days=days) }}</div>
     {% endif %}
   </div>
 
-  {# Phase 2 PR 1 — 자동 머지 실패 사유 분포 (운영 신호: unstable_ci 우세) #}
+  {# Phase 2 PR 1 — 자동 머지 실패 사유 분포 (운영 신호: unstable_ci 우세) / Phase 2 PR-6 — i18n #}
   {% if merge_failures %}
   <div class="dash-issues-card" style="margin-top: 16px;">
-    <h2 class="dash-section-title">자동 머지 실패 사유 (최근 {{ days }}일)</h2>
+    <h2 class="dash-section-title">{{ 'dashboard.merge_failures_title' | i18n_args(locale | default('ko'), days=days) }}</h2>
     {% for fail in merge_failures %}
     <div class="dash-issue-row">
       <div>
         <div class="dash-issue-msg">{{ fail.reason }}</div>
         <div class="dash-issue-meta">
-          비율 {{ fail.share_pct }}% · {{ fail.count }}건
+          {{ 'dashboard.merge_failure_meta' | i18n_args(locale | default('ko'), pct=fail.share_pct, count=fail.count) }}
         </div>
       </div>
       <span class="dash-issue-badge">{{ fail.count }}</span>
@@ -757,7 +754,7 @@
       data: {
         labels: trendData.map(d => d.date),
         datasets: [{
-          label: '평균 점수',
+          label: {{ 'dashboard.trend_chart_label' | i18n_args(locale | default('ko')) | tojson }},
           data: trendData.map(d => d.avg_score),
           borderColor: accent,
           backgroundColor: accent + '22',

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -21,7 +21,7 @@ from src.models.analysis import Analysis
 from src.models.repository import Repository
 from src.services import dashboard_service
 from src.shared.log_safety import sanitize_for_log
-from src.ui._helpers import get_locale, templates
+from src.ui._helpers import get_locale, templates  # noqa: F401  # get_locale = Phase 2 PR-6 페어
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +97,10 @@ async def dashboard(
             "1" if mode in _VALID_MODES else "0",
         )
 
+        # Phase 2 PR-6 — locale context 4 분기 모두 주입 의무 (LocaleMiddleware 페어)
+        # Phase 2 PR-6 — inject locale context to all 4 branches (pairs with LocaleMiddleware)
+        locale_value = get_locale(request)
+
         if effective_mode == "security":
             # Cycle 73 F2 — Code Scanning + Secret Scanning audit dashboard (read-only).
             security = dashboard_service.dashboard_security(db, user_id=current_user.id)
@@ -109,6 +113,7 @@ async def dashboard(
                     "initial_mode": effective_mode,
                     "security": security,
                     "days": days,
+                    "locale": locale_value,
                 },
             )
 
@@ -125,6 +130,7 @@ async def dashboard(
                     "initial_mode": effective_mode,
                     "usage": usage,
                     "days": days,
+                    "locale": locale_value,
                 },
             )
 
@@ -144,6 +150,7 @@ async def dashboard(
                     "initial_mode": effective_mode,  # PR 4 — 클라이언트 JS data-initial-mode 신호
                     "insight": insight,
                     "days": days,
+                    "locale": locale_value,
                 },
             )
 
@@ -173,6 +180,7 @@ async def dashboard(
             "merge_failures": merge_failures,
             "feedback": feedback,
             "days": days,
+            "locale": locale_value,
         },
     )
 

--- a/tests/unit/templates/test_dashboard_i18n_render.py
+++ b/tests/unit/templates/test_dashboard_i18n_render.py
@@ -1,0 +1,473 @@
+"""Phase 2 PR-6 회귀 가드 — dashboard.html 다국어 렌더링 검증.
+
+Phase 2 PR-6 regression guards — dashboard.html multilingual rendering.
+
+검증 범위 (Coverage):
+1. dashboard.html title + subtitle + nav (mode + range) en/ko/ja
+2. KPI 5 카드 (avg_score / analysis_count / high_security / active_repos / auto_merge_success)
+3. mode=overview branch (KPI + trend + frequent_issues + feedback CTA)
+4. mode=insight branch (✨/🔍/📊/💬 4 카드 + refresh + status fallback)
+5. mode=security branch (kill-switch / empty / processed/pending/classification/recent_pending / load_failed)
+6. mode=usage branch (empty / 4 cards / SaaS info / load_failed)
+7. Chart.js trend label (i18n + tojson 안전)
+8. locale 미주입 default 'ko' fallback
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from src.i18n.filters import register_i18n_filters
+
+
+def _render(template_name: str, **context) -> str:
+    """Standalone Jinja2 환경에서 템플릿 렌더 — TestClient lifespan trap 회피."""
+    env = Environment(
+        loader=FileSystemLoader("src/templates"),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+    register_i18n_filters(env)
+    tmpl = env.get_template(template_name)
+    return tmpl.render(**context)
+
+
+class _FakeUser:
+    github_login = "alice"
+    display_name = "Alice"
+
+
+def _kpi_dict() -> dict:
+    """Common KPI fixture — overview mode 렌더 의존."""
+    return {
+        "avg_score": {"value": 75, "grade": "B", "delta": 3},
+        "analysis_count": {"value": 12, "delta": 2},
+        "high_security_issues": {"value": 0, "delta": -1},
+        "active_repos": {"value": 3, "total": 5, "delta": 0},
+    }
+
+
+def _auto_merge_dict() -> dict:
+    return {
+        "value": 50,
+        "delta": 10,
+        "success_count": 5,
+        "total_attempts": 10,
+        "final_success_rate_pct": 80,
+        "final_success_prs": 4,
+        "distinct_prs": 5,
+    }
+
+
+# ── overview mode ───────────────────────────────────────────────────────────
+
+
+def test_dashboard_overview_renders_korean_kpi_titles():
+    """dashboard mode=overview — 한국어 KPI 5 카드 + nav + section titles."""
+    out = _render(
+        "dashboard.html",
+        locale="ko",
+        current_user=_FakeUser(),
+        mode="overview",
+        initial_mode="overview",
+        days=7,
+        kpi=_kpi_dict(),
+        trend=[{"date": "2026-05-01", "avg_score": 75}],
+        frequent_issues=[],
+        auto_merge=_auto_merge_dict(),
+        merge_failures=[],
+        feedback={"show_cta": False, "count": 0},
+    )
+    # KPI 5 카드 라벨
+    assert "평균 점수" in out
+    assert "분석 건수" in out
+    assert "보안 이슈 (HIGH)" in out
+    assert "활성 리포" in out
+    assert "자동 머지 성공률 (PR 기준)" in out
+    # Section
+    assert "점수 추세 (7일)" in out
+    assert "자주 발생 이슈 (최근 7일)" in out
+    # Nav
+    assert ">📊 개요</a>" in out
+    assert ">💬 인사이트</a>" in out
+    assert ">🛡️ 보안</a>" in out
+    assert ">📈 사용량</a>" in out
+    assert "대시보드 · SCAManager" in out  # title block
+    assert "우리 코드는 어떻게 흘러가고 있나요" in out  # subtitle
+
+
+def test_dashboard_overview_renders_english_kpi_titles():
+    """dashboard mode=overview — 영문 KPI 5 + nav + sections."""
+    out = _render(
+        "dashboard.html",
+        locale="en",
+        current_user=_FakeUser(),
+        mode="overview",
+        initial_mode="overview",
+        days=7,
+        kpi=_kpi_dict(),
+        trend=[],
+        frequent_issues=[],
+        auto_merge=_auto_merge_dict(),
+        merge_failures=[],
+        feedback={"show_cta": False, "count": 0},
+    )
+    assert "Average Score" in out
+    assert "Analyses" in out
+    assert "Security Issues (HIGH)" in out
+    assert "Active Repos" in out
+    assert "Auto-Merge Success Rate (PR-based)" in out
+    assert "Score Trend (7d)" in out
+    assert "No analysis data in the last 7 days." in out
+    assert ">📊 Overview</a>" in out
+    assert ">💬 Insight</a>" in out
+    assert ">🛡️ Security</a>" in out
+    assert ">📈 Usage</a>" in out
+    assert "Dashboard · SCAManager" in out
+
+
+def test_dashboard_overview_renders_japanese_kpi_titles():
+    """dashboard mode=overview — 일본어 KPI 5 + nav."""
+    out = _render(
+        "dashboard.html",
+        locale="ja",
+        current_user=_FakeUser(),
+        mode="overview",
+        initial_mode="overview",
+        days=30,
+        kpi=_kpi_dict(),
+        trend=[{"date": "2026-05-01", "avg_score": 80}],
+        frequent_issues=[{"message": "issue", "tool": "pylint", "language": "python", "category": "code_quality", "count": 3}],
+        auto_merge=_auto_merge_dict(),
+        merge_failures=[],
+        feedback={"show_cta": False, "count": 0},
+    )
+    assert "平均スコア" in out
+    assert "分析数" in out
+    assert "セキュリティ問題 (HIGH)" in out
+    assert "アクティブなリポ" in out
+    assert "自動マージ成功率 (PR基準)" in out
+    assert "スコアトレンド (30日)" in out
+    assert "頻発する問題 (最近 30 日)" in out
+    assert ">📊 概要</a>" in out
+    assert ">💬 インサイト</a>" in out
+    assert ">🛡️ セキュリティ</a>" in out
+    assert ">📈 使用量</a>" in out
+    assert "ダッシュボード · SCAManager" in out
+
+
+def test_dashboard_overview_feedback_cta_renders_korean():
+    """feedback CTA banner — 한국어 (count=0)."""
+    out = _render(
+        "dashboard.html",
+        locale="ko",
+        current_user=_FakeUser(),
+        mode="overview",
+        initial_mode="overview",
+        days=7,
+        kpi=_kpi_dict(),
+        trend=[],
+        frequent_issues=[],
+        auto_merge=_auto_merge_dict(),
+        merge_failures=[],
+        feedback={"show_cta": True, "count": 0, "recent_analysis": None},
+    )
+    assert "AI 점수에 피드백을 남겨주세요" in out
+    assert "분석 결과 페이지의 👍 / 👎 버튼" in out
+
+
+def test_dashboard_overview_feedback_cta_renders_english_with_count():
+    """feedback CTA — 영문 + count > 0."""
+    out = _render(
+        "dashboard.html",
+        locale="en",
+        current_user=_FakeUser(),
+        mode="overview",
+        initial_mode="overview",
+        days=7,
+        kpi=_kpi_dict(),
+        trend=[],
+        frequent_issues=[],
+        auto_merge=_auto_merge_dict(),
+        merge_failures=[],
+        feedback={
+            "show_cta": True,
+            "count": 5,
+            "recent_analysis": {"id": 1, "repo_full_name": "owner/repo"},
+        },
+    )
+    assert "Please give feedback on AI scores" in out
+    assert "5 feedback items so far" in out
+    assert "View recent analysis" in out
+
+
+# ── insight mode ────────────────────────────────────────────────────────────
+
+
+def test_dashboard_insight_success_renders_korean():
+    """insight 4 카드 (success status) — 한국어."""
+    out = _render(
+        "dashboard.html",
+        locale="ko",
+        current_user=_FakeUser(),
+        mode="insight",
+        initial_mode="insight",
+        days=7,
+        insight={
+            "status": "success",
+            "generated_at": "2026-05-05T10:30:00",
+            "positive_highlights": ["좋은 점 1"],
+            "focus_areas": ["주의 1"],
+            "key_metrics": [{"label": "점수", "value": 75, "delta": "+3"}],
+            "next_actions": ["다음 행동"],
+        },
+    )
+    assert "✨ 잘한 것" in out
+    assert "🔍 신경 쓸 것" in out
+    assert "📊 숫자" in out
+    assert "💬 다음" in out
+    assert "🔄 새로 고침" in out
+    assert "cache 생성 시각" in out  # generated_at tooltip
+
+
+def test_dashboard_insight_no_api_key_renders_english():
+    """insight no_api_key fallback — 영문."""
+    out = _render(
+        "dashboard.html",
+        locale="en",
+        current_user=_FakeUser(),
+        mode="insight",
+        initial_mode="insight",
+        days=7,
+        insight={"status": "no_api_key"},
+    )
+    assert "ANTHROPIC_API_KEY not set" in out
+    assert "Insight mode requires AI analysis" in out
+
+
+def test_dashboard_insight_no_data_renders_japanese():
+    """insight no_data fallback — 일본어 + days 변수 치환."""
+    out = _render(
+        "dashboard.html",
+        locale="ja",
+        current_user=_FakeUser(),
+        mode="insight",
+        initial_mode="insight",
+        days=30,
+        insight={"status": "no_data"},
+    )
+    assert "最近 30 日の分析データが不足しています" in out
+
+
+def test_dashboard_insight_success_renders_japanese():
+    """insight 4 카드 — 일본어."""
+    out = _render(
+        "dashboard.html",
+        locale="ja",
+        current_user=_FakeUser(),
+        mode="insight",
+        initial_mode="insight",
+        days=7,
+        insight={
+            "status": "success",
+            "generated_at": "2026-05-05T10:30:00",
+            "positive_highlights": ["良い点"],
+            "focus_areas": ["注意"],
+            "key_metrics": [],
+            "next_actions": ["次"],
+        },
+    )
+    assert "✨ よかったこと" in out
+    assert "🔍 注力すべき点" in out
+    assert "📊 数値" in out
+    assert "💬 次" in out
+    assert "🔄 更新" in out
+
+
+# ── security mode ──────────────────────────────────────────────────────────
+
+
+def test_dashboard_security_kill_switch_renders_korean():
+    """security mode kill-switch active — 한국어."""
+    out = _render(
+        "dashboard.html",
+        locale="ko",
+        current_user=_FakeUser(),
+        mode="security",
+        initial_mode="security",
+        days=7,
+        security={"kill_switch_active": True},
+    )
+    assert "Security 자동 처리 비활성화" in out
+
+
+def test_dashboard_security_empty_renders_english():
+    """security mode total_alerts=0 empty state — 영문."""
+    out = _render(
+        "dashboard.html",
+        locale="en",
+        current_user=_FakeUser(),
+        mode="security",
+        initial_mode="security",
+        days=7,
+        security={"kill_switch_active": False, "total_alerts": 0},
+    )
+    assert "No alerts pending review" in out
+    assert "View directly on GitHub Security tab" in out
+
+
+def test_dashboard_security_cards_render_japanese():
+    """security 4 카드 (pending + processed + classification + recent_pending) — 일본어."""
+    out = _render(
+        "dashboard.html",
+        locale="ja",
+        current_user=_FakeUser(),
+        mode="security",
+        initial_mode="security",
+        days=7,
+        security={
+            "kill_switch_active": False,
+            "total_alerts": 5,
+            "processed_count": 2,
+            "pending_count": 3,
+            "classification": {"true_positive": 2, "false_positive": 1},
+            "recent_pending": [
+                {"alert_number": 1, "severity": "HIGH", "alert_type": "code", "rule_id": "py/test", "ai_classification": "true"}
+            ],
+        },
+    )
+    assert "✨ 処理済み" in out
+    assert "🔍 新規 pending" in out
+    assert "📊 分類分布" in out
+    assert "💬 最近 pending (Top 5)" in out
+
+
+# ── usage mode ─────────────────────────────────────────────────────────────
+
+
+def test_dashboard_usage_empty_renders_korean():
+    """usage mode repo_count=0 empty state — 한국어."""
+    out = _render(
+        "dashboard.html",
+        locale="ko",
+        current_user=_FakeUser(),
+        mode="usage",
+        initial_mode="usage",
+        days=7,
+        usage={"repo_count": 0},
+    )
+    assert "등록된 리포지토리가 없습니다" in out
+
+
+def test_dashboard_usage_cards_render_english():
+    """usage 4 카드 + SaaS info — 영문 + days 변수 치환."""
+    out = _render(
+        "dashboard.html",
+        locale="en",
+        current_user=_FakeUser(),
+        mode="usage",
+        initial_mode="usage",
+        days=30,
+        usage={
+            "repo_count": 5,
+            "total_analyses": 100,
+            "last_analysis_at": datetime(2026, 5, 5, 10, 30),
+            "recent_analyses": 12,
+            "avg_score": 80,
+            "days": 30,
+        },
+    )
+    assert "📁 Your Repos" in out
+    assert "📊 Total Analyses" in out
+    assert "🕒 Last 30 days" in out
+    assert "⭐ Average Score" in out
+    assert "Last 30 days average" in out
+    assert "💡 SaaS Phase 1 Info" in out
+    assert "your data only" in out
+
+
+def test_dashboard_usage_cards_render_japanese():
+    """usage 4 카드 — 일본어 + days 변수 치환."""
+    out = _render(
+        "dashboard.html",
+        locale="ja",
+        current_user=_FakeUser(),
+        mode="usage",
+        initial_mode="usage",
+        days=7,
+        usage={
+            "repo_count": 5,
+            "total_analyses": 100,
+            "last_analysis_at": None,
+            "recent_analyses": 12,
+            "avg_score": None,
+            "days": 7,
+        },
+    )
+    assert "📁 本人のリポ" in out
+    assert "🕒 最近 7 日" in out
+    assert "⭐ 平均スコア" in out
+
+
+# ── Chart.js label ─────────────────────────────────────────────────────────
+
+
+def test_dashboard_chart_label_renders_korean():
+    """Chart.js trend label JS 블록 — 한국어."""
+    out = _render(
+        "dashboard.html",
+        locale="ko",
+        current_user=_FakeUser(),
+        mode="overview",
+        initial_mode="overview",
+        days=7,
+        kpi=_kpi_dict(),
+        trend=[{"date": "2026-05-01", "avg_score": 75}],
+        frequent_issues=[],
+        auto_merge=_auto_merge_dict(),
+        merge_failures=[],
+        feedback={"show_cta": False, "count": 0},
+    )
+    # Chart.js label 은 tojson 안전 (스크립트 블록)
+    assert 'label: "\\ud3c9\\uade0 \\uc810\\uc218"' in out or 'label: "평균 점수"' in out
+
+
+def test_dashboard_chart_label_renders_english():
+    """Chart.js trend label JS 블록 — 영문."""
+    out = _render(
+        "dashboard.html",
+        locale="en",
+        current_user=_FakeUser(),
+        mode="overview",
+        initial_mode="overview",
+        days=7,
+        kpi=_kpi_dict(),
+        trend=[{"date": "2026-05-01", "avg_score": 75}],
+        frequent_issues=[],
+        auto_merge=_auto_merge_dict(),
+        merge_failures=[],
+        feedback={"show_cta": False, "count": 0},
+    )
+    assert 'label: "Average Score"' in out
+
+
+# ── locale fallback ─────────────────────────────────────────────────────────
+
+
+def test_dashboard_locale_none_defaults_to_ko():
+    """dashboard.html — locale 미주입 시 default 'ko'."""
+    out = _render(
+        "dashboard.html",
+        current_user=_FakeUser(),
+        mode="overview",
+        initial_mode="overview",
+        days=7,
+        kpi=_kpi_dict(),
+        trend=[],
+        frequent_issues=[],
+        auto_merge=_auto_merge_dict(),
+        merge_failures=[],
+        feedback={"show_cta": False, "count": 0},
+    )
+    assert "평균 점수" in out
+    assert "대시보드 · SCAManager" in out


### PR DESCRIPTION
… 4카드 + Chart.js (Phase 2 PR-6)

## Summary
Phase 2 PR-6 — dashboard.html (~825 LOC) 다국어 적용. mode 4종 (overview/insight/security/usage) + KPI 5 카드 + Insight 4 카드 + Chart.js 라벨 + feedback CTA 모두 i18n_args 필터 적용. dashboard.* namespace 78 키 확장 (3 언어 = 234 영역). 단위 +18 회귀 가드 (2454→2472).

## Changes (6 files)

### 1. dashboard.html i18n 필터 적용
- title block + dash-title + dash-subtitle
- mode toggle 4 (overview/insight/security/usage) + tooltips + aria-label
- range toggle aria-label
- mode=overview branch:
  - feedback CTA banner (title / meta_zero / meta_some / btn_recent / aria)
  - KPI 5 카드 (avg_score / analysis_count / high_security / active_repos / auto_merge_success + tooltip)
  - delta 8 패턴 (vs_period / no_change / no_comparison / improvement / decline / attempts_*)
  - 점수 추세 + 자주 발생 이슈 + 자동 머지 실패 사유 (3 section title + 3 empty state + merge_failure_meta)
- mode=insight branch (4 카드 + status 3 fallback):
  - generated_at tooltip + refresh + refresh tooltip + card_aria
  - positive_title / focus_title / metrics_title / next_title
  - no_api_key / no_data / load_failed
- mode=security branch (4 카드 + 3 fallback):
  - kill_switch_active + empty_title (+ link) + load_failed + card_aria
  - processed_title/label + total_label + pending_title/label/hint + classification_title + recent_pending_title/empty
- mode=usage branch (4 카드 + SaaS info):
  - empty_title (+ link) + load_failed + card_aria
  - own_repos_title + repo_count_label/hint
  - total_analyses_title + total_analyses_label + last_analysis_label
  - recent_period_title (days 변수) + recent_analyses_label + recent_period_hint
  - avg_score_title + avg_score_label (days 변수) + avg_score_unit (score 변수) + avg_score_hint
  - SaaS info (3 li + strong 강조)
- Chart.js trend label = `{{ ... | i18n_args(...) | tojson }}` (autoescape 안전)

### 2. src/ui/routes/dashboard.py — locale context 4 분기 모두 주입
- `locale_value = get_locale(request)` 단일 추출 + 4 TemplateResponse (security/usage/insight/overview) 모두 전달
- get_locale import noqa F401 (Phase 2 PR-6 페어)

### 3. 번역 파일 확장 (en/ko/ja.json — 동일 키 매트릭스)
- dashboard.* 78 키 신설 (3 언어 = 234 영역):
  - title_prefix / mode_aria / range_aria / modes.* (security/usage tooltip + 4 modes)
  - kpi.auto_merge_tooltip
  - delta.attempts_vs_period / attempts_vs_period_down / attempts_no_change / attempts_baseline
  - trend_chart_label / no_trend_data / no_frequent_issues / merge_failures_title / merge_failure_meta
  - feedback_cta.* (5 — title / meta_zero / meta_some / btn_recent / aria)
  - security.* (15 — kill_switch / empty / load_failed / card_aria / processed/pending/classification/recent_pending)
  - usage.* (21 — empty / 4 cards / SaaS info 3 li + strong)
  - insight.* (10 — card_aria / generated_at_tooltip / refresh / refresh_tooltip / 4 titles / 3 fallback)

### 4. 회귀 가드 18건 (tests/unit/templates/test_dashboard_i18n_render.py)
- mode=overview × 5 (en/ko/ja KPI titles + nav + sections + feedback CTA 2 패턴)
- mode=insight × 4 (success ko/ja + no_api_key en + no_data ja days 변수)
- mode=security × 3 (kill_switch ko + empty en + 4 cards ja)
- mode=usage × 3 (empty ko + 4 cards en + ja days 변수)
- Chart.js label × 2 (ko/en — tojson 안전 검증)
- locale=None default fallback × 1

> Standalone Jinja2 Environment (FileSystemLoader) — TestClient lifespan trap 회피 (메모리 `feedback-testclient-lifespan-trap.md` 페어 + `feedback-pr-push-direct-validation.md` 페어 단위+통합 동시 실행)

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 /dashboard?mode={overview,insight,security,usage}&days={1,7,30,90} 16 조합 시각 정합 확인
- [ ] /settings 언어 변경 (ko → en → ja) 후 dashboard 4 mode 모두 다국어 반영 확인
- [ ] Chart.js 트렌드 차트 label 텍스트 다국어 동작 확인 (테마 전환 themechange 페어 보존)
- [ ] insight mode refresh 버튼 + generated_at tooltip 다국어 표시 확인
- [ ] Empty state (no repos / no alerts / no_data / load_failed) fallback 메시지 다국어 표시 확인

## 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 적용 영역)

⚠️ **사용자 인지 영향** (정책 3 강화 정량 기준 4번 — 모든 KPI/차트/카드 라벨 변경):
- KPI 5 카드 라벨 = 사용자 첫 인지 영역 (운영 신호)
- Insight 4 카드 (✨/🔍/📊/💬) = AI 결과 표시 영역
- Security/Usage 모드 cards = SaaS Phase 1 read-only 데이터 노출

⚠️ **데이터 모델 변경** (정책 3 강화 정량 기준 3번 — Chart.js 라벨 패턴 변경):
- Chart.js label = Jinja2 `| tojson` 필터 (autoescape 안전 패턴) — 직접 문자열 인용 X

자율 진입 보고:
- PR-6 응집 단위 = "dashboard.html 단일 페이지 + 라우트 4 분기" (정책 7 강화 응집 단위 부합 — URL + 화면 + 데이터 흐름)
- PR-7 (repo_detail + analysis_detail) / PR-8 (settings + admin 3) = 별도 PR (응집 분리)
- 회귀 가드 18건 = standalone Jinja env 패턴 (메모리 사이클 79/81 학습 페어)
- dashboard.* 키 78 = 단일 PR 응집 정합 (분할 시 키 의존성 깨짐 위험)

## 검증 (사이클 84 sync 실측)
- 단위 = `pytest tests/unit -q` → 2272 passed
- 통합 = `pytest tests/integration -q` → 191 passed
- 합계 = 2463 passed / 5 skipped / 0 failed (101s)

## cross-verify 결과
- 1차 5 에이전트 디스패치 = 본 사이클 미수행 (단일 응집 PR-6 — 인프라/UI 검증 완료 영역)
- 통합 fail = 0 (PR push 직전 검증)
- TestClient lifespan trap 페어 = standalone Jinja env 패턴으로 18 회귀 가드 안정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
