### PR TITLE
feat(i18n-phase4-pr14): review_guides Tier2 20 가이드 다국어 — PHP/Swift/Ko…

### DIFF
--- a/src/analyzer/pure/review_guides/tier2/clojure.py
+++ b/src/analyzer/pure/review_guides/tier2/clojure.py
@@ -1,6 +1,22 @@
-"""Clojure review guide — Tier 2."""
+"""Clojure review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Clojure review checklist
+- **Immutability**: Use persistent data structures; minimize shared state via `atom` / `ref` / `agent`
+- **Namespaces**: Explicit `require` / `use` / `import`; no `:refer :all`
+- **Errors**: Structured errors with `ex-info` / `ex-data`; `try/catch/finally`; `:cause` chains
+- **Sequences**: lazy seq vs realization (`doall` / `dorun` for infinite seqs); avoid head-holding leaks
+- **Macros**: Pick macro vs function carefully; hygienic macros via `#` gensym; minimize `defmacro`
+- **Concurrency**: `future` / `promise`; STM `dosync`; close channels in core.async `go` blocks
+- **Security**: Parameterize SQL via `clojure.java.jdbc`; `read-string` → `edn/read-string`
+"""
+
+COMPACT = "## Clojure: persistent data, no :refer :all, lazy seq head leaks, STM, edn/read-string"
+
+FULL_KO = """\
 ## Clojure 검토 기준
 - **불변성**: 영속 자료구조 활용, `atom`/`ref`/`agent` 공유 상태 최소화
 - **네임스페이스**: `require`/`use`/`import` 명시, `:refer :all` 금지
@@ -11,4 +27,17 @@ FULL = """\
 - **보안**: SQL `clojure.java.jdbc` 파라미터화, `read-string` → `edn/read-string`
 """
 
-COMPACT = "## Clojure: 불변 자료구조, :refer :all 금지, lazy seq 헤드 누수, STM, edn/read-string"
+COMPACT_KO = "## Clojure: 불변 자료구조, :refer :all 금지, lazy seq 헤드 누수, STM, edn/read-string"
+
+FULL_JA = """\
+## Clojure レビュー基準
+- **不変性**: 永続データ構造を活用、`atom` / `ref` / `agent` の共有状態を最小化
+- **名前空間**: `require` / `use` / `import` を明示、`:refer :all` 禁止
+- **エラー**: `ex-info` / `ex-data` 構造化エラー、`try/catch/finally`、`:cause` チェーン
+- **シーケンス**: lazy seq 無限シーケンス時の `doall` / `dorun` 実体化、ヘッド保持リーク
+- **マクロ**: マクロ vs 関数の選択基準、gensym `#` 衛生マクロ、`defmacro` 最小化
+- **並行性**: `future` / `promise`、STM `dosync`、core.async `go` ブロックでチャネルクローズ
+- **セキュリティ**: SQL `clojure.java.jdbc` パラメータ化、`read-string` → `edn/read-string`
+"""
+
+COMPACT_JA = "## Clojure: 永続データ、:refer :all 禁止、lazy seq ヘッドリーク、STM、edn/read-string"

--- a/src/analyzer/pure/review_guides/tier2/css.py
+++ b/src/analyzer/pure/review_guides/tier2/css.py
@@ -1,6 +1,22 @@
-"""CSS/SCSS review guide — Tier 2."""
+"""CSS/SCSS review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## CSS/SCSS review checklist
+- **Performance**: No `@import` (blocking) → `@use` (SCSS); avoid deep selector nesting (≤3 levels)
+- **Layout**: Minimize `!important`; turn magic pixel values into CSS variables (`--spacing-md`)
+- **Accessibility**: Don't convey info via color alone (contrast ≥4.5:1); never remove `:focus` styles
+- **Responsive**: Prefer `rem` / `em` / `%` / `vw` over fixed `px`; `@media` mobile-first (`min-width`)
+- **BEM / modules**: Minimize global selector pollution; consistent CSS modules or BEM naming
+- **SCSS**: Reuse via `@mixin` / `@function`; separate variable files; warn on `@extend` overuse
+- **Animation**: Prefer `transform` / `opacity` (GPU-accelerated); don't overuse `will-change`
+"""
+
+COMPACT = "## CSS: minimize !important, CSS vars, rem/em, keep :focus, @import→@use, BEM"
+
+FULL_KO = """\
 ## CSS/SCSS 검토 기준
 - **성능**: `@import` 금지(블로킹) → `@use`(SCSS), 과도한 선택자 중첩(3단계 이하)
 - **레이아웃**: `!important` 최소화, 매직 넘버 픽셀값 → CSS 변수(`--spacing-md`)
@@ -11,4 +27,17 @@ FULL = """\
 - **애니메이션**: `transform`/`opacity` 선호(GPU 가속), `will-change` 남용 금지
 """
 
-COMPACT = "## CSS: !important 최소화, CSS 변수, rem/em 단위, :focus 삭제 금지, @import→@use, BEM"
+COMPACT_KO = "## CSS: !important 최소화, CSS 변수, rem/em 단위, :focus 삭제 금지, @import→@use, BEM"
+
+FULL_JA = """\
+## CSS/SCSS レビュー基準
+- **パフォーマンス**: `@import` 禁止 (ブロッキング) → `@use` (SCSS)、セレクタの深いネスト回避 (3 階層以下)
+- **レイアウト**: `!important` を最小化、マジックナンバーのピクセル値 → CSS 変数 (`--spacing-md`)
+- **アクセシビリティ**: 色のみでの情報伝達禁止 (コントラスト比 4.5:1)、`:focus` スタイル削除禁止
+- **レスポンシブ**: `px` 固定の代わりに `rem` / `em` / `%` / `vw`、`@media` はモバイルファースト (min-width)
+- **BEM / モジュール**: グローバルセレクタ汚染を最小化、CSS モジュールまたは BEM 命名の一貫性
+- **SCSS**: `@mixin` / `@function` の再利用、変数ファイル分離、`@extend` の濫用に警告
+- **アニメーション**: `transform` / `opacity` 推奨 (GPU 加速)、`will-change` の濫用禁止
+"""
+
+COMPACT_JA = "## CSS: !important 最小化、CSS 変数、rem/em 単位、:focus 維持、@import→@use、BEM"

--- a/src/analyzer/pure/review_guides/tier2/dart.py
+++ b/src/analyzer/pure/review_guides/tier2/dart.py
@@ -1,6 +1,21 @@
-"""Dart/Flutter review guide — Tier 2."""
+"""Dart/Flutter review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Dart review checklist
+- **Null safety**: Enable sound null safety; minimize `!` force-non-null; use `??` / `?.`
+- **Async**: `async` / `await`; handle Future errors (`.catchError` vs try/catch); cancel Stream subscriptions
+- **Flutter**: Use `const` widgets (avoid rebuilds); don't reuse `BuildContext` after async gaps
+- **State management**: Minimize `setState` scope; consistent Provider / Riverpod / Bloc pattern
+- **Memory**: Call `dispose()` for controllers/stream subscriptions; avoid GlobalKey overuse
+- **Types**: Minimize `dynamic`; distinguish `Object?` vs `dynamic`; explicit generics
+"""
+
+COMPACT = "## Dart: null safety, minimize !, const widgets, no BuildContext after async, dispose()"
+
+FULL_KO = """\
 ## Dart 검토 기준
 - **null 안전**: sound null safety 활성화, `!` 강제 non-null 최소화, `??`/`?.` 활용
 - **비동기**: `async`/`await`, Future 에러 처리(`.catchError` vs try/catch), Stream 구독 해제
@@ -10,4 +25,16 @@ FULL = """\
 - **타입**: `dynamic` 최소화, `Object?` vs `dynamic` 구분, 제네릭 명시
 """
 
-COMPACT = "## Dart: null safety, ! 최소화, const 위젯, BuildContext 비동기 금지, dispose() 필수"
+COMPACT_KO = "## Dart: null safety, ! 최소화, const 위젯, BuildContext 비동기 금지, dispose() 필수"
+
+FULL_JA = """\
+## Dart レビュー基準
+- **null 安全**: sound null safety を有効化、`!` 強制 non-null を最小化、`??` / `?.` を活用
+- **非同期**: `async` / `await`、Future エラー処理 (`.catchError` vs try/catch)、Stream 購読解除
+- **Flutter**: `const` ウィジェット活用 (リビルド防止)、非同期後の `BuildContext` 使用禁止
+- **状態管理**: `setState` スコープを最小化、Provider / Riverpod / Bloc パターンの一貫性
+- **メモリ**: コントローラ・ストリーム購読の `dispose()`、GlobalKey の濫用注意
+- **型**: `dynamic` を最小化、`Object?` vs `dynamic` 区別、ジェネリクスを明示
+"""
+
+COMPACT_JA = "## Dart: null safety、! 最小化、const ウィジェット、BuildContext 非同期後禁止、dispose() 必須"

--- a/src/analyzer/pure/review_guides/tier2/elixir.py
+++ b/src/analyzer/pure/review_guides/tier2/elixir.py
@@ -1,6 +1,22 @@
-"""Elixir review guide — Tier 2."""
+"""Elixir review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Elixir review checklist
+- **Pattern matching**: Exhaustive `case` / `cond` / `with`; explicit intent for `_` wildcards
+- **Pipelines**: Readable `|>` chains; follow first-arg data-flow pattern
+- **Processes**: Correct GenServer `handle_call` / `handle_cast` return tuples; avoid process leaks
+- **Errors**: `{:ok, result}` / `{:error, reason}` tuple pattern; error propagation in `with` chains
+- **Immutability**: Clear data transformation chains; serialize access to ETS shared state
+- **Tests**: ExUnit `describe` / `test`; `Mox` for mocks; `ExUnit.Case async: true`
+- **Security**: Validate external input via `Ecto.Changeset`; parameterize via Ecto for SQL injection
+"""
+
+COMPACT = "## Elixir: {:ok/:error} tuples, with error propagation, GenServer return, Ecto Changeset"
+
+FULL_KO = """\
 ## Elixir 검토 기준
 - **패턴 매칭**: `case`/`cond`/`with` 완전 매칭, `_` 와일드카드 명시적 의도
 - **파이프라인**: `|>` 체인 가독성, 첫 인수 데이터 흐름 패턴 준수
