### PR TITLE
feat(i18n-phase3-pr9): Telegram + telegram_commands 다국어 + 3-layer 사용자…

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -534,6 +534,38 @@
   "notifier": {
     "no_issues": "No issues",
     "score_label": "Score: {score}/100",
-    "grade_label": "Grade {grade}"
+    "grade_label": "Grade {grade}",
+    "telegram": {
+      "title": "{emoji} <b>SCA Analysis Result</b>",
+      "ref_line": "📁 <code>{repo}</code> — {ref}",
+      "total": "<b>Total:</b> {total}/100  (Grade {grade})",
+      "breakdown_header": "<b>Score breakdown:</b>",
+      "breakdown_commit": "  Commit message: {value}/15",
+      "breakdown_quality": "  Code quality: {value}/25",
+      "breakdown_security": "  Security: {value}/20",
+      "breakdown_direction": "  Implementation direction: {value}/25",
+      "breakdown_test": "  Tests: {value}/15",
+      "ai_summary": "<b>AI summary:</b> {summary}",
+      "ai_suggestions_header": "<b>Suggestions:</b>",
+      "issues_header": "<b>Static analysis issues:</b> {count}",
+      "no_issues": "No issues"
+    },
+    "commands": {
+      "not_connected": "Connect your account first: /connect <code>",
+      "unknown_command": "Unknown command. Available: /stats <repo>, /settings, /connect <code>",
+      "connect_usage": "Usage: /connect <6-digit code>",
+      "connect_invalid_otp": "Invalid or expired OTP.",
+      "connect_already_linked": "This Telegram account is already linked to another user.",
+      "connect_success": "✅ Account linked for {name}!",
+      "connect_default_name": "user",
+      "stats_usage": "Usage: /stats <owner/repo>",
+      "stats_repo_not_found": "Repository not found: {repo}",
+      "stats_no_data_title": "📊 {repo}",
+      "stats_no_data_body": "No analysis data in the past 7 days.",
+      "stats_summary": "📊 {repo}\nAnalyses (7d): {count}\nAverage score: {avg}{trend}\nMin: {min} / Max: {max}",
+      "stats_trend": " (vs 7d moving avg {diff:+.1f})",
+      "settings_no_repos": "No repositories registered.",
+      "settings_header": "📋 Registered repositories:"
+    }
   }
 }

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -534,6 +534,38 @@
   "notifier": {
     "no_issues": "問題なし",
     "score_label": "スコア: {score}/100",
-    "grade_label": "グレード {grade}"
+    "grade_label": "グレード {grade}",
+    "telegram": {
+      "title": "{emoji} <b>SCA 分析結果</b>",
+      "ref_line": "📁 <code>{repo}</code> — {ref}",
+      "total": "<b>合計:</b> {total}/100  (グレード {grade})",
+      "breakdown_header": "<b>スコア詳細:</b>",
+      "breakdown_commit": "  コミットメッセージ: {value}/15",
+      "breakdown_quality": "  コード品質: {value}/25",
+      "breakdown_security": "  セキュリティ: {value}/20",
+      "breakdown_direction": "  実装方向性: {value}/25",
+      "breakdown_test": "  テスト: {value}/15",
+      "ai_summary": "<b>AI 要約:</b> {summary}",
+      "ai_suggestions_header": "<b>改善提案:</b>",
+      "issues_header": "<b>静的解析の問題:</b> {count}件",
+      "no_issues": "問題なし"
+    },
+    "commands": {
+      "not_connected": "先に /connect <コード> でアカウントを連携してください。",
+      "unknown_command": "対応していないコマンドです。利用可能: /stats <repo>, /settings, /connect <コード>",
+      "connect_usage": "使い方: /connect <6桁コード>",
+      "connect_invalid_otp": "OTP が無効または期限切れです。",
+      "connect_already_linked": "この Telegram アカウントは既に他のユーザーに連携されています。",
+      "connect_success": "✅ {name} さんのアカウントが連携されました!",
+      "connect_default_name": "ユーザー",
+      "stats_usage": "使い方: /stats <リポジトリ全体名 (owner/repo)>",
+      "stats_repo_not_found": "リポジトリが見つかりません: {repo}",
+      "stats_no_data_title": "📊 {repo}",
+      "stats_no_data_body": "最近 7 日間の分析データがありません。",
+      "stats_summary": "📊 {repo}\n最近 7 日分析: {count}件\n平均スコア: {avg}点{trend}\n最低: {min} / 最高: {max}",
+      "stats_trend": " (7日移動平均比 {diff:+.1f}点)",
+      "settings_no_repos": "登録されたリポジトリがありません。",
+      "settings_header": "📋 登録されたリポジトリ:"
+    }
   }
 }

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -534,6 +534,38 @@
   "notifier": {
     "no_issues": "이슈 없음",
     "score_label": "점수: {score}/100",
-    "grade_label": "등급 {grade}"
+    "grade_label": "등급 {grade}",
+    "telegram": {
+      "title": "{emoji} <b>SCA 분석 결과</b>",
+      "ref_line": "📁 <code>{repo}</code> — {ref}",
+      "total": "<b>총점:</b> {total}/100  (등급 {grade})",
+      "breakdown_header": "<b>점수 상세:</b>",
+      "breakdown_commit": "  커밋 메시지: {value}/15",
+      "breakdown_quality": "  코드 품질: {value}/25",
+      "breakdown_security": "  보안: {value}/20",
+      "breakdown_direction": "  구현 방향성: {value}/25",
+      "breakdown_test": "  테스트: {value}/15",
+      "ai_summary": "<b>AI 요약:</b> {summary}",
+      "ai_suggestions_header": "<b>개선 제안:</b>",
+      "issues_header": "<b>정적 분석 이슈:</b> {count}건",
+      "no_issues": "이슈 없음"
+    },
+    "commands": {
+      "not_connected": "먼저 /connect <코드>로 계정을 연결하세요.",
+      "unknown_command": "지원하지 않는 명령입니다. 사용 가능: /stats <repo>, /settings, /connect <코드>",
+      "connect_usage": "사용법: /connect <6자리 코드>",
+      "connect_invalid_otp": "OTP가 잘못되었거나 만료되었습니다.",
+      "connect_already_linked": "이 Telegram 계정은 이미 다른 사용자에게 연결되어 있습니다.",
+      "connect_success": "✅ {name} 님의 계정이 연결되었습니다!",
+      "connect_default_name": "사용자",
+      "stats_usage": "사용법: /stats <리포지토리 전체 이름 (owner/repo)>",
+      "stats_repo_not_found": "리포지토리를 찾을 수 없습니다: {repo}",
+      "stats_no_data_title": "📊 {repo}",
+      "stats_no_data_body": "최근 7일간 분석 데이터가 없습니다.",
+      "stats_summary": "📊 {repo}\n최근 7일 분석: {count}건\n평균 점수: {avg}점{trend}\n최저: {min} / 최고: {max}",
+      "stats_trend": " (7일 이동평균 대비 {diff:+.1f}점)",
+      "settings_no_repos": "등록된 리포지토리가 없습니다.",
+      "settings_header": "📋 등록된 리포지토리:"
+    }
   }
 }

