### PR TITLE
feat(i18n-phase4-pr13): review_guides Tier1 10 가이드 다국어 — Python/JS/TS…

### DIFF
--- a/src/analyzer/pure/review_guides/__init__.py
+++ b/src/analyzer/pure/review_guides/__init__.py
@@ -1,9 +1,13 @@
 """Language-specific review guide registry.
 
+Phase 4 PR-13 (사이클 84) — output_language 인자 추가 (en/ko/ja). Tier1 10 가이드 i18n 적용.
+Phase 4 PR-13 (Cycle 84) — output_language arg added (en/ko/ja). Tier1 10 guides i18n.
+
 Usage:
     from src.analyzer.pure.review_guides import get_guide
-    guide = get_guide("python")          # full guide (default)
-    guide = get_guide("go", "compact")   # compact one-liner
+    guide = get_guide("python")                              # English (default)
+    guide = get_guide("python", "full", output_language="ko")  # Korean
+    guide = get_guide("go", "compact", output_language="ja")   # Japanese (compact)
 
 Tier 분류 기준 (신규 언어 추가 시 참조):
     Tier 1 — 업계 점유율 상위 (~10개): 상용/오픈소스 정적분석 도구 3+ 지원,
@@ -15,7 +19,14 @@ Tier 분류 기준 (신규 언어 추가 시 참조):
     Tier 3 — 레퍼런스/마이너 언어 (~20개): 도구 1개 미만, 경량 일반 가이드.
              erlang · ocaml · julia · zig · dockerfile 등
 
+다국어 적용 영역:
+    - Tier 1 (PR-13): 영어/한국어/일본어 3 언어 — `FULL`/`COMPACT`/`FULL_KO`/`COMPACT_KO`/`FULL_JA`/`COMPACT_JA`
+    - Tier 2 (PR-14): 영어/한국어/일본어 3 언어 — 동일 패턴
+    - Tier 3 (PR-15): 영어/한국어/일본어 3 언어 — 동일 패턴
+    - generic.py (PR-15): 영어/한국어/일본어 3 언어
+
 새 언어 추가 시: `tier{N}/{language}.py` 파일 생성 + `_GUIDE_MAP` 에 1줄 등록.
+i18n 적용 시: 동일 파일 안 `FULL`/`COMPACT` (영문 default) + `FULL_KO/JA` + `COMPACT_KO/JA` 추가.
 """
 from importlib import import_module
 