@@ -11,4 +27,17 @@ FULL = """\
 - **보안**: 외부 입력 `Ecto.Changeset` 검증, SQL injection Ecto 파라미터화
 """
 
-COMPACT = "## Elixir: {:ok/:error} 튜플, with 에러 전파, GenServer 반환 튜플, Ecto Changeset 검증"
+COMPACT_KO = "## Elixir: {:ok/:error} 튜플, with 에러 전파, GenServer 반환 튜플, Ecto Changeset 검증"
+
+FULL_JA = """\
+## Elixir レビュー基準
+- **パターンマッチ**: `case` / `cond` / `with` の網羅的マッチ、`_` ワイルドカードは意図を明示
+- **パイプライン**: `|>` チェーンの可読性、第一引数のデータフローパターンに従う
+- **プロセス**: GenServer `handle_call` / `handle_cast` の戻り値タプルの正確性、プロセス漏れ
+- **エラー**: `{:ok, result}` / `{:error, reason}` タプルパターン、`with` チェーンでのエラー伝播
+- **不変性**: データ変換チェーンの明確性、ETS 共有状態アクセスの直列化
+- **テスト**: ExUnit `describe` / `test`、`Mox` モック、`ExUnit.Case async: true`
+- **セキュリティ**: 外部入力を `Ecto.Changeset` で検証、SQL injection は Ecto でパラメータ化
+"""
+
+COMPACT_JA = "## Elixir: {:ok/:error} タプル、with エラー伝播、GenServer 戻り値タプル、Ecto Changeset"

--- a/src/analyzer/pure/review_guides/tier2/fsharp.py
+++ b/src/analyzer/pure/review_guides/tier2/fsharp.py
@@ -1,6 +1,21 @@
-"""F# review guide — Tier 2."""
+"""F# review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## F# review checklist
+- **Immutability**: Prefer `let` immutable bindings; minimize `mutable`; use record `with` updates
+- **Types**: Discriminated unions (DU) for domain modeling; `Option<T>` / `Result<T,E>` for errors; watch `unit` returns
+- **Pipelines**: Readable `|>` chains; appropriate function composition (`>>`)
+- **Async**: `async { }` computation expression; don't overuse `Async.RunSynchronously`
+- **Pattern matching**: Exhaustive `match` (compiler warning); cap active pattern complexity
+- **.NET interop**: Defensive null handling; `Option.ofObj`; `try/with` exception catch
+"""
+
+COMPACT = "## F#: immutable let, DU domain model, Option/Result, |> pipe, async computation, null defense"
+
+FULL_KO = """\
 ## F# 검토 기준
 - **불변성**: `let` 불변 바인딩 선호, `mutable` 최소화, 레코드 `with` 업데이트
 - **타입**: 판별 유니온(DU) 도메인 모델링, `Option<T>`/`Result<T,E>` 에러 처리, `unit` 반환 주의
@@ -10,4 +25,16 @@ FULL = """\
 - **.NET 상호운용**: `null` 방어적 처리, `Option.ofObj`, `try/with` 예외 캐치
 """
 
-COMPACT = "## F#: 불변 let, DU 도메인 모델, Option/Result, |> 파이프, async 컴퓨테이션, null 방어"
+COMPACT_KO = "## F#: 불변 let, DU 도메인 모델, Option/Result, |> 파이프, async 컴퓨테이션, null 방어"
+
+FULL_JA = """\
+## F# レビュー基準
+- **不変性**: `let` 不変バインディング推奨、`mutable` を最小化、レコード `with` 更新
+- **型**: 判別共用体 (DU) によるドメインモデリング、`Option<T>` / `Result<T,E>` でエラー処理、`unit` 戻り値に注意
+- **パイプライン**: `|>` チェーンの可読性、関数合成 (`>>`) の適切性
+- **非同期**: `async { }` コンピュテーション式、`Async.RunSynchronously` の濫用禁止
+- **パターンマッチ**: `match` の網羅性 (コンパイラ警告)、アクティブパターンの複雑度を制限
+- **.NET 相互運用**: `null` の防御的処理、`Option.ofObj`、`try/with` 例外キャッチ
+"""
+
+COMPACT_JA = "## F#: 不変 let、DU ドメインモデル、Option/Result、|> パイプ、async コンピュテーション、null 防御"

--- a/src/analyzer/pure/review_guides/tier2/groovy.py
+++ b/src/analyzer/pure/review_guides/tier2/groovy.py
@@ -1,6 +1,21 @@
-"""Groovy/Gradle review guide — Tier 2."""
+"""Groovy/Gradle review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Groovy review checklist
+- **Types**: Avoid overusing `def` — declare explicit types when possible; use `@TypeChecked` / `@CompileStatic`
+- **Null safety**: Safe navigation `?.`; Elvis `?:`; watch for null in GStrings
+- **Gradle**: `implementation` vs `api` dependency scope; `buildscript` vs `plugins` block
+- **Closures**: Be clear about delegates (`delegate`, `owner`, `this`); understand `return` inside closures
+- **Security**: Watch shell command injection in GStrings; no `evaluate()` / `Eval.me()`
+- **Tests**: Spock `given/when/then` structure; `@Unroll` parametrization; distinguish Mock / Stub / Spy
+"""
+
+COMPACT = "## Groovy: @CompileStatic, ?. Elvis, Gradle implementation vs api, no evaluate(), Spock"
+
+FULL_KO = """\
 ## Groovy 검토 기준
 - **타입**: `def` 과용 금지 — 가능한 명시적 타입 선언, `@TypeChecked`/`@CompileStatic`
 - **null 안전**: `?.` 안전 탐색, `?:` Elvis 연산자, GString 내 null 삽입 주의
@@ -10,4 +25,16 @@ FULL = """\
 - **테스트**: Spock `given/when/then` 구조, `@Unroll` 파라미터화, Mock/Stub/Spy 구분
 """
 
-COMPACT = "## Groovy: @CompileStatic, ?. Elvis, Gradle implementation vs api, evaluate() 금지, Spock"
+COMPACT_KO = "## Groovy: @CompileStatic, ?. Elvis, Gradle implementation vs api, evaluate() 금지, Spock"
+
+FULL_JA = """\
+## Groovy レビュー基準
+- **型**: `def` の濫用禁止 — 可能な限り明示的な型宣言、`@TypeChecked` / `@CompileStatic`
+- **null 安全**: 安全ナビゲーション `?.`、Elvis 演算子 `?:`、GString 内の null 注入に注意
+- **Gradle**: `implementation` vs `api` の依存スコープ、`buildscript` vs `plugins` ブロック
+- **クロージャ**: デリゲートの明確化 (`delegate`、`owner`、`this`)、クロージャ内 `return` の動作
+- **セキュリティ**: GString 内のシェルコマンド注入、`evaluate()` / `Eval.me()` 禁止
+- **テスト**: Spock `given/when/then` 構造、`@Unroll` パラメータ化、Mock / Stub / Spy 区別
+"""
+
+COMPACT_JA = "## Groovy: @CompileStatic、?. Elvis、Gradle implementation vs api、evaluate() 禁止、Spock"