--- a/src/notifier/_language.py
+++ b/src/notifier/_language.py
@@ -1,0 +1,96 @@
+"""알림 채널 사용자 언어 결정 — 3-layer fallback (Phase 3 PR-9 — 사이클 84).
+
+Notification channel user-language resolver — 3-layer fallback (Phase 3 PR-9 — Cycle 84).
+
+3-layer 우선순위 (priority order):
+1. User.preferred_language — Telegram 연결된 사용자 (`user_repo.find_by_telegram_user_id`).
+   가장 정확 (사용자 명시 선택). NULL/empty → next layer.
+   Most accurate (user-explicit choice). NULL/empty → next layer.
+
+2. RepoConfig.notification_language — repo 별 알림 언어 (Phase 3 PR-9 페어, Phase 1 PR-1c #285 도입).
+   repo 단위로 알림 언어 별도 설정 가능 (예: 한국어 사용자가 글로벌 팀 위해 영문 알림 선택).
+   Per-repo notification language (introduced in Phase 1 PR-1c).
+
+3. settings.default_locale — 환경변수 `DEFAULT_LOCALE` (default 'en').
+   Final fallback — 환경변수 + SUPPORTED_LOCALES 검증 (config.py field_validator).
+   Final fallback — env var + SUPPORTED_LOCALES validated.
+
+사용 패턴 (usage):
+    from src.notifier._language import resolve_notification_language
+    lang = resolve_notification_language(db, repo_full_name=ctx.repo_name, config=ctx.config)
+    # → "ko" / "en" / "ja"
+    msg = get_text("notifier.telegram.title", lang)
+
+DI 패턴 (dependency injection): db 와 user_repo 는 Optional — 단위 테스트 시 mock 가능.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from sqlalchemy.orm import Session
+
+from src.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_notification_language(
+    db: Optional[Session] = None,
+    *,
+    repo_full_name: Optional[str] = None,
+    config: Any = None,
+    telegram_user_id: Optional[str] = None,
+) -> str:
+    """알림 채널 사용자 언어 결정 — 3-layer fallback.
+
+    Resolve notification channel user language via 3-layer fallback.
+
+    Args:
+        db: SQLAlchemy 세션 — User 조회 시 의무. None 시 layer 1 skip.
+        repo_full_name: 리포 full name (현재 unused — Layer 2 는 config 인자 직접 사용).
+        config: RepoConfigData (notification_language 필드 보유). None 시 layer 2 skip.
+        telegram_user_id: Telegram 사용자 ID — User.preferred_language 조회 키.
+            None 시 layer 1 skip (Telegram 미연결 사용자 — Discord/Slack/Email 등).
+
+    Returns:
+        언어 코드 (예: 'ko', 'en', 'ja'). SUPPORTED_LOCALES 영역 내.
+        Language code (e.g. 'ko', 'en', 'ja'). Within SUPPORTED_LOCALES.
+
+    Examples:
+        >>> # Telegram 연결 사용자 (Layer 1)
+        >>> resolve_notification_language(db, telegram_user_id="123456789")
+        "ko"
+
+        >>> # repo 별 강제 (Layer 2 — Telegram 미연결 영역)
+        >>> resolve_notification_language(config=RepoConfigData(notification_language="ja"))
+        "ja"
+
+        >>> # default fallback (Layer 3)
+        >>> resolve_notification_language()
+        "en"  # settings.default_locale
+    """
+    # Layer 1: User.preferred_language (Telegram 연결 사용자)
+    # Layer 1: User.preferred_language (Telegram-linked user)
+    if db is not None and telegram_user_id:
+        try:
+            from src.repositories import user_repo  # noqa: WPS433  (지연 import — circular 회피)
+            user = user_repo.find_by_telegram_user_id(db, telegram_user_id)
+            if user and user.preferred_language:
+                return user.preferred_language
+        except Exception as exc:  # noqa: BLE001 — graceful fallback (운영 보호)
+            logger.warning(
+                "Layer 1 (User.preferred_language) lookup failed: %s — fall through to Layer 2",
+                exc,
+            )
+
+    # Layer 2: RepoConfig.notification_language (repo 단위 강제)
+    # Layer 2: RepoConfig.notification_language (per-repo override)
+    if config is not None:
+        repo_lang = getattr(config, "notification_language", None)
+        if repo_lang:
+            return repo_lang
+
+    # Layer 3: settings.default_locale (env 기반 fallback)
+    # Layer 3: settings.default_locale (env-based fallback)
+    return settings.default_locale

--- a/src/notifier/telegram.py
+++ b/src/notifier/telegram.py
@@ -4,6 +4,7 @@ import logging
 from html import escape
 
 from src.constants import GRADE_EMOJI, TELEGRAM_MAX_MESSAGE_LENGTH, NOTIFIER_MAX_ISSUES_SHORT
+from src.i18n.loader import get_text
 from src.shared.http_client import get_http_client
 from src.scorer.calculator import ScoreResult
 from src.analyzer.io.static import StaticAnalysisResult
@@ -104,7 +105,15 @@ def _build_message(  # pylint: disable=too-many-positional-arguments
     analysis_results: list[StaticAnalysisResult],
     pr_number: int | None,
     ai_review: AiReviewResult | None = None,
+    language: str = "en",
 ) -> str:
+    """분석 결과를 Telegram HTML 메시지로 빌드 (Phase 3 PR-9 — 사이클 84 i18n).
+
+    Build Telegram HTML message for analysis result (Phase 3 PR-9 — Cycle 84 i18n).
+
+    Args:
+        language: 사용자 언어 ('ko'/'en'/'ja'). 3-layer fallback (resolve_notification_language).
+    """
     ref = format_ref(commit_sha, pr_number)
     all_issues = get_all_issues(analysis_results)
     top_issues = [
@@ -113,35 +122,43 @@ def _build_message(  # pylint: disable=too-many-positional-arguments
     ]
 
     grade_emoji = GRADE_EMOJI.get(score_result.grade, "⚪")  # type: ignore[union-attr]
-    issues_text = "\n".join(top_issues) if top_issues else "이슈 없음"
+    no_issues_text = get_text("notifier.telegram.no_issues", language)
+    issues_text = "\n".join(top_issues) if top_issues else no_issues_text
     bd = score_result.breakdown
 
     lines = [
-        f"{grade_emoji} <b>SCA 분석 결과</b>",
-        f"📁 <code>{escape(repo_name)}</code> — {escape(ref)}",
+        get_text("notifier.telegram.title", language, emoji=grade_emoji),
+        get_text("notifier.telegram.ref_line", language, repo=escape(repo_name), ref=escape(ref)),
         "",
-        f"<b>총점:</b> {score_result.total}/100  (등급 {score_result.grade})",
+        get_text(
+            "notifier.telegram.total", language,
+            total=score_result.total, grade=score_result.grade,
+        ),
         "",
-        "<b>점수 상세:</b>",
-        f"  커밋 메시지: {bd.get('commit_message', '-')}/15",
-        f"  코드 품질: {bd.get('code_quality', '-')}/25",
-        f"  보안: {bd.get('security', '-')}/20",
-        f"  구현 방향성: {bd.get('ai_review', '-')}/25",
-        f"  테스트: {bd.get('test_coverage', '-')}/15",
+        get_text("notifier.telegram.breakdown_header", language),
+        get_text("notifier.telegram.breakdown_commit", language, value=bd.get("commit_message", "-")),
+        get_text("notifier.telegram.breakdown_quality", language, value=bd.get("code_quality", "-")),
+        get_text("notifier.telegram.breakdown_security", language, value=bd.get("security", "-")),
+        get_text("notifier.telegram.breakdown_direction", language, value=bd.get("ai_review", "-")),
+        get_text("notifier.telegram.breakdown_test", language, value=bd.get("test_coverage", "-")),
     ]
 
     if ai_review and ai_review.summary:
-        lines += ["", f"<b>AI 요약:</b> {escape(ai_review.summary)}"]
+        lines += ["", get_text(
+            "notifier.telegram.ai_summary", language, summary=escape(ai_review.summary),
+        )]
 
     if ai_review and ai_review.suggestions:
-        lines += ["", "<b>개선 제안:</b>"]
+        lines += ["", get_text("notifier.telegram.ai_suggestions_header", language)]
         for s in ai_review.suggestions:
             lines.append(f"- {escape(s)}")
 
     if top_issues:
         lines += [
             "",
-            f"<b>정적 분석 이슈:</b> {len(all_issues)}건",
+            get_text(
+                "notifier.telegram.issues_header", language, count=len(all_issues),
+            ),
             issues_text,
         ]
 
@@ -158,9 +175,16 @@ async def send_analysis_result(
     analysis_results: list[StaticAnalysisResult],
     pr_number: int | None = None,
     ai_review: AiReviewResult | None = None,
+    language: str = "en",
 ) -> None:
-    """분석 결과를 Telegram HTML 메시지로 전송한다."""
-    text = _build_message(repo_name, commit_sha, score_result, analysis_results, pr_number, ai_review=ai_review)
+    """분석 결과를 Telegram HTML 메시지로 전송한다 (Phase 3 PR-9 — i18n).
+
+    Send analysis result via Telegram HTML message (Phase 3 PR-9 — i18n).
+    """
+    text = _build_message(
+        repo_name, commit_sha, score_result, analysis_results, pr_number,
+        ai_review=ai_review, language=language,
+    )
     await telegram_post_message(bot_token, chat_id, {"text": text, "parse_mode": "HTML"})
 
 
@@ -181,8 +205,17 @@ class _TelegramNotifier:
         return True
 
     async def send(self, ctx: NotifyContext) -> None:
-        """알림을 전송한다."""
+        """알림을 전송한다 (Phase 3 PR-9 — 사이클 84 i18n 3-layer fallback).
+
+        Send notification (Phase 3 PR-9 — Cycle 84 i18n 3-layer fallback).
+        """
         chat_id = (ctx.config.notify_chat_id if ctx.config else None) or settings.telegram_chat_id
+        # Phase 3 PR-9 — 3-layer 사용자 언어 결정 (User → RepoConfig → settings.default_locale)
+        # Phase 3 PR-9 — 3-layer language resolve (User → RepoConfig → settings.default_locale)
+        from src.database import SessionLocal  # noqa: WPS433  (지연 import)
+        from src.notifier._language import resolve_notification_language  # noqa: WPS433
+        with SessionLocal() as db:
+            language = resolve_notification_language(db, config=ctx.config)
         await send_analysis_result(
             bot_token=settings.telegram_bot_token,
             chat_id=chat_id,
@@ -192,6 +225,7 @@ class _TelegramNotifier:
             analysis_results=ctx.analysis_results,
             pr_number=ctx.pr_number,
             ai_review=ctx.ai_review,
+            language=language,
         )
 
 

--- a/src/notifier/telegram_commands.py
+++ b/src/notifier/telegram_commands.py
@@ -5,6 +5,11 @@ Telegram bot text-command and cmd: callback handlers.
 Layer dependency rule: only import from repositories/*, models/*, services/analytics_service, config.py.
 api/, ui/, webhook/ import 금지.
 Do NOT import from api/, ui/, webhook/.
+
+Phase 3 PR-9 (사이클 84 — 다국어 i18n) — `/connect` 시점은 사용자 미연결 = 환경 default locale,
+`/stats /settings` 시점은 연결 사용자 = User.preferred_language 적용 (3-layer fallback).
+Phase 3 PR-9 (Cycle 84 — i18n) — `/connect` uses settings default (user not yet linked),
+`/stats /settings` use User.preferred_language via 3-layer fallback.
 """
 from __future__ import annotations
 
