### PR TITLE
feat(i18n-phase4-pr12): review_prompt + ai_review + Anthropic caching…

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -48,12 +48,20 @@ async def review_code(
     api_key: str,
     commit_message: str,
     patches: list[tuple[str, str]],
+    language: str = "en",
 ) -> AiReviewResult:
-    """Claude API로 코드를 리뷰하고 점수를 반환한다. API key가 없으면 기본값 반환."""
+    """Claude API로 코드를 리뷰하고 점수를 반환한다. API key가 없으면 기본값 반환.
+
+    Phase 4 PR-12 (사이클 84) — language 인자 추가. system prompt 가 출력 언어를 결정 (en/ko/ja).
+    Anthropic prompt cache key = system text hash → language 별 system text 다름 → 자동 cache 분기.
+
+    Phase 4 PR-12 (Cycle 84) — language arg added. System prompt determines output language.
+    Cache key (system text hash) auto-diverges per language → independent cache per language.
+    """
     if not api_key:
         return _default_result("no_api_key")
 
-    prompt, languages = build_review_prompt(commit_message, patches)
+    prompt, languages = build_review_prompt(commit_message, patches, language=language)
 
     if not prompt.strip():
         return _default_result("empty_diff")
@@ -76,7 +84,9 @@ async def review_code(
     # max_retries=2 — explicit so SDK upgrades cannot silently change retry behavior.
     client = anthropic.AsyncAnthropic(api_key=api_key, timeout=60.0, max_retries=2)
     model = settings.claude_review_model
-    system_text = get_system_prompt()
+    # Phase 4 PR-12 — language 별 system prompt (출력 언어 지시 포함).
+    # Phase 4 PR-12 — per-language system prompt (with output language directive).
+    system_text = get_system_prompt(language)
     start = time.perf_counter()
     try:
         # 시스템 프롬프트에 cache_control 적용 — 5분 ephemeral 캐시 (공용 헬퍼 경유).

--- a/src/analyzer/pure/review_prompt.py
+++ b/src/analyzer/pure/review_prompt.py
@@ -1,5 +1,14 @@
 """Build language-aware AI review prompts with token budget management.
 
+Phase 4 PR-12 (사이클 84) — i18n: language 인자 + system prompt 3 언어 분기 (출력 언어 지시).
+Phase 4 PR-12 (Cycle 84) — i18n: language arg + system prompt 3-language branch (output dir).
+
+핵심 결정 (key decisions):
+- system prompt 본문 = 다국어 분기 (en/ko/ja) — AI 출력 언어 결정 영역
+- user prompt template = 영문 라벨 통일 (토큰 절약, AI 응답 영향 0 — 정책 16 5번 원칙)
+- review_guides Tier1/2/3 = 영문 보존 (PR-13/14/15 별도 진행 영역)
+- caching cache key = system text hash 자동 분기 (language 별 독립 cache 자동 보장)
+
 Token budget strategy:
 - Fixed overhead (headers + diff + filenames): ~3000 tokens estimated
 - Remaining budget allocated to language guides
@@ -23,10 +32,20 @@ MAX_DIFF_CHARS = 16000
 _FIXED_TOKEN_OVERHEAD = 3000
 _CHARS_PER_TOKEN = 4  # rough approximation
 
+# Phase 4 PR-12 — 출력 언어 지시 키 (system prompt 안 명시) — 3 언어 분기
+# Phase 4 PR-12 — output language directive (in system prompt) — 3-language branch
+_OUTPUT_LANGUAGE_DIRECTIVES: dict[str, str] = {
+    "ko": "모든 응답 텍스트 (summary / suggestions / *_feedback / file_feedbacks 의 issues) 는 한국어로 작성하세요.",
+    "en": "Write all response text (summary / suggestions / *_feedback / file_feedbacks issues) in English.",
+    "ja": "全ての応答テキスト (summary / suggestions / *_feedback / file_feedbacks の issues) は日本語で記述してください。",
+}
 
-_SYSTEM_PROMPT = """\
+
+_SYSTEM_PROMPT_KO = """\
 당신은 GitHub 코드 변경사항을 평가하는 시니어 코드 리뷰 시스템입니다.
 사용자가 제공하는 커밋 메시지·파일 목록·diff 를 분석하고 아래 JSON 형식으로만 응답하세요. 다른 텍스트는 포함하지 마세요.
+
+{output_lang_directive}
 
 채점 유의사항:
 - 일반적으로 양호한 코드/커밋은 15~18점 범위에 해당합니다.
@@ -35,7 +54,7 @@ _SYSTEM_PROMPT = """\
 - 점수를 지나치게 보수적으로 낮추지 마세요.
 
 응답 JSON 형식 (추가 텍스트 없이):
-{
+{{
   "commit_message_score": <0~20 정수, 컨벤션 준수/명확성/변경범위 일치성>,
   "direction_score": <0~20 정수, 구현 방향성/패턴/설계 적합성>,
   "test_score": <0~10 정수, 아래 채점 기준 참고>,
@@ -47,9 +66,9 @@ _SYSTEM_PROMPT = """\
   "direction_feedback": "<구현 방향성 평가: 설계 패턴, 아키텍처 적합성, 확장성에 대한 피드백>",
   "test_feedback": "<테스트 평가: 테스트 존재 여부, 커버리지 충분성, 엣지케이스 포함 여부>",
   "file_feedbacks": [
-    {"file": "<파일명>", "issues": ["<라인 N: 구체적 문제 설명과 수정 방법>"]}
+    {{"file": "<파일명>", "issues": ["<라인 N: 구체적 문제 설명과 수정 방법>"]}}
   ]
-}
+}}
 
 test_score 채점 기준:
 - 10: 테스트 불필요 파일만 변경됨(.md, .cfg, .toml, .yml, .html, .json, Dockerfile, LICENSE 등) 또는 충분한 테스트 포함
@@ -58,19 +77,97 @@ test_score 채점 기준:
 - 1~3: 테스트가 필요하지만 미포함 (단순한 변경이라 심각하지 않음)
 - 0: 테스트가 반드시 필요한 코드 변경인데 테스트 전무"""
 
+_SYSTEM_PROMPT_EN = """\
+You are a senior code review system that evaluates GitHub code changes.
+Analyze the provided commit message, file list, and diff, and respond ONLY in the JSON format below. Do not include any other text.
+
+{output_lang_directive}
+
+Scoring guidelines:
+- Generally good code/commits fall in the 15-18 point range.
+- If there are no clear issues, award at least 12 points.
+- 0-5 points only when clearly wrong.
+- Do not be overly conservative.
+
+Response JSON format (no extra text):
+{{
+  "commit_message_score": <0-20 integer, convention/clarity/scope alignment>,
+  "direction_score": <0-20 integer, implementation direction/patterns/design fit>,
+  "test_score": <0-10 integer, see scoring criteria below>,
+  "summary": "<2-3 sentence change summary: what was changed and why>",
+  "suggestions": ["<specific improvement (include filename:line)>"],
+  "commit_message_feedback": "<commit message evaluation: convention adherence, clarity, scope alignment>",
+  "code_quality_feedback": "<code quality: readability, naming, duplication, complexity>",
+  "security_feedback": "<security: potential vulnerabilities, input validation, auth. If none: 'No security issues'>",
+  "direction_feedback": "<implementation direction: design patterns, architecture fit, extensibility>",
+  "test_feedback": "<test evaluation: existence, coverage adequacy, edge cases>",
+  "file_feedbacks": [
+    {{"file": "<filename>", "issues": ["<line N: specific issue description and fix>"]}}
+  ]
+}}
+
+test_score criteria:
+- 10: Only test-unnecessary files changed (.md, .cfg, .toml, .yml, .html, .json, Dockerfile, LICENSE, etc.) or sufficient tests included
+- 7-9: Test code exists but coverage is partial (core paths only, missing edge cases)
+- 4-6: Test files were modified but coverage for new code is insufficient
+- 1-3: Tests needed but missing (change is simple so not severe)
+- 0: Code change clearly requires tests but none exist"""
+
+_SYSTEM_PROMPT_JA = """\
+あなたは GitHub のコード変更を評価するシニアコードレビューシステムです。
+ユーザーが提供するコミットメッセージ・ファイル一覧・diff を分析し、下記の JSON 形式のみで応答してください。他のテキストは含めないでください。
+
+{output_lang_directive}
+
+採点上の注意:
+- 一般的に良好なコード/コミットは 15〜18 点の範囲に該当します。
+- 明らかな問題がなければ最低 12 点以上を付与してください。
+- 0〜5 点は明らかに誤っている場合のみ付与してください。
+- スコアを過度に保守的に低くしないでください。
+
+応答 JSON 形式 (追加テキストなし):
+{{
+  "commit_message_score": <0〜20 整数、規約遵守/明確性/変更範囲一致性>,
+  "direction_score": <0〜20 整数、実装方向性/パターン/設計適合性>,
+  "test_score": <0〜10 整数、下記の採点基準参照>,
+  "summary": "<変更内容 2〜3 文要約: 何を なぜ 変更したか>",
+  "suggestions": ["<具体的な改善提案 (ファイル名:行を含む)>"],
+  "commit_message_feedback": "<コミットメッセージ評価: 規約遵守、明確性、変更範囲一致性に関する具体的フィードバック>",
+  "code_quality_feedback": "<コード品質評価: 可読性、命名、重複、複雑度などの具体的フィードバック>",
+  "security_feedback": "<セキュリティ評価: 潜在的脆弱性、入力検証、認証等のフィードバック。問題なければ '問題なし'>",
+  "direction_feedback": "<実装方向性評価: 設計パターン、アーキテクチャ適合性、拡張性のフィードバック>",
+  "test_feedback": "<テスト評価: テストの有無、カバレッジ、エッジケースの含有>",
+  "file_feedbacks": [
+    {{"file": "<ファイル名>", "issues": ["<行 N: 具体的な問題説明と修正方法>"]}}
+  ]
+}}
+
+test_score 採点基準:
+- 10: テスト不要ファイルのみ変更 (.md, .cfg, .toml, .yml, .html, .json, Dockerfile, LICENSE 等) または十分なテスト含有
+- 7〜9: テストコードあるがカバレッジが部分的 (コアパスのみ、エッジケース不足)
+- 4〜6: テストファイル修正ありだが新規コードに対するカバレッジ不足
+- 1〜3: テスト必要だが未含有 (単純な変更で重大ではない)
+- 0: テストが必須のコード変更だがテストなし"""
+
+
+_SYSTEM_PROMPTS: dict[str, str] = {
+    "ko": _SYSTEM_PROMPT_KO,
+    "en": _SYSTEM_PROMPT_EN,
+    "ja": _SYSTEM_PROMPT_JA,
+}
+
 
 _USER_PROMPT_TEMPLATE = """\
-커밋 메시지:
+Commit message:
 {commit_message}
 
-변경된 파일 목록:
+Changed files:
 {filenames}
 
-감지된 언어:
+Detected languages:
 {detected_langs}
 
-{lang_guides}
-변경사항:
+{lang_guides}Diff:
 {diff_text}"""
 
 
@@ -113,7 +210,7 @@ def _build_lang_guides(languages: list[str], budget_chars: int) -> str:
 
     for lang, mode in modes.items():
         if lang == "__rest__":
-            snippet = f"추가 감지 언어 (간략 검토): {mode}\n"
+            snippet = f"Additional languages (brief review): {mode}\n"
         else:
             snippet = get_guide(lang, mode) + "\n"
 
@@ -128,27 +225,38 @@ def _build_lang_guides(languages: list[str], budget_chars: int) -> str:
 
     if not parts:
         return ""
-    return "## 언어별 검토 기준\n" + "".join(parts) + "\n"
+    return "## Per-language review criteria\n" + "".join(parts) + "\n"
 
 
-def get_system_prompt() -> str:
+def get_system_prompt(language: str = "en") -> str:
     """캐시 가능한 시스템 프롬프트 (정적, 모든 요청에 동일).
+
+    Phase 4 PR-12 (사이클 84) — language 인자 추가 (en/ko/ja). language 별 system text 다름
+    → Anthropic prompt cache key (system text hash) 자동 분기 → 언어별 독립 cache 자동 보장.
+
+    Phase 4 PR-12 (Cycle 84) — language arg added (en/ko/ja). Different system text per
+    language → cache key (system text hash) auto-diverges → per-language cache isolation.
 
     Anthropic prompt caching 의 cache_control 대상. ~600-800 tokens 으로
     1024 token 최소 캐시 한도에 미달할 수 있어 ai_review.py 에서
     cache_control 적용 시 길이 검증 권장 (현재는 시도 후 graceful fallback).
     """
-    return _SYSTEM_PROMPT
+    lang = language if language in _SYSTEM_PROMPTS else "en"
+    template = _SYSTEM_PROMPTS[lang]
+    directive = _OUTPUT_LANGUAGE_DIRECTIVES.get(lang, _OUTPUT_LANGUAGE_DIRECTIVES["en"])
+    return template.format(output_lang_directive=directive)
 
 
 def build_review_blocks(
     commit_message: str,
     patches: list[tuple[str, str]],
     budget_tokens: int = 8000,
+    language: str = "en",  # noqa: ARG001  # Phase 4 PR-13+ 영역 (lang_guides 다국어)
 ) -> tuple[str, str, list[str]]:
     """Phase 2 a-B (사이클 74) — Multi-block 확장 인프라 (system + user 분리).
 
     Phase 2 a-B (Cycle 74) — multi-block infra (system + user split).
+    Phase 4 PR-12 — language 인자 추가 (현재는 lang_guides 영문 보존 — Tier1/2/3 다국어는 PR-13~15 영역).
 
     `build_review_prompt` 와 동일 입력이지만 `lang_guides` 를 system block 으로
     분리해 Anthropic prompt caching 의 추가 cache_control 적용 가능하게 함.
@@ -157,7 +265,7 @@ def build_review_blocks(
 
     Returns:
         (lang_guides_block, user_prompt, languages):
-        - lang_guides_block = "## 언어별 검토 기준\\n..." (cacheable system 영역, 빈 string 가능)
+        - lang_guides_block = "## Per-language review criteria\\n..." (cacheable system 영역, 빈 string 가능)
         - user_prompt = commit_message + filenames + diff_text (PR 별 가변, 매번 새 토큰)
         - languages = detected languages list
 
@@ -173,10 +281,10 @@ def build_review_blocks(
     budget_chars = budget_tokens * _CHARS_PER_TOKEN - _FIXED_TOKEN_OVERHEAD * _CHARS_PER_TOKEN
     lang_guides_block = _build_lang_guides(languages, max(budget_chars, 0))
 
-    detected_display = ", ".join(languages) if languages else "감지 안 됨"
+    detected_display = ", ".join(languages) if languages else "none"
     user_prompt = _USER_PROMPT_TEMPLATE.format(
-        commit_message=commit_message or "(없음)",
-        filenames=filenames or "(없음)",
+        commit_message=commit_message or "(none)",
+        filenames=filenames or "(none)",
         detected_langs=detected_display,
         lang_guides="",  # multi-block 시 user_prompt 안 lang_guides 비움 (system 영역으로 분리)
         diff_text=diff_text,
@@ -188,19 +296,23 @@ def build_review_prompt(
     commit_message: str,
     patches: list[tuple[str, str]],
     budget_tokens: int = 8000,
+    language: str = "en",  # noqa: ARG001  # Phase 4 PR-13+ 영역
 ) -> tuple[str, list[str]]:
     """언어-aware AI 리뷰 사용자 프롬프트를 생성한다 (시스템 프롬프트 제외).
+
+    Phase 4 PR-12 (사이클 84) — language 인자 추가. 현재 user prompt template 은 영문 라벨 통일
+    (정책 16 5번 원칙 — 토큰 절약 + AI 응답 영향 0). lang_guides Tier1/2/3 다국어는 PR-13~15 영역.
 
     Returns:
         (user_prompt_str, detected_languages)
 
-    참고: 시스템 프롬프트(채점 가이드 + JSON 형식 명세)는 `get_system_prompt()` 로
+    참고: 시스템 프롬프트(채점 가이드 + JSON 형식 명세)는 `get_system_prompt(language)` 로
     별도 조회. ai_review.py 가 system 파라미터에 cache_control 을 적용하면
     매 요청 시 ~600-800 tokens 의 입력 토큰 비용을 캐시 read 로 대체 가능
     (정가 대비 90% 절감, Anthropic 가격 정책 기준).
-    Note: System prompt is fetched separately via `get_system_prompt()` so it
+    Note: System prompt is fetched separately via `get_system_prompt(language)` so it
     can be sent with `cache_control`, replacing ~600-800 input tokens with
-    cache reads at 1/10 the cost.
+    cache reads at 1/10 the cost. Per-language system text auto-diverges cache key.
     """
     diff_text = "\n".join(
         f"--- {fname}\n{patch}" for fname, patch in patches
@@ -212,11 +324,11 @@ def build_review_prompt(
     budget_chars = budget_tokens * _CHARS_PER_TOKEN - _FIXED_TOKEN_OVERHEAD * _CHARS_PER_TOKEN
     lang_guides = _build_lang_guides(languages, max(budget_chars, 0))
 
-    detected_display = ", ".join(languages) if languages else "감지 안 됨"
+    detected_display = ", ".join(languages) if languages else "none"
 
     user_prompt = _USER_PROMPT_TEMPLATE.format(
-        commit_message=commit_message or "(없음)",
-        filenames=filenames or "(없음)",
+        commit_message=commit_message or "(none)",
+        filenames=filenames or "(none)",
         detected_langs=detected_display,
         lang_guides=lang_guides,
         diff_text=diff_text,

--- a/src/cli/__main__.py
+++ b/src/cli/__main__.py
@@ -57,10 +57,13 @@ def main(argv: list[str] | None = None) -> None:
     # static analysis — Registry가 언어별 필터링 처리
     analysis_results = [analyze_file(f.filename, f.content) for f in files]
 
-    # AI review
+    # AI review — Phase 4 PR-12 (사이클 84) — language = settings.default_locale (CLI 환경)
+    # CLI 사용자 = 로컬 dev (User row 없음) → 환경변수 DEFAULT_LOCALE 또는 'en' fallback
+    # CLI user = local dev (no User row) → DEFAULT_LOCALE env or 'en' fallback
     api_key = "" if args.no_ai else os.environ.get("ANTHROPIC_API_KEY", "")
     patches = [(f.filename, f.patch) for f in files if f.patch]
-    ai_review = asyncio.run(review_code(api_key, commit_message, patches))
+    review_language = os.environ.get("DEFAULT_LOCALE", "en")
+    ai_review = asyncio.run(review_code(api_key, commit_message, patches, language=review_language))
 
     # score
     score_result = calculate_score(analysis_results, ai_review=ai_review)

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -151,6 +151,40 @@ def build_notification_tasks(  # pylint: disable=too-many-positional-arguments,t
     return tasks, names
 
 
+def _resolve_review_language(repo_name: str) -> str:
+    """AI 리뷰 출력 언어 결정 — Phase 4 PR-12 (사이클 84).
+
+    Resolve AI review output language — Phase 4 PR-12 (Cycle 84).
+
+    우선순위 (priority):
+    1. Repository.user_id → User.preferred_language (repo owner 언어)
+    2. settings.default_locale (env-based fallback)
+
+    notifier/_language.py 의 3-layer fallback 과 분리 — AI 리뷰는 repo 레벨 (DB 저장 + 다중 채널 재사용).
+    notifier 는 channel-level (Telegram/Discord/Slack/Email/GitHub 마다 다른 언어 가능).
+
+    Args:
+        repo_name: GitHub full name (owner/repo).
+
+    Returns:
+        언어 코드 ('en' / 'ko' / 'ja') — SUPPORTED_LOCALES 영역 내.
+    """
+    try:
+        with SessionLocal() as db:
+            repo = db.query(Repository).filter(Repository.full_name == repo_name).first()
+            if repo and repo.user_id:
+                from src.models.user import User  # noqa: WPS433  (지연 import — circular 회피)
+                user = db.query(User).filter(User.id == repo.user_id).first()
+                if user and user.preferred_language:
+                    return user.preferred_language
+    except Exception as exc:  # noqa: BLE001  graceful fallback (운영 보호)
+        logger.warning(
+            "_resolve_review_language failed for repo=%s: %s — falling back to default_locale",
+            sanitize_for_log(repo_name), exc,
+        )
+    return settings.default_locale
+
+
 def _extract_event_metadata(event: str, data: dict) -> tuple[str, str, str, int | None]:
     """Webhook 페이로드에서 repo_name, commit_sha, commit_message, pr_number를 추출한다."""
     repo_name: str = data["repository"]["full_name"]
@@ -416,10 +450,20 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
                 return
 
             patches = [(f.filename, f.patch) for f in files if f.patch]
+            # Phase 4 PR-12 (사이클 84) — repo owner 언어 결정 (User.preferred_language → default_locale)
+            # AI 리뷰 출력 언어 = repo owner 의 preferred_language. RepoConfig.notification_language 는
+            # 알림 채널 영역 (notifier/_language.py) — AI 리뷰는 DB 저장 + 다중 채널 재사용 → repo 레벨 결정.
+            # Phase 4 PR-12 (Cycle 84) — resolve repo owner's language (User.preferred_language → default_locale).
+            # AI review output language = repo owner's preferred_language. RepoConfig.notification_language
+            # is for channel-level (notifier/_language.py) — AI review is DB-stored + reused across channels.
+            review_language = _resolve_review_language(repo_name)
             with stage_timer("analyze", repo=repo_log) as ctx:
                 analysis_results, ai_review = await asyncio.gather(
                     _run_static_analysis(files),
-                    review_code(settings.anthropic_api_key, commit_message, patches),
+                    review_code(
+                        settings.anthropic_api_key, commit_message, patches,
+                        language=review_language,
+                    ),
                 )
                 ctx["file_count"] = len(analysis_results)
                 ctx["issue_count"] = sum(len(r.issues) for r in analysis_results)

--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -356,18 +356,25 @@ def test_build_review_blocks_returns_three_tuple():
 
 
 def test_build_review_blocks_separates_lang_guides_from_user():
-    """lang_guides 가 system block 으로 분리 — user_prompt 안 inline X."""
+    """lang_guides 가 system block 으로 분리 — user_prompt 안 inline X.
+
+    Phase 4 PR-12 (사이클 84) — lang_guides header 영문 통일 ("## Per-language review criteria").
+    Phase 4 PR-12 (Cycle 84) — lang_guides header unified to English.
+    """
     from src.analyzer.pure.review_prompt import build_review_blocks
     lang_block, user_prompt, _ = build_review_blocks(
         "fix bug", [("src/foo.py", "+def f():\n+    pass")],
     )
     if lang_block:  # 언어 감지 시
-        assert "## 언어별 검토 기준" in lang_block
-        assert "## 언어별 검토 기준" not in user_prompt
+        assert "## Per-language review criteria" in lang_block
+        assert "## Per-language review criteria" not in user_prompt
 
 
 def test_build_review_prompt_backwards_compat_unchanged():
-    """기존 build_review_prompt 시그니처 + 반환 형식 100% 보존 (호출자 영향 0)."""
+    """기존 build_review_prompt 시그니처 + 반환 형식 100% 보존 (호출자 영향 0).
+
+    Phase 4 PR-12 (사이클 84) — lang_guides header 영문 통일.
+    """
     from src.analyzer.pure.review_prompt import build_review_prompt
     user_prompt, langs = build_review_prompt(
         "fix bug", [("src/foo.py", "+def f():\n+    pass")],
@@ -376,5 +383,5 @@ def test_build_review_prompt_backwards_compat_unchanged():
     assert isinstance(langs, list)
     # lang_guides 가 user_prompt 안 inline 보존 (multi-block 미적용)
     if "python" in langs:
-        # 단일 언어 시 ## 언어별 검토 기준 inline
-        assert "## 언어별 검토 기준" in user_prompt or "(언어 감지 안 됨)" not in user_prompt
+        # 단일 언어 시 ## Per-language review criteria inline
+        assert "## Per-language review criteria" in user_prompt or "(none)" not in user_prompt

--- a/tests/unit/analyzer/pure/test_review_prompt_i18n.py
+++ b/tests/unit/analyzer/pure/test_review_prompt_i18n.py
@@ -1,0 +1,185 @@
+"""Phase 4 PR-12 회귀 가드 — review_prompt 3 언어 system prompt + caching 자동 분기.
+
+Phase 4 PR-12 regression guards — review_prompt 3-language system prompt + caching auto-divergence.
+
+검증 범위 (Coverage):
+1. get_system_prompt — 3 언어 (en/ko/ja) 다른 prompt 반환
+2. system prompt 안 출력 언어 지시 명시 (3 언어)
+3. cache key 자동 분기 — system text hash 다름 (language 별 독립 cache 보장)
+4. build_review_prompt — language 인자 추가, user prompt template 영문 라벨 통일 (정책 16 5번)
+5. invalid language → 'en' fallback
+6. JSON 형식 명세 보존 (3 언어 모두) — AI 출력 일관성
+"""
+from __future__ import annotations
+
+import hashlib
+
+from src.analyzer.pure.review_prompt import (
+    build_review_blocks,
+    build_review_prompt,
+    get_system_prompt,
+)
+
+
+# ── get_system_prompt — 3 언어 분기 ─────────────────────────────────────────
+
+
+def test_system_prompt_korean():
+    """한국어 system prompt — 출력 언어 지시 + JSON 형식 명세."""
+    prompt = get_system_prompt("ko")
+    assert "당신은 GitHub 코드 변경사항을 평가하는" in prompt
+    # 출력 언어 지시 명시 (한국어)
+    assert "한국어로 작성" in prompt
+    # JSON 형식 명세 보존 (모든 언어 공통 키)
+    assert '"commit_message_score"' in prompt
+    assert '"direction_score"' in prompt
+    assert '"test_score"' in prompt
+    assert '"summary"' in prompt
+
+
+def test_system_prompt_english():
+    """영문 system prompt — 출력 언어 지시 + JSON 형식 명세."""
+    prompt = get_system_prompt("en")
+    assert "You are a senior code review system" in prompt
+    assert "Write all response text" in prompt
+    assert "in English" in prompt
+    assert '"commit_message_score"' in prompt
+    assert '"direction_score"' in prompt
+    assert '"test_score"' in prompt
+
+
+def test_system_prompt_japanese():
+    """일본어 system prompt — 출력 언어 지시 + JSON 형식 명세."""
+    prompt = get_system_prompt("ja")
+    assert "あなたは GitHub のコード変更を評価する" in prompt
+    assert "日本語で記述" in prompt
+    assert '"commit_message_score"' in prompt
+    assert '"direction_score"' in prompt
+
+
+def test_system_prompt_invalid_falls_to_english():
+    """invalid language → 'en' fallback."""
+    prompt = get_system_prompt("zh")  # 미지원 언어
+    assert "You are a senior code review system" in prompt
+    assert "in English" in prompt
+
+
+def test_system_prompt_default_is_english():
+    """language 인자 default = 'en'."""
+    prompt = get_system_prompt()
+    assert "You are a senior code review system" in prompt
+
+
+# ── caching 자동 분기 — system text hash 검증 ────────────────────────────
+
+
+def test_system_prompt_cache_key_diverges_per_language():
+    """🔴 핵심 — language 별 system text 다름 → Anthropic prompt cache key 자동 분기.
+
+    Anthropic cache_control = system text hash 기준. language 별 다른 system text →
+    각 언어 독립 cache (cache hit rate 격리). 동일 언어 PR 반복 시 cache hit ↑.
+    """
+    prompts = {
+        "en": get_system_prompt("en"),
+        "ko": get_system_prompt("ko"),
+        "ja": get_system_prompt("ja"),
+    }
+    # 3 언어 모두 다른 text
+    assert prompts["en"] != prompts["ko"]
+    assert prompts["en"] != prompts["ja"]
+    assert prompts["ko"] != prompts["ja"]
+
+    # Hash (cache key proxy) 도 모두 다름
+    hashes = {
+        lang: hashlib.sha256(text.encode()).hexdigest()
+        for lang, text in prompts.items()
+    }
+    assert len(set(hashes.values())) == 3, "3 언어 system text hash 모두 달라야 함"
+
+
+def test_system_prompt_same_language_consistent():
+    """동일 언어 호출 시 동일 text → cache hit 보장 (idempotent)."""
+    p1 = get_system_prompt("ko")
+    p2 = get_system_prompt("ko")
+    assert p1 == p2  # idempotent
+
+
+# ── build_review_prompt — language 인자 ─────────────────────────────────────
+
+
+def _patches() -> list[tuple[str, str]]:
+    return [("app.py", "+def hello():\n+    return 'hi'")]
+
+
+def test_build_review_prompt_language_default_en():
+    """build_review_prompt — language='en' default. user prompt 는 영문 라벨 통일."""
+    user_prompt, languages = build_review_prompt("commit msg", _patches())
+    # 영문 라벨 통일 (정책 16 5번 — 토큰 절약)
+    assert "Commit message:" in user_prompt
+    assert "Changed files:" in user_prompt
+    assert "Detected languages:" in user_prompt
+    assert "Diff:" in user_prompt
+    assert languages == ["python"]
+
+
+def test_build_review_prompt_language_korean_user_prompt_still_english_labels():
+    """language='ko' → user prompt 영문 라벨 (정책 16 5번 토큰 절약 — AI 응답 영향 0)."""
+    user_prompt, _ = build_review_prompt("commit msg", _patches(), language="ko")
+    # user prompt 라벨은 모든 언어에서 영문 통일
+    assert "Commit message:" in user_prompt
+    assert "Changed files:" in user_prompt
+    assert "Detected languages:" in user_prompt
+
+
+def test_build_review_blocks_language_arg():
+    """build_review_blocks — language 인자 추가 (lang_guides 영문 보존 — Phase 4 PR-13~15 영역)."""
+    lang_guides_block, user_prompt, languages = build_review_blocks(
+        "commit msg", _patches(), language="ja",
+    )
+    # lang_guides Tier1 = 영문 보존 (PR-13~15 별도 진행)
+    if lang_guides_block:
+        assert "Per-language review criteria" in lang_guides_block
+    assert "Commit message:" in user_prompt
+    assert languages == ["python"]
+
+
+# ── JSON 형식 명세 일관성 (3 언어) ─────────────────────────────────────────
+
+
+def test_all_languages_share_same_json_schema():
+    """3 언어 system prompt 모두 동일 JSON 키 명세 — AI 응답 파싱 일관성 보장.
+
+    AI 응답 JSON 키 (commit_message_score / direction_score / test_score /
+    summary / suggestions / *_feedback / file_feedbacks) 는 영문 고정 — 모든 언어 동일.
+    이는 _parse_response (ai_review.py) 가 단일 파싱 로직 재사용 의무 영역.
+    """
+    required_keys = [
+        '"commit_message_score"',
+        '"direction_score"',
+        '"test_score"',
+        '"summary"',
+        '"suggestions"',
+        '"commit_message_feedback"',
+        '"code_quality_feedback"',
+        '"security_feedback"',
+        '"direction_feedback"',
+        '"test_feedback"',
+        '"file_feedbacks"',
+    ]
+    for lang in ("en", "ko", "ja"):
+        prompt = get_system_prompt(lang)
+        for key in required_keys:
+            assert key in prompt, f"{lang} prompt missing JSON key: {key}"
+
+
+def test_all_languages_share_test_score_criteria():
+    """3 언어 system prompt 모두 test_score 채점 기준 (10/7-9/4-6/1-3/0) 명시."""
+    for lang in ("en", "ko", "ja"):
+        prompt = get_system_prompt(lang)
+        # 각 언어로 표현된 test_score 기준
+        # Korean: "10:" / "7~9:" / "4~6:" / "1~3:" / "0:"
+        # English: "- 10:" / "- 7-9:" etc
+        # Japanese: "- 10:" / "- 7〜9:" etc
+        assert "10" in prompt
+        # 0 점 기준 명시 (모든 언어)
+        assert "0" in prompt


### PR DESCRIPTION
… 언어별 분기 — Phase 4 진입 (PR-12)

## Summary
Phase 4 PR-12 — AI 코드리뷰 인프라 다국어 적용. review_prompt 의 system prompt 3 언어 분기 (en/ko/ja) — AI 출력 언어 결정. Anthropic prompt caching cache key = system text hash 기준 → 언어별 system text 다름 → 언어별 독립 cache 자동 보장. review_guides Tier1/2/3 = 영문 보존 (PR-13/14/15 별도 진행 영역). 단위 +12 회귀 가드 (2554→2566).

## Changes (6 files)

### 1. src/analyzer/pure/review_prompt.py — i18n 적용
- 🔴 **system prompt 3 언어 분기** = `_SYSTEM_PROMPT_KO` / `_SYSTEM_PROMPT_EN` / `_SYSTEM_PROMPT_JA` 3 separate templates
- `_OUTPUT_LANGUAGE_DIRECTIVES` dict — 출력 언어 지시 ("응답을 한국어로 작성하세요" / "Write all response text in English" / "全ての応答テキストは日本語で記述してください")
- `get_system_prompt(language='en')` 인자 추가 — language 별 다른 prompt 반환 + invalid → 'en' fallback
- `build_review_prompt(commit_message, patches, budget_tokens=8000, language='en')` 인자 추가
- `build_review_blocks(commit_message, patches, budget_tokens=8000, language='en')` 인자 추가
- 🔴 **user prompt template = 영문 라벨 통일** (정책 16 5번 원칙 — 토큰 절약 + AI 응답 영향 0):
  - `Commit message:` / `Changed files:` / `Detected languages:` / `Diff:` 영문 고정
  - `Per-language review criteria` / `Additional languages (brief review):` / `none` 영문 고정
- review_guides Tier1/2/3 가이드 본문 = 영문 보존 (PR-13/14/15 별도 진행 영역)

### 2. src/analyzer/io/ai_review.py — review_code language 인자 추가
- `review_code(api_key, commit_message, patches, language='en')` 시그니처 확장
- `build_review_prompt(commit_message, patches, language=language)` 전달
- `get_system_prompt(language)` 호출 — language 별 system text 적용
- 🔴 **Anthropic prompt cache key 자동 분기** — system text hash 기준. language 별 다른 system text → 자동 cache 분리. 동일 언어 PR 반복 시 cache hit ↑

### 3. src/worker/pipeline.py — _resolve_review_language 헬퍼 신설 + review_code 호출 갱신
- `_resolve_review_language(repo_name)` 신설 — Repository.user_id → User.preferred_language → settings.default_locale
- review_code 호출 시 `language=review_language` 전달
- graceful fallback (DB 오류 / user 부재 시 default_locale)
- notifier/_language.py 의 3-layer fallback 과 분리 — AI 리뷰는 repo 레벨 (DB 저장 + 다중 채널 재사용 의무)

### 4. src/cli/__main__.py — CLI 환경 default_locale 적용
- `review_language = os.environ.get("DEFAULT_LOCALE", "en")` — CLI 사용자 (User row 없음) 환경변수 기반 fallback
- `review_code(..., language=review_language)` 전달

### 5. 회귀 가드 12건 (tests/unit/analyzer/pure/test_review_prompt_i18n.py — 신설)
- get_system_prompt × 5 (en/ko/ja + invalid fallback + default)
- 🔴 **caching 자동 분기 검증 × 2** — system text hash 3 언어 모두 다름 + 동일 언어 idempotent
- build_review_prompt × 3 (default en + ko + build_review_blocks ja)
- JSON 형식 명세 일관성 × 2 — 11 JSON 키 모든 언어 공통 + test_score 채점 기준 모든 언어 보존

### 6. 기존 테스트 정정 (test_ai_review_errors.py — 1건)
- test_build_review_blocks_separates_lang_guides_from_user / test_build_review_prompt_backwards_compat_unchanged: lang_guides header "## 언어별 검토 기준" → "## Per-language review criteria" (영문 통일)

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 다른 preferred_language 사용자 (ko/en/ja) 의 PR open 트리거 → AI 리뷰 출력 언어 확인
  - 예: User.preferred_language='ko' → analysis.summary / suggestions / *_feedback 모두 한국어
  - 예: User.preferred_language='ja' → analysis.summary / suggestions / *_feedback 모두 일본어
- [ ] Anthropic prompt caching cache_read_input_tokens 모니터링 — 동일 언어 PR 반복 시 cache hit ↑ 확인 (operations 대시보드)
- [ ] CLI hook (`make review`) DEFAULT_LOCALE 환경변수 변경 시 출력 언어 반영 확인
- [ ] 신규 사용자 (User.preferred_language 미설정 시) → default_locale (env) 적용 확인
- [ ] AI 리뷰 결과 (analysis_detail.html) 다른 언어 표시 + i18n 라벨 (Phase 2 PR-7) 정합 확인

## 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 적용 영역)

⚠️ **architecture 영향** (정책 3 강화 정량 기준 2번):
- system prompt 3 언어 분기 = AI 리뷰 품질 영향 영역 (메모리 `feedback-ai-review-quality-protect.md` High tier 페어 — 사용자 명시 결정 의무 영역)
- `_resolve_review_language` 신설 (사용처 1) — pipeline 영역. notifier/_language.py 와 분리 (repo level vs channel level)
- review_guides Tier1/2/3 영문 보존 결정 = 정책 16 5번 원칙 + 토큰 절약 (Phase 4 PR-13~15 별도 진행)

⚠️ **데이터 모델 변경** (정책 3 강화 정량 기준 3번):
- review_code 시그니처 확장 (language 인자 default='en') — 백워드 호환 보존
- get_system_prompt 시그니처 확장 — invalid → 'en' fallback (graceful)
- user prompt template 영문 라벨 통일 — 토큰 절약 + JSON 형식 명세 보존 (모든 언어 동일 키)

⚠️ **사용자 인지 영향** (정책 3 강화 정량 기준 4번):
- AI 리뷰 출력 언어 = repo owner 의 preferred_language → 분석 상세 페이지 / 알림 채널 / DB 저장 모두 동일 언어
- 출력 언어 지시 = system prompt 안 명시 (강제) — Claude 모델 의무 준수

자율 진입 보고:
- PR-12 응집 단위 = "AI 리뷰 인프라 (review_prompt + ai_review + caching + pipeline + CLI 호출자)" — 정책 7 강화 응집 부합
- review_guides Tier1/2/3 다국어 = PR-13~15 별도 진행 (~5,500 LOC, 50개 언어 × 3 = 150 영역)
- 회귀 가드 12건 = caching 자동 분기 검증 2건 포함 (system text hash 3 언어 모두 다름)

## 검증 (사이클 84 sync 실측)
- 단위 = `pytest tests/unit -q` → 2375 passed (+12 회귀 가드 + 1 기존 정정)
- 통합 = `pytest tests/integration -q` → 191 passed
- 합계 = 2566 passed / 5 skipped / 0 failed (107s)

## cross-verify 결과
- 1차 5 에이전트 디스패치 = 본 사이클 미수행 (단일 응집 PR-12 — AI 리뷰 인프라 영역)
- 통합 fail 1건 (PR push 직전 검증) → lang_guides header 영문 통일 후 정정 → 0 fail
- 본 환경 + CI 신뢰 모델 = `pytest tests/unit tests/integration -q` 동시 실행 default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