--- a/src/analyzer/pure/review_guides/tier2/haskell.py
+++ b/src/analyzer/pure/review_guides/tier2/haskell.py
@@ -1,6 +1,21 @@
-"""Haskell review guide — Tier 2."""
+"""Haskell review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Haskell review checklist
+- **Types**: Explicit type signatures (required for public functions); `Maybe` / `Either` error handling
+- **Purity**: Minimize IO side effects — separate pure functions from IO; no `unsafePerformIO`
+- **Lazy evaluation**: Watch for space leaks; use `seq` / `deepseq` / `!` for strict evaluation
+- **Monads**: Readable `do` blocks; cap monad stack complexity; correct `liftIO`
+- **Imports**: Prefer qualified imports (`import qualified Data.Map as Map`); avoid wildcard imports
+- **GHC extensions**: Only enable what's needed (`{-# LANGUAGE ... #-}`); `OverloadedStrings` is common
+"""
+
+COMPACT = "## Haskell: type signatures, Maybe/Either, separate IO, lazy space leaks, qualified imports"
+
+FULL_KO = """\
 ## Haskell 검토 기준
 - **타입**: 명시적 타입 시그니처(공개 함수 필수), `Maybe`/`Either` 에러 처리
 - **순수성**: IO 부작용 최소화 — 순수 함수와 IO 분리, `unsafePerformIO` 금지
@@ -10,4 +25,16 @@ FULL = """\
 - **GHC 확장**: 필요한 확장만 명시(`{-# LANGUAGE ... #-}`), `OverloadedStrings` 기본
 """
 
-COMPACT = "## Haskell: 타입 시그니처 필수, Maybe/Either, IO 분리, lazy space leak, qualified import"
+COMPACT_KO = "## Haskell: 타입 시그니처 필수, Maybe/Either, IO 분리, lazy space leak, qualified import"
+
+FULL_JA = """\
+## Haskell レビュー基準
+- **型**: 明示的型シグネチャ (公開関数で必須)、`Maybe` / `Either` でエラー処理
+- **純粋性**: IO 副作用を最小化 — 純粋関数と IO を分離、`unsafePerformIO` 禁止
+- **遅延評価**: 空間漏れ (space leak) に注意、`seq` / `deepseq` / `!` で正格評価
+- **モナド**: `do` ブロックの可読性、モナドスタックの複雑度を制限、`liftIO` の適切性
+- **インポート**: qualified import 推奨 (`import qualified Data.Map as Map`)、ワイルドカード import 注意
+- **GHC 拡張**: 必要な拡張のみ明示 (`{-# LANGUAGE ... #-}`)、`OverloadedStrings` が一般的
+"""
+
+COMPACT_JA = "## Haskell: 型シグネチャ必須、Maybe/Either、IO 分離、lazy space leak、qualified import"

--- a/src/analyzer/pure/review_guides/tier2/html.py
+++ b/src/analyzer/pure/review_guides/tier2/html.py
@@ -1,6 +1,21 @@
-"""HTML review guide — Tier 2."""
+"""HTML review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## HTML review checklist
+- **Security**: Don't inject raw user input (XSS); add SRI (`integrity`) on external CDN `<script src>`
+- **Accessibility**: `alt` required on images; `<label>` + `for` / `aria-label`; semantic tags (`<nav>`, `<main>`, `<button>`)
+- **Semantics**: Use semantic elements instead of overusing `<div>`; no `<table>` for layout
+- **Performance**: Set image `width` / `height` (prevent CLS); `loading="lazy"`; `<script defer>` / `async`
+- **Forms**: Choose `<form method>` GET vs POST; CSRF tokens; `autocomplete` attribute
+- **Meta**: `<meta charset="UTF-8">`, viewport, `lang` attribute required
+"""
+
+COMPACT = "## HTML: XSS prevention, alt/aria-label, semantic tags, SRI integrity, <script defer>, lang"
+
+FULL_KO = """\
 ## HTML 검토 기준
 - **보안**: 사용자 입력 직접 삽입 금지(XSS), `<script src>` 외부 CDN SRI(`integrity`) 속성
 - **접근성**: `alt` 속성 필수(이미지), `<label>` + `for`/`aria-label`, 시맨틱 태그(`<nav>`, `<main>`, `<button>`)
@@ -10,4 +25,16 @@ FULL = """\
 - **메타**: `<meta charset="UTF-8">`, viewport 설정, `lang` 속성 필수
 """
 
-COMPACT = "## HTML: XSS 방지, alt/aria-label, 시맨틱 태그, SRI integrity, <script defer>, lang 속성"
+COMPACT_KO = "## HTML: XSS 방지, alt/aria-label, 시맨틱 태그, SRI integrity, <script defer>, lang 속성"
+
+FULL_JA = """\
+## HTML レビュー基準
+- **セキュリティ**: ユーザー入力の直接挿入禁止 (XSS)、外部 CDN `<script src>` には SRI (`integrity`) 属性
+- **アクセシビリティ**: 画像に `alt` 必須、`<label>` + `for` / `aria-label`、セマンティックタグ (`<nav>`、`<main>`、`<button>`)
+- **セマンティクス**: `<div>` の濫用ではなくセマンティック要素、レイアウト目的の `<table>` 禁止
+- **パフォーマンス**: 画像 `width` / `height` 明示 (CLS 防止)、`loading="lazy"`、`<script defer>` / `async`
+- **フォーム**: `<form method>` GET vs POST 選択、CSRF トークン、`autocomplete` 属性
+- **メタ**: `<meta charset="UTF-8">`、viewport 設定、`lang` 属性必須
+"""
+
+COMPACT_JA = "## HTML: XSS 防止、alt/aria-label、セマンティックタグ、SRI integrity、<script defer>、lang 属性"

--- a/src/analyzer/pure/review_guides/tier2/kotlin.py
+++ b/src/analyzer/pure/review_guides/tier2/kotlin.py
@@ -1,6 +1,22 @@
-"""Kotlin review guide — Tier 2."""
+"""Kotlin review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Kotlin review checklist
+- **Null safety**: Minimize force `!!`; use `?.` / `?:`; correct `lateinit` use
+- **Coroutines**: No `GlobalScope` → `CoroutineScope` + structured concurrency; `Dispatchers.IO` for I/O
+- **Functional**: Extension functions, lambdas; pick `let` / `run` / `apply` / `also` / `with` correctly
+- **Data classes**: `data class` with immutable fields (`val`); use `copy()`; auto-generated `equals` / `hashCode`
+- **Sealed classes**: Use `sealed class` for exhaustive `when`; minimize `else` branch
+- **Android**: Lifecycle-aware components; watch Context leaks; `viewModelScope` / `lifecycleScope`
+- **Security**: No hardcoded secrets; validate `JavascriptInterface` input on WebViews
+"""
+
+COMPACT = "## Kotlin: avoid !!, no GlobalScope→structured, sealed class, data class val, Context leak"
+
+FULL_KO = """\
 ## Kotlin 검토 기준
 - **null 안전**: `!!` 강제 non-null 최소화, `?.`/`?:` 활용, `lateinit` 적절성
 - **코루틴**: `GlobalScope` 금지 → `CoroutineScope` + 구조적 동시성, `Dispatchers.IO` I/O 전환
@@ -11,4 +27,17 @@ FULL = """\
 - **보안**: 하드코딩 시크릿 금지, Webview `JavascriptInterface` 입력 검증
 """
 
-COMPACT = "## Kotlin: !! 금지, GlobalScope 금지→구조적 동시성, sealed class, data class val, Context leak"
+COMPACT_KO = "## Kotlin: !! 금지, GlobalScope 금지→구조적 동시성, sealed class, data class val, Context leak"
+
+FULL_JA = """\
+## Kotlin レビュー基準
+- **null 安全**: `!!` 強制 non-null を最小化、`?.` / `?:` を活用、`lateinit` の適切性
+- **コルーチン**: `GlobalScope` 禁止 → `CoroutineScope` + 構造化並行性、I/O は `Dispatchers.IO`
+- **関数型**: 拡張関数、ラムダ、`let` / `run` / `apply` / `also` / `with` の適切な選択
+- **データクラス**: `data class` 不変フィールド (`val`)、`copy()` 活用、`equals` / `hashCode` 自動生成
+- **シールドクラス**: `sealed class` で `when` の網羅性保証、`else` ブランチを最小化
+- **Android**: Lifecycle 対応コンポーネント、Context leak、`viewModelScope` / `lifecycleScope`
+- **セキュリティ**: ハードコードされたシークレット禁止、WebView `JavascriptInterface` の入力検証
+"""
+
+COMPACT_JA = "## Kotlin: !! 禁止、GlobalScope 禁止→構造化並行、sealed class、data class val、Context leak"

--- a/src/analyzer/pure/review_guides/tier2/lua.py
+++ b/src/analyzer/pure/review_guides/tier2/lua.py
@@ -1,6 +1,22 @@
-"""Lua review guide — Tier 2."""
+"""Lua review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Lua review checklist
+- **Globals**: Always declare `local` — global leakage hurts debugging and performance
+- **nil checks**: Validate function argument nils; check table key existence before access
+- **Error handling**: Wrap with `pcall` / `xpcall`; consistent error object types
+- **Tables**: Arrays (1-indexed); careful when mixing with dicts; `#` length operator only reliable on sequences
+- **Modules**: `return M` pattern; cache `require` results locally; watch for circular require
+- **Performance**: Avoid string concat in loops (`..`) → `table.concat`; minimize repeated closure creation
+- **Nginx/OpenResty**: cosocket non-blocking; shared dict races; phase restrictions
+"""
+
+COMPACT = "## Lua: local required, pcall error handling, # only sequences, table.concat, cache require"
+
+FULL_KO = """\
 ## Lua 검토 기준
 - **전역 변수**: `local` 선언 필수 — 전역 누출은 디버깅 어렵고 성능 저하
 - **nil 체크**: 함수 인자 nil 검증, table 키 접근 전 존재 여부 확인
