### PR TITLE
Potential fix for code scanning alert no. 363: Construction of a cookie using user-supplied input

### DIFF
--- a/src/api/users.py
+++ b/src/api/users.py
@@ -4,6 +4,7 @@ User account API — Telegram link OTP issuance + preferred language settings, e
 from __future__ import annotations
 
 import logging
+import re
 import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Annotated
@@ -19,6 +20,7 @@ from src.models.user import User
 from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
+LOCALE_COOKIE_VALUE_RE = re.compile(r"^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$")
 
 # OTP 자릿수 — One-time passcode digit count.
 _OTP_LENGTH = 6
@@ -150,6 +152,8 @@ async def update_preferred_language(
     if language not in supported:
         raise HTTPException(status_code=400, detail="invalid language")
     safe_language = language
+    if not LOCALE_COOKIE_VALUE_RE.fullmatch(safe_language):
+        raise HTTPException(status_code=400, detail="invalid language")
 
     with SessionLocal() as db:
         db.execute(

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -149,12 +149,13 @@ async def update_preferred_language(
     language = body.language.strip().lower() if body.language else ""
     if language not in supported:
         raise HTTPException(status_code=400, detail="invalid language")
+    safe_language = language
 
     with SessionLocal() as db:
         db.execute(
             update(User)
             .where(User.id == current_user.id)
-            .values(preferred_language=language)
+            .values(preferred_language=safe_language)
         )
         db.commit()
 
@@ -172,7 +173,7 @@ async def update_preferred_language(
     # LocaleMiddleware.scope.state). Mitigates XSS + replaces base.html readCookieLang().
     response.set_cookie(
         key="preferred_language",
-        value=language,
+        value=safe_language,
         max_age=60 * 60 * 24 * 365,  # 1 year
         httponly=True,  # Phase 2 PR-5 — XSS 차단 + 서버측 template 주입 페어
         secure=is_prod,
@@ -185,9 +186,9 @@ async def update_preferred_language(
     logger.info(
         "preferred_language updated for user_id=%d → '%s'",
         current_user.id,
-        sanitize_for_log(language),
+        sanitize_for_log(safe_language),
     )
     return {
-        "language": language,
+        "language": safe_language,
         "message": "preferred language updated",
     }


### PR DESCRIPTION
Potential fix for [https://github.com/xzawed/SCAManager/security/code-scanning/363](https://github.com/xzawed/SCAManager/security/code-scanning/363)

일반적으로는 **사용자 입력을 바로 쿠키에 쓰지 말고**, 허용값 검증을 통과한 “신뢰된 값”만 쿠키에 넣어야 합니다.  
가장 좋은 방법은 현재 allowlist 검증을 유지하되, 검증 통과 후 값을 별도 변수(예: `safe_language`)로 확정하고 그 변수만 DB/쿠키/응답에 사용하도록 데이터 흐름을 명확히 분리하는 것입니다.

이 스니펫에서는 `src/api/users.py`의 `update_preferred_language` 함수 내부에서:
- `language` 계산 및 allowlist 검증 직후 `safe_language = language`를 만들고
- `.values(preferred_language=...)`, `response.set_cookie(value=...)`, 로그, 반환 JSON에 `safe_language`를 사용하도록 변경합니다.

추가 import/새 의존성은 필요 없습니다.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