@@ -16,18 +21,20 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from src.config import settings
+from src.i18n.loader import get_text
 from src.models.repository import Repository
 from src.repositories import repository_repo, user_repo
 from src.services.analytics_service import moving_average, weekly_summary
 
 logger = logging.getLogger(__name__)
 
-# 미연결 사용자 공통 안내 메시지
-# Common prompt message for disconnected users
-_NOT_CONNECTED_MSG = (
-    "먼저 /connect <코드>로 계정을 연결하세요.\n"
-    "Connect your account first: /connect <code>"
-)
+
+# Phase 3 PR-9 (사이클 84) — 미연결 사용자 공통 안내 메시지 (settings.default_locale 적용).
+# Phase 3 PR-9 (Cycle 84) — common prompt for disconnected users (settings.default_locale).
+# 백워드 호환 — 기존 단위 테스트 (`test_telegram_commands.py`) `_NOT_CONNECTED_MSG` 직접 비교 영역.
+# Backwards-compat — preserved for legacy tests doing direct equality comparisons.
+_NOT_CONNECTED_MSG = get_text("notifier.commands.not_connected", settings.default_locale)
 
 
 @dataclass(frozen=True)
@@ -87,9 +94,24 @@ def parse_cmd_callback(data: str) -> CmdCallback | None:
     return None
 
 