@@ -11,4 +27,17 @@ FULL = """\
 - **Nginx/OpenResty**: cosocket non-blocking, shared dict 경쟁 조건, phase 제약
 """
 
-COMPACT = "## Lua: local 선언 필수, pcall 에러 처리, #은 시퀀스만, table.concat, require 캐싱"
+COMPACT_KO = "## Lua: local 선언 필수, pcall 에러 처리, #은 시퀀스만, table.concat, require 캐싱"
+
+FULL_JA = """\
+## Lua レビュー基準
+- **グローバル変数**: `local` 宣言必須 — グローバル漏れはデバッグ困難・パフォーマンス低下
+- **nil チェック**: 関数引数の nil 検証、table キーアクセス前に存在確認
+- **エラー処理**: `pcall` / `xpcall` でラップ、エラーオブジェクトの型を一貫化
+- **テーブル**: 配列 (1-indexed)、辞書混用に注意、`#` 長さ演算子はシーケンスのみ信頼
+- **モジュール**: `return M` パターン、`require` 結果のローカルキャッシュ、循環 require に注意
+- **パフォーマンス**: ループ内文字列連結 (`..`) → `table.concat`、クロージャの繰り返し生成を最小化
+- **Nginx/OpenResty**: cosocket non-blocking、shared dict の競合、phase 制約
+"""
+
+COMPACT_JA = "## Lua: local 必須、pcall エラー処理、# はシーケンスのみ、table.concat、require キャッシュ"

--- a/src/analyzer/pure/review_guides/tier2/objc.py
+++ b/src/analyzer/pure/review_guides/tier2/objc.py
@@ -1,6 +1,21 @@
-"""Objective-C review guide — Tier 2."""
+"""Objective-C review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Objective-C review checklist
+- **Memory**: Confirm ARC; pick `strong` / `weak` / `unsafe_unretained`; retain cycles (`__weak`)
+- **nil handling**: Sending messages to nil is safe (Obj-C feature); nil-return vs NSError dual pattern
+- **Blocks**: Capture `self` → `__weak typeof(self) weakSelf`; copy block properties
+- **Threading**: Correct `@synchronized` / `dispatch_async`; UI updates on the main thread
+- **API mixing**: Swift ↔ Obj-C bridging nullability annotations (`_Nullable`, `_Nonnull`)
+- **Protocols**: Mark `@optional` / `@required`; delegate properties as `weak`
+"""
+
+COMPACT = "## Objective-C: __weak retain cycle, nil dual pattern, block weakSelf, main thread UI, nullability"
+
+FULL_KO = """\
 ## Objective-C 검토 기준
 - **메모리**: ARC 환경 확인, `strong`/`weak`/`unsafe_unretained` 선택, retain cycle(`__weak`)
 - **nil 처리**: nil 메시지 전송 안전(Obj-C 특성), nil 반환 vs NSError 이중 패턴
@@ -10,4 +25,16 @@ FULL = """\
 - **프로토콜**: `@optional`/`@required` 명시, delegate `weak` property
 """
 
-COMPACT = "## Objective-C: __weak retain cycle, nil 이중 패턴, 블록 weakSelf, main thread UI, nullability"
+COMPACT_KO = "## Objective-C: __weak retain cycle, nil 이중 패턴, 블록 weakSelf, main thread UI, nullability"
+
+FULL_JA = """\
+## Objective-C レビュー基準
+- **メモリ**: ARC 環境確認、`strong` / `weak` / `unsafe_unretained` の選択、retain cycle (`__weak`)
+- **nil 処理**: nil メッセージ送信は安全 (Obj-C 特性)、nil 戻り値 vs NSError 二重パターン
+- **ブロック**: ブロック内 `self` キャプチャ → `__weak typeof(self) weakSelf`、ブロックコピー (`copy` property)
+- **スレッド**: `@synchronized` / `dispatch_async` の適切性、UI 更新は main thread
+- **API ミックス**: Swift ↔ Obj-C ブリッジングの nullability アノテーション (`_Nullable`、`_Nonnull`)
+- **プロトコル**: `@optional` / `@required` 明示、delegate は `weak` property
+"""
+
+COMPACT_JA = "## Objective-C: __weak retain cycle、nil 二重パターン、ブロック weakSelf、main thread UI、nullability"

--- a/src/analyzer/pure/review_guides/tier2/perl.py
+++ b/src/analyzer/pure/review_guides/tier2/perl.py
@@ -1,6 +1,21 @@
-"""Perl review guide — Tier 2."""
+"""Perl review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Perl review checklist
+- **Strict mode**: `use strict; use warnings;` required; `use utf8;` for encoding
+- **Error handling**: `die` / `eval` / `$@` pattern; use `Carp` module (`croak` / `confess`); `or die` chains
+- **Regex**: Use `/x` flag for comments; capture `$1` immediately; watch `/g` infinite loops
+- **File handling**: `open(my $fh, '<', $file) or die`; 3-argument `open` required
+- **Security**: Use list form for `system()` / `exec()` (prevents shell injection); `taint mode` (`-T`)
+- **Modules**: `use Moo` / `Moose` for OOP; use `local $_` to prevent scope pollution
+"""
+
+COMPACT = "## Perl: use strict/warnings, 3-arg open, system() list form, taint mode, Carp"
+
+FULL_KO = """\
 ## Perl 검토 기준
 - **엄격 모드**: `use strict; use warnings;` 필수, `use utf8;` 인코딩
 - **에러 처리**: `die`/`eval`/`$@` 패턴, `Carp` 모듈 사용(croak/confess), `or die` 체인
@@ -10,4 +25,16 @@ FULL = """\
 - **모듈**: `use Moo`/`Moose` OOP, `local $_` 스코프 오염 방지
 """
 
-COMPACT = "## Perl: use strict/warnings, 3인수 open, system() 리스트 형식, taint mode, Carp 사용"
+COMPACT_KO = "## Perl: use strict/warnings, 3인수 open, system() 리스트 형식, taint mode, Carp 사용"
+
+FULL_JA = """\
+## Perl レビュー基準
+- **strict モード**: `use strict; use warnings;` 必須、エンコーディングに `use utf8;`
+- **エラー処理**: `die` / `eval` / `$@` パターン、`Carp` モジュール (`croak` / `confess`)、`or die` チェーン
+- **正規表現**: `/x` フラグでコメント追加、`$1` キャプチャ変数を即時保存、`/g` 無限ループ注意
+- **ファイル処理**: `open(my $fh, '<', $file) or die`、3 引数 `open` 必須
+- **セキュリティ**: `system()` / `exec()` はリスト形式 (シェル注入防止)、`taint mode` (`-T`)
+- **モジュール**: `use Moo` / `Moose` OOP、`local $_` でスコープ汚染防止
+"""
+
+COMPACT_JA = "## Perl: use strict/warnings、3 引数 open、system() リスト形式、taint mode、Carp"

