### PR TITLE
feat(i18n-phase2-pr7): repo_detail + analysis_detail 다국어 — 분석 영역 응집 (…

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -197,6 +197,115 @@
     "api_error_prefix": "API error: ",
     "submit": "Create Webhook + Add Repository"
   },
+  "repo_detail": {
+    "back": "← List",
+    "settings_link": "⚙️ Settings",
+    "score_trend_label": "Score Trend",
+    "history_title": "Analysis History",
+    "history_count_recent": "Last {count} entries",
+    "history_count_filtered": "{filtered} / total {total} entries",
+    "search_placeholder": "Search commit message or SHA…",
+    "score_range_label": "Score",
+    "table": {
+      "date": "Date",
+      "commit": "Commit",
+      "pr": "PR",
+      "score": "Score",
+      "grade": "Grade",
+      "source": "Source"
+    },
+    "filter_all": "All",
+    "date_filter": {
+      "today": "Today",
+      "week": "This Week",
+      "month": "This Month",
+      "year": "This Year",
+      "custom": "Custom"
+    },
+    "source_filter": {
+      "pr": "PR",
+      "push": "Push",
+      "cli": "CLI"
+    },
+    "chart_score_label": "Score",
+    "filter_empty": "No analysis entries match your filters.",
+    "page_total": "Total {count} entries",
+    "page_range": "{start}–{end} / {total} entries",
+    "hook_installed_title": "CLI code review hook is set up!",
+    "hook_installed_desc_part1": "Run the following in your local repo, and code review will run automatically on ",
+    "hook_installed_desc_code": "git push",
+    "hook_installed_desc_part2": "."
+  },
+  "analysis_detail": {
+    "title": "Analysis #{id}",
+    "back": "← History",
+    "prev": "◀ Previous",
+    "next": "Next ▶",
+    "nav_label": "Analysis #{id}",
+    "source_cli": "🖥️ CLI",
+    "source_pr": "🔀 PR",
+    "source_push": "📤 Push",
+    "section_commit_msg": "📝 Commit Message",
+    "commit_msg_empty": "(no commit message)",
+    "score_unit_suffix": "/100",
+    "grade_label": "Grade {grade}",
+    "score_message": {
+      "excellent": "Exemplary",
+      "good": "Solid PR",
+      "fair": "Decent, with room for improvement",
+      "needs_review": "Some areas to review",
+      "poor": "Needs review"
+    },
+    "feedback": {
+      "prompt": "Do you think this score is accurate?",
+      "hint": "(Used to improve Claude AI calibration)",
+      "aria_group": "Score accuracy feedback",
+      "thumbs_up": "Accurate",
+      "thumbs_up_title": "Accurate",
+      "thumbs_up_aria": "Feedback that this score is accurate (Thumbs up)",
+      "thumbs_down": "Inaccurate",
+      "thumbs_down_title": "Inaccurate",
+      "thumbs_down_aria": "Feedback that this score is inaccurate (Thumbs down)",
+      "saving": "Saving...",
+      "saved": "Thank you!",
+      "save_failed": "Save failed: {message}"
+    },
+    "trend_section_title": "📈 Score Trend (last {count} entries)",
+    "trend_chart_score_prefix": "Score: ",
+    "trend_chart_current_marker": " ★ Current",
+    "ai_defaults": {
+      "title": "AI review defaults applied",
+      "no_api_key": "ANTHROPIC_API_KEY is not set, so neutral defaults were applied to AI scores.",
+      "api_error": "AI API call failed, so defaults were applied. Please check server logs.",
+      "empty_diff": "No analyzable code changes — defaults applied.",
+      "parse_error": "AI response parsing failed — defaults applied.",
+      "other": "AI review could not run — defaults applied."
+    },
+    "breakdown": {
+      "section_title": "📊 Score Breakdown",
+      "code_quality": "Code Quality",
+      "security": "Security",
+      "commit_message": "Commit Message",
+      "ai_review": "Implementation Direction",
+      "test_coverage": "Tests",
+      "th_item": "Item",
+      "th_score": "Score",
+      "th_ratio": "Ratio"
+    },
+    "ai": {
+      "summary_title": "🤖 AI Summary",
+      "suggestions_title": "💡 Suggestions",
+      "category_feedback_title": "📋 Category Feedback",
+      "file_feedback_title": "📁 Per-file Feedback",
+      "issues_title": "🔍 Static Analysis Issues ({count})"
+    },
+    "empty": {
+      "ai_no_data": "No AI review data available.",
+      "legacy_no_result_part1": "This analysis has no detailed data.",
+      "legacy_no_result_part2": "(Recorded before AI review was introduced)",
+      "no_result": "No analysis result data available."
+    }
+  },
   "settings": {
     "title": "Settings",
     "language": "Language",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -197,6 +197,115 @@
     "api_error_prefix": "APIエラー: ",
     "submit": "Webhook生成 + リポ追加"
   },
+  "repo_detail": {
+    "back": "← 一覧",
+    "settings_link": "⚙️ 設定",
+    "score_trend_label": "スコア推移",
+    "history_title": "分析履歴",
+    "history_count_recent": "最近 {count} 件",
+    "history_count_filtered": "{filtered}件 / 全体 {total}件",
+    "search_placeholder": "コミットメッセージまたはSHA検索…",
+    "score_range_label": "スコア",
+    "table": {
+      "date": "日付",
+      "commit": "コミット",
+      "pr": "PR",
+      "score": "スコア",
+      "grade": "グレード",
+      "source": "ソース"
+    },
+    "filter_all": "全て",
+    "date_filter": {
+      "today": "今日",
+      "week": "今週",
+      "month": "今月",
+      "year": "今年",
+      "custom": "カスタム"
+    },
+    "source_filter": {
+      "pr": "PR",
+      "push": "Push",
+      "cli": "CLI"
+    },
+    "chart_score_label": "スコア",
+    "filter_empty": "条件に合う分析履歴がありません。",
+    "page_total": "計 {count} 件",
+    "page_range": "{start}–{end} / {total}件",
+    "hook_installed_title": "CLI コードレビューフックが設定されました!",
+    "hook_installed_desc_part1": "ローカルリポジトリで下記コマンドを実行すると、",
+    "hook_installed_desc_code": "git push",
+    "hook_installed_desc_part2": " 時に自動的にコードレビューが実行されます。"
+  },
+  "analysis_detail": {
+    "title": "分析 #{id}",
+    "back": "← 履歴",
+    "prev": "◀ 前へ",
+    "next": "次へ ▶",
+    "nav_label": "分析 #{id}",
+    "source_cli": "🖥️ CLI",
+    "source_pr": "🔀 PR",
+    "source_push": "📤 Push",
+    "section_commit_msg": "📝 コミットメッセージ",
+    "commit_msg_empty": "(コミットメッセージなし)",
+    "score_unit_suffix": "/100",
+    "grade_label": "グレード {grade}",
+    "score_message": {
+      "excellent": "模範的です",
+      "good": "堅実な PR です",
+      "fair": "良好ですが改善の余地があります",
+      "needs_review": "確認すべき点があります",
+      "poor": "確認が必要です"
+    },
+    "feedback": {
+      "prompt": "このスコアは正しいと思いますか?",
+      "hint": "(Claude AI の整合性改善に使用されます)",
+      "aria_group": "スコア整合性フィードバック",
+      "thumbs_up": "正しい",
+      "thumbs_up_title": "正しいです",
+      "thumbs_up_aria": "このスコアが正しいというフィードバック (Thumbs up)",
+      "thumbs_down": "違う",
+      "thumbs_down_title": "違います",
+      "thumbs_down_aria": "このスコアが正しくないというフィードバック (Thumbs down)",
+      "saving": "保存中...",
+      "saved": "ありがとうございます!",
+      "save_failed": "保存失敗: {message}"
+    },
+    "trend_section_title": "📈 スコア推移 (最近 {count} 件)",
+    "trend_chart_score_prefix": "スコア: ",
+    "trend_chart_current_marker": " ★ 現在",
+    "ai_defaults": {
+      "title": "AI レビューのデフォルト値が適用されました",
+      "no_api_key": "ANTHROPIC_API_KEY が設定されていないため、AI スコアに中立的なデフォルト値が適用されました。",
+      "api_error": "AI API 呼び出しに失敗したためデフォルト値が適用されました。サーバーログをご確認ください。",
+      "empty_diff": "分析可能なコード変更がないためデフォルト値が適用されました。",
+      "parse_error": "AI レスポンスのパース失敗のためデフォルト値が適用されました。",
+      "other": "AI レビューを実行できなかったためデフォルト値が適用されました。"
+    },
+    "breakdown": {
+      "section_title": "📊 スコア詳細",
+      "code_quality": "コード品質",
+      "security": "セキュリティ",
+      "commit_message": "コミットメッセージ",
+      "ai_review": "実装方向性",
+      "test_coverage": "テスト",
+      "th_item": "項目",
+      "th_score": "スコア",
+      "th_ratio": "比率"
+    },
+    "ai": {
+      "summary_title": "🤖 AI 要約",
+      "suggestions_title": "💡 改善提案",
+      "category_feedback_title": "📋 カテゴリ別フィードバック",
+      "file_feedback_title": "📁 ファイル別フィードバック",
+      "issues_title": "🔍 静的解析の問題 ({count}件)"
+    },
+    "empty": {
+      "ai_no_data": "AI レビューデータがありません。",
+      "legacy_no_result_part1": "この分析には詳細データがありません。",
+      "legacy_no_result_part2": "(AI レビュー導入前の分析記録)",
+      "no_result": "分析結果データがありません。"
+    }
+  },
   "settings": {
     "title": "設定",
     "language": "言語",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -197,6 +197,115 @@
     "api_error_prefix": "API 오류: ",
     "submit": "Webhook 생성 + 리포 추가"
   },