+def _resolve_user_language(user: Any | None) -> str:
+    """연결된 User 의 preferred_language → settings.default_locale fallback.
+
+    Resolve linked user's preferred_language → settings.default_locale fallback.
+
+    Phase 3 PR-9 — User.preferred_language NOT NULL default 'en' (alembic 0030).
+    """
+    if user is not None and getattr(user, "preferred_language", None):
+        return user.preferred_language
+    return settings.default_locale
+
+
 def handle_message_command(db: Session, telegram_user_id: str, text: str) -> str:
     """Telegram 텍스트 명령을 처리하고 응답 텍스트를 반환한다.
     Handle a Telegram text command and return the reply text.
+
+    Phase 3 PR-9 (사이클 84) — i18n: User.preferred_language → 응답 언어 결정.
+    Phase 3 PR-9 (Cycle 84) — i18n: User.preferred_language drives reply language.
 
     Args:
         db: SQLAlchemy 세션 / SQLAlchemy session
@@ -112,27 +134,31 @@ def handle_message_command(db: Session, telegram_user_id: str, text: str) -> str
     # All other commands require a linked user
     user = user_repo.find_by_telegram_user_id(db, telegram_user_id)
     if user is None:
-        return _NOT_CONNECTED_MSG
+        # 미연결 사용자 응답 = settings.default_locale (User row 없음)
+        # Unlinked user reply = settings.default_locale (no User row)
+        return get_text("notifier.commands.not_connected", settings.default_locale)
+
+    lang = _resolve_user_language(user)
 
     if text.startswith("/stats"):
         parts = text.split(maxsplit=1)
         repo_name = parts[1].strip() if len(parts) > 1 else ""
-        return _handle_stats(db, user, repo_name)
+        return _handle_stats(db, user, repo_name, lang)
 
     if text.startswith("/settings"):
-        return _handle_settings(db, user)
+        return _handle_settings(db, user, lang)
 
     # 알 수 없는 명령 — 도움말 반환
     # Unknown command — return help
-    return (
-        "지원하지 않는 명령입니다. 사용 가능: /stats <repo>, /settings, /connect <코드>\n"
-        "Unknown command. Available: /stats <repo>, /settings, /connect <code>"
-    )
+    return get_text("notifier.commands.unknown_command", lang)
 
 
 def _handle_connect(db: Session, telegram_user_id: str, otp: str) -> str:
     """OTP를 검증해 계정을 연결한다.
     Validate OTP and link the Telegram account.
+
+    Phase 3 PR-9 — 연결 시점 = 미연결 사용자 → settings.default_locale 응답.
+    Phase 3 PR-9 — at connect time, user is not yet linked → settings.default_locale.
 
     Args:
         db: SQLAlchemy 세션 / SQLAlchemy session
@@ -142,16 +168,18 @@ def _handle_connect(db: Session, telegram_user_id: str, otp: str) -> str:
     Returns:
         성공 또는 실패 메시지 / Success or failure message
     """
+    default_lang = settings.default_locale
+
     # OTP 인수 미입력 시 사용법 안내
     # Show usage if OTP argument is missing
     if not otp:
-        return "사용법: /connect <6자리 코드>\nUsage: /connect <6-digit code>"
+        return get_text("notifier.commands.connect_usage", default_lang)
 
     # 만료되지 않은 OTP로 사용자 조회
     # Look up user by unexpired OTP
     found = user_repo.find_by_otp(db, otp)
     if found is None:
-        return "OTP가 잘못되었거나 만료되었습니다.\nInvalid or expired OTP."
+        return get_text("notifier.commands.connect_invalid_otp", default_lang)
 
     try:
         # telegram_user_id 매핑 + OTP 무효화
@@ -160,16 +188,17 @@ def _handle_connect(db: Session, telegram_user_id: str, otp: str) -> str:
     except ValueError:
         # 이미 다른 사용자에게 연결된 Telegram ID
         # Telegram ID already linked to another user
-        return (
-            "이 Telegram 계정은 이미 다른 사용자에게 연결되어 있습니다.\n"
-            "This Telegram account is already linked to another user."
-        )
+        return get_text("notifier.commands.connect_already_linked", default_lang)
 
-    name = found.display_name or found.github_login or "사용자"
-    return f"✅ {name} 님의 계정이 연결되었습니다!\n✅ Account linked for {name}!"
+    # 연결 성공 응답 = 연결된 User 의 preferred_language 적용 (즉시 다국어 활성화)
+    # Connect success = linked User.preferred_language (immediate i18n activation)
+    user_lang = _resolve_user_language(found)
+    default_name = get_text("notifier.commands.connect_default_name", user_lang)
+    name = found.display_name or found.github_login or default_name
+    return get_text("notifier.commands.connect_success", user_lang, name=name)
 
 
-def _handle_stats(db: Session, user: Any, repo_name: str) -> str:
+def _handle_stats(db: Session, user: Any, repo_name: str, language: str) -> str:
     """리포지토리 주간 통계를 반환한다.
     Return weekly stats for a repository.
 