--- a/src/analyzer/pure/review_guides/tier2/php.py
+++ b/src/analyzer/pure/review_guides/tier2/php.py
@@ -1,6 +1,21 @@
-"""PHP review guide — Tier 2."""
+"""PHP review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## PHP review checklist
+- **Security**: No SQL string formatting → PDO/MySQLi prepared statements; `htmlspecialchars()` for XSS
+- **Types**: `declare(strict_types=1)`; type hints; no `===` vs `==` mixing
+- **Errors**: No `@` error suppression; use `try/catch`; configure `error_reporting`
+- **Modern PHP**: Arrow functions, named arguments, union types (PHP 8.0+), `match` expressions
+- **Dependencies**: Use Composer autoload; minimize `global` variables
+- **Input validation**: No direct use of `$_GET` / `$_POST` / `$_REQUEST` — validate and sanitize
+"""
+
+COMPACT = "## PHP: prepared statements, htmlspecialchars, strict_types=1, no @, validate input"
+
+FULL_KO = """\
 ## PHP 검토 기준
 - **보안**: SQL 문자열 포맷팅 금지 → PDO/MySQLi prepared statement, `htmlspecialchars()` XSS 방어
 - **타입**: strict_types=1 선언, 타입 힌트 사용, `===` vs `==` 혼용 금지
@@ -10,4 +25,16 @@ FULL = """\
 - **입력 검증**: `$_GET`/`$_POST`/`$_REQUEST` 직접 사용 금지 — 검증·sanitize 필수
 """
 
-COMPACT = "## PHP: prepared statement, htmlspecialchars, strict_types=1, @ 연산자 금지, 입력 검증"
+COMPACT_KO = "## PHP: prepared statement, htmlspecialchars, strict_types=1, @ 연산자 금지, 입력 검증"
+
+FULL_JA = """\
+## PHP レビュー基準
+- **セキュリティ**: SQL 文字列フォーマット禁止 → PDO/MySQLi prepared statement、`htmlspecialchars()` で XSS 防御
+- **型**: `declare(strict_types=1)`、型ヒント使用、`===` vs `==` 混用禁止
+- **エラー**: `@` エラー抑制演算子禁止、`try/catch`、`error_reporting` 設定
+- **モダン PHP**: アロー関数、named arguments、union types (PHP 8.0+)、match 式
+- **依存**: Composer autoload 活用、グローバル変数 (`global`) を最小化
+- **入力検証**: `$_GET` / `$_POST` / `$_REQUEST` 直接使用禁止 — 検証・sanitize 必須
+"""
+
+COMPACT_JA = "## PHP: prepared statement、htmlspecialchars、strict_types=1、@ 禁止、入力検証"

--- a/src/analyzer/pure/review_guides/tier2/powershell.py
+++ b/src/analyzer/pure/review_guides/tier2/powershell.py
@@ -1,6 +1,21 @@
-"""PowerShell review guide — Tier 2."""
+"""PowerShell review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## PowerShell review checklist
+- **Error handling**: `$ErrorActionPreference = 'Stop'`, `try/catch/finally`, `trap`
+- **Variables**: Type hints (`[string]$Name`), `Set-StrictMode -Version Latest`
+- **Security**: No `Invoke-Expression`; `ConvertTo-SecureString` for credentials; `ExecutionPolicy`
+- **Pipeline**: Support pipeline input (`ValueFromPipeline`); avoid unnecessary `ForEach-Object` vs `foreach`
+- **Output**: Distinguish `Write-Verbose` / `Write-Debug` vs `Write-Host`; explicit `return`
+- **Modules**: `#Requires -Modules`, explicit `Export-ModuleMember`, approved verbs
+"""
+
+COMPACT = "## PowerShell: ErrorActionPreference=Stop, no Invoke-Expression, SecureString, Set-StrictMode"
+
+FULL_KO = """\
 ## PowerShell 검토 기준
 - **에러 처리**: `$ErrorActionPreference = 'Stop'`, `try/catch/finally`, `trap`
 - **변수**: 타입 힌트(`[string]$Name`), `Set-StrictMode -Version Latest`
@@ -10,4 +25,16 @@ FULL = """\
 - **모듈**: `#Requires -Modules`, Export 함수 명시(`Export-ModuleMember`), 승인된 동사
 """
 
-COMPACT = "## PowerShell: ErrorActionPreference=Stop, Invoke-Expression 금지, SecureString, Set-StrictMode"
+COMPACT_KO = "## PowerShell: ErrorActionPreference=Stop, Invoke-Expression 금지, SecureString, Set-StrictMode"
+
+FULL_JA = """\
+## PowerShell レビュー基準
+- **エラー処理**: `$ErrorActionPreference = 'Stop'`、`try/catch/finally`、`trap`
+- **変数**: 型ヒント (`[string]$Name`)、`Set-StrictMode -Version Latest`
+- **セキュリティ**: `Invoke-Expression` 禁止、認証情報に `ConvertTo-SecureString`、`ExecutionPolicy`
+- **パイプライン**: パイプライン入力サポート (`ValueFromPipeline`)、不要な `ForEach-Object` vs `foreach`
+- **出力**: `Write-Verbose` / `Write-Debug` vs `Write-Host` 区別、`return` 明示
+- **モジュール**: `#Requires -Modules`、`Export-ModuleMember` で Export 明示、承認済み動詞
+"""
+
+COMPACT_JA = "## PowerShell: ErrorActionPreference=Stop、Invoke-Expression 禁止、SecureString、Set-StrictMode"

--- a/src/analyzer/pure/review_guides/tier2/r.py
+++ b/src/analyzer/pure/review_guides/tier2/r.py
@@ -1,6 +1,21 @@
-"""R review guide — Tier 2."""
+"""R review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## R review checklist
+- **Vectorization**: Prefer `apply` / `lapply` / `sapply` / `vapply` over for loops; use `Vectorize()`
+- **Types**: `is.na()` for NA; distinguish `NULL` vs `NA` vs `NaN`; watch implicit conversions
+- **Packages**: `library()` vs `require()` — scripts use `library()`, packages internal use `requireNamespace()`
+- **Environment**: Minimize global env pollution; cautious `<<-` superassign; `local({})` to limit scope
+- **Reproducibility**: `set.seed()` for RNG; record `sessionInfo()`; pin deps with `renv` / `packrat`
+- **tidyverse**: `%>%` / `|>` pipe readability; `across()` for multi-column; pair `group_by` with `ungroup()`
+"""
+
+COMPACT = "## R: vectorize first, NA/NULL distinct, library() vs requireNamespace, watch <<-, set.seed"
+
+FULL_KO = """\
 ## R 검토 기준
 - **벡터화**: for 루프 대신 `apply`/`lapply`/`sapply`/`vapply` 권장, `Vectorize()` 활용
 - **타입**: `is.na()` NA 체크, `NULL` vs `NA` vs `NaN` 구분, 암묵적 타입 변환 주의
@@ -10,4 +25,16 @@ FULL = """\
 - **tidyverse**: `%>%`/`|>` 파이프 가독성, `across()` 다중 컬럼, `group_by` + `ungroup()` 쌍
 """
 
-COMPACT = "## R: 벡터화 우선, NA/NULL 구분, library() vs requireNamespace(), <<- 주의, set.seed"
+COMPACT_KO = "## R: 벡터화 우선, NA/NULL 구분, library() vs requireNamespace(), <<- 주의, set.seed"
+
+FULL_JA = """\
+## R レビュー基準
+- **ベクトル化**: for ループより `apply` / `lapply` / `sapply` / `vapply` 推奨、`Vectorize()` 活用
+- **型**: `is.na()` で NA チェック、`NULL` vs `NA` vs `NaN` の区別、暗黙的型変換に注意
+- **パッケージ**: `library()` vs `require()` — スクリプトは `library()`、パッケージ内部は `requireNamespace()`
+- **環境**: グローバル環境の汚染を最小化、`<<-` スーパーアサインに注意、`local({})` でスコープ制限
+- **再現性**: `set.seed()` で乱数固定、`sessionInfo()` を記録、`renv` / `packrat` で依存固定
+- **tidyverse**: `%>%` / `|>` パイプの可読性、`across()` 複数列、`group_by` + `ungroup()` ペア
+"""
+
+COMPACT_JA = "## R: ベクトル化優先、NA/NULL 区別、library() vs requireNamespace()、<<- 注意、set.seed"

--- a/src/analyzer/pure/review_guides/tier2/scala.py
+++ b/src/analyzer/pure/review_guides/tier2/scala.py
@@ -1,6 +1,22 @@
-"""Scala review guide — Tier 2."""
+"""Scala review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Scala review checklist
+- **Immutability**: Prefer `val` (minimize `var`); use immutable collections (`List`, `Map`)
+- **Option / Either**: No null returns → `Option[T]`; errors as `Either[Error, T]` or `Try`
+- **Pattern matching**: Exhaustive `match` (sealed trait); avoid wildcard `_` overuse
+- **Functional**: `map` / `flatMap` / `filter` chains; for-comprehension for readability
+- **Future**: Explicit `ExecutionContext`; wrap blocking work with `blocking {}`
+- **Types**: Avoid implicit overuse (Scala 3: `given/using`); don't over-trust type inference
+- **Akka / Play**: Immutable Actor messages; validate HTTP request params
+"""
+
+COMPACT = "## Scala: val/immutable collections, Option/Either, sealed trait exhaustive, minimize implicit"
+
+FULL_KO = """\
 ## Scala 검토 기준
 - **불변성**: `val` 우선(`var` 최소화), 불변 컬렉션(`List`, `Map`) 선호
 - **Option/Either**: `null` 반환 금지 → `Option[T]`, 에러는 `Either[Error, T]` or `Try`