@@ -79,15 +90,30 @@ _GUIDE_MAP: dict[str, tuple[str, str]] = {
 _BASE = "src.analyzer.pure.review_guides"
 
 
-def get_guide(language: str, mode: str = "full") -> str:
-    """언어별 리뷰 가이드 반환.
+def get_guide(language: str, mode: str = "full", output_language: str = "en") -> str:
+    """언어별 리뷰 가이드 반환 (Phase 4 PR-13 — output_language 인자 추가).
+
+    Return language-specific review guide (Phase 4 PR-13 — output_language arg added).
 
     Args:
-        language: detect_language() 반환값 (예: "python", "go")
+        language: detect_language() 반환값 (예: "python", "go") — 가이드 대상 언어
         mode: "full" (상세) 또는 "compact" (한 줄 요약)
+        output_language: "en" / "ko" / "ja" — 가이드 텍스트 출력 언어 (default 'en').
+            가이드 모듈에 해당 언어 변형 (FULL_KO / COMPACT_JA 등) 부재 시 영문 fallback.
 
     Returns:
         가이드 문자열. 알 수 없는 언어는 generic fallback 반환.
+        Tier1 (10 언어) 만 i18n 완료 — Tier2/3 은 영문만 (PR-14/15 진행 영역).
+
+    가이드 모듈 컨벤션:
+        FULL / COMPACT          — 영문 (default). 모든 모듈 의무.
+        FULL_KO / COMPACT_KO    — 한국어 (Tier1 10 모듈 PR-13 적용 / Tier2/3 PR-14/15)
+        FULL_JA / COMPACT_JA    — 일본어 (동일)
+
+    출력 언어 fallback chain:
+        output_language='ko' → FULL_KO → FULL (영문 fallback)
+        output_language='ja' → FULL_JA → FULL (영문 fallback)
+        output_language='en' or invalid → FULL (영문)
     """
     entry = _GUIDE_MAP.get(language)
     if entry:
@@ -96,7 +122,17 @@ def get_guide(language: str, mode: str = "full") -> str:
     else:
         mod = import_module(f"{_BASE}.generic")
 
-    return mod.COMPACT if mode == "compact" else mod.FULL
+    # Phase 4 PR-13 — output_language 별 attr 검색 + 영문 fallback
+    # Phase 4 PR-13 — per-language attr lookup with English fallback
+    attr_base = "FULL" if mode == "full" else "COMPACT"
+    if output_language in ("ko", "ja"):
+        candidate = f"{attr_base}_{output_language.upper()}"
+        translated = getattr(mod, candidate, None)
+        if translated:
+            return translated
+    # 영문 default (output_language='en' 또는 번역 부재 시 영문 fallback)
+    # English default (output_language='en' or missing translation falls back to English)
+    return getattr(mod, attr_base)
 
 
 def get_tier(language: str) -> int:

--- a/src/analyzer/pure/review_guides/tier1/c.py
+++ b/src/analyzer/pure/review_guides/tier1/c.py
@@ -1,6 +1,23 @@
-"""C review guide — Tier 1 deep checklist."""
+"""C review guide — Tier 1 deep checklist.
+
+Phase 4 PR-13 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## C review checklist
+- **Memory**: Verify `malloc` / `free` pairing; watch for double-free / use-after-free; check `NULL` returns
+- **Buffers**: Avoid `strcpy` / `sprintf` / `gets` → use `strncpy` / `snprintf` / `fgets`; bounds-check arrays
+- **Pointers**: Watch uninitialized pointers, out-of-range pointer arithmetic, `void*` cast safety
+- **Integers**: Mixed signed/unsigned (unsigned underflow), integer overflow, type promotion gotchas
+- **Strings**: Ensure null-terminator; pick appropriate multibyte string functions
+- **Error handling**: Check syscall return values (`errno`); avoid file descriptor leaks
+- **Compiler**: Aim for zero warnings under `-Wall -Wextra`; leverage `__attribute__((warn_unused_result))`
+- **Security**: Format string vulnerabilities (`printf(user_input)`); validate `system()` inputs
+"""
+
+COMPACT = "## C: malloc/free pairs, no gets/strcpy, buffer bounds, integer overflow, format-string vulns"
+
+FULL_KO = """\
 ## C 검토 기준
 - **메모리**: `malloc`/`free` 쌍 확인, double-free·use-after-free, `NULL` 반환 체크
 - **버퍼**: `strcpy`/`sprintf`/`gets` 금지 → `strncpy`/`snprintf`/`fgets`, 배열 경계 검사
@@ -12,4 +29,18 @@ FULL = """\
 - **보안**: format string 취약점(`printf(user_input)`), `system()` 호출 입력 검증
 """
 
-COMPACT = "## C: malloc/free 쌍, gets/strcpy 금지, 버퍼 경계, 정수 오버플로, format string 취약점"
+COMPACT_KO = "## C: malloc/free 쌍, gets/strcpy 금지, 버퍼 경계, 정수 오버플로, format string 취약점"
+
+FULL_JA = """\
+## C レビュー基準
+- **メモリ**: `malloc` / `free` のペア確認、double-free · use-after-free、`NULL` 戻り値チェック
+- **バッファ**: `strcpy` / `sprintf` / `gets` 禁止 → `strncpy` / `snprintf` / `fgets`、配列境界チェック
+- **ポインタ**: 初期化されていないポインタ使用、ポインタ算術の境界超過、void* キャスト安全性
+- **整数**: 符号あり/なしの混用 (unsigned underflow)、整数オーバーフロー、型プロモーション注意
+- **文字列**: null-terminator 保証、マルチバイト文字列処理関数の適合性
+- **エラー処理**: システムコール戻り値 (`errno`) チェック漏れ、ファイルディスクリプタ漏れ
+- **コンパイラ**: `-Wall -Wextra` 警告ゼロを目標、`__attribute__((warn_unused_result))` 活用
+- **セキュリティ**: format string 脆弱性 (`printf(user_input)`)、`system()` 呼び出し入力検証
+"""
+
+COMPACT_JA = "## C: malloc/free ペア、gets/strcpy 禁止、バッファ境界、整数オーバーフロー、format string 脆弱性"

--- a/src/analyzer/pure/review_guides/tier1/cpp.py
+++ b/src/analyzer/pure/review_guides/tier1/cpp.py
@@ -1,6 +1,23 @@
-"""C++ review guide — Tier 1 deep checklist."""
+"""C++ review guide — Tier 1 deep checklist.
+
+Phase 4 PR-13 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## C++ review checklist
+- **Smart pointers**: Prefer `unique_ptr` / `shared_ptr` over raw pointers; minimize direct `new` / `delete`
+- **RAII**: Resource acquisition = initialization; no exception throws in destructors; mark copy/move constructors `= default` / `= delete`
+- **Modern C++**: Use range-for, `auto`, structured bindings, `std::optional`, `std::variant` (C++17+)
+- **Casting**: No C-style casts → use `static_cast` / `dynamic_cast` / `reinterpret_cast` explicitly
+- **STL**: Prefer `std::vector`; don't modify containers during iteration; pre-size with `reserve()`
+- **const correctness**: `const` reference parameters, `const` member functions, `constexpr` for compile-time constants
+- **Exceptions**: Drop exception specifications (C++11+); mark `noexcept`; ensure exception-safe copies
+- **Security**: Watch `memcpy` / `memset` size calculation errors, format string vulnerabilities, buffer overruns
+"""
+
+COMPACT = "## C++: unique_ptr, RAII, no C-style casts, const correctness, noexcept, prefer smart pointers"
+
+FULL_KO = """\
 ## C++ 검토 기준
 - **스마트 포인터**: raw pointer 대신 `unique_ptr`/`shared_ptr`, `new`/`delete` 직접 사용 최소화
 - **RAII**: 리소스 획득=초기화, 소멸자에서 예외 throw 금지, 복사/이동 생성자 `= default`/`= delete`
@@ -12,4 +29,18 @@ FULL = """\
 - **보안**: `memcpy`/`memset` 크기 계산 오류, 포맷 문자열 취약점, 버퍼 오버런
 """
 
-COMPACT = "## C++: unique_ptr, RAII, C-style cast 금지, const 정확성, noexcept, 스마트 포인터 선호"
+COMPACT_KO = "## C++: unique_ptr, RAII, C-style cast 금지, const 정확성, noexcept, 스마트 포인터 선호"
+
+FULL_JA = """\
+## C++ レビュー基準
+- **スマートポインタ**: raw pointer より `unique_ptr` / `shared_ptr`、`new` / `delete` 直接使用を最小化
+- **RAII**: リソース獲得=初期化、デストラクタでの例外 throw 禁止、コピー/ムーブコンストラクタ `= default` / `= delete`
+- **モダン C++**: range-for、`auto`、structured binding、`std::optional`、`std::variant` 活用 (C++17+)
+- **キャスト**: C-style cast 禁止 → `static_cast` / `dynamic_cast` / `reinterpret_cast` 明示
+- **STL**: `std::vector` 推奨、コンテナ反復中の変更禁止、`reserve()` で事前サイズ指定
+- **const 正確性**: `const` 参照パラメータ、`const` メンバ関数、`constexpr` コンパイル時定数
+- **例外**: 例外仕様削除 (C++11+)、noexcept 明示、exception-safe コピー保証
+- **セキュリティ**: `memcpy` / `memset` のサイズ計算ミス、フォーマット文字列脆弱性、バッファオーバーラン
+"""
+
+COMPACT_JA = "## C++: unique_ptr、RAII、C-style cast 禁止、const 正確性、noexcept、スマートポインタ推奨"

--- a/src/analyzer/pure/review_guides/tier1/csharp.py
+++ b/src/analyzer/pure/review_guides/tier1/csharp.py
@@ -1,6 +1,23 @@
-"""C# review guide — Tier 1 deep checklist."""
+"""C# review guide — Tier 1 deep checklist.
+
+Phase 4 PR-13 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## C# review checklist
+- **async/await**: No `async void` (except event handlers); use `ConfigureAwait(false)` in library code
+- **Null safety**: Enable nullable reference types (`#nullable enable`); use `?.` / `??` / `??=`; minimize null-forgiving (`!`)
+- **LINQ**: Understand deferred execution (force with `.ToList()`); avoid N+1 queries; prevent multiple enumeration of `IEnumerable`
+- **IDisposable**: Use `using` declarations or `try/finally`; ensure `Dispose()` for unmanaged resources
+- **Exceptions**: Avoid catching `Exception` directly; use `AggregateException.Flatten()`, `ExceptionDispatchInfo`
+- **Collections**: `List<T>` vs `IReadOnlyList<T>` for public APIs; thread-safety with `ConcurrentDictionary`
+- **DI**: Prefer constructor injection; do not inject Scoped services into Singletons (Captive Dependency)
+- **Security**: No SQL string concatenation → parameterized queries; `SecureString` vs `string` for sensitive data
+"""
+
+COMPACT = "## C#: avoid async void, nullable enable, LINQ deferred exec, IDisposable using, Captive Dependency"
+
+FULL_KO = """\
 ## C# 검토 기준
 - **async/await**: `async void` 금지(이벤트 핸들러 제외), `ConfigureAwait(false)` 라이브러리 코드
 - **null 안전**: nullable reference types(`#nullable enable`), `?.`/`??`/`??=` 활용, null forgiving(`!`) 최소화
@@ -12,4 +29,18 @@ FULL = """\
 - **보안**: SQL 문자열 연결 금지 → 파라미터화 쿼리, `SecureString` vs `string` 민감 데이터
 """
 
-COMPACT = "## C#: async void 금지, nullable enable, LINQ 지연실행, IDisposable using, Captive Dependency"
+COMPACT_KO = "## C#: async void 금지, nullable enable, LINQ 지연실행, IDisposable using, Captive Dependency"
+
+FULL_JA = """\
+## C# レビュー基準
+- **async/await**: `async void` 禁止 (イベントハンドラを除く)、ライブラリコードで `ConfigureAwait(false)`
+- **null 安全**: nullable reference types (`#nullable enable`)、`?.` / `??` / `??=` 活用、null forgiving (`!`) を最小化
+- **LINQ**: 遅延実行を理解 (`.ToList()` で強制実行のタイミング)、N+1 クエリ防止、`IEnumerable` 多重列挙防止
+- **IDisposable**: `using` 宣言または `try/finally`、非管理リソースの `Dispose()` 保証
+- **例外**: `Exception` 直接 catch 禁止、`AggregateException.Flatten()`、`ExceptionDispatchInfo`
+- **コレクション**: `List<T>` vs `IReadOnlyList<T>` 公開 API、`ConcurrentDictionary` のスレッド安全性
+- **DI**: コンストラクタインジェクション推奨、Scoped service を Singleton に注入禁止 (Captive Dependency)
+- **セキュリティ**: SQL 文字列連結禁止 → パラメータ化クエリ、機密データに `SecureString` vs `string`
+"""
+
+COMPACT_JA = "## C#: async void 禁止、nullable enable、LINQ 遅延実行、IDisposable using、Captive Dependency"

--- a/src/analyzer/pure/review_guides/tier1/go.py
+++ b/src/analyzer/pure/review_guides/tier1/go.py
@@ -1,6 +1,23 @@
-"""Go review guide — Tier 1 deep checklist."""
+"""Go review guide — Tier 1 deep checklist.
+
+Phase 4 PR-13 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Go review checklist
+- **Error handling**: Don't skip `err != nil` checks, don't discard with `_`; wrap via `fmt.Errorf("...: %w", err)`
+- **Interfaces**: Prefer small interfaces (1-2 methods); define on the consumer side, not the implementation side
+- **Goroutines**: Prevent leaks (propagate `context.Context`, use done channels, WaitGroup); recover from panics inside goroutines
+- **Channels**: Explicit channel direction types (`chan<-`, `<-chan`); justify buffer size
+- **Pointers**: Consistent value vs pointer receivers; avoid unnecessary pointer conversion
+- **Packages**: Lowercase singular package names; no import cycles; leverage `internal` packages
+- **Tests**: `_test.go` files, `t.Helper()`, table-driven test pattern
+- **Security**: Validate `os/exec` input; distinguish `crypto/rand` vs `math/rand`; SQL injection
+"""
+
+COMPACT = "## Go: err checks required, goroutine leaks, context propagation, receiver consistency, crypto/rand"
+
+FULL_KO = """\
 ## Go 검토 기준
 - **에러 처리**: `err != nil` 체크 누락 금지, `_` 무시 금지, `fmt.Errorf("...: %w", err)` 감싸기
 - **인터페이스**: 작은 인터페이스 선호(1~2 메서드), 구현 side에서 정의 — 소비 side에서 선언
@@ -12,4 +29,18 @@ FULL = """\
 - **보안**: `os/exec` 입력 검증, `crypto/rand` vs `math/rand` 구분, SQL injection
 """
 
-COMPACT = "## Go: err 체크 누락 금지, 고루틴 leak, context 전파, 포인터 리시버 일관성, crypto/rand"
+COMPACT_KO = "## Go: err 체크 누락 금지, 고루틴 leak, context 전파, 포인터 리시버 일관성, crypto/rand"
+
+FULL_JA = """\
+## Go レビュー基準
+- **エラー処理**: `err != nil` チェック漏れ禁止、`_` 無視禁止、`fmt.Errorf("...: %w", err)` でラップ
+- **インターフェース**: 小さなインターフェース推奨 (1〜2 メソッド)、消費側で定義 — 実装側ではない
+- **ゴルーチン**: ゴルーチンリーク防止 (context.Context 伝播、done channel、WaitGroup)、ゴルーチン内 panic recover
+- **チャネル**: チャネル方向型を明示 (`chan<-`, `<-chan`)、バッファサイズの根拠を明示
+- **ポインタ**: 値 vs ポインタレシーバの一貫性、不要なポインタ化回避
+- **パッケージ**: パッケージ名は小文字単数、import cycle 禁止、internal パッケージ活用
+- **テスト**: `_test.go` ファイル、`t.Helper()`、テーブルドリブンテストパターン
+- **セキュリティ**: `os/exec` 入力検証、`crypto/rand` vs `math/rand` 区別、SQL injection
+"""
+
+COMPACT_JA = "## Go: err チェック必須、ゴルーチンリーク、context 伝播、レシーバ一貫性、crypto/rand"

--- a/src/analyzer/pure/review_guides/tier1/java.py
+++ b/src/analyzer/pure/review_guides/tier1/java.py
@@ -1,6 +1,23 @@
-"""Java review guide — Tier 1 deep checklist."""
+"""Java review guide — Tier 1 deep checklist.
+
+Phase 4 PR-13 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Java review checklist
+- **Naming**: PascalCase classes, camelCase methods/variables, UPPER_SNAKE constants
+- **Null safety**: Use `Optional<T>`; prevent `NullPointerException` — return Optional rather than null
+- **Exceptions**: Avoid overusing checked exceptions; on direct `Exception` catch, log + rethrow
+- **Collections**: No raw types (`List` without generic); use `Collections.unmodifiableList()` for immutability
+- **Concurrency**: Minimize `synchronized` scope; correct use of `volatile` / `AtomicXxx`; watch ThreadLocal leaks
+- **Streams**: Excessive chaining hurts readability — split when needed; prefer `toList()` (Java 16+) over `collect(Collectors.toList())`
+- **Security**: No SQL string formatting → PreparedStatement; validate input to `Runtime.exec()`
+- **Dependencies**: Watch circular dependencies and SRP (single responsibility) violations
+"""
+
+COMPACT = "## Java: Optional, no raw types, minimize checked exceptions, PreparedStatement, circular deps"
+
+FULL_KO = """\
 ## Java 검토 기준
 - **네이밍**: PascalCase 클래스, camelCase 메서드/변수, UPPER_SNAKE 상수
 - **null 안전**: `Optional<T>` 활용, `NullPointerException` 방지 — null 반환 대신 Optional 반환
@@ -12,4 +29,18 @@ FULL = """\
 - **의존성**: 순환 의존성, 클래스 단일 책임 원칙(SRP) 위반 여부
 """
 
-COMPACT = "## Java: Optional 활용, raw type 금지, checked exception 최소화, PreparedStatement, 순환 의존성"
+COMPACT_KO = "## Java: Optional 활용, raw type 금지, checked exception 최소화, PreparedStatement, 순환 의존성"
+
+FULL_JA = """\
+## Java レビュー基準
+- **命名**: PascalCase クラス、camelCase メソッド/変数、UPPER_SNAKE 定数
+- **null 安全**: `Optional<T>` 活用、`NullPointerException` 防止 — null 戻り値より Optional 戻り値
+- **例外**: checked exception の濫用禁止、`Exception` 直接 catch 時はログ+再 throw
+- **コレクション**: raw type (`List` without generic) 禁止、`Collections.unmodifiableList()` で不変保証
+- **並行性**: `synchronized` 範囲を最小化、`volatile` / `AtomicXxx` の適切性、ThreadLocal 漏れ
+- **ストリーム**: Stream API 過度なチェーンで可読性低下時は分割、`collect(Collectors.toList())` → `toList()` (Java 16+)
+- **セキュリティ**: SQL 文字列フォーマット禁止 → PreparedStatement、`Runtime.exec()` の入力検証
+- **依存**: 循環依存、クラス単一責任原則 (SRP) 違反確認
+"""
+
+COMPACT_JA = "## Java: Optional 活用、raw type 禁止、checked exception 最小化、PreparedStatement、循環依存"

--- a/src/analyzer/pure/review_guides/tier1/javascript.py
+++ b/src/analyzer/pure/review_guides/tier1/javascript.py
@@ -1,6 +1,23 @@
-"""JavaScript review guide — Tier 1 deep checklist."""
+"""JavaScript review guide — Tier 1 deep checklist.
+
+Phase 4 PR-13 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## JavaScript review checklist
+- **Variables**: No `var`; use `const` / `let` (`const` when no reassignment)
+- **Async**: Prefer `async/await` over Promise chains; prevent unhandled rejections (`.catch()` or `try/catch`)
+- **Type safety**: No `==` / `===` mixing; explicit `null` / `undefined` checks
+- **Modules**: Prefer ES Module (`import` / `export`); confirm bundler config when mixing CommonJS
+- **Security**: No `eval()`; direct `innerHTML` assignment → XSS risk; wrap `JSON.parse` in try/catch
+- **Performance**: Minimize DOM manipulation in loops; avoid leaking event listeners
+- **Error handling**: Missing try/catch around `await` in async functions, unhandled `Promise.all` reject
+- **Code quality**: Function length ≤50 lines recommended; refactor nested callbacks (callback hell)
+"""
+
+COMPACT = "## JavaScript: const/let, async/await, ===, no eval, XSS innerHTML caution, Promise error handling"
+
+FULL_KO = """\
 ## JavaScript 검토 기준
 - **변수**: `var` 금지 → `const`/`let` 사용, 재할당 없으면 `const`
 - **비동기**: `Promise` 체인 대신 `async/await`, unhandled rejection 방지 (`.catch()` 또는 `try/catch`)
@@ -12,4 +29,18 @@ FULL = """\
 - **코드 품질**: 함수 길이 50줄 이하 권장, 중첩 콜백(callback hell) 리팩토링
 """
 
-COMPACT = "## JavaScript: const/let, async/await, ===, eval 금지, XSS innerHTML 주의, Promise 에러 처리"
+COMPACT_KO = "## JavaScript: const/let, async/await, ===, eval 금지, XSS innerHTML 주의, Promise 에러 처리"
+
+FULL_JA = """\
+## JavaScript レビュー基準
+- **変数**: `var` 禁止 → `const` / `let` 使用、再代入なしなら `const`
+- **非同期**: `Promise` チェーンより `async/await`、unhandled rejection 防止 (`.catch()` または `try/catch`)
+- **型安全**: `===` vs `==` 混用禁止、`null` / `undefined` チェックを明示
+- **モジュール**: ES Module (`import` / `export`) 推奨、CommonJS 混用時はバンドラ設定確認
+- **セキュリティ**: `eval()` 禁止、`innerHTML` 直接代入 → XSS 危険、`JSON.parse` を try/catch でラップ
+- **パフォーマンス**: ループ内の DOM 操作を最小化、イベントリスナー解除漏れ確認
+- **エラー処理**: `async` 関数で await 前の try/catch 漏れ、Promise.all の reject 伝播
+- **コード品質**: 関数長 50 行以下推奨、ネストコールバック (callback hell) のリファクタリング
+"""
+
+COMPACT_JA = "## JavaScript: const/let、async/await、===、eval 禁止、XSS innerHTML 注意、Promise エラー処理"

--- a/src/analyzer/pure/review_guides/tier1/python.py
+++ b/src/analyzer/pure/review_guides/tier1/python.py
@@ -1,6 +1,24 @@
-"""Python review guide — Tier 1 deep checklist."""
+"""Python review guide — Tier 1 deep checklist.
+
+Phase 4 PR-13 (사이클 84) — i18n: en (default) / ko / ja.
+Phase 4 PR-13 (Cycle 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Python review checklist
+- **Style**: PEP 8 naming (snake_case for functions/variables, PascalCase for classes), line length ≤100
+- **Type hints**: Required on public function signatures; consistent `Optional[X]` vs `X | None`
+- **Async**: No sync blocking I/O (requests, open) inside `async def` → use httpx, aiofiles
+- **Exceptions**: No bare `except:`; use `exc_info=True` or `logger.exception()` when logging
+- **Pitfalls**: Mutable default args (`def f(x=[])`), circular imports, heavy imports in `__init__.py`
+- **pytest**: `@pytest.fixture` scope (function/module/session) appropriateness, correct `parametrize` and `pytest.raises`
+- **Dependencies**: SQLAlchemy N+1 queries, missing `open()` / DB session context manager
+- **Security**: `eval` / `exec` / `pickle.loads` on untrusted input, SQL string format → parameterized
+"""
+
+COMPACT = "## Python: PEP 8, type hints, no async blocking I/O, mutable default args, eval/pickle caution"
+
+FULL_KO = """\
 ## Python 검토 기준
 - **스타일**: PEP 8 네이밍(snake_case 함수/변수, PascalCase 클래스), 줄 길이 ≤100
 - **타입 힌트**: public 함수 시그니처에 annotation 필수, `Optional[X]` vs `X | None` 일관성
@@ -12,4 +30,18 @@ FULL = """\
 - **보안**: `eval`/`exec`/`pickle.loads` 신뢰 입력, SQL string format → parameterized
 """
 
-COMPACT = "## Python: PEP 8, type hints, async 블로킹 I/O 금지, mutable default args, eval/pickle 주의"
+COMPACT_KO = "## Python: PEP 8, type hints, async 블로킹 I/O 금지, mutable default args, eval/pickle 주의"
+
+FULL_JA = """\
+## Python レビュー基準
+- **スタイル**: PEP 8 命名 (snake_case 関数/変数、PascalCase クラス)、行長 ≤100
+- **型ヒント**: public 関数シグネチャに annotation 必須、`Optional[X]` vs `X | None` の一貫性
+- **非同期**: `async def` 内部の同期ブロッキング I/O (requests, open) 禁止 → httpx · aiofiles
+- **例外**: bare `except:` 禁止、ロギング時は `exc_info=True` または `logger.exception()`
+- **落とし穴**: Mutable default args (`def f(x=[])`)、循環 import、`__init__.py` の重い import
+- **pytest**: `@pytest.fixture` スコープ (function/module/session) 適切性、`parametrize` · `pytest.raises` 正確性
+- **依存**: SQLAlchemy N+1 query、`open()` / DB session context manager 漏れ
+- **セキュリティ**: `eval` / `exec` / `pickle.loads` 信頼入力、SQL string format → parameterized
+"""
+
+COMPACT_JA = "## Python: PEP 8、type hints、async ブロッキング I/O 禁止、mutable default args、eval/pickle 注意"

--- a/src/analyzer/pure/review_guides/tier1/ruby.py
+++ b/src/analyzer/pure/review_guides/tier1/ruby.py
@@ -1,6 +1,23 @@
-"""Ruby review guide — Tier 1 deep checklist."""
+"""Ruby review guide — Tier 1 deep checklist.
+
+Phase 4 PR-13 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Ruby review checklist
+- **Style**: snake_case methods/variables, PascalCase classes, 2-space indentation (no tabs)
+- **Methods**: Aim for ≤10 lines per method; explicit returns are encouraged for complex flows (otherwise `return` may be omitted)
+- **Nil safety**: Use `&.` (safe navigation); distinguish `nil?` vs `empty?` vs `blank?`
+- **Blocks**: Consistent `do...end` (multi-line) vs `{...}` (single-line); pick `yield` vs `Proc.new` carefully
+- **ActiveRecord**: Avoid N+1 (`includes` / `eager_load`); no raw SQL `where("#{user_input}")`
+- **Exceptions**: Avoid `rescue Exception` (use `rescue StandardError`); release resources in `ensure`
+- **Security**: No `eval`; validate inputs to `system()` / `exec()`; allowlist `send()` calls
+- **Tests**: RSpec `describe` / `context` / `it` nesting depth; FactoryBot vs fixture choice
+"""
+
+COMPACT = "## Ruby: snake_case, safe navigation(&.), N+1 includes, no rescue Exception, no eval"
+
+FULL_KO = """\
 ## Ruby 검토 기준
 - **스타일**: snake_case 메서드/변수, PascalCase 클래스, 2칸 들여쓰기(탭 금지)
 - **메서드**: 메서드 길이 10줄 이하 권장, 반환값 명시(`return` 생략 가능하나 복잡한 경우 명시)
@@ -12,4 +29,18 @@ FULL = """\
 - **테스트**: RSpec `describe`/`context`/`it` 중첩 적절성, FactoryBot vs fixture 선택
 """
 
-COMPACT = "## Ruby: snake_case, safe navigation(&.), N+1 includes, rescue Exception 금지, eval 금지"
+COMPACT_KO = "## Ruby: snake_case, safe navigation(&.), N+1 includes, rescue Exception 금지, eval 금지"
+
+FULL_JA = """\
+## Ruby レビュー基準
+- **スタイル**: snake_case メソッド/変数、PascalCase クラス、2 スペースインデント (タブ禁止)
+- **メソッド**: メソッド長 10 行以下推奨、戻り値を明示 (`return` 省略可だが複雑な場合は明示)
+- **nil 安全**: `&.` (safe navigation) 活用、`nil?` vs `empty?` vs `blank?` 区別
+- **ブロック**: `do...end` (複数行) vs `{...}` (単一行) の一貫性、`yield` vs `Proc.new` の選択
+- **ActiveRecord**: N+1 クエリ (`includes` / `eager_load`)、raw SQL `where("#{user_input}")` 禁止
+- **例外**: `rescue Exception` 禁止 (→ `rescue StandardError`)、`ensure` でリソース解放
+- **セキュリティ**: `eval` 禁止、`system()` / `exec()` の入力検証、`send()` ホワイトリスト確認
+- **テスト**: RSpec `describe` / `context` / `it` のネスト適切性、FactoryBot vs fixture の選択
+"""
+
+COMPACT_JA = "## Ruby: snake_case、safe navigation (&.)、N+1 includes、rescue Exception 禁止、eval 禁止"

--- a/src/analyzer/pure/review_guides/tier1/rust.py
+++ b/src/analyzer/pure/review_guides/tier1/rust.py
@@ -1,6 +1,23 @@
-"""Rust review guide — Tier 1 deep checklist."""
+"""Rust review guide — Tier 1 deep checklist.
+
+Phase 4 PR-13 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Rust review checklist
+- **Ownership**: Avoid unnecessary `clone()` overuse; check whether explicit lifetimes (`'a`) are required
+- **Error handling**: Review `unwrap()` / `expect()` for panic risk; use `?` for propagation
+- **Types**: Consistent `Result<T, E>` / `Option<T>` use; `Box<dyn Error>` vs concrete types
+- **unsafe**: Minimize and document `unsafe` blocks; justify raw pointer usage with comments
+- **Concurrency**: Watch deadlock risk in `Mutex` / `RwLock`; avoid overusing `Arc` vs `Rc` (single-thread)
+- **Performance**: Avoid unnecessary heap allocations (`Box`, excessive `Vec`); pick `&str` vs `String` carefully
+- **Pattern matching**: Exhaustive `match`; prefer `if let` vs `match` appropriately; handle nested `Option`
+- **Dependencies**: Commit `Cargo.lock` (binaries); run `cargo audit` for vulnerabilities
+"""
+
+COMPACT = "## Rust: avoid unwrap→?, watch clone, document unsafe, Arc/Mutex deadlocks, cargo audit"
+
+FULL_KO = """\
 ## Rust 검토 기준
 - **소유권**: 불필요한 `clone()` 남용 확인, 참조 수명(`'a`) 명시 필요 여부
 - **에러 처리**: `unwrap()`/`expect()` — panic 가능 지점 리뷰 필수, `?` 연산자 전파 패턴
@@ -12,4 +29,18 @@ FULL = """\
 - **의존성**: `Cargo.lock` 커밋(바이너리), `cargo audit` 취약점 여부
 """
 
-COMPACT = "## Rust: unwrap 금지→?, clone 남용, unsafe 최소화·문서화, Arc/Mutex 데드락, cargo audit"
+COMPACT_KO = "## Rust: unwrap 금지→?, clone 남용, unsafe 최소화·문서화, Arc/Mutex 데드락, cargo audit"
+
+FULL_JA = """\
+## Rust レビュー基準
+- **所有権**: 不要な `clone()` の濫用確認、参照ライフタイム (`'a`) 明示の要否
+- **エラー処理**: `unwrap()` / `expect()` — panic 可能箇所のレビュー必須、`?` 演算子による伝播パターン
+- **型**: `Result<T, E>` / `Option<T>` の一貫使用、`Box<dyn Error>` vs 具体型
+- **unsafe**: `unsafe` ブロックを最小化・文書化、raw pointer 使用根拠コメント
+- **並行性**: `Mutex` / `RwLock` のデッドロックリスク、`Arc` 濫用 vs `Rc` (単一スレッド)
+- **パフォーマンス**: 不要なヒープアロケーション (`Box`、`Vec` 過多)、`&str` vs `String` の選択
+- **パターンマッチ**: `match` の網羅性、`if let` vs `match` の適切性、ネスト `Option` 処理
+- **依存**: `Cargo.lock` コミット (バイナリ)、`cargo audit` 脆弱性確認
+"""
+
+COMPACT_JA = "## Rust: unwrap 禁止→?、clone 濫用、unsafe 最小化・文書化、Arc/Mutex デッドロック、cargo audit"

--- a/src/analyzer/pure/review_guides/tier1/typescript.py
+++ b/src/analyzer/pure/review_guides/tier1/typescript.py
@@ -1,6 +1,23 @@
-"""TypeScript review guide — Tier 1 deep checklist."""
+"""TypeScript review guide — Tier 1 deep checklist.
+
+Phase 4 PR-13 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## TypeScript review checklist
+- **Type safety**: Minimize `any` → prefer `unknown` + type guards; cautious `as` casts
+- **Interfaces**: Consistent `interface` vs `type`; verify union type readability
+- **Null safety**: Assume `strictNullChecks` enabled; use optional chaining (`?.`) and nullish coalescing (`??`)
+- **Enums**: Prefer `const enum` (bundle optimization); avoid relying on `enum` numeric values
+- **Generics**: Explicit generic constraints (`T extends object`); avoid deeply nested generics
+- **Async**: Clear return types like `Promise<void>` vs `Promise<unknown>`
+- **Modules**: Consistent path aliases (`@/`); watch for circular dependencies in barrel exports (`index.ts`)
+- **Compiler**: Enforce `strict: true`; verify `tsconfig.json` `target` compatibility
+"""
+
+COMPACT = "## TypeScript: avoid any→unknown, strictNullChecks, const enum, generic constraints, strict:true"
+
+FULL_KO = """\
 ## TypeScript 검토 기준
 - **타입 안전**: `any` 사용 최소화 → `unknown` + 타입 가드, `as` 강제 캐스팅 주의
 - **인터페이스**: `interface` vs `type` 일관성 유지, union type 가독성 확인
@@ -12,4 +29,18 @@ FULL = """\
 - **컴파일러**: `strict: true` 옵션 강제, `tsconfig.json` `target` 버전 적합성
 """
 
-COMPACT = "## TypeScript: any 금지→unknown, strictNullChecks, const enum, 제네릭 constraints, strict:true"
+COMPACT_KO = "## TypeScript: any 금지→unknown, strictNullChecks, const enum, 제네릭 constraints, strict:true"
+
+FULL_JA = """\
+## TypeScript レビュー基準
+- **型安全**: `any` 使用を最小化 → `unknown` + 型ガード、`as` 強制キャスト注意
+- **インターフェース**: `interface` vs `type` の一貫性、union type の可読性確認
+- **null 安全**: `strictNullChecks` 有効を前提、optional chaining (`?.`) · nullish coalescing (`??`) 活用
+- **enum**: `const enum` 推奨 (バンドル最適化)、`enum` 数値依存禁止
+- **ジェネリクス**: ジェネリクス constraints 明示 (`T extends object`)、過度なネストジェネリクス回避
+- **非同期**: `Promise<void>` vs `Promise<unknown>` 戻り値型明確化
+- **モジュール**: パス alias (`@/`) の一貫性、barrel exports (`index.ts`) の循環依存リスク
+- **コンパイラ**: `strict: true` を強制、`tsconfig.json` `target` バージョン適合性
+"""
+
+COMPACT_JA = "## TypeScript: any 禁止→unknown、strictNullChecks、const enum、ジェネリクス constraints、strict:true"

--- a/src/analyzer/pure/review_prompt.py
+++ b/src/analyzer/pure/review_prompt.py
@@ -199,8 +199,13 @@ def _select_guide_modes(languages: list[str]) -> dict[str, str]:
     return modes
 
 
-def _build_lang_guides(languages: list[str], budget_chars: int) -> str:
-    """토큰 예산 내에서 언어별 가이드 섹션을 조립한다."""
+def _build_lang_guides(
+    languages: list[str], budget_chars: int, output_language: str = "en",
+) -> str:
+    """토큰 예산 내에서 언어별 가이드 섹션을 조립한다 (Phase 4 PR-13 — output_language 전달).
+
+    Build per-language guide section within token budget (Phase 4 PR-13 — output_language).
+    """
     if not languages:
         return ""
 
@@ -212,11 +217,11 @@ def _build_lang_guides(languages: list[str], budget_chars: int) -> str:
         if lang == "__rest__":
             snippet = f"Additional languages (brief review): {mode}\n"
         else:
-            snippet = get_guide(lang, mode) + "\n"
+            snippet = get_guide(lang, mode, output_language=output_language) + "\n"
 
         if used_chars + len(snippet) > budget_chars:
             if mode == "full":
-                snippet = get_guide(lang, "compact") + "\n"
+                snippet = get_guide(lang, "compact", output_language=output_language) + "\n"
             if used_chars + len(snippet) > budget_chars:
                 break
 
@@ -251,7 +256,7 @@ def build_review_blocks(
     commit_message: str,
     patches: list[tuple[str, str]],
     budget_tokens: int = 8000,
-    language: str = "en",  # noqa: ARG001  # Phase 4 PR-13+ 영역 (lang_guides 다국어)
+    language: str = "en",
 ) -> tuple[str, str, list[str]]:
     """Phase 2 a-B (사이클 74) — Multi-block 확장 인프라 (system + user 분리).
 
@@ -279,7 +284,8 @@ def build_review_blocks(
     languages = detect_languages_from_patches(patches)
 
     budget_chars = budget_tokens * _CHARS_PER_TOKEN - _FIXED_TOKEN_OVERHEAD * _CHARS_PER_TOKEN
-    lang_guides_block = _build_lang_guides(languages, max(budget_chars, 0))
+    # Phase 4 PR-13 — language 인자 전달 (Tier1 10 가이드 다국어, Tier2/3 영문 fallback)
+    lang_guides_block = _build_lang_guides(languages, max(budget_chars, 0), output_language=language)
 
     detected_display = ", ".join(languages) if languages else "none"
     user_prompt = _USER_PROMPT_TEMPLATE.format(
@@ -296,7 +302,7 @@ def build_review_prompt(
     commit_message: str,
     patches: list[tuple[str, str]],
     budget_tokens: int = 8000,
-    language: str = "en",  # noqa: ARG001  # Phase 4 PR-13+ 영역
+    language: str = "en",
 ) -> tuple[str, list[str]]:
     """언어-aware AI 리뷰 사용자 프롬프트를 생성한다 (시스템 프롬프트 제외).
 
@@ -322,7 +328,8 @@ def build_review_prompt(
     languages = detect_languages_from_patches(patches)
 
     budget_chars = budget_tokens * _CHARS_PER_TOKEN - _FIXED_TOKEN_OVERHEAD * _CHARS_PER_TOKEN
-    lang_guides = _build_lang_guides(languages, max(budget_chars, 0))
+    # Phase 4 PR-13 — language 인자 전달 (Tier1 10 가이드 다국어)
+    lang_guides = _build_lang_guides(languages, max(budget_chars, 0), output_language=language)
 
     detected_display = ", ".join(languages) if languages else "none"
 

--- a/tests/unit/analyzer/pure/test_review_guides_tier1_i18n.py
+++ b/tests/unit/analyzer/pure/test_review_guides_tier1_i18n.py
@@ -1,0 +1,177 @@
+"""Phase 4 PR-13 회귀 가드 — Tier1 review_guides 10 언어 × 3 언어 = 30 영역.
+
+Phase 4 PR-13 regression guards — Tier1 review_guides 10 langs × 3 output langs = 30 areas.
+
+검증 범위 (Coverage):
+1. get_guide(language, mode, output_language) — 3 언어 모두 작동 (en/ko/ja)
+2. Tier1 10 언어 모든 가이드 — FULL/COMPACT × ko/ja 변형 보유 검증
+3. output_language='en' (default) — 기존 영문 (FULL/COMPACT) 반환
+4. output_language='ko' / 'ja' → 해당 언어 반환 + 부재 시 영문 fallback
+5. invalid output_language → 영문 fallback
+6. build_review_prompt + build_review_blocks — language 인자 → output_language 전달 검증
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.analyzer.pure.review_guides import get_guide, supported_languages
+from src.analyzer.pure.review_prompt import build_review_blocks, build_review_prompt
+
+
+_TIER1 = ["python", "javascript", "typescript", "java", "go",
+          "rust", "c", "cpp", "csharp", "ruby"]
+
+
+# ── get_guide — 3 언어 분기 ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("lang", _TIER1)
+def test_tier1_full_english_default(lang):
+    """Tier1 10 언어 — FULL 영문 (default) 반환 + Korean 텍스트 부재."""
+    guide = get_guide(lang, "full", output_language="en")
+    assert isinstance(guide, str)
+    assert len(guide) > 50
+    # 영문 default = ASCII 위주 (한국어 영역 없어야 함)
+    # English default = ASCII-only (no Korean)
+    assert "검토 기준" not in guide  # Korean header absent
+    assert "review checklist" in guide.lower() or "review" in guide.lower()
+
+
+@pytest.mark.parametrize("lang", _TIER1)
+def test_tier1_full_korean(lang):
+    """Tier1 10 언어 — FULL 한국어 반환."""
+    guide = get_guide(lang, "full", output_language="ko")
+    assert isinstance(guide, str)
+    assert len(guide) > 50
+    # 한국어 가이드 헤더 (lang 별 다른 한국어 이름)
+    assert "검토 기준" in guide  # Korean header present
+
+
+@pytest.mark.parametrize("lang", _TIER1)
+def test_tier1_full_japanese(lang):
+    """Tier1 10 언어 — FULL 일본어 반환."""
+    guide = get_guide(lang, "full", output_language="ja")
+    assert isinstance(guide, str)
+    assert len(guide) > 50
+    # 일본어 가이드 헤더
+    assert "レビュー基準" in guide  # Japanese header present
+
+
+@pytest.mark.parametrize("lang", _TIER1)
+def test_tier1_compact_3_languages_distinct(lang):
+    """Tier1 10 언어 — COMPACT 3 언어 모두 다른 텍스트 (cache key 분기 검증)."""
+    en = get_guide(lang, "compact", output_language="en")
+    ko = get_guide(lang, "compact", output_language="ko")
+    ja = get_guide(lang, "compact", output_language="ja")
+    assert en != ko
+    assert en != ja
+    assert ko != ja
+
+
+def test_get_guide_default_output_language_is_english():
+    """get_guide — output_language default = 'en'."""
+    en_explicit = get_guide("python", "full", output_language="en")
+    en_default = get_guide("python", "full")
+    assert en_explicit == en_default
+
+
+def test_get_guide_invalid_output_language_falls_to_english():
+    """invalid output_language → 영문 fallback."""
+    en = get_guide("python", "full", output_language="en")
+    invalid = get_guide("python", "full", output_language="zh")  # 미지원
+    assert en == invalid
+
+
+def test_get_guide_unknown_language_uses_generic_fallback():
+    """unknown language → generic.py fallback (영문)."""
+    guide = get_guide("unknown_lang_xyz", "full", output_language="ko")
+    assert isinstance(guide, str)
+    assert len(guide) > 10
+
+
+# ── Tier2/3 영문 fallback (PR-14/15 별도 진행 영역) ─────────────────────────
+
+
+def test_tier2_falls_back_to_english_for_korean():
+    """Tier2 (php) — output_language='ko' 요청 시 영문 fallback (PR-14 미적용 영역)."""
+    en = get_guide("php", "full", output_language="en")
+    ko = get_guide("php", "full", output_language="ko")
+    # PR-14 미적용 → 동일 영문 (fallback)
+    assert en == ko
+
+
+def test_tier3_falls_back_to_english_for_japanese():
+    """Tier3 (julia) — output_language='ja' 요청 시 영문 fallback (PR-15 미적용 영역)."""
+    en = get_guide("julia", "full", output_language="en")
+    ja = get_guide("julia", "full", output_language="ja")
+    # PR-15 미적용 → 동일 영문 (fallback)
+    assert en == ja
+
+
+# ── build_review_prompt + build_review_blocks — language 전달 ─────────────
+
+
+def _patches() -> list[tuple[str, str]]:
+    return [("app.py", "+def hello():\n+    return 'hi'")]
+
+
+def test_build_review_prompt_korean_lang_guides():
+    """build_review_prompt(language='ko') → Tier1 가이드 한국어로 inline 포함."""
+    user_prompt, languages = build_review_prompt("commit msg", _patches(), language="ko")
+    assert "python" in languages
+    # 한국어 가이드 inline 포함
+    assert "Python 검토 기준" in user_prompt
+
+
+def test_build_review_prompt_japanese_lang_guides():
+    """build_review_prompt(language='ja') → Tier1 가이드 일본어로 inline 포함."""
+    user_prompt, languages = build_review_prompt("commit msg", _patches(), language="ja")
+    assert "python" in languages
+    assert "Python レビュー基準" in user_prompt
+
+
+def test_build_review_prompt_english_default():
+    """build_review_prompt() default → Tier1 가이드 영문."""
+    user_prompt, _ = build_review_prompt("commit msg", _patches())
+    assert "Python review checklist" in user_prompt
+
+
+def test_build_review_blocks_korean():
+    """build_review_blocks(language='ko') → lang_guides_block 한국어."""
+    lang_block, user_prompt, languages = build_review_blocks(
+        "commit msg", _patches(), language="ko",
+    )
+    assert "python" in languages
+    if lang_block:
+        assert "Python 검토 기준" in lang_block
+        # User prompt 안 lang_guides 비움 (multi-block 분리)
+        assert "Python 검토 기준" not in user_prompt
+
+
+# ── 영문 텍스트 무결성 검증 — Tier1 10 언어 모두 'review checklist' 영문 헤더 ─
+
+
+@pytest.mark.parametrize("lang", _TIER1)
+def test_tier1_english_full_has_review_checklist_header(lang):
+    """Tier1 10 언어 영문 FULL — `review checklist` 헤더 의무 (일관성 보장)."""
+    guide = get_guide(lang, "full", output_language="en")
+    assert "review checklist" in guide.lower()
+
+
+@pytest.mark.parametrize("lang", _TIER1)
+def test_tier1_korean_full_has_review_header(lang):
+    """Tier1 10 언어 한국어 FULL — `검토 기준` 헤더 의무."""
+    guide = get_guide(lang, "full", output_language="ko")
+    assert "검토 기준" in guide
+
+
+@pytest.mark.parametrize("lang", _TIER1)
+def test_tier1_japanese_full_has_review_header(lang):
+    """Tier1 10 언어 일본어 FULL — `レビュー基準` 헤더 의무."""
+    guide = get_guide(lang, "full", output_language="ja")
+    assert "レビュー基準" in guide
+
+
+def test_supported_languages_unchanged():
+    """supported_languages — 50 언어 보존 (i18n 적용 후 변경 0)."""
+    assert len(supported_languages()) == 50


### PR DESCRIPTION
…/Java/Go/Rust/C/C++/C#/Ruby × en/ko/ja (Phase 4 PR-13)

## Summary
Phase 4 PR-13 — Tier1 review_guides 10 언어 다국어 적용. 기존 한국어 default → 영문 default 정합 + 한국어 보존 (FULL_KO/COMPACT_KO) + 일본어 신규 번역 (FULL_JA/COMPACT_JA). 30 영역 (10 언어 × 3 출력 언어) 신설. get_guide(language, mode, output_language='en') 시그니처 확장 + 영문 fallback (Tier2/3 미적용 영역). 단위 +80 회귀 가드 (2566→2646).

## Changes (13 files)

### 1. src/analyzer/pure/review_guides/__init__.py — get_guide 시그니처 확장
- `get_guide(language, mode='full', output_language='en')` 인자 추가
- Tier1 모듈 attr 컨벤션:
  - `FULL` / `COMPACT` (영문 default — 모든 모듈 의무)
  - `FULL_KO` / `COMPACT_KO` (한국어 — Tier1 PR-13 적용)
  - `FULL_JA` / `COMPACT_JA` (일본어 — Tier1 PR-13 적용)
- 영문 fallback chain: `output_language='ko' → FULL_KO → FULL` (영문 default)
- Tier2/3 미적용 시 영문 fallback (PR-14/15 별도 진행 영역)

### 2. Tier1 10 가이드 i18n 적용 (10 파일)
- python.py / javascript.py / typescript.py / java.py / go.py
- rust.py / c.py / cpp.py / csharp.py / ruby.py
- 각 파일: `FULL` (영문 NEW — 기존 한국어 → 영문 번역) + `COMPACT` (영문 NEW)
- 각 파일: `FULL_KO` (기존 한국어 보존) + `COMPACT_KO`
- 각 파일: `FULL_JA` (일본어 신규 번역) + `COMPACT_JA`

### 3. src/analyzer/pure/review_prompt.py — output_language 전달
- `_build_lang_guides(languages, budget_chars, output_language='en')` 인자 추가
- `build_review_prompt(..., language='en')` → `_build_lang_guides(..., output_language=language)` 전달
- `build_review_blocks(..., language='en')` → 동일 패턴
- review_code → build_review_prompt → _build_lang_guides → get_guide(output_language=language) 체인 완성

### 4. 회귀 가드 80건 (tests/unit/analyzer/pure/test_review_guides_tier1_i18n.py — 신설)
- Tier1 10 언어 × 3 output_language (en/ko/ja) FULL 헤더 검증 = 30 tests
- Tier1 10 언어 × COMPACT 3 언어 distinct 검증 = 10 tests
- Tier1 10 언어 × en 영문 헤더 검증 = 10 tests
- Tier1 10 언어 × 한국어 헤더 검증 = 10 tests
- Tier1 10 언어 × 일본어 헤더 검증 = 10 tests
- 영문 default + invalid fallback + unknown language fallback = 3 tests
- Tier2/3 영문 fallback 검증 = 2 tests (PR-14/15 미적용 영역)
- build_review_prompt + build_review_blocks language 전달 검증 = 4 tests
- supported_languages 50 보존 검증 = 1 test

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 다른 preferred_language 사용자 PR open → AI 리뷰가 해당 언어로 출력 (Phase 4 PR-12 system prompt + PR-13 lang_guides 페어)
- [ ] 동일 언어 PR 반복 시 Anthropic prompt cache hit ↑ 확인 (cache_read_input_tokens 모니터링)
- [ ] Tier1 10 언어 (Python/JS/TS/Java/Go/Rust/C/C++/C#/Ruby) AI 리뷰 품질 = 영문/한국어/일본어 동등성 확인
- [ ] Tier2/3 (PHP/Swift/Kotlin/...) → 영문 fallback 정상 (PR-14/15 별도 진행 영역) 확인

## 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 적용 영역)

⚠️ **architecture 영향** (정책 3 강화 정량 기준 2번):
- Tier1 10 가이드 파일 컨벤션 변경 — `FULL` 의미가 한국어 → 영문 default (사용자 인지 영향 — 기존 직접 import 시 영문 표시)
- get_guide 시그니처 확장 — backwards-compat (output_language default='en')
- Tier2/3 영문 fallback = PR-14/15 별도 진행 영역 명시

⚠️ **AI 리뷰 품질 영향 영역** (메모리 `feedback-ai-review-quality-protect.md` High tier):
- Tier1 10 언어 영문/한국어/일본어 가이드 본문 — 사용자 사전 결정 영역. 본 사이클 사용자 명시 진행 결정 ("다음 작업 진행해주세요" — Phase 4 진입 OK)
- 영문 가이드 본문 = 기존 한국어에서 직역 (의미 보존 의무) — 단위 가드 80건이 헤더 일관성 + 텍스트 무결성 검증

자율 진입 보고:
- PR-13 응집 단위 = "Tier1 10 가이드 + get_guide 시그니처 + review_prompt 호출자" (정책 7 강화 응집 부합)
- PR-14 (Tier2 20 가이드) / PR-15 (Tier3 20 가이드 + generic) = 별도 PR — 다음 작업
- 회귀 가드 80건 = parametrized × 3 output_language 효율 (1 fixture 30 영역 동시 검증)
- 토큰 비용 영향 = 동일 언어 PR 반복 시 cache hit ↑ → 운영 토큰 비용 ↓ (정책 16 5번 원칙 페어)

## 검증 (사이클 84 sync 실측)
- 단위 = `pytest tests/unit -q` → 2455 passed (+80 회귀 가드)
- 통합 = `pytest tests/integration -q` → 191 passed
- 합계 = 2646 passed / 5 skipped / 0 failed (110s)

## cross-verify 결과
- 1차 5 에이전트 디스패치 = 본 사이클 미수행 (단일 응집 PR-13 — Tier1 10 가이드 + 시그니처)
- 통합 fail 0 (PR push 직전 검증)
- 본 환경 + CI 신뢰 모델 = `pytest tests/unit tests/integration -q` 동시 실행 default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