@@ -177,23 +206,18 @@ def _handle_stats(db: Session, user: Any, repo_name: str) -> str:
         db: SQLAlchemy 세션 / SQLAlchemy session
         user: 인증된 User ORM 인스턴스 / Authenticated User ORM instance
         repo_name: 조회할 리포 전체 이름 (owner/repo) / Target repo full name
+        language: 사용자 언어 (3-layer fallback) / User language
     """
     # 리포 인수 미입력 시 사용법 안내
     # Show usage if repo argument is missing
     if not repo_name:
-        return (
-            "사용법: /stats <리포지토리 전체 이름 (owner/repo)>\n"
-            "Usage: /stats <owner/repo>"
-        )
+        return get_text("notifier.commands.stats_usage", language)
 
     # 리포 존재 여부 및 소유권 확인
     # Verify repo existence and ownership
     repo = repository_repo.find_by_full_name(db, repo_name)
     if repo is None or repo.user_id != user.id:
-        return (
-            f"리포지토리를 찾을 수 없습니다: {repo_name}\n"
-            f"Repository not found: {repo_name}"
-        )
+        return get_text("notifier.commands.stats_repo_not_found", language, repo=repo_name)
 
     # 주간 집계 — 현재 시각 기준 7일 전부터
     # Weekly summary — from 7 days before current time
@@ -202,11 +226,9 @@ def _handle_stats(db: Session, user: Any, repo_name: str) -> str:
     summary = weekly_summary(db, repo.id, week_start, now=now)
 
     if summary is None:
-        return (
-            f"📊 {repo_name}\n"
-            f"최근 7일간 분석 데이터가 없습니다.\n"
-            f"No analysis data in the past 7 days."
-        )
+        title = get_text("notifier.commands.stats_no_data_title", language, repo=repo_name)
+        body = get_text("notifier.commands.stats_no_data_body", language)
+        return f"{title}\n{body}"
 
     avg = summary["avg_score"]
     count = summary["count"]
@@ -217,24 +239,30 @@ def _handle_stats(db: Session, user: Any, repo_name: str) -> str:
     trend = ""
     if avg_ma is not None:
         diff = round(avg - avg_ma, 1)
-        trend = f" (7일 이동평균 대비 {diff:+.1f}점 / vs 7d avg {diff:+.1f})"
+        # `{diff:+.1f}` 형식 보존 — translation key 안 placeholder 매핑 의무
+        # Preserve `{diff:+.1f}` format — map via i18n placeholder
+        trend = get_text("notifier.commands.stats_trend", language, diff=diff)
 
-    return (
-        f"📊 {repo_name}\n"
-        f"최근 7일 분석: {count}건\n"
-        f"평균 점수: {avg:.1f}점{trend}\n"
-        f"최저: {summary['min_score']} / 최고: {summary['max_score']}\n"
-        f"Analyses (7d): {count} | Avg: {avg:.1f}{trend}"
+    return get_text(
+        "notifier.commands.stats_summary",
+        language,
+        repo=repo_name,
+        count=count,
+        avg=f"{avg:.1f}",
+        trend=trend,
+        min=summary["min_score"],
+        max=summary["max_score"],
     )
 
 
-def _handle_settings(db: Session, user: Any) -> str:
+def _handle_settings(db: Session, user: Any, language: str) -> str:
     """사용자의 등록 리포지토리 목록을 반환한다.
     Return the user's registered repository list.
 
     Args:
         db: SQLAlchemy 세션 / SQLAlchemy session
         user: 인증된 User ORM 인스턴스 / Authenticated User ORM instance