@@ -11,4 +27,17 @@ FULL = """\
 - **Akka/Play**: Actor 메시지 불변성, HTTP 요청 파라미터 검증
 """
 
-COMPACT = "## Scala: val/불변 컬렉션, Option/Either, sealed trait 완전 매칭, implicit 최소화"
+COMPACT_KO = "## Scala: val/불변 컬렉션, Option/Either, sealed trait 완전 매칭, implicit 최소화"
+
+FULL_JA = """\
+## Scala レビュー基準
+- **不変性**: `val` 推奨 (`var` 最小化)、不変コレクション (`List`、`Map`) 推奨
+- **Option / Either**: `null` 戻り値禁止 → `Option[T]`、エラーは `Either[Error, T]` または `Try`
+- **パターンマッチ**: match の網羅性 (sealed trait)、`_` ワイルドカードの濫用注意
+- **関数型**: `map` / `flatMap` / `filter` チェーン、for-comprehension の可読性
+- **Future**: `ExecutionContext` 明示、blocking 作業を `blocking {}` でラップ
+- **型**: implicit の濫用禁止 (Scala 3: given/using)、型推論への過信注意
+- **Akka / Play**: Actor メッセージの不変性、HTTP リクエストパラメータ検証
+"""
+
+COMPACT_JA = "## Scala: val/不変コレクション、Option/Either、sealed trait 網羅マッチ、implicit 最小化"

--- a/src/analyzer/pure/review_guides/tier2/shell.py
+++ b/src/analyzer/pure/review_guides/tier2/shell.py
@@ -1,6 +1,22 @@
-"""Shell/Bash review guide — Tier 2."""
+"""Shell/Bash review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Shell review checklist
+- **Safety options**: `set -euo pipefail` at top of script — without it, errors are silently ignored
+- **Variables**: Always quote `"${VAR}"`; whitespace/glob-safe; default with `${VAR:-default}`
+- **Command injection**: No `eval` or `bash -c "$(user_input)"`; separate external input with `--`
+- **Arrays**: Use arrays for paths with spaces (`cmd "${args[@]}"`); avoid word-splitting
+- **Compatibility**: `#!/bin/bash` vs `#!/bin/sh` matters; verify bash-only syntax (`[[ ]]`, arrays)
+- **Temp files**: Use `mktemp`; clean up with trap (`trap 'rm -f "$tmp"' EXIT`)
+- **Error handling**: Check results in `||` / `&&` chains; subshell error propagation (`set -e` limitations)
+"""
+
+COMPACT = "## Shell: set -euo pipefail, quote variables, no eval, mktemp+trap, prevent injection"
+
+FULL_KO = """\
 ## Shell 검토 기준
 - **안전 옵션**: 스크립트 상단 `set -euo pipefail` 필수 — 미설정 시 에러 무시
 - **변수**: 변수 항상 `"${VAR}"` 쌍따옴표 감싸기, 공백·glob 안전, `${VAR:-default}` 기본값
@@ -11,4 +27,17 @@ FULL = """\
 - **에러 처리**: `||` / `&&` 체인 결과 확인, 서브쉘 에러 전파(`set -e` 제한사항)
 """
 
-COMPACT = "## Shell: set -euo pipefail, 변수 쌍따옴표, eval 금지, mktemp+trap, 명령 주입 방지"
+COMPACT_KO = "## Shell: set -euo pipefail, 변수 쌍따옴표, eval 금지, mktemp+trap, 명령 주입 방지"
+
+FULL_JA = """\
+## Shell レビュー基準
+- **安全オプション**: スクリプト先頭で `set -euo pipefail` 必須 — 未設定だとエラーが無視される
+- **変数**: 変数は常に `"${VAR}"` でクォート、空白/glob 安全、`${VAR:-default}` デフォルト値
+- **コマンド注入**: `eval` / `bash -c "$(user_input)"` 禁止、外部入力は `--` で分離
+- **配列**: 空白を含むパスには配列を使用 (`cmd "${args[@]}"`)、word splitting に注意
+- **互換性**: `#!/bin/bash` vs `#!/bin/sh` 区別、bash 専用構文確認 (`[[ ]]`、配列)
+- **一時ファイル**: `mktemp` 使用、trap で後始末 (`trap 'rm -f "$tmp"' EXIT`)
+- **エラー処理**: `||` / `&&` チェーンの結果確認、サブシェルのエラー伝播 (`set -e` 制限)
+"""
+
+COMPACT_JA = "## Shell: set -euo pipefail、変数クォート、eval 禁止、mktemp+trap、コマンド注入防止"

--- a/src/analyzer/pure/review_guides/tier2/solidity.py
+++ b/src/analyzer/pure/review_guides/tier2/solidity.py
@@ -1,6 +1,22 @@
-"""Solidity review guide — Tier 2."""
+"""Solidity review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Solidity review checklist
+- **Reentrancy**: CEI pattern (Checks-Effects-Interactions); `nonReentrant` modifier; place external calls last
+- **Integers**: Overflow/underflow — Solidity 0.8+ auto-checks (older needs SafeMath)
+- **Access control**: Explicit `public` / `external` / `internal` / `private` visibility; `onlyOwner` permissions
+- **Gas**: Cap loop length; cache storage reads (copy to `memory`); `uint256` vs `uint8` gas differences
+- **Upgradeable**: Proxy pattern storage collisions; careful `delegatecall` context
+- **Randomness**: `block.timestamp` / `blockhash` are manipulable — prefer Chainlink VRF
+- **Events**: Emit events for important state changes; use indexed parameters for filtering
+"""
+
+COMPACT = "## Solidity: CEI pattern, nonReentrant, SafeMath(0.7-), onlyOwner, loop gas, no block.timestamp RNG"
+
+FULL_KO = """\
 ## Solidity 검토 기준
 - **재진입 공격**: CEI 패턴(Checks-Effects-Interactions), `nonReentrant` modifier, 외부 호출 마지막 배치
 - **정수**: 오버플로/언더플로 — Solidity 0.8+ 자동 체크(이전 버전은 SafeMath 필수)
@@ -11,4 +27,17 @@ FULL = """\
 - **이벤트**: 중요 상태 변경 이벤트 emit, indexed 파라미터 필터링
 """
 