+  "repo_detail": {
+    "back": "← 목록",
+    "settings_link": "⚙️ 설정",
+    "score_trend_label": "점수 추이",
+    "history_title": "분석 이력",
+    "history_count_recent": "최근 {count}건",
+    "history_count_filtered": "{filtered}건 / 전체 {total}건",
+    "search_placeholder": "커밋 메시지 또는 SHA 검색…",
+    "score_range_label": "점수",
+    "table": {
+      "date": "날짜",
+      "commit": "커밋",
+      "pr": "PR",
+      "score": "점수",
+      "grade": "등급",
+      "source": "소스"
+    },
+    "filter_all": "전체",
+    "date_filter": {
+      "today": "오늘",
+      "week": "금주",
+      "month": "이번달",
+      "year": "올해",
+      "custom": "직접 지정"
+    },
+    "source_filter": {
+      "pr": "PR",
+      "push": "Push",
+      "cli": "CLI"
+    },
+    "chart_score_label": "점수",
+    "filter_empty": "조건에 맞는 분석 이력이 없습니다.",
+    "page_total": "총 {count}건",
+    "page_range": "{start}–{end} / {total}건",
+    "hook_installed_title": "CLI 코드리뷰 훅이 설정됐습니다!",
+    "hook_installed_desc_part1": "로컬 리포에서 아래 명령어를 실행하면 ",
+    "hook_installed_desc_code": "git push",
+    "hook_installed_desc_part2": " 시 자동으로 코드리뷰가 실행됩니다."
+  },
+  "analysis_detail": {
+    "title": "분석 #{id}",
+    "back": "← 이력",
+    "prev": "◀ 이전",
+    "next": "다음 ▶",
+    "nav_label": "분석 #{id}",
+    "source_cli": "🖥️ CLI",
+    "source_pr": "🔀 PR",
+    "source_push": "📤 Push",
+    "section_commit_msg": "📝 커밋 메시지",
+    "commit_msg_empty": "(커밋 메시지 없음)",
+    "score_unit_suffix": "/100",
+    "grade_label": "등급 {grade}",
+    "score_message": {
+      "excellent": "모범적이에요",
+      "good": "견고한 PR이에요",
+      "fair": "양호하지만 개선 여지가 있어요",
+      "needs_review": "살펴볼 부분이 있어요",
+      "poor": "꼭 확인이 필요해요"
+    },
+    "feedback": {
+      "prompt": "이 점수가 맞다고 생각하시나요?",
+      "hint": "(Claude AI 정합도 개선에 사용됩니다)",
+      "aria_group": "점수 정합도 피드백",
+      "thumbs_up": "맞음",
+      "thumbs_up_title": "맞습니다",
+      "thumbs_up_aria": "이 점수가 맞다고 피드백 (Thumbs up)",
+      "thumbs_down": "아님",
+      "thumbs_down_title": "아닙니다",
+      "thumbs_down_aria": "이 점수가 맞지 않다고 피드백 (Thumbs down)",
+      "saving": "저장 중...",
+      "saved": "감사합니다!",
+      "save_failed": "저장 실패: {message}"
+    },
+    "trend_section_title": "📈 점수 추이 (최근 {count}건)",
+    "trend_chart_score_prefix": "점수: ",
+    "trend_chart_current_marker": " ★ 현재",
+    "ai_defaults": {
+      "title": "AI 리뷰 기본값 적용",
+      "no_api_key": "ANTHROPIC_API_KEY가 설정되지 않아 AI 점수에 중립적 기본값이 적용되었습니다.",
+      "api_error": "AI API 호출에 실패하여 기본값이 적용되었습니다. 서버 로그를 확인하세요.",
+      "empty_diff": "분석 가능한 코드 변경사항이 없어 기본값이 적용되었습니다.",
+      "parse_error": "AI 응답 파싱에 실패하여 기본값이 적용되었습니다.",
+      "other": "AI 리뷰를 수행하지 못해 기본값이 적용되었습니다."
+    },
+    "breakdown": {
+      "section_title": "📊 점수 상세",
+      "code_quality": "코드 품질",
+      "security": "보안",
+      "commit_message": "커밋 메시지",
+      "ai_review": "구현 방향성",
+      "test_coverage": "테스트",
+      "th_item": "항목",
+      "th_score": "점수",
+      "th_ratio": "비율"
+    },
+    "ai": {
+      "summary_title": "🤖 AI 요약",
+      "suggestions_title": "💡 개선 제안",
+      "category_feedback_title": "📋 카테고리별 피드백",
+      "file_feedback_title": "📁 파일별 피드백",
+      "issues_title": "🔍 정적 분석 이슈 ({count}건)"
+    },
+    "empty": {
+      "ai_no_data": "AI 리뷰 데이터가 없습니다.",
+      "legacy_no_result_part1": "이 분석에는 상세 데이터가 없습니다.",
+      "legacy_no_result_part2": "(AI 리뷰 도입 전 분석 기록)",
+      "no_result": "분석 결과 데이터가 없습니다."
+    }
+  },
   "settings": {
     "title": "설정",
     "language": "언어",

--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}분석 #{{ analysis.id }} — {{ repo_name }} — SCAManager{% endblock %}
+{% block title %}{{ 'analysis_detail.title' | i18n_args(locale | default('ko'), id=analysis.id) }} — {{ repo_name }} — SCAManager{% endblock %}
 {% block content %}
 <style>
   .ad-header {
@@ -225,9 +225,9 @@
   }
 </style>
 
-<!-- 헤더 / Header -->
+<!-- 헤더 / Header / Phase 2 PR-7 — i18n -->
 <div class="ad-header">
-  <a class="back-btn" href="/repos/{{ repo_name }}">← 이력</a>
+  <a class="back-btn" href="/repos/{{ repo_name }}">{{ 'analysis_detail.back' | i18n_args(locale | default('ko')) }}</a>
   <h2>{{ repo_name }}</h2>
   <span class="grade grade-{{ analysis.grade }}" style="margin-left:auto">{{ analysis.grade }}</span>
 </div>
@@ -235,15 +235,15 @@
 <!-- 이전/다음 내비게이션 / Prev/Next navigation -->
 <div class="analysis-nav">
   {% if prev_id %}
-    <a href="/repos/{{ repo_name }}/analyses/{{ prev_id }}" class="nav-btn">◀ 이전</a>
+    <a href="/repos/{{ repo_name }}/analyses/{{ prev_id }}" class="nav-btn">{{ 'analysis_detail.prev' | i18n_args(locale | default('ko')) }}</a>
   {% else %}
-    <span class="nav-btn disabled">◀ 이전</span>
+    <span class="nav-btn disabled">{{ 'analysis_detail.prev' | i18n_args(locale | default('ko')) }}</span>
   {% endif %}
-  <span class="nav-label">분석 #{{ analysis.id }}</span>
+  <span class="nav-label">{{ 'analysis_detail.nav_label' | i18n_args(locale | default('ko'), id=analysis.id) }}</span>
   {% if next_id %}
-    <a href="/repos/{{ repo_name }}/analyses/{{ next_id }}" class="nav-btn">다음 ▶</a>
+    <a href="/repos/{{ repo_name }}/analyses/{{ next_id }}" class="nav-btn">{{ 'analysis_detail.next' | i18n_args(locale | default('ko')) }}</a>
   {% else %}
-    <span class="nav-btn disabled">다음 ▶</span>
+    <span class="nav-btn disabled">{{ 'analysis_detail.next' | i18n_args(locale | default('ko')) }}</span>
   {% endif %}
 </div>
 
@@ -255,17 +255,17 @@
   <span>🔀 PR #{{ analysis.pr_number }}</span>
   {% endif %}
   <span>
-    {% if analysis.source == 'cli' %}🖥️ CLI
-    {% elif analysis.source == 'pr' %}🔀 PR
-    {% else %}📤 Push
+    {% if analysis.source == 'cli' %}{{ 'analysis_detail.source_cli' | i18n_args(locale | default('ko')) }}
+    {% elif analysis.source == 'pr' %}{{ 'analysis_detail.source_pr' | i18n_args(locale | default('ko')) }}
+    {% else %}{{ 'analysis_detail.source_push' | i18n_args(locale | default('ko')) }}
     {% endif %}
   </span>
 </div>
 
 <!-- 커밋 메시지 / Commit message -->
 <div class="card ad-section">
-  <div class="ad-section-title">📝 커밋 메시지</div>
-  <div class="commit-msg-text">{{ analysis.commit_message or "(커밋 메시지 없음)" }}</div>
+  <div class="ad-section-title">{{ 'analysis_detail.section_commit_msg' | i18n_args(locale | default('ko')) }}</div>
+  <div class="commit-msg-text">{{ analysis.commit_message or ('analysis_detail.commit_msg_empty' | i18n_args(locale | default('ko'))) }}</div>
 </div>
 
 <!-- 점수 배너 / Score banner -->
@@ -275,37 +275,42 @@
     <span class="ad-score-big {% if analysis.score >= 75 %}high{% elif analysis.score >= 50 %}mid{% else %}low{% endif %}">
       {{ analysis.score }}
     </span>
-    <span style="font-size:1.2rem;color:var(--text-muted)">/100</span>
+    <span style="font-size:1.2rem;color:var(--text-muted)">{{ 'analysis_detail.score_unit_suffix' | i18n_args(locale | default('ko')) }}</span>
   </div>
   <div>