+        language: 사용자 언어 (3-layer fallback) / User language
     """
     # 사용자 소유 리포를 이름순 정렬로 조회
     # Fetch user-owned repos sorted alphabetically
@@ -245,9 +273,9 @@ def _handle_settings(db: Session, user: Any) -> str:
     ).all()
 
     if not repos:
-        return "등록된 리포지토리가 없습니다.\nNo repositories registered."
+        return get_text("notifier.commands.settings_no_repos", language)
 
-    lines = ["📋 등록된 리포지토리 / Registered repositories:"]
+    lines = [get_text("notifier.commands.settings_header", language)]
     for repo in repos:
         lines.append(f"  • {repo.full_name}")
     return "\n".join(lines)

--- a/tests/unit/notifier/test_notifier_telegram.py
+++ b/tests/unit/notifier/test_notifier_telegram.py
@@ -87,10 +87,14 @@ def test_build_message_uses_html_formatting():
 
 
 def test_build_message_includes_score_breakdown():
+    """Phase 3 PR-9 (사이클 84) — i18n 적용 후 default locale 'en' 또는 'ko' 양호.
+
+    Phase 3 PR-9 (Cycle 84) — after i18n, accept either default locale en or ko.
+    """
     msg = _build_message("owner/repo", "abc1234", _make_score(), _make_analysis(), None)
-    assert "코드 품질" in msg
-    assert "보안" in msg
-    assert "커밋" in msg
+    assert "Code quality" in msg or "코드 품질" in msg or "コード品質" in msg
+    assert "Security" in msg or "보안" in msg or "セキュリティ" in msg
+    assert "Commit" in msg or "커밋" in msg or "コミット" in msg
 
 
 @pytest.mark.asyncio

--- a/tests/unit/notifier/test_telegram_i18n.py
+++ b/tests/unit/notifier/test_telegram_i18n.py
@@ -1,0 +1,367 @@
+"""Phase 3 PR-9 회귀 가드 — Telegram + telegram_commands 다국어 + 3-layer fallback.
+
+Phase 3 PR-9 regression guards — Telegram + telegram_commands i18n + 3-layer fallback.
+
+검증 범위 (Coverage):
+1. resolve_notification_language — 3-layer 우선순위 (User → RepoConfig → settings.default_locale)
+2. _build_message — en/ko/ja 3 언어 분기 (title / breakdown / AI summary / issues / no_issues)
+3. handle_message_command — User.preferred_language 기반 응답 언어 결정
+4. _handle_connect — 미연결 사용자 = settings.default_locale, 성공 시 user lang
+5. _handle_stats / _handle_settings — language 인자 기반 응답
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.notifier._language import resolve_notification_language
+from src.notifier.telegram import _build_message
+from src.notifier.telegram_commands import (
+    _handle_settings,
+    _handle_stats,
+    _resolve_user_language,
+    handle_message_command,
+)
+
+
+# ── ScoreResult / AiReviewResult fixtures ────────────────────────────────────
+
+
+def _score_result(grade: str = "B", total: int = 80):
+    """Lightweight ScoreResult-like mock."""
+    return MagicMock(
+        total=total,
+        grade=grade,
+        breakdown={
+            "code_quality": 22,
+            "security": 18,
+            "commit_message": 13,
+            "ai_review": 22,
+            "test_coverage": 12,
+        },
+    )
+
+
+def _ai_review(summary: str = "Good code.", suggestions=None):
+    return MagicMock(summary=summary, suggestions=suggestions or [])
+
+
+# ── resolve_notification_language ───────────────────────────────────────────
+
+
+def test_resolve_language_layer1_user_preferred(monkeypatch):
+    """Layer 1 — User.preferred_language 우선."""
+    db = MagicMock()
+    user = MagicMock(preferred_language="ja")
+
+    monkeypatch.setattr(
+        "src.repositories.user_repo.find_by_telegram_user_id",
+        lambda db, tid: user,
+    )
+
+    result = resolve_notification_language(db, telegram_user_id="123")
+    assert result == "ja"
+
+
+def test_resolve_language_layer1_user_no_preferred_falls_through(monkeypatch):
+    """Layer 1 — preferred_language 빈 값 → Layer 2 fallthrough."""
+    db = MagicMock()
+    user = MagicMock(preferred_language="")
+    config = MagicMock(notification_language="ko")
+
+    monkeypatch.setattr(
+        "src.repositories.user_repo.find_by_telegram_user_id",
+        lambda db, tid: user,
+    )
+
+    result = resolve_notification_language(db, telegram_user_id="123", config=config)
+    assert result == "ko"
+
+
+def test_resolve_language_layer2_repo_config():
+    """Layer 2 — RepoConfig.notification_language (Telegram 미연결 영역)."""
+    config = MagicMock(notification_language="ja")
+    result = resolve_notification_language(config=config)
+    assert result == "ja"
+
+
+def test_resolve_language_layer3_default_locale():
+    """Layer 3 — settings.default_locale fallback (모든 layer 부재)."""
+    result = resolve_notification_language()
+    # default_locale = 'en' (config.py default)
+    assert result in ("en", "ko", "ja")
+
+
+def test_resolve_language_layer1_exception_falls_through(monkeypatch):
+    """Layer 1 raise 시 Layer 2 fallthrough (graceful degradation)."""
+    db = MagicMock()
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("DB connection lost")
+
+    monkeypatch.setattr(
+        "src.repositories.user_repo.find_by_telegram_user_id",
+        _raise,
+    )
+    config = MagicMock(notification_language="ja")
+    result = resolve_notification_language(db, telegram_user_id="123", config=config)
+    assert result == "ja"  # Layer 2 fallthrough
+
+
+# ── _build_message — 3 languages ────────────────────────────────────────────
+
+
+def test_build_message_korean():
+    """Telegram message — 한국어."""
+    out = _build_message(
+        repo_name="owner/repo",
+        commit_sha="abc1234",
+        score_result=_score_result(),
+        analysis_results=[],
+        pr_number=42,
+        ai_review=_ai_review(suggestions=["Improve tests"]),
+        language="ko",
+    )
+    assert "<b>SCA 분석 결과</b>" in out
+    assert "<b>총점:</b> 80/100" in out
+    assert "등급 B" in out
+    assert "<b>점수 상세:</b>" in out
+    assert "  커밋 메시지: 13/15" in out
+    assert "  코드 품질: 22/25" in out
+    assert "  보안: 18/20" in out
+    assert "<b>AI 요약:</b>" in out
+    assert "<b>개선 제안:</b>" in out
+
+
+def test_build_message_english():
+    """Telegram message — 영문."""
+    out = _build_message(
+        repo_name="owner/repo",
+        commit_sha="abc1234",
+        score_result=_score_result(grade="A", total=92),
+        analysis_results=[],
+        pr_number=None,
+        ai_review=None,
+        language="en",
+    )
+    assert "<b>SCA Analysis Result</b>" in out
+    assert "<b>Total:</b> 92/100" in out
+    assert "(Grade A)" in out
+    assert "<b>Score breakdown:</b>" in out
+    assert "  Commit message: 13/15" in out
+    assert "  Code quality: 22/25" in out
+    assert "  Security: 18/20" in out
+
+
+def test_build_message_japanese():
+    """Telegram message — 일본어."""
+    out = _build_message(
+        repo_name="owner/repo",
+        commit_sha="abc1234",
+        score_result=_score_result(),
+        analysis_results=[],
+        pr_number=42,
+        ai_review=_ai_review(),
+        language="ja",
+    )
+    assert "<b>SCA 分析結果</b>" in out
+    assert "<b>合計:</b> 80/100" in out
+    assert "(グレード B)" in out
+    assert "<b>スコア詳細:</b>" in out
+    assert "  コミットメッセージ: 13/15" in out
+    assert "<b>AI 要約:</b>" in out
+
+
+def test_build_message_no_ai_no_issues_korean():
+    """ai_review None + no issues → 한국어."""
+    out = _build_message(
+        repo_name="owner/repo",
+        commit_sha="abc1234",
+        score_result=_score_result(),
+        analysis_results=[],
+        pr_number=None,
+        ai_review=None,
+        language="ko",
+    )
+    assert "AI 요약" not in out  # ai_review is None
+    assert "개선 제안" not in out
+    assert "정적 분석 이슈" not in out
+
+
+def test_build_message_default_language_falls_to_en():
+    """language 인자 default = 'en' → 영문 응답."""
+    out = _build_message(
+        repo_name="owner/repo",
+        commit_sha="abc1234",
+        score_result=_score_result(),
+        analysis_results=[],
+        pr_number=None,
+    )
+    assert "SCA Analysis Result" in out
+
+
+# ── telegram_commands ──────────────────────────────────────────────────────
+
+
+def test_resolve_user_language_with_user():
+    """_resolve_user_language — User 있으면 preferred_language 반환."""
+    user = MagicMock(preferred_language="ja")
+    assert _resolve_user_language(user) == "ja"
+
+
+def test_resolve_user_language_user_none():
+    """_resolve_user_language — User None → settings.default_locale."""
+    result = _resolve_user_language(None)
+    assert result in ("en", "ko", "ja")
+
+
+def test_handle_message_unlinked_user_returns_default_locale_message(monkeypatch):
+    """미연결 사용자 → not_connected 메시지 (settings.default_locale)."""
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.user_repo.find_by_telegram_user_id",
+        lambda db, tid: None,
+    )
+    db = MagicMock()
+    out = handle_message_command(db, "tg_user_123", "/stats owner/repo")
+    # default_locale = 'en' or 'ko' or 'ja' — multilingual default
+    assert ("Connect your account first" in out) or ("계정을 연결" in out) or ("連携してください" in out)
+
+
+def test_handle_message_unknown_command_uses_user_language(monkeypatch):
+    """연결된 사용자 — 알 수 없는 명령 시 User.preferred_language 기반 응답."""
+    user = MagicMock(preferred_language="ja", display_name="Tanaka")
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.user_repo.find_by_telegram_user_id",
+        lambda db, tid: user,
+    )
+    db = MagicMock()
+    out = handle_message_command(db, "tg_user_123", "/unknown_cmd")
+    assert "対応していないコマンド" in out
+
+
+def test_handle_stats_no_repo_uses_language():
+    """_handle_stats — repo 미입력 시 사용법 안내 (한국어)."""
+    db = MagicMock()
+    user = MagicMock(id=1)
+    out = _handle_stats(db, user, repo_name="", language="ko")
+    assert "사용법: /stats" in out
+
+
+def test_handle_stats_repo_not_found_japanese(monkeypatch):
+    """_handle_stats — 리포 미존재 시 일본어 응답."""
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.repository_repo.find_by_full_name",
+        lambda db, name: None,
+    )
+    db = MagicMock()
+    user = MagicMock(id=1)
+    out = _handle_stats(db, user, repo_name="missing/repo", language="ja")
+    assert "リポジトリが見つかりません" in out
+    assert "missing/repo" in out
+
+
+def test_handle_stats_no_data_korean(monkeypatch):
+    """_handle_stats — 7일 데이터 부재 시 한국어 응답."""
+    repo = MagicMock(id=10, user_id=1)
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.repository_repo.find_by_full_name",
+        lambda db, name: repo,
+    )
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.weekly_summary",
+        lambda db, repo_id, week_start, now: None,
+    )
+    db = MagicMock()
+    user = MagicMock(id=1)
+    out = _handle_stats(db, user, repo_name="owner/repo", language="ko")
+    assert "최근 7일간 분석 데이터가 없습니다" in out
+
+
+def test_handle_stats_summary_english(monkeypatch):
+    """_handle_stats — summary 영문 + trend."""
+    repo = MagicMock(id=10, user_id=1)
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.repository_repo.find_by_full_name",
+        lambda db, name: repo,
+    )
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.weekly_summary",
+        lambda db, repo_id, week_start, now: {
+            "avg_score": 80.5, "count": 5, "min_score": 65, "max_score": 92,
+        },
+    )
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.moving_average",
+        lambda db, repo_id, now: 75.0,
+    )
+    db = MagicMock()
+    user = MagicMock(id=1)
+    out = _handle_stats(db, user, repo_name="owner/repo", language="en")
+    assert "Analyses (7d): 5" in out
+    assert "Average score: 80.5" in out
+    assert "vs 7d moving avg" in out
+
+
+def test_handle_settings_no_repos_korean():
+    """_handle_settings — 리포 0개 시 한국어 응답."""
+    db = MagicMock()
+    db.scalars.return_value.all.return_value = []
+    user = MagicMock(id=1)
+    out = _handle_settings(db, user, language="ko")
+    assert "등록된 리포지토리가 없습니다" in out
+
+
+def test_handle_settings_with_repos_japanese():
+    """_handle_settings — 리포 N개 시 일본어 헤더 + 리스트."""
+    db = MagicMock()
+    repo1 = MagicMock(full_name="owner/repo1")
+    repo2 = MagicMock(full_name="owner/repo2")
+    db.scalars.return_value.all.return_value = [repo1, repo2]
+    user = MagicMock(id=1)
+    out = _handle_settings(db, user, language="ja")
+    assert "登録されたリポジトリ" in out
+    assert "owner/repo1" in out
+    assert "owner/repo2" in out
+
+
+def test_handle_connect_no_otp_default_locale(monkeypatch):
+    """_handle_connect — OTP 빈 값 시 default_locale 사용법."""
+    from src.notifier.telegram_commands import _handle_connect
+    db = MagicMock()
+    out = _handle_connect(db, "tg_user_123", "")
+    # default_locale = 'en' or 'ko' or 'ja'
+    assert ("Usage:" in out) or ("사용법:" in out) or ("使い方:" in out)
+
+
+def test_handle_connect_invalid_otp(monkeypatch):
+    """_handle_connect — OTP 잘못/만료 시 default_locale 응답."""
+    from src.notifier.telegram_commands import _handle_connect
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.user_repo.find_by_otp",
+        lambda db, otp: None,
+    )
+    db = MagicMock()
+    out = _handle_connect(db, "tg_user_123", "123456")
+    assert ("Invalid or expired OTP" in out) or ("OTP가 잘못" in out) or ("OTP が無効" in out)
+
+
+def test_handle_connect_success_uses_user_language(monkeypatch):
+    """_handle_connect — 성공 시 연결 User.preferred_language 사용 (즉시 다국어 활성화)."""
+    from src.notifier.telegram_commands import _handle_connect
+    user = MagicMock(
+        id=42, preferred_language="ja",
+        display_name="Tanaka", github_login="tanaka",
+    )
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.user_repo.find_by_otp",
+        lambda db, otp: user,
+    )
+    monkeypatch.setattr(
+        "src.notifier.telegram_commands.user_repo.set_telegram_user_id",
+        lambda db, user_id, tid: None,
+    )
+    db = MagicMock()
+    out = _handle_connect(db, "tg_user_123", "123456")
+    assert "Tanaka さんのアカウントが連携されました" in out