-COMPACT = "## Solidity: CEI 패턴, nonReentrant, SafeMath(0.7-), onlyOwner, 루프 가스, block.timestamp 난수 금지"
+COMPACT_KO = "## Solidity: CEI 패턴, nonReentrant, SafeMath(0.7-), onlyOwner, 루프 가스, block.timestamp 난수 금지"
+
+FULL_JA = """\
+## Solidity レビュー基準
+- **リエントランシー**: CEI パターン (Checks-Effects-Interactions)、`nonReentrant` modifier、外部呼び出しは最後に配置
+- **整数**: オーバーフロー/アンダーフロー — Solidity 0.8+ 自動チェック (それ以前は SafeMath 必須)
+- **アクセス制御**: `public` / `external` / `internal` / `private` 可視性を明示、`onlyOwner` 権限
+- **ガス**: ループ長を制限、storage 読み取りをキャッシュ (`memory` コピー)、`uint256` vs `uint8` のガス差
+- **アップグレード可能**: プロキシパターンの storage 衝突、`delegatecall` コンテキスト注意
+- **乱数**: `block.timestamp` / `blockhash` は操作可能 — Chainlink VRF 推奨
+- **イベント**: 重要な状態変更でイベント emit、indexed パラメータでフィルタリング
+"""
+
+COMPACT_JA = "## Solidity: CEI パターン、nonReentrant、SafeMath(0.7-)、onlyOwner、ループガス、block.timestamp 乱数禁止"

--- a/src/analyzer/pure/review_guides/tier2/sql.py
+++ b/src/analyzer/pure/review_guides/tier2/sql.py
@@ -1,6 +1,22 @@
-"""SQL review guide — Tier 2."""
+"""SQL review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## SQL review checklist
+- **Security**: Use parameterized queries — no string formatting for query composition (SQL Injection)
+- **Performance**: No `SELECT *` → only needed columns; avoid N+1 (`JOIN` or subquery); verify index usage
+- **Transactions**: Keep transactions short; pick appropriate isolation; ensure ROLLBACK paths
+- **NULL**: Use `IS NULL` / `IS NOT NULL`; null-safe aggregates (`COALESCE`)
+- **Naming**: snake_case for tables/columns; avoid reserved words (`date`, `user`, `order`)
+- **Migrations**: Prefer non-destructive changes (ADD before DROP); prepare rollback SQL
+- **Indexes**: Don't miss FK column indexes; avoid wasteful indexes on low-cardinality columns
+"""
+
+COMPACT = "## SQL: parameterized queries, no SELECT *, IS NULL, FK indexes, non-destructive migrations"
+
+FULL_KO = """\
 ## SQL 검토 기준
 - **보안**: 파라미터화 쿼리 사용 — 문자열 포맷팅으로 쿼리 조합 금지(SQL Injection)
 - **성능**: `SELECT *` 금지 → 필요 컬럼만, N+1 방지(`JOIN` 또는 subquery), 인덱스 활용 확인
@@ -11,4 +27,17 @@ FULL = """\
 - **인덱스**: FK 컬럼 인덱스 누락, 카디널리티 낮은 컬럼 인덱스 낭비
 """
 
-COMPACT = "## SQL: 파라미터화 쿼리, SELECT * 금지, NULL IS NULL, FK 인덱스, 비파괴적 마이그레이션"
+COMPACT_KO = "## SQL: 파라미터화 쿼리, SELECT * 금지, NULL IS NULL, FK 인덱스, 비파괴적 마이그레이션"
+
+FULL_JA = """\
+## SQL レビュー基準
+- **セキュリティ**: パラメータ化クエリ使用 — 文字列フォーマットでのクエリ組み立て禁止 (SQL Injection)
+- **パフォーマンス**: `SELECT *` 禁止 → 必要な列のみ、N+1 防止 (`JOIN` または subquery)、インデックス活用確認
+- **トランザクション**: 長いトランザクションを最小化、適切な分離レベル選択、ROLLBACK 経路保証
+- **NULL**: `NULL` 比較は `IS NULL` / `IS NOT NULL`、NULL-safe 集約関数 (`COALESCE`)
+- **命名**: テーブル・カラムは snake_case、予約語のカラム名禁止 (`date`、`user`、`order`)
+- **マイグレーション**: 非破壊的変更を推奨 (ADD COLUMN before DROP COLUMN)、ロールバック SQL 準備
+- **インデックス**: FK カラムのインデックス漏れ、カーディナリティの低いカラムへの無駄なインデックス
+"""
+
+COMPACT_JA = "## SQL: パラメータ化クエリ、SELECT * 禁止、IS NULL、FK インデックス、非破壊マイグレーション"

--- a/src/analyzer/pure/review_guides/tier2/swift.py
+++ b/src/analyzer/pure/review_guides/tier2/swift.py
@@ -1,6 +1,21 @@
-"""Swift review guide — Tier 2."""
+"""Swift review guide — Tier 2.
+
+Phase 4 PR-14 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Swift review checklist
+- **Optionals**: Minimize force-unwrap (`!`); use `guard let` / `if let`; `??` nil-coalescing
+- **Memory**: ARC retain cycles — `[weak self]` / `[unowned self]` capture lists in closures
+- **Concurrency**: Swift Concurrency (`async/await`, `Actor`); watch DispatchQueue races
+- **Types**: `struct` vs `class` (prefer value types); `protocol` + `extension` composition
+- **Errors**: `throws` / `try` / `catch`; `Result<T, Error>` return type
+- **SwiftUI**: Correct `@State` / `@Binding` / `@ObservedObject`; minimize view recomputation
+"""
+
+COMPACT = "## Swift: avoid force-unwrap, [weak self], async/await, prefer struct, protocol+extension"
+
+FULL_KO = """\
 ## Swift 검토 기준
 - **옵셔널**: 강제 언래핑(`!`) 최소화, `guard let`/`if let` 활용, `??` nil 병합 연산자
 - **메모리**: ARC retain cycle — `[weak self]`/`[unowned self]` 클로저 캡처 목록
@@ -10,4 +25,16 @@ FULL = """\
 - **SwiftUI**: `@State`/`@Binding`/`@ObservedObject` 적절성, View 재연산 최소화
 """
 
-COMPACT = "## Swift: 강제 언래핑 금지, [weak self], async/await, struct 선호, protocol+extension"
+COMPACT_KO = "## Swift: 강제 언래핑 금지, [weak self], async/await, struct 선호, protocol+extension"
+
+FULL_JA = """\
+## Swift レビュー基準
+- **オプショナル**: 強制アンラップ (`!`) を最小化、`guard let` / `if let` を活用、`??` nil 結合演算子
+- **メモリ**: ARC retain cycle — クロージャキャプチャリスト `[weak self]` / `[unowned self]`
+- **並行性**: Swift Concurrency (`async/await`、`Actor`)、DispatchQueue 競合
+- **型**: `struct` vs `class` 選択 (値型推奨)、`protocol` + `extension` 構成
+- **エラー**: `throws` / `try` / `catch`、`Result<T, Error>` 戻り値型
+- **SwiftUI**: `@State` / `@Binding` / `@ObservedObject` の適切性、View 再計算を最小化
+"""
+
+COMPACT_JA = "## Swift: 強制アンラップ禁止、[weak self]、async/await、struct 推奨、protocol+extension"

--- a/tests/unit/analyzer/pure/test_review_guides_tier1_i18n.py
+++ b/tests/unit/analyzer/pure/test_review_guides_tier1_i18n.py
@@ -92,12 +92,15 @@ def test_get_guide_unknown_language_uses_generic_fallback():
 # ── Tier2/3 영문 fallback (PR-14/15 별도 진행 영역) ─────────────────────────
 
 
-def test_tier2_falls_back_to_english_for_korean():
-    """Tier2 (php) — output_language='ko' 요청 시 영문 fallback (PR-14 미적용 영역)."""
+def test_tier2_now_supports_korean_after_pr14():
+    """Tier2 (php) — PR-14 적용 후 한국어 지원 (영문/한국어/일본어 distinct)."""
     en = get_guide("php", "full", output_language="en")
     ko = get_guide("php", "full", output_language="ko")
-    # PR-14 미적용 → 동일 영문 (fallback)
-    assert en == ko
+    ja = get_guide("php", "full", output_language="ja")
+    # Phase 4 PR-14 적용 후 — Tier2 도 다국어 지원
+    assert en != ko
+    assert en != ja
+    assert ko != ja
 
 
 def test_tier3_falls_back_to_english_for_japanese():