-    <div style="font-size:15px;font-weight:700;color:var(--text-primary)">등급 {{ analysis.grade }}</div>
-    {# Phase 1B (UI 개편) — 친근한 의미 라벨 (대화체). 등급별 짧은 코멘트 1줄. #}
+    <div style="font-size:15px;font-weight:700;color:var(--text-primary)">{{ 'analysis_detail.grade_label' | i18n_args(locale | default('ko'), grade=analysis.grade) }}</div>
+    {# Phase 1B (UI 개편) — 친근한 의미 라벨. Phase 2 PR-7 — i18n / 5 score messages #}
     <div class="ad-score-label">
-      {% if analysis.score >= 90 %}모범적이에요{% elif analysis.score >= 75 %}견고한 PR이에요
-      {% elif analysis.score >= 60 %}양호하지만 개선 여지가 있어요{% elif analysis.score >= 45 %}살펴볼 부분이 있어요
-      {% else %}꼭 확인이 필요해요{% endif %}
+      {% if analysis.score >= 90 %}{{ 'analysis_detail.score_message.excellent' | i18n_args(locale | default('ko')) }}
+      {% elif analysis.score >= 75 %}{{ 'analysis_detail.score_message.good' | i18n_args(locale | default('ko')) }}
+      {% elif analysis.score >= 60 %}{{ 'analysis_detail.score_message.fair' | i18n_args(locale | default('ko')) }}
+      {% elif analysis.score >= 45 %}{{ 'analysis_detail.score_message.needs_review' | i18n_args(locale | default('ko')) }}
+      {% else %}{{ 'analysis_detail.score_message.poor' | i18n_args(locale | default('ko')) }}{% endif %}
     </div>
   </div>
 </div>
 {% endif %}
 
-<!-- Phase E.3 — 이 점수가 맞나요? thumbs up/down 피드백 / Is this score accurate? thumbs up/down feedback -->
+<!-- Phase E.3 — 이 점수가 맞나요? thumbs up/down 피드백 / Phase 2 PR-7 — i18n -->
 <div class="card feedback-card" id="feedbackCard"
      data-analysis-id="{{ analysis.id }}"
      data-repo="{{ repo_name }}"
-     data-current-thumbs="{{ user_feedback.thumbs if user_feedback and user_feedback.thumbs else '' }}">
+     data-current-thumbs="{{ user_feedback.thumbs if user_feedback and user_feedback.thumbs else '' }}"
+     data-i18n-saving="{{ 'analysis_detail.feedback.saving' | i18n_args(locale | default('ko')) }}"
+     data-i18n-saved="{{ 'analysis_detail.feedback.saved' | i18n_args(locale | default('ko')) }}"
+     data-i18n-save-failed="{{ 'analysis_detail.feedback.save_failed' | i18n_args(locale | default('ko'), message='__M__') }}">
   <div class="feedback-prompt">
-    <span class="feedback-label">이 점수가 맞다고 생각하시나요?</span>
-    <span class="feedback-hint">(Claude AI 정합도 개선에 사용됩니다)</span>
+    <span class="feedback-label">{{ 'analysis_detail.feedback.prompt' | i18n_args(locale | default('ko')) }}</span>
+    <span class="feedback-hint">{{ 'analysis_detail.feedback.hint' | i18n_args(locale | default('ko')) }}</span>
   </div>
-  <div class="feedback-buttons" role="group" aria-label="점수 정합도 피드백">
+  <div class="feedback-buttons" role="group" aria-label="{{ 'analysis_detail.feedback.aria_group' | i18n_args(locale | default('ko')) }}">
     <button type="button" class="fb-btn fb-up" data-value="1"
-            title="맞습니다" aria-label="이 점수가 맞다고 피드백 (Thumbs up)">
-      <span aria-hidden="true">👍</span> <span class="fb-btn-label">맞음</span>
+            title="{{ 'analysis_detail.feedback.thumbs_up_title' | i18n_args(locale | default('ko')) }}" aria-label="{{ 'analysis_detail.feedback.thumbs_up_aria' | i18n_args(locale | default('ko')) }}">
+      <span aria-hidden="true">👍</span> <span class="fb-btn-label">{{ 'analysis_detail.feedback.thumbs_up' | i18n_args(locale | default('ko')) }}</span>
     </button>
     <button type="button" class="fb-btn fb-down" data-value="-1"
-            title="아닙니다" aria-label="이 점수가 맞지 않다고 피드백 (Thumbs down)">
-      <span aria-hidden="true">👎</span> <span class="fb-btn-label">아님</span>
+            title="{{ 'analysis_detail.feedback.thumbs_down_title' | i18n_args(locale | default('ko')) }}" aria-label="{{ 'analysis_detail.feedback.thumbs_down_aria' | i18n_args(locale | default('ko')) }}">
+      <span aria-hidden="true">👎</span> <span class="fb-btn-label">{{ 'analysis_detail.feedback.thumbs_down' | i18n_args(locale | default('ko')) }}</span>
     </button>
     <span class="fb-status" id="fbStatus" role="status" aria-live="polite"></span>
   </div>
@@ -350,7 +355,7 @@
   btns.forEach(btn => btn.addEventListener('click', async () => {
     const thumbs = parseInt(btn.dataset.value, 10);
     btns.forEach(b => b.disabled = true);
-    status.textContent = '저장 중...';
+    status.textContent = card.dataset.i18nSaving;
     status.className = 'fb-status';
     try {
       const url = `/repos/${encodeURIComponent(repo)}/analyses/${analysisId}/feedback`;
@@ -363,11 +368,11 @@
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       btns.forEach(b => b.classList.remove('active'));
       btn.classList.add('active');
-      status.textContent = '감사합니다!';
+      status.textContent = card.dataset.i18nSaved;
       status.className = 'fb-status ok';
       setTimeout(() => { status.textContent = ''; }, 2500);
     } catch (err) {
-      status.textContent = `저장 실패: ${err.message}`;
+      status.textContent = card.dataset.i18nSaveFailed.replace('__M__', err.message);
       status.className = 'fb-status error';
     } finally {
       btns.forEach(b => b.disabled = false);
@@ -378,31 +383,30 @@
 
 {% set r = analysis.result %}
 
-<!-- 점수 추이 트렌드 차트 / Score trend chart — Step E (E2): canvas wrap container -->
+<!-- 점수 추이 트렌드 차트 / Phase 2 PR-7 — i18n -->
 {% if trend_data is defined and trend_data|length > 1 %}
 <div class="card trend-section">
-  <div class="trend-section-title">📈 점수 추이 (최근 {{ trend_data|length }}건)</div>
+  <div class="trend-section-title">{{ 'analysis_detail.trend_section_title' | i18n_args(locale | default('ko'), count=trend_data|length) }}</div>
   <div class="chart-wrap-inner">
     <canvas id="trendChart"></canvas>
   </div>
 </div>
 {% endif %}
 
-<!-- AI 기본값 적용 경고 배너 / AI defaults applied warning banner -->
+<!-- AI 기본값 적용 경고 배너 / Phase 2 PR-7 — i18n -->
 {% set ai_status = r.get('ai_review_status', 'success') if r else 'success' %}
 {% if ai_status != 'success' %}
-<!-- Step D: AI 기본값 안내 배너 시맨틱 토큰화 / AI defaults notice — semantic warning tokens -->
 <div class="card ad-section" style="border-left:4px solid var(--warning);background:rgba(245,158,11,0.08)">
   <div style="display:flex;align-items:center;gap:.6rem">
     <span style="font-size:1.1rem">⚠️</span>
     <div>
-      <div style="font-size:13px;font-weight:700;color:var(--warning);margin-bottom:2px">AI 리뷰 기본값 적용</div>
+      <div style="font-size:13px;font-weight:700;color:var(--warning);margin-bottom:2px">{{ 'analysis_detail.ai_defaults.title' | i18n_args(locale | default('ko')) }}</div>
       <div style="font-size:13px;color:var(--text-primary)">
-        {% if ai_status == 'no_api_key' %}ANTHROPIC_API_KEY가 설정되지 않아 AI 점수에 중립적 기본값이 적용되었습니다.
-        {% elif ai_status == 'api_error' %}AI API 호출에 실패하여 기본값이 적용되었습니다. 서버 로그를 확인하세요.
-        {% elif ai_status == 'empty_diff' %}분석 가능한 코드 변경사항이 없어 기본값이 적용되었습니다.
-        {% elif ai_status == 'parse_error' %}AI 응답 파싱에 실패하여 기본값이 적용되었습니다.
-        {% else %}AI 리뷰를 수행하지 못해 기본값이 적용되었습니다.
+        {% if ai_status == 'no_api_key' %}{{ 'analysis_detail.ai_defaults.no_api_key' | i18n_args(locale | default('ko')) }}
+        {% elif ai_status == 'api_error' %}{{ 'analysis_detail.ai_defaults.api_error' | i18n_args(locale | default('ko')) }}
+        {% elif ai_status == 'empty_diff' %}{{ 'analysis_detail.ai_defaults.empty_diff' | i18n_args(locale | default('ko')) }}
+        {% elif ai_status == 'parse_error' %}{{ 'analysis_detail.ai_defaults.parse_error' | i18n_args(locale | default('ko')) }}
+        {% else %}{{ 'analysis_detail.ai_defaults.other' | i18n_args(locale | default('ko')) }}
         {% endif %}
       </div>
     </div>
@@ -410,25 +414,25 @@
 </div>
 {% endif %}
 
-<!-- 점수 상세 / Score breakdown -->
+<!-- 점수 상세 / Phase 2 PR-7 — i18n -->
 {% set bd = r.get('breakdown', {}) if r else {} %}
 {% if bd %}
 <div class="card ad-breakdown">
-  <div class="ad-section-title">📊 점수 상세</div>
+  <div class="ad-section-title">{{ 'analysis_detail.breakdown.section_title' | i18n_args(locale | default('ko')) }}</div>
   <table>
     <thead class="sr-only">
       <tr>
-        <th scope="col">항목</th>
-        <th scope="col">점수</th>
-        <th scope="col">비율</th>
+        <th scope="col">{{ 'analysis_detail.breakdown.th_item' | i18n_args(locale | default('ko')) }}</th>
+        <th scope="col">{{ 'analysis_detail.breakdown.th_score' | i18n_args(locale | default('ko')) }}</th>
+        <th scope="col">{{ 'analysis_detail.breakdown.th_ratio' | i18n_args(locale | default('ko')) }}</th>
       </tr>
     </thead>
     <tbody>
-    {% for label, key, mx in [('코드 품질','code_quality',25),('보안','security',20),('커밋 메시지','commit_message',15),('구현 방향성','ai_review',25),('테스트','test_coverage',15)] %}
+    {% for label_key, key, mx in [('code_quality','code_quality',25),('security','security',20),('commit_message','commit_message',15),('ai_review','ai_review',25),('test_coverage','test_coverage',15)] %}
     {% set val = bd.get(key, 0) %}
     {% set pct = (val / mx * 100) if mx else 0 %}
     <tr>
-      <th scope="row" style="width:110px;font-size:13px;padding:6px 8px;color:var(--text-muted);text-align:left;font-weight:normal;">{{ label }}</th>
+      <th scope="row" style="width:110px;font-size:13px;padding:6px 8px;color:var(--text-muted);text-align:left;font-weight:normal;">{{ ('analysis_detail.breakdown.' + label_key) | i18n_args(locale | default('ko')) }}</th>
       <td style="font-size:14px;font-weight:700;padding:6px 4px;width:60px;text-align:right">{{ val }}/{{ mx }}</td>
       <td class="ad-bar-cell" style="padding:6px 8px">
         <div class="ad-bar-wrap">
@@ -443,18 +447,18 @@
 {% endif %}
 
 {% if r %}
-<!-- AI 요약 / AI summary -->
+<!-- AI 요약 / Phase 2 PR-7 — i18n -->
 {% if r.get('ai_summary') %}
 <div class="card ad-section">
-  <div class="ad-section-title">🤖 AI 요약</div>
+  <div class="ad-section-title">{{ 'analysis_detail.ai.summary_title' | i18n_args(locale | default('ko')) }}</div>
   <div class="ad-text">{{ r.ai_summary }}</div>
 </div>
 {% endif %}
 
-<!-- 개선 제안 / Improvement suggestions -->
+<!-- 개선 제안 / Phase 2 PR-7 — i18n -->
 {% if r.get('ai_suggestions') %}
 <div class="card ad-section">
-  <div class="ad-section-title">💡 개선 제안</div>
+  <div class="ad-section-title">{{ 'analysis_detail.ai.suggestions_title' | i18n_args(locale | default('ko')) }}</div>
   <ul class="ad-list">
     {% for s in r.ai_suggestions %}
     <li>{{ s }}</li>
@@ -463,22 +467,22 @@
 </div>
 {% endif %}
 
-<!-- 카테고리별 피드백 / Category feedback -->
+<!-- 카테고리별 피드백 / Phase 2 PR-7 — i18n (label key 5종 분리 → breakdown.* 재사용) -->
 {% set feedbacks = [
-  ('커밋 메시지', r.get('commit_message_feedback', '')),
-  ('코드 품질', r.get('code_quality_feedback', '')),
-  ('보안', r.get('security_feedback', '')),
-  ('구현 방향성', r.get('direction_feedback', '')),
-  ('테스트', r.get('test_feedback', '')),
+  ('commit_message', r.get('commit_message_feedback', '')),
+  ('code_quality', r.get('code_quality_feedback', '')),
+  ('security', r.get('security_feedback', '')),
+  ('ai_review', r.get('direction_feedback', '')),
+  ('test_coverage', r.get('test_feedback', '')),
 ] %}
 {% set has_fb = feedbacks | selectattr('1') | list %}
 {% if has_fb %}
 <div class="card ad-section">
-  <div class="ad-section-title">📋 카테고리별 피드백</div>
-  {% for label, fb in feedbacks %}
+  <div class="ad-section-title">{{ 'analysis_detail.ai.category_feedback_title' | i18n_args(locale | default('ko')) }}</div>
+  {% for label_key, fb in feedbacks %}
   {% if fb %}
   <div class="ad-feedback-item">
-    <div class="ad-feedback-label">{{ label }}</div>
+    <div class="ad-feedback-label">{{ ('analysis_detail.breakdown.' + label_key) | i18n_args(locale | default('ko')) }}</div>
     <div class="ad-feedback-text">{{ fb }}</div>
   </div>
   {% endif %}
@@ -486,10 +490,10 @@
 </div>
 {% endif %}
 
-<!-- 파일별 피드백 / Per-file feedback -->
+<!-- 파일별 피드백 / Phase 2 PR-7 — i18n -->
 {% if r.get('file_feedbacks') %}
 <div class="card ad-section">
-  <div class="ad-section-title">📁 파일별 피드백</div>
+  <div class="ad-section-title">{{ 'analysis_detail.ai.file_feedback_title' | i18n_args(locale | default('ko')) }}</div>
   {% for ff in r.file_feedbacks %}
   <div style="margin-bottom:1rem">
     <div class="ad-file-name">{{ ff.get('file', '?') }}</div>
@@ -503,11 +507,11 @@
 </div>
 {% endif %}
 
-<!-- 정적 분석 이슈 / Static analysis issues -->
+<!-- 정적 분석 이슈 / Phase 2 PR-7 — i18n -->
 {% set issues = r.get('issues', []) %}
 {% if issues %}
 <div class="card ad-section">
-  <div class="ad-section-title">🔍 정적 분석 이슈 ({{ issues | length }}건)</div>
+  <div class="ad-section-title">{{ 'analysis_detail.ai.issues_title' | i18n_args(locale | default('ko'), count=issues | length) }}</div>
   {% for issue in issues %}
   <div class="ad-issue-row">
     <span class="ad-issue-tool {{ issue.get('severity', 'warning') }}">{{ issue.get('tool', '?') }}</span>
@@ -518,32 +522,30 @@
 </div>
 {% endif %}
 
-<!-- result는 있지만 모든 AI 필드가 비어있는 경우 / result exists but all AI fields are empty -->
+<!-- result 있지만 모든 AI 필드가 비어있는 경우 / Phase 2 PR-7 — i18n -->
 {% if not (r.get('ai_summary') or r.get('ai_suggestions') or has_fb or r.get('file_feedbacks') or r.get('issues')) %}
 <div class="card">
   <div class="ad-empty">
     <div style="font-size:2rem;margin-bottom:.75rem;opacity:0.5">🤖</div>
-    <p>AI 리뷰 데이터가 없습니다.</p>
+    <p>{{ 'analysis_detail.empty.ai_no_data' | i18n_args(locale | default('ko')) }}</p>
   </div>
 </div>
 {% endif %}
 
 {% else %}
-<!-- result가 없는 경우 / result is missing -->
+<!-- result 없는 경우 / Phase 2 PR-7 — i18n -->
 {% if analysis.score is none %}
-<!-- result도 없고 score도 없는 구버전 분석 / legacy analysis with no result and no score -->
 <div class="card">
   <div class="ad-empty">
     <div style="font-size:2rem;margin-bottom:.75rem;opacity:0.5">📭</div>
-    <p>이 분석에는 상세 데이터가 없습니다.<br>(AI 리뷰 도입 전 분석 기록)</p>
+    <p>{{ 'analysis_detail.empty.legacy_no_result_part1' | i18n_args(locale | default('ko')) }}<br>{{ 'analysis_detail.empty.legacy_no_result_part2' | i18n_args(locale | default('ko')) }}</p>
   </div>
 </div>
 {% else %}
-<!-- score는 있지만 result가 없는 경우 / score exists but result is missing -->
 <div class="card">
   <div class="ad-empty">
     <div style="font-size:2rem;margin-bottom:.75rem;opacity:0.5">📭</div>
-    <p>분석 결과 데이터가 없습니다.</p>
+    <p>{{ 'analysis_detail.empty.no_result' | i18n_args(locale | default('ko')) }}</p>
   </div>
 </div>
 {% endif %}
@@ -631,9 +633,9 @@
           callbacks: {
             title: function(items) {
               var idx = items[0].dataIndex;
-              return TREND[idx].label + (TREND[idx].id === CURRENT_ID ? ' ★ 현재' : '');
+              return TREND[idx].label + (TREND[idx].id === CURRENT_ID ? {{ 'analysis_detail.trend_chart_current_marker' | i18n_args(locale | default('ko')) | tojson }} : '');
             },
-            label: function(item) { return '점수: ' + item.raw; }
+            label: function(item) { return {{ 'analysis_detail.trend_chart_score_prefix' | i18n_args(locale | default('ko')) | tojson }} + item.raw; }
           }
         }
       },

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -212,8 +212,8 @@
 <div style="background:var(--accent-blue,#2563eb);color:#fff;border-radius:10px;padding:1rem 1.25rem;margin-bottom:1.25rem;display:flex;align-items:flex-start;gap:.75rem;">
   <span style="font-size:1.3rem;flex-shrink:0;">✅</span>
   <div>
-    <strong>CLI 코드리뷰 훅이 설정됐습니다!</strong><br>
-    <span style="font-size:13px;opacity:.9;">로컬 리포에서 아래 명령어를 실행하면 <code style="background:rgba(255,255,255,.2);padding:1px 5px;border-radius:4px;">git push</code> 시 자동으로 코드리뷰가 실행됩니다.</span>
+    <strong>{{ 'repo_detail.hook_installed_title' | i18n_args(locale | default('ko')) }}</strong><br>
+    <span style="font-size:13px;opacity:.9;">{{ 'repo_detail.hook_installed_desc_part1' | i18n_args(locale | default('ko')) }}<code style="background:rgba(255,255,255,.2);padding:1px 5px;border-radius:4px;">{{ 'repo_detail.hook_installed_desc_code' | i18n_args(locale | default('ko')) }}</code>{{ 'repo_detail.hook_installed_desc_part2' | i18n_args(locale | default('ko')) }}</span>
     <div style="margin-top:.6rem;background:rgba(0,0,0,.25);border-radius:6px;padding:.5rem .75rem;font-family:monospace;font-size:13px;">
       git pull &amp;&amp; bash .scamanager/install-hook.sh
     </div>
@@ -221,41 +221,49 @@
 </div>
 {% endif %}
 
-<!-- 헤더 / Header -->
+<!-- 헤더 / Header / Phase 2 PR-7 — i18n -->
 <div class="detail-header">
-  <a class="back-btn" href="/">← 목록</a>
+  <a class="back-btn" href="/">{{ 'repo_detail.back' | i18n_args(locale | default('ko')) }}</a>
   <div class="detail-header-text">
     <h2>{{ repo_name }}</h2>
   </div>
-  <a class="settings-btn" href="/repos/{{ repo_name }}/settings">⚙️ 설정</a>
+  <a class="settings-btn" href="/repos/{{ repo_name }}/settings">{{ 'repo_detail.settings_link' | i18n_args(locale | default('ko')) }}</a>
 </div>
 
-<!-- 점수 차트 / Score chart — Step E (E2): canvas 명시 height 컨테이너로 감싸 모바일 압착 회피 -->
+<!-- 점수 차트 / Score chart — Step E (E2) -->
 <div class="card chart-card">
-  <div class="chart-label">점수 추이</div>
+  <div class="chart-label">{{ 'repo_detail.score_trend_label' | i18n_args(locale | default('ko')) }}</div>
   <div class="chart-wrap-inner">
     <canvas id="scoreChart"></canvas>
   </div>
 </div>
 
-<!-- 분석 이력 / Analysis history -->
-<div class="card" style="padding:1.25rem 1.5rem;">
+<!-- 분석 이력 / Analysis history / Phase 2 PR-7 — i18n + data-i18n-* (JS 동적 텍스트 서버 주입 — XSS 차단) -->
+<div class="card history-card" style="padding:1.25rem 1.5rem;"
+     data-i18n-history-recent="{{ 'repo_detail.history_count_recent' | i18n_args(locale | default('ko'), count='__N__') }}"
+     data-i18n-history-filtered="{{ 'repo_detail.history_count_filtered' | i18n_args(locale | default('ko'), filtered='__F__', total='__T__') }}"
+     data-i18n-filter-empty="{{ 'repo_detail.filter_empty' | i18n_args(locale | default('ko')) }}"
+     data-i18n-page-total="{{ 'repo_detail.page_total' | i18n_args(locale | default('ko'), count='__N__') }}"
+     data-i18n-page-range="{{ 'repo_detail.page_range' | i18n_args(locale | default('ko'), start='__S__', end='__E__', total='__T__') }}"
+     data-i18n-source-pr="{{ 'repo_detail.source_filter.pr' | i18n_args(locale | default('ko')) }}"
+     data-i18n-source-push="{{ 'repo_detail.source_filter.push' | i18n_args(locale | default('ko')) }}"
+     data-i18n-source-cli="{{ 'repo_detail.source_filter.cli' | i18n_args(locale | default('ko')) }}">
   <div class="history-header">
-    <h3>분석 이력</h3>
-    <span class="history-count" id="historyCount">최근 {{ analyses | length }}건</span>
+    <h3>{{ 'repo_detail.history_title' | i18n_args(locale | default('ko')) }}</h3>
+    <span class="history-count" id="historyCount">{{ 'repo_detail.history_count_recent' | i18n_args(locale | default('ko'), count=(analyses | length)) }}</span>
   </div>
 
   <!-- 필터 바 / Filter bar -->
   <div class="filter-bar">
     <input type="search" class="filter-search" id="searchInput"
-      placeholder="커밋 메시지 또는 SHA 검색…" autocomplete="off">
+      placeholder="{{ 'repo_detail.search_placeholder' | i18n_args(locale | default('ko')) }}" autocomplete="off">
     <div class="filter-group" id="dateFilter">
-      <button class="filter-btn active" data-date="all">전체</button>
-      <button class="filter-btn" data-date="today">오늘</button>
-      <button class="filter-btn" data-date="week">금주</button>
-      <button class="filter-btn" data-date="month">이번달</button>
-      <button class="filter-btn" data-date="year">올해</button>
-      <button class="filter-btn" data-date="custom">직접 지정</button>
+      <button class="filter-btn active" data-date="all">{{ 'repo_detail.filter_all' | i18n_args(locale | default('ko')) }}</button>
+      <button class="filter-btn" data-date="today">{{ 'repo_detail.date_filter.today' | i18n_args(locale | default('ko')) }}</button>
+      <button class="filter-btn" data-date="week">{{ 'repo_detail.date_filter.week' | i18n_args(locale | default('ko')) }}</button>
+      <button class="filter-btn" data-date="month">{{ 'repo_detail.date_filter.month' | i18n_args(locale | default('ko')) }}</button>
+      <button class="filter-btn" data-date="year">{{ 'repo_detail.date_filter.year' | i18n_args(locale | default('ko')) }}</button>
+      <button class="filter-btn" data-date="custom">{{ 'repo_detail.date_filter.custom' | i18n_args(locale | default('ko')) }}</button>
     </div>
     <div class="custom-date-wrap" id="customDateWrap">
       <input type="date" class="date-input" id="dateFrom">
@@ -264,7 +272,7 @@
     </div>
     <div class="filter-divider"></div>
     <div class="filter-group" id="gradeFilter">
-      <button class="filter-btn active" data-grade="all">전체</button>
+      <button class="filter-btn active" data-grade="all">{{ 'repo_detail.filter_all' | i18n_args(locale | default('ko')) }}</button>
       <button class="filter-btn" data-grade="A">A</button>
       <button class="filter-btn" data-grade="B">B</button>
       <button class="filter-btn" data-grade="C">C</button>
@@ -273,14 +281,14 @@
     </div>
     <div class="filter-divider"></div>
     <div class="filter-group" id="sourceFilter">
-      <button class="filter-btn active" data-source="all">전체</button>
-      <button class="filter-btn" data-source="pr">PR</button>
-      <button class="filter-btn" data-source="push">Push</button>
-      <button class="filter-btn" data-source="cli">CLI</button>
+      <button class="filter-btn active" data-source="all">{{ 'repo_detail.filter_all' | i18n_args(locale | default('ko')) }}</button>
+      <button class="filter-btn" data-source="pr">{{ 'repo_detail.source_filter.pr' | i18n_args(locale | default('ko')) }}</button>
+      <button class="filter-btn" data-source="push">{{ 'repo_detail.source_filter.push' | i18n_args(locale | default('ko')) }}</button>
+      <button class="filter-btn" data-source="cli">{{ 'repo_detail.source_filter.cli' | i18n_args(locale | default('ko')) }}</button>
     </div>
     <div class="filter-divider"></div>
     <div class="score-range-wrap">
-      <span>점수</span>
+      <span>{{ 'repo_detail.score_range_label' | i18n_args(locale | default('ko')) }}</span>
       <div class="dual-slider-track" id="dualSliderTrack">
         <div class="dual-slider-bg"></div>
         <div class="dual-slider-fill" id="sliderFill"></div>
@@ -297,12 +305,12 @@
   <table>
     <thead>
       <tr>
-        <th class="sortable-th" data-sort="created_at">날짜 <span class="sort-icon"></span></th>
-        <th>커밋</th>
-        <th>PR</th>
-        <th class="sortable-th" data-sort="score">점수 <span class="sort-icon"></span></th>
-        <th>등급</th>
-        <th>소스</th>
+        <th class="sortable-th" data-sort="created_at">{{ 'repo_detail.table.date' | i18n_args(locale | default('ko')) }} <span class="sort-icon"></span></th>
+        <th>{{ 'repo_detail.table.commit' | i18n_args(locale | default('ko')) }}</th>
+        <th>{{ 'repo_detail.table.pr' | i18n_args(locale | default('ko')) }}</th>
+        <th class="sortable-th" data-sort="score">{{ 'repo_detail.table.score' | i18n_args(locale | default('ko')) }} <span class="sort-icon"></span></th>
+        <th>{{ 'repo_detail.table.grade' | i18n_args(locale | default('ko')) }}</th>
+        <th>{{ 'repo_detail.table.source' | i18n_args(locale | default('ko')) }}</th>
       </tr>
     </thead>
     <tbody id="analysisTable"></tbody>
@@ -343,7 +351,7 @@
       data: {
         labels: labels,
         datasets: [{
-          label: '점수',
+          label: {{ 'repo_detail.chart_score_label' | i18n_args(locale | default('ko')) | tojson }},
           data: scores,
           borderColor: accent,
           backgroundColor: accent + '22',
@@ -398,6 +406,20 @@
 const ALL_ANALYSES = {{ analyses | tojson }};
 const REPO_NAME_JS = {{ repo_name | tojson }};
 const PAGE_SIZE = 20;
+
+// Phase 2 PR-7 — 다국어 동적 텍스트 (data-i18n-* 속성 — 서버 Jinja injection 페어, XSS 차단)
+// Phase 2 PR-7 — i18n dynamic text (data-i18n-* attributes — server-side Jinja, XSS-safe)
+const _i18nCard = document.querySelector('.history-card');
+const I18N = {
+  historyRecent: _i18nCard.dataset.i18nHistoryRecent,
+  historyFiltered: _i18nCard.dataset.i18nHistoryFiltered,
+  filterEmpty: _i18nCard.dataset.i18nFilterEmpty,
+  pageTotal: _i18nCard.dataset.i18nPageTotal,
+  pageRange: _i18nCard.dataset.i18nPageRange,
+  sourcePr: _i18nCard.dataset.i18nSourcePr,
+  sourcePush: _i18nCard.dataset.i18nSourcePush,
+  sourceCli: _i18nCard.dataset.i18nSourceCli,
+};
 
 // ── 상태 ─────────────────────────────────────────────
 const state = {
@@ -487,14 +509,25 @@ document.getElementById('scoreMax').addEventListener('input', function() {
 // Step D: 소스 배지 시맨틱 토큰화 — push=success / cli=warning / pr=accent (모두 var)
 // Step D: source badge semantic tokens — auto across 4 themes
 function renderSourceBadge(src) {
-  const m = { pr: ['PR','var(--accent)'], push: ['Push','var(--success)'], cli: ['CLI','var(--warning)'] };
+  const m = {
+    pr:   [I18N.sourcePr,   'var(--accent)'],
+    push: [I18N.sourcePush, 'var(--success)'],
+    cli:  [I18N.sourceCli,  'var(--warning)']
+  };
   const [label, color] = m[src] || [src || '—', 'var(--text-muted)'];
   return '<span style="font-size:11px;font-weight:600;color:' + color + '">' + label + '</span>';
 }
 function renderTable(data) {
   const tbody = document.getElementById('analysisTable');
   if (!data.length) {
-    tbody.innerHTML = '<tr><td colspan="6" class="filter-empty">조건에 맞는 분석 이력이 없습니다.</td></tr>';
+    const tr = document.createElement('tr');
+    const td = document.createElement('td');
+    td.colSpan = 6;
+    td.className = 'filter-empty';
+    td.textContent = I18N.filterEmpty;
+    tr.appendChild(td);
+    tbody.innerHTML = '';
+    tbody.appendChild(tr);
     return;
   }
   tbody.innerHTML = data.map(function(a) {
@@ -532,7 +565,7 @@ function renderPagination(totalPages, total, start, count) {
   const info = document.getElementById('pageInfo');
   if (totalPages <= 1) {
     pg.innerHTML = '';
-    info.textContent = total > 0 ? '총 ' + total + '건' : '';
+    info.textContent = total > 0 ? I18N.pageTotal.replace('__N__', total) : '';
     return;
   }
   const cp = state.currentPage;
@@ -546,7 +579,10 @@ function renderPagination(totalPages, total, start, count) {
   });
   parts.push('<button class="page-btn" ' + (cp === totalPages ? 'disabled' : '') + ' data-page="' + (cp+1) + '">›</button>');
   pg.innerHTML = parts.join('');
-  info.textContent = (start+1) + '–' + (start+count) + ' / ' + total + '건';
+  info.textContent = I18N.pageRange
+    .replace('__S__', start + 1)
+    .replace('__E__', start + count)
+    .replace('__T__', total);
   pg.onclick = function(e) {
     var btn = e.target.closest('[data-page]');
     if (!btn || btn.disabled) return;
@@ -588,8 +624,8 @@ function applyFilters() {
   renderPagination(totalPages, total, start, pageData.length);
   var el = document.getElementById('historyCount');
   if (el) el.textContent = total === ALL_ANALYSES.length
-    ? '최근 ' + total + '건'
-    : total + '건 / 전체 ' + ALL_ANALYSES.length + '건';
+    ? I18N.historyRecent.replace('__N__', total)
+    : I18N.historyFiltered.replace('__F__', total).replace('__T__', ALL_ANALYSES.length);
   // 필터 결과를 시간 오름차순으로 차트에 동기화
   var chartData = filtered.slice().sort(function(a, b) {
     return (a.created_at || '') < (b.created_at || '') ? -1 : 1;

--- a/src/ui/routes/detail.py
+++ b/src/ui/routes/detail.py
@@ -11,7 +11,7 @@ from src.auth.session import CurrentUser, require_login
 from src.database import SessionLocal
 from src.models.analysis import Analysis
 from src.repositories import analysis_feedback_repo
-from src.ui._helpers import get_accessible_repo, templates
+from src.ui._helpers import get_accessible_repo, get_locale, templates
 
 router = APIRouter()
 
@@ -84,6 +84,7 @@ def analysis_detail(
         "repo_name": repo_name, "analysis": data, "current_user": current_user,
         "trend_data": trend_data, "prev_id": prev_id, "next_id": next_id,
         "user_feedback": _serialize_feedback(user_feedback),
+        "locale": get_locale(request),
     })
 
 
@@ -159,4 +160,5 @@ def repo_detail(  # pylint: disable=too-many-positional-arguments
         "chart_scores": [a["score"] for a in rev],
         "hook_installed": bool(hook_installed),
         "current_user": current_user,
+        "locale": get_locale(request),
     })

--- a/tests/unit/templates/test_detail_i18n_render.py
+++ b/tests/unit/templates/test_detail_i18n_render.py
@@ -1,0 +1,307 @@
+"""Phase 2 PR-7 회귀 가드 — repo_detail.html + analysis_detail.html 다국어 렌더링.
+
+Phase 2 PR-7 regression guards — repo_detail + analysis_detail multilingual rendering.
+
+검증 범위 (Coverage):
+1. repo_detail.html — 헤더 / chart label / table 6 헤더 / filter 16종 / search placeholder / hook installed banner
+2. repo_detail.html data-i18n-* 속성 (JS 동적 텍스트 — XSS-safe 서버 주입)
+3. analysis_detail.html — title / nav prev/next / source 3종 / 등급 메시지 5종 / feedback 8 / AI 4 sections / empty 3 / breakdown 5 + headers
+4. analysis_detail.html chart label/marker (tojson 안전)
+5. en/ko/ja 3 언어 + locale=None default fallback
+"""
+from __future__ import annotations
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from src.i18n.filters import register_i18n_filters
+
+
+def _render(template_name: str, **context) -> str:
+    """Standalone Jinja2 환경 — TestClient lifespan trap 회피."""
+    env = Environment(
+        loader=FileSystemLoader("src/templates"),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+    register_i18n_filters(env)
+    tmpl = env.get_template(template_name)
+    return tmpl.render(**context)
+
+
+class _FakeUser:
+    github_login = "alice"
+    display_name = "Alice"
+
+
+# ── repo_detail.html ────────────────────────────────────────────────────────
+
+
+def _repo_ctx(**overrides) -> dict:
+    base = {
+        "current_user": _FakeUser(),
+        "repo_name": "owner/repo",
+        "analyses": [
+            {"id": 1, "score": 80, "grade": "B", "commit_sha": "abc1234",
+             "pr_number": 1, "commit_message": "msg",
+             "source": "pr", "created_at": "2026-05-01T10:00:00"},
+        ],
+        "chart_labels": ["2026-05-01"],
+        "chart_scores": [80],
+        "hook_installed": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_repo_detail_renders_korean():
+    """repo_detail.html — 한국어 헤더/필터/테이블."""
+    out = _render("repo_detail.html", locale="ko", **_repo_ctx())
+    assert "← 목록" in out  # back
+    assert "⚙️ 설정" in out  # settings_link
+    assert "점수 추이" in out  # score_trend_label
+    assert "분석 이력" in out  # history_title
+    assert "최근 1건" in out  # history_count_recent
+    assert "커밋 메시지 또는 SHA 검색…" in out  # search_placeholder
+    assert ">날짜 " in out and ">커밋</th>" in out and ">PR</th>" in out
+    assert ">점수 " in out and ">등급</th>" in out and ">소스</th>" in out
+    assert ">전체</button>" in out  # filter_all
+    assert ">오늘</button>" in out and ">금주</button>" in out
+    assert ">이번달</button>" in out and ">올해</button>" in out
+    assert ">직접 지정</button>" in out
+    # data-i18n-* 속성
+    assert 'data-i18n-filter-empty="조건에 맞는 분석 이력이 없습니다."' in out
+
+
+def test_repo_detail_renders_english():
+    """repo_detail.html — 영문."""
+    out = _render("repo_detail.html", locale="en", **_repo_ctx())
+    assert "← List" in out
+    assert "⚙️ Settings" in out
+    assert "Score Trend" in out
+    assert "Analysis History" in out
+    assert "Last 1 entries" in out
+    assert "Search commit message or SHA…" in out
+    assert ">Date " in out and ">Commit</th>" in out
+    assert ">Score " in out and ">Grade</th>" in out and ">Source</th>" in out
+    assert ">All</button>" in out
+    assert ">Today</button>" in out and ">This Week</button>" in out
+    assert ">Custom</button>" in out
+
+
+def test_repo_detail_renders_japanese():
+    """repo_detail.html — 일본어."""
+    out = _render("repo_detail.html", locale="ja", **_repo_ctx())
+    assert "← 一覧" in out
+    assert "スコア推移" in out
+    assert "分析履歴" in out
+    assert "最近 1 件" in out
+    assert "コミットメッセージまたはSHA検索" in out
+    assert ">日付 " in out and ">コミット</th>" in out
+    assert ">グレード</th>" in out and ">ソース</th>" in out
+    assert ">全て</button>" in out
+    assert ">今日</button>" in out and ">今週</button>" in out
+
+
+def test_repo_detail_hook_installed_banner_korean():
+    """repo_detail.html hook_installed=True 배너 — 한국어."""
+    out = _render("repo_detail.html", locale="ko", **_repo_ctx(hook_installed=True))
+    assert "CLI 코드리뷰 훅이 설정됐습니다!" in out
+    assert "로컬 리포에서 아래 명령어를 실행하면" in out
+
+
+def test_repo_detail_chart_label_renders_korean():
+    """repo_detail.html chart label JS (tojson 안전) — 한국어."""
+    out = _render("repo_detail.html", locale="ko", **_repo_ctx())
+    # tojson 은 한국어를 \uXXXX escape 또는 그대로 유지 (ensure_ascii=False)
+    assert ('label: "\\uc810\\uc218"' in out) or ('label: "점수"' in out)
+
+
+def test_repo_detail_chart_label_renders_english():
+    """repo_detail.html chart label — 영문."""
+    out = _render("repo_detail.html", locale="en", **_repo_ctx())
+    assert 'label: "Score"' in out
+
+
+# ── analysis_detail.html ────────────────────────────────────────────────────
+
+
+def _analysis_ctx(**overrides) -> dict:
+    base = {
+        "current_user": _FakeUser(),
+        "repo_name": "owner/repo",
+        "analysis": {
+            "id": 42,
+            "commit_sha": "abc1234",
+            "commit_message": "fix: bug",
+            "pr_number": 7,
+            "score": 80,
+            "grade": "B",
+            "result": {
+                "ai_review_status": "success",
+                "breakdown": {"code_quality": 20, "security": 18, "commit_message": 12,
+                              "ai_review": 20, "test_coverage": 10},
+                "ai_summary": "Good code",
+                "ai_suggestions": ["Improve tests"],
+                "issues": [{"tool": "pylint", "severity": "warning", "line": 10, "message": "test"}],
+            },
+            "source": "pr",
+            "created_at": "2026-05-01T10:00:00",
+        },
+        "trend_data": [
+            {"id": 41, "score": 75, "label": "05/01"},
+            {"id": 42, "score": 80, "label": "05/02"},
+        ],
+        "prev_id": 41,
+        "next_id": None,
+        "user_feedback": {"thumbs": None, "comment": None, "updated_at": None},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_analysis_detail_renders_korean():
+    """analysis_detail.html — 한국어 핵심 텍스트."""
+    out = _render("analysis_detail.html", locale="ko", **_analysis_ctx())
+    assert "분석 #42" in out  # title + nav_label
+    assert "← 이력" in out  # back
+    assert "◀ 이전" in out  # prev (active)
+    assert "다음 ▶" in out  # next (disabled)
+    assert "📝 커밋 메시지" in out
+    assert "/100" in out
+    assert "등급 B" in out
+    assert "견고한 PR이에요" in out  # score 80 → good
+    # feedback
+    assert "이 점수가 맞다고 생각하시나요?" in out
+    assert "맞음</span>" in out and "아님</span>" in out
+    # trend section
+    assert "📈 점수 추이 (최근 2건)" in out
+    # AI sections
+    assert "🤖 AI 요약" in out
+    assert "💡 개선 제안" in out
+    assert "📊 점수 상세" in out
+    assert "🔍 정적 분석 이슈 (1건)" in out
+    # source
+    assert "🔀 PR" in out
+
+
+def test_analysis_detail_renders_english():
+    """analysis_detail.html — 영문."""
+    out = _render("analysis_detail.html", locale="en", **_analysis_ctx())
+    assert "Analysis #42" in out
+    assert "← History" in out
+    assert "◀ Previous" in out
+    assert "Next ▶" in out
+    assert "📝 Commit Message" in out
+    assert "Grade B" in out
+    assert "Solid PR" in out
+    assert "Do you think this score is accurate?" in out
+    assert "Accurate</span>" in out and "Inaccurate</span>" in out
+    assert "📈 Score Trend (last 2 entries)" in out
+    assert "🤖 AI Summary" in out
+    assert "💡 Suggestions" in out
+    assert "📊 Score Breakdown" in out
+    assert "🔍 Static Analysis Issues (1)" in out
+    assert "Code Quality" in out  # breakdown labels
+    assert "Implementation Direction" in out
+
+
+def test_analysis_detail_renders_japanese():
+    """analysis_detail.html — 일본어."""
+    out = _render("analysis_detail.html", locale="ja", **_analysis_ctx())
+    assert "分析 #42" in out
+    assert "← 履歴" in out
+    assert "◀ 前へ" in out
+    assert "次へ ▶" in out
+    assert "📝 コミットメッセージ" in out
+    assert "グレード B" in out
+    assert "堅実な PR です" in out
+    assert "このスコアは正しいと思いますか?" in out
+    assert "正しい</span>" in out and "違う</span>" in out
+    assert "📈 スコア推移 (最近 2 件)" in out
+    assert "🤖 AI 要約" in out
+    assert "💡 改善提案" in out
+    assert "📊 スコア詳細" in out
+    assert "🔍 静的解析の問題 (1件)" in out
+
+
+def test_analysis_detail_score_messages_5_bands():
+    """analysis_detail.html score message 5 분기 (90+/75+/60+/45+/<45) — 한국어."""
+    for score, expected_msg in [
+        (95, "모범적이에요"),
+        (80, "견고한 PR이에요"),
+        (65, "양호하지만 개선 여지가 있어요"),
+        (50, "살펴볼 부분이 있어요"),
+        (30, "꼭 확인이 필요해요"),
+    ]:
+        ctx = _analysis_ctx()
+        ctx["analysis"] = {**ctx["analysis"], "score": score}
+        out = _render("analysis_detail.html", locale="ko", **ctx)
+        assert expected_msg in out, f"score={score} expected '{expected_msg}'"
+
+
+def test_analysis_detail_ai_defaults_banner_korean():
+    """analysis_detail.html ai_review_status != success → 경고 배너 — 한국어 5 분기."""
+    for status, msg_part in [
+        ("no_api_key", "ANTHROPIC_API_KEY가 설정되지 않아"),
+        ("api_error", "AI API 호출에 실패하여"),
+        ("empty_diff", "분석 가능한 코드 변경사항이 없어"),
+        ("parse_error", "AI 응답 파싱에 실패하여"),
+        ("other_status", "AI 리뷰를 수행하지 못해"),
+    ]:
+        ctx = _analysis_ctx()
+        ctx["analysis"] = {**ctx["analysis"], "result": {"ai_review_status": status, "breakdown": {}}}
+        out = _render("analysis_detail.html", locale="ko", **ctx)
+        assert "AI 리뷰 기본값 적용" in out
+        assert msg_part in out, f"status={status} expected '{msg_part}'"
+
+
+def test_analysis_detail_empty_states_renders_japanese():
+    """analysis_detail.html empty 상태 3 분기 — 일본어."""
+    # legacy (result=None + score=None)
+    ctx_legacy = _analysis_ctx()
+    ctx_legacy["analysis"] = {**ctx_legacy["analysis"], "result": None, "score": None}
+    out = _render("analysis_detail.html", locale="ja", **ctx_legacy)
+    assert "この分析には詳細データがありません" in out
+    assert "(AI レビュー導入前の分析記録)" in out
+
+    # no_result (result=None + score=N)
+    ctx_no = _analysis_ctx()
+    ctx_no["analysis"] = {**ctx_no["analysis"], "result": None, "score": 50}
+    out2 = _render("analysis_detail.html", locale="ja", **ctx_no)
+    assert "分析結果データがありません" in out2
+
+    # ai_no_data (result={} but no AI fields)
+    ctx_empty = _analysis_ctx()
+    ctx_empty["analysis"] = {**ctx_empty["analysis"], "result": {"ai_review_status": "success"}}
+    out3 = _render("analysis_detail.html", locale="ja", **ctx_empty)
+    assert "AI レビューデータがありません" in out3
+
+
+def test_analysis_detail_chart_tooltip_localizable():
+    """analysis_detail.html chart tooltip i18n + tojson 안전 (한국어)."""
+    out = _render("analysis_detail.html", locale="ko", **_analysis_ctx())
+    # trend_chart_score_prefix = "점수: " / current_marker = " ★ 현재"
+    assert ('"\\uc810\\uc218: "' in out or '"점수: "' in out)
+
+
+def test_analysis_detail_chart_tooltip_english():
+    """analysis_detail.html chart tooltip — 영문."""
+    out = _render("analysis_detail.html", locale="en", **_analysis_ctx())
+    assert '"Score: "' in out
+    assert '" \\u2605 Current"' in out or '" ★ Current"' in out
+
+
+# ── locale fallback ─────────────────────────────────────────────────────────
+
+
+def test_repo_detail_locale_none_defaults_to_ko():
+    """repo_detail.html — locale 미주입 시 default 'ko'."""
+    out = _render("repo_detail.html", **_repo_ctx())
+    assert "← 목록" in out  # back ko default
+    assert "분석 이력" in out
+
+
+def test_analysis_detail_locale_none_defaults_to_ko():
+    """analysis_detail.html — locale 미주입 시 default 'ko'."""
+    out = _render("analysis_detail.html", **_analysis_ctx())
+    assert "← 이력" in out  # back ko default
+    assert "분석 #42" in out

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -710,7 +710,9 @@ def test_analysis_detail_shows_fallback_when_no_commit_message():
     with patch("src.ui.routes.detail.SessionLocal", return_value=_ctx(mock_db)):
         r = client.get("/repos/owner%2Frepo/analyses/42")
     assert r.status_code == 200
-    assert "커밋 메시지 없음" in r.text
+    # Phase 2 PR-7 (사이클 84) — i18n 적용 후 default locale 'en' 또는 'ko' 양호
+    # Phase 2 PR-7 (Cycle 84) — after i18n, accept either default locale en or ko
+    assert "no commit message" in r.text or "커밋 메시지 없음" in r.text
 
 
 def test_analysis_detail_shows_score_when_result_empty():
@@ -1102,7 +1104,13 @@ def test_analysis_detail_result_none_shows_fallback():
     assert "75" in r.text
     assert "/100" in r.text
     # fallback 메시지 포함 (result 데이터 없음을 안내)
-    assert "분석 결과 데이터가 없습니다" in r.text or "상세 데이터가 없습니다" in r.text
+    # Phase 2 PR-7 (사이클 84) — i18n 적용 후 default locale 'en' 또는 'ko' 양호
+    assert (
+        "No analysis result data available" in r.text
+        or "분석 결과 데이터가 없습니다" in r.text
+        or "상세 데이터가 없습니다" in r.text
+        or "no detailed data" in r.text
+    )
     # AI 관련 섹션은 없어야 함 (result가 없으므로)
     assert "ai_summary" not in r.text
     assert "AI 요약" not in r.text
@@ -1137,7 +1145,13 @@ def test_analysis_detail_result_empty_dict_shows_fallback():
     assert "80" in r.text
     assert "/100" in r.text
     # fallback 메시지 포함
-    assert "분석 결과 데이터가 없습니다" in r.text or "상세 데이터가 없습니다" in r.text
+    # Phase 2 PR-7 (사이클 84) — i18n 적용 후 default locale 'en' 또는 'ko' 양호
+    assert (
+        "No analysis result data available" in r.text
+        or "분석 결과 데이터가 없습니다" in r.text
+        or "상세 데이터가 없습니다" in r.text
+        or "no detailed data" in r.text
+    )
     # AI 요약 섹션 없음
     # AI summary section must not be present.
     assert "AI 요약" not in r.text


### PR DESCRIPTION
…Phase 2 PR-7)

## Summary
Phase 2 PR-7 — repo_detail.html (~681 LOC) + analysis_detail.html (~649 LOC) 다국어 적용. 정책 7 강화 응집 단위 = 분석 영역 (URL + 화면 + 데이터). repo_detail.* + analysis_detail.* namespace 확장 (3 언어 = ~330 영역). 단위 +16 회귀 가드 (2463→2479).

## Changes (8 files)

### 1. repo_detail.html i18n (~30 키)
- title (repo_name 그대로 유지) + back link + settings_link
- 점수 추이 chart-label + section title (분석 이력)
- 검색 placeholder + filter buttons (date 6 / grade 6 / source 4 + 점수 라벨)
- table header 6 (날짜/커밋/PR/점수/등급/소스)
- hook installed 배너 (CLI 코드리뷰 안내 — 3 분할)
- Chart.js label = `{{ ... | i18n_args(...) | tojson }}` (XSS 안전)
- JS 동적 텍스트 8건 → data-i18n-* 속성 패턴:
  - history_count_recent / history_count_filtered (최근 N건 / N건 / 전체 N건)
  - filter_empty (조건 무관 시 메시지)
  - page_total / page_range (페이지네이션)
  - source_pr / source_push / source_cli (renderSourceBadge)
- innerHTML XSS 회피 — document.createElement + textContent 사용

### 2. analysis_detail.html i18n (~50 키)
- title (analysis_detail.title with id 변수) + back + nav prev/next + nav_label
- meta source 3종 (CLI / PR / Push)
- 커밋 메시지 section title + empty fallback
- 점수 배너 unit suffix (/100) + grade label + score message 5 분기 (90+/75+/60+/45+/<45)
- feedback card (prompt / hint / aria_group / thumbs_up + thumbs_down (label + title + aria) / status 3 — saving / saved / save_failed)
- trend section title (count 변수)
- AI 기본값 배너 (title + 5 분기 메시지)
- 점수 상세 table (section title + 5 카테고리 + th 3)
- AI sections (summary / suggestions / category_feedback / file_feedback / static issues)
- empty 3 분기 (ai_no_data / legacy / no_result)
- chart tooltip title/label (tojson 안전 — current_marker + score_prefix)
- JS 동적 텍스트 3건 → data-i18n-saving / saved / save-failed (fetch error 변수 치환)

### 3. 번역 파일 확장 (en/ko/ja.json — 동일 키 매트릭스)
- repo_detail.* 26 키 (back / settings_link / score_trend_label / history_title / count 2 / search / score_range / table 6 / filter_all / date 5 / source 3 / chart_score / filter_empty / page 2 / hook_installed 4)
- analysis_detail.* 50+ 키 (title / nav 4 / source 3 / commit 2 / score 3 / score_message 5 / feedback 12 / trend 3 / ai_defaults 6 / breakdown 8 / ai 5 / empty 4)
- 합계 신설 ~76 키 × 3 언어 = ~228 영역

### 4. src/ui/routes/detail.py — locale context 2 분기 모두 주입
- analysis_detail TemplateResponse + repo_detail TemplateResponse → `locale: get_locale(request)` 추가
- get_locale import 추가

### 5. 회귀 가드 16건 (tests/unit/templates/test_detail_i18n_render.py)
- repo_detail × 6 (en/ko/ja + hook_installed banner ko + chart label ko/en)
- analysis_detail × 7 (en/ko/ja + score 5 bands + ai_defaults 5 분기 + empty 3 분기 + chart tooltip ko/en)
- locale=None default fallback × 2 (repo_detail + analysis_detail)
- TestClient lifespan trap 회피 standalone Jinja env 패턴 (메모리 페어)

### 6. 기존 테스트 정정 (tests/unit/ui/test_router.py)
- test_analysis_detail_shows_fallback_when_no_commit_message: "no commit message" or "커밋 메시지 없음" or
- test_analysis_detail_result_none_shows_fallback: "No analysis result data available" 또는 "분석 결과 데이터가 없습니다" 또는 "no detailed data"
- test_analysis_detail_result_empty_dict_shows_fallback: 동일 패턴

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 /repos/{owner}/{repo} + /repos/{owner}/{repo}/analyses/{id} 진입 페이지 4-테마 × 모바일/데스크탑 8 조합 시각 정합 확인
- [ ] /settings 언어 변경 (ko → en → ja) 후 분석 영역 다국어 반영 확인
- [ ] repo_detail filter (date 6 / grade 6 / source 4) 클릭 + 검색 placeholder + 페이지네이션 다국어 표시 확인
- [ ] analysis_detail score 5 bands (90/75/60/45/<45) 메시지 다국어 + grade label 변수 치환 확인
- [ ] analysis_detail feedback 👍/👎 클릭 → saving / saved / save_failed 동적 메시지 다국어 표시 확인
- [ ] 트렌드 차트 tooltip (점수: N + ★ 현재) 다국어 동작 확인 (테마 전환 페어)

## 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 적용 영역)

⚠️ **사용자 인지 영향** (정책 3 강화 정량 기준 4번):
- score message 5 분기 (모범적/견고/양호/살펴볼/꼭 확인) = 사용자 점수 인지 영역
- breakdown 5 카테고리 (코드 품질/보안/커밋 메시지/구현 방향성/테스트) = AI 결과 라벨
- feedback button label (맞음/아님 + thumbs up/down) = 사용자 행동 영역
- repo_detail filter 16종 = 분석 이력 탐색 영역

⚠️ **데이터 모델 변경** (정책 3 강화 정량 기준 3번):
- repo_detail JS data-i18n-* 속성 패턴 (8건) — 서버 Jinja injection + JS placeholder replace 패턴
- analysis_detail data-i18n-saving/saved/save-failed (3건) — fetch error 변수 치환 패턴
- innerHTML XSS 회피 → document.createElement + textContent 사용 (renderTable empty branch)
- breakdown.* 키 재사용 — `analysis_detail.breakdown.code_quality` 등 5 키를 카테고리 피드백 레이블에도 재사용 (DRY)

자율 진입 보고:
- PR-7 응집 단위 = "분석 영역 2 템플릿" (repo_detail + analysis_detail) — 정책 7 강화 응집 단위 부합
- PR-8 (settings + admin 3) = 별도 PR — 다음 작업
- 회귀 가드 16건 = standalone Jinja env 패턴 (메모리 사이클 79/81 학습 페어)
- 기존 test_router.py 3건 정정 = i18n 적용 후 default locale 'en' or 'ko' 양호 (PR-5 같은 패턴)

## 검증 (사이클 84 sync 실측)
- 단위 = `pytest tests/unit -q` → 2288 passed (+16 회귀 가드 + +3 기존 정정)
- 통합 = `pytest tests/integration -q` → 191 passed
- 합계 = 2479 passed / 5 skipped / 0 failed (100s)

## cross-verify 결과
- 1차 5 에이전트 디스패치 = 본 사이클 미수행 (단일 응집 PR-7 — 인프라/UI 검증 완료 영역)
- 통합 fail 3건 (PR push 직전 검증) → i18n 적용 후 default locale 의존 텍스트 어서션 정정 후 0 fail
- TestClient lifespan trap 페어 = standalone Jinja env 패턴으로 16 회귀 가드 안정

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