### PR DESCRIPTION
… 언어 fallback (Phase 3 PR-9)

## Summary
Phase 3 PR-9 — Telegram notifier (분석 결과 메시지 + /stats /settings /connect 명령) 다국어 적용. 사용자 언어 결정 3-layer fallback 헬퍼 신설 (User.preferred_language → RepoConfig.notification_language → settings.default_locale). notifier.* namespace 확장 (3 언어 = ~96 영역). 단위 +23 회귀 가드 (2505→2528).

## Changes (8 files)

### 1. 사용자 언어 결정 3-layer fallback 헬퍼 (src/notifier/_language.py — 신설)
- `resolve_notification_language(db, *, repo_full_name, config, telegram_user_id)` 단일 entry point
- Layer 1: User.preferred_language (Telegram-linked user — `user_repo.find_by_telegram_user_id`)
- Layer 2: RepoConfig.notification_language (per-repo override — Phase 1 PR-1c #285 페어)
- Layer 3: settings.default_locale (env-based final fallback)
- Layer 1 graceful degradation — exception 시 Layer 2 fallthrough (운영 보호)
- 지연 import 패턴 (circular 회피)

### 2. src/notifier/telegram.py — i18n 적용
- `_build_message(..., language='en')` 인자 추가 — i18n 키 경유 (notifier.telegram.*)
- title / ref_line / total / breakdown_header / breakdown_commit/quality/security/direction/test
- ai_summary / ai_suggestions_header / issues_header / no_issues
- `send_analysis_result(..., language='en')` 인자 추가
- `_TelegramNotifier.send` — `resolve_notification_language(db, config=ctx.config)` 호출 (Layer 2 + 3, NotifyContext 에 telegram_user_id 부재 — Layer 1 skip)

### 3. src/notifier/telegram_commands.py — i18n 적용
- `_resolve_user_language(user)` 헬퍼 — User.preferred_language → settings.default_locale fallback
- `handle_message_command` — User.preferred_language 기반 응답 언어 결정 (User row 부재 시 settings.default_locale)
- `_handle_connect` — 미연결 사용자 = settings.default_locale, 성공 시 연결 User.preferred_language (즉시 다국어 활성화)
- `_handle_stats(..., language)` / `_handle_settings(..., language)` — 인자 기반 응답
- `_NOT_CONNECTED_MSG` 백워드 호환 보존 (i18n 결과 — 기존 단위 테스트 직접 비교 영역)

### 4. 번역 파일 확장 (en/ko/ja.json — 동일 키 매트릭스)
- notifier.telegram.* 14 키 (title / ref_line / total / breakdown 6 / ai_summary / ai_suggestions / issues / no_issues)
- notifier.commands.* 18 키 (not_connected / unknown_command / connect 5 / stats 6 / settings 2)
- 합계 신설 32 키 × 3 언어 = 96 영역

### 5. 회귀 가드 23건 (tests/unit/notifier/test_telegram_i18n.py — 신설)
- resolve_notification_language × 5 (Layer 1 user / no_preferred fallthrough / Layer 2 / Layer 3 default / exception fallthrough)
- _build_message × 5 (en/ko/ja + no_ai_no_issues + default language fallback)
- _resolve_user_language × 2 (with user / None)
- handle_message_command × 2 (unlinked default_locale / unknown command user_lang)
- _handle_stats × 4 (no_repo / not_found ja / no_data ko / summary en + trend)
- _handle_settings × 2 (no_repos ko / with_repos ja)
- _handle_connect × 3 (no_otp default / invalid_otp / success uses user_language)

### 6. 기존 테스트 정정 (test_notifier_telegram.py)
- test_build_message_includes_score_breakdown: i18n 적용 후 en/ko/ja 양호 (영문 default — Code quality / Security / Commit)

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 분석 트리거 (PR open) → Telegram 메시지 다국어 표시 확인 (RepoConfig.notification_language 미설정 시 default_locale = 'en')
- [ ] /settings 페이지에서 RepoConfig.notification_language 설정 후 Telegram 메시지 다국어 적용 확인 (Phase 1 PR-1c 페어)
- [ ] User.preferred_language 변경 (헤더 dropdown) 후 /stats /settings /unknown 명령 응답 다국어 즉시 반영 확인
- [ ] /connect 미연결 상태 → /stats 호출 시 default_locale 응답 (영문) 확인
- [ ] /connect 성공 후 다음 명령 → User.preferred_language 응답 자동 적용 확인
- [ ] Telegram 이모지 + HTML escape (commit_sha / repo_name) 보존 확인

## 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 적용 영역)

⚠️ **architecture 영향** (정책 3 강화 정량 기준 2번):
- 3-layer fallback 헬퍼 신설 — 정책 16 4번 원칙 (사용처 추후 확장 — Discord/Slack/Email/n8n PR-10)
- 지연 import 패턴 (`from src.repositories import user_repo`) — circular import 회피 의무
- `_NOT_CONNECTED_MSG` 백워드 호환 모듈 attribute — 기존 단위 테스트 (`test_telegram_commands.py`) 직접 비교 영역 보존

⚠️ **데이터 모델 변경** (정책 3 강화 정량 기준 3번):
- `_build_message` / `send_analysis_result` 함수 시그니처 확장 (language 인자 default='en')
- `_handle_stats` / `_handle_settings` private 시그니처 확장 (language 인자 의무)
- `NotifyContext` dataclass 변경 0 — `_TelegramNotifier.send` 안에서 `SessionLocal()` + `resolve_notification_language` 직접 호출 (5-way sync 영향 0)

자율 진입 보고:
- PR-9 응집 단위 = "Telegram + 사용자 언어 결정" (정책 7 강화 응집 부합)
- PR-10 (Discord + Slack + Email + n8n) = 별도 PR — 다음 작업
- PR-11 (GitHub PR Comment + Commit Comment + Issue) = 별도 PR
- 회귀 가드 23건 = mock 패턴 (DB 의존성 graceful — 단위 테스트 빠름)

## 검증 (사이클 84 sync 실측)
- 단위 = `pytest tests/unit -q` → 2337 passed (+23 회귀 가드 + 1 기존 정정)
- 통합 = `pytest tests/integration -q` → 191 passed
- 합계 = 2528 passed / 5 skipped / 0 failed (129s)

## cross-verify 결과
- 1차 5 에이전트 디스패치 = 본 사이클 미수행 (단일 응집 PR-9 — 인프라/notifier 검증 완료 영역)
- 통합 fail 1건 (PR push 직전 검증) → i18n 적용 후 default locale 의존 텍스트 어서션 정정 후 0 fail
- 본 환경 + CI 신뢰 모델 = `pytest tests/unit tests/integration -q` 동시 실행 default (메모리 `feedback-pr-push-direct-validation.md` 페어)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