--- a/tests/unit/analyzer/pure/test_review_guides_tier2_i18n.py
+++ b/tests/unit/analyzer/pure/test_review_guides_tier2_i18n.py
@@ -1,0 +1,84 @@
+"""Phase 4 PR-14 회귀 가드 — Tier2 review_guides 20 언어 × 3 출력 언어 = 60 영역.
+
+Phase 4 PR-14 regression guards — Tier2 review_guides 20 langs × 3 output langs = 60 areas.
+
+검증 범위 (Coverage):
+1. Tier2 20 언어 모든 가이드 — FULL/COMPACT × en/ko/ja 변형 보유 검증
+2. output_language='en' (default) — 영문 반환
+3. output_language='ko' / 'ja' → 해당 언어 반환
+4. 각 가이드 헤더 일관성 (review checklist / 검토 기준 / レビュー基準)
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.analyzer.pure.review_guides import get_guide
+
+_TIER2 = [
+    "php", "swift", "kotlin", "scala", "shell", "powershell",
+    "sql", "dart", "lua", "perl", "r", "elixir", "haskell",
+    "clojure", "groovy", "html", "css", "solidity", "objc", "fsharp",
+]
+
+
+# ── Tier2 20 언어 × 3 출력 언어 헤더 검증 ──────────────────────────────
+
+
+@pytest.mark.parametrize("lang", _TIER2)
+def test_tier2_full_english(lang):
+    """Tier2 20 언어 — FULL 영문 반환 + `review checklist` 헤더 일관성."""
+    guide = get_guide(lang, "full", output_language="en")
+    assert isinstance(guide, str)
+    assert len(guide) > 50
+    assert "review checklist" in guide.lower()
+    # 한국어 헤더 부재 확인 (영문 default)
+    assert "검토 기준" not in guide
+
+
+@pytest.mark.parametrize("lang", _TIER2)
+def test_tier2_full_korean(lang):
+    """Tier2 20 언어 — FULL 한국어 반환 + `검토 기준` 헤더 일관성."""
+    guide = get_guide(lang, "full", output_language="ko")
+    assert isinstance(guide, str)
+    assert len(guide) > 50
+    assert "검토 기준" in guide
+
+
+@pytest.mark.parametrize("lang", _TIER2)
+def test_tier2_full_japanese(lang):
+    """Tier2 20 언어 — FULL 일본어 반환 + `レビュー基準` 헤더 일관성."""
+    guide = get_guide(lang, "full", output_language="ja")
+    assert isinstance(guide, str)
+    assert len(guide) > 50
+    assert "レビュー基準" in guide
+
+
+# ── COMPACT 3 언어 distinct ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("lang", _TIER2)
+def test_tier2_compact_3_languages_distinct(lang):
+    """Tier2 20 언어 — COMPACT 3 언어 모두 다른 텍스트 (cache key 분기 검증)."""
+    en = get_guide(lang, "compact", output_language="en")
+    ko = get_guide(lang, "compact", output_language="ko")
+    ja = get_guide(lang, "compact", output_language="ja")
+    assert en != ko
+    assert en != ja
+    assert ko != ja
+
+
+# ── Tier2 fallback to English when invalid output_language ─────────────
+
+
+def test_tier2_invalid_output_language_falls_to_english():
+    """invalid output_language → 영문 fallback."""
+    en = get_guide("php", "full", output_language="en")
+    invalid = get_guide("php", "full", output_language="zh")
+    assert en == invalid
+
+
+def test_tier2_default_output_language_is_english():
+    """get_guide — output_language default = 'en' (Tier2)."""
+    en_explicit = get_guide("php", "full", output_language="en")
+    en_default = get_guide("php", "full")
+    assert en_explicit == en_default


### PR DESCRIPTION
…tlin/Scala/Shell/PowerShell/SQL/Dart/Lua/Perl/R/Elixir/Haskell/Clojure/Groovy/HTML/CSS/Solidity/ObjC/F# × en/ko/ja (Phase 4 PR-14)

## Summary
Phase 4 PR-14 — Tier2 review_guides 20 언어 다국어 적용. 기존 한국어 default → 영문 default 정합 + 한국어 보존 (FULL_KO/COMPACT_KO) + 일본어 신규 번역 (FULL_JA/COMPACT_JA). 60 영역 (20 언어 × 3 출력 언어) 신설. Tier3 (~20 가이드) 영문 fallback 보존 (PR-15 별도 진행). 단위 +82 회귀 가드 (2646→2728).

## Changes (22 files)

### 1. Tier2 20 가이드 i18n 적용 (20 파일)
- php.py / swift.py / kotlin.py / scala.py / shell.py / powershell.py / sql.py / dart.py / lua.py / perl.py
- r.py / elixir.py / haskell.py / clojure.py / groovy.py / html.py / css.py / solidity.py / objc.py / fsharp.py
- 각 파일: `FULL` (영문 NEW — 기존 한국어 → 영문 번역) + `COMPACT` (영문 NEW)
- 각 파일: `FULL_KO` (기존 한국어 보존) + `COMPACT_KO`
- 각 파일: `FULL_JA` (일본어 신규 번역) + `COMPACT_JA`
- PR-13 패턴 동일 (Tier1 10 가이드 컨벤션 그대로)

### 2. 회귀 가드 82건 (tests/unit/analyzer/pure/test_review_guides_tier2_i18n.py — 신설)
- Tier2 20 언어 × 3 output_language (en/ko/ja) FULL 헤더 검증 = 60 tests
- Tier2 20 언어 × COMPACT 3 언어 distinct 검증 = 20 tests
- Tier2 invalid → 영문 fallback = 1 test
- Tier2 default = 영문 = 1 test

### 3. 기존 테스트 정정 (test_review_guides_tier1_i18n.py — 1건)
- test_tier2_falls_back_to_english_for_korean → test_tier2_now_supports_korean_after_pr14
  - PR-13 시점: Tier2 미적용 → 영문 fallback
  - PR-14 시점: Tier2 적용 후 영문/한국어/일본어 distinct

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 Tier2 20 언어 (PHP/Swift/Kotlin/Scala/Shell/PowerShell/SQL/Dart/Lua/Perl/R/Elixir/Haskell/Clojure/Groovy/HTML/CSS/Solidity/ObjC/F#) AI 리뷰 출력 — 다른 preferred_language 사용자별 확인
- [ ] 동일 언어 PR 반복 시 Anthropic prompt cache hit ↑ 확인 (cache_read_input_tokens)
- [ ] Tier3 (Erlang/OCaml/Julia/Zig/Nim/Crystal/Gleam/Elm/VimScript/GDScript/Dockerfile/Makefile/Terraform/YAML/TOML/GraphQL/Protobuf/XML/LaTeX/JSON Schema) → 영문 fallback 정상 (PR-15 별도 진행 영역) 확인

## 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 적용 영역)

⚠️ **architecture 영향** (정책 3 강화 정량 기준 2번):
- Tier2 20 가이드 파일 컨벤션 변경 — `FULL` 의미가 한국어 → 영문 default
- PR-13 시그니처 (output_language='en') 그대로 재사용 — 시그니처 변경 0
- Tier3 영문 fallback = PR-15 별도 진행 영역 명시

⚠️ **AI 리뷰 품질 영향 영역** (메모리 `feedback-ai-review-quality-protect.md` High tier):
- Tier2 20 언어 영문/한국어/일본어 가이드 본문 — 사용자 사전 결정 영역. 본 사이클 사용자 명시 진행 결정 ("머지 완료 했습니다. 다음 작업 진행해주세요")
- 영문 가이드 본문 = 기존 한국어에서 직역 (의미 보존 의무) — 단위 가드 82건이 헤더 일관성 + 텍스트 무결성 검증

자율 진입 보고:
- PR-14 응집 단위 = "Tier2 20 가이드" (정책 7 강화 응집 부합)
- PR-15 (Tier3 20 가이드 + generic) = 별도 PR — 다음 작업
- 회귀 가드 82건 = parametrized × 3 output_language 효율 (1 fixture 60 영역 동시 검증)

## 검증 (사이클 84 sync 실측)
- 단위 = `pytest tests/unit -q` → 2537 passed (+82 회귀 가드 + 1 PR-13 정정)
- 통합 = `pytest tests/integration -q` → 191 passed
- 합계 = 2728 passed / 5 skipped / 0 failed (106s)

## cross-verify 결과
- 1차 5 에이전트 디스패치 = 본 사이클 미수행 (단일 응집 PR-14 — Tier2 20 가이드)
- 통합 fail 1건 (PR push 직전 검증) → PR-13 시점 가정 (Tier2 미적용) 정정 후 0 fail
- 본 환경 + CI 신뢰 모델 = `pytest tests/unit tests/integration -q` 동시 실행 default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
