### PR TITLE
feat(i18n-phase4-pr15): review_guides Tier3 20 + generic 다국어 — Phase …

### DIFF
--- a/src/analyzer/pure/review_guides/generic.py
+++ b/src/analyzer/pure/review_guides/generic.py
@@ -1,6 +1,21 @@
-"""Generic fallback review guide — used when language is undetected or has no specific guide."""
+"""Generic fallback review guide — used when language is undetected or has no specific guide.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Generic code review checklist
+- **Readability**: Verify variables and function names clearly convey purpose
+- **Error handling**: Verify exception/error paths are handled appropriately
+- **Security**: External input validation, hardcoded secrets, missing permission checks
+- **Duplication**: Extract repeated logic into functions/modules
+- **Tests**: Verify tests exist for core logic
+- **Dependencies**: Avoid adding unnecessary external dependencies
+"""
+
+COMPACT = "## Generic: clear naming, error handling, validate input, no hardcoded secrets, deduplicate"
+
+FULL_KO = """\
 ## 일반 코드 검토 기준
 - **가독성**: 변수·함수명이 목적을 명확히 전달하는지 확인
 - **에러 처리**: 예외/에러 상황이 적절히 처리되는지 확인
@@ -10,4 +25,16 @@ FULL = """\
 - **의존성**: 불필요한 외부 의존성 추가 여부
 """
 
-COMPACT = "## 일반: 명확한 명명, 에러 처리, 외부 입력 검증, 하드코딩 시크릿 금지, 중복 제거"
+COMPACT_KO = "## 일반: 명확한 명명, 에러 처리, 외부 입력 검증, 하드코딩 시크릿 금지, 중복 제거"
+
+FULL_JA = """\
+## 一般コードレビュー基準
+- **可読性**: 変数・関数名が目的を明確に伝えるか確認
+- **エラー処理**: 例外/エラー状況が適切に処理されているか確認
+- **セキュリティ**: 外部入力検証、ハードコードされたシークレット、権限チェック漏れ
+- **重複**: 同一ロジックの繰り返し → 関数/モジュール抽出推奨
+- **テスト**: コアロジックに対するテストの存在確認
+- **依存**: 不要な外部依存追加の有無
+"""
+
+COMPACT_JA = "## 一般: 明確な命名、エラー処理、外部入力検証、ハードコードシークレット禁止、重複排除"

--- a/src/analyzer/pure/review_guides/tier3/crystal.py
+++ b/src/analyzer/pure/review_guides/tier3/crystal.py
@@ -1,6 +1,20 @@
-"""Crystal review guide — Tier 3."""
+"""Crystal review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Crystal review checklist
+- **Null safety**: `Nil` union type; minimize `not_nil!`; handle nil with `try` / `if`
+- **Types**: Explicit type annotations on public APIs; generic type constraints
+- **Concurrency**: Fiber-based; `Channel` communication; `Mutex` for shared state
+- **Exceptions**: `rescue` / `ensure` / `raise`; Ruby-like syntax but with static type constraints
+- **C bindings**: `lib` / `fun` FFI type safety; manual `Pointer` memory management
+"""
+
+COMPACT = "## Crystal: avoid not_nil!, generic constraints, Fiber/Channel, C FFI type safety"
+
+FULL_KO = """\
 ## Crystal 검토 기준
 - **null 안전**: `Nil` 공용체 타입, `not_nil!` 최소화, `try`/`if`로 nil 처리
 - **타입**: 명시적 타입 어노테이션(public API), 제네릭 타입 제약
@@ -9,4 +23,15 @@ FULL = """\
 - **C 바인딩**: `lib`/`fun` FFI 타입 안전성, `Pointer` 수동 메모리 관리
 """
 
-COMPACT = "## Crystal: not_nil! 금지, 제네릭 타입 제약, Fiber/Channel, C FFI 타입 안전성"
+COMPACT_KO = "## Crystal: not_nil! 금지, 제네릭 타입 제약, Fiber/Channel, C FFI 타입 안전성"
+
+FULL_JA = """\
+## Crystal レビュー基準
+- **null 安全**: `Nil` 共用体型、`not_nil!` を最小化、`try` / `if` で nil 処理
+- **型**: 公開 API に明示的型アノテーション、ジェネリック型制約
+- **並行性**: Fiber ベース、`Channel` 通信、`Mutex` で共有状態
+- **例外**: `rescue` / `ensure` / `raise`、Ruby ライクな構文だが静的型制約あり
+- **C バインディング**: `lib` / `fun` FFI 型安全性、`Pointer` 手動メモリ管理
+"""
+
+COMPACT_JA = "## Crystal: not_nil! 禁止、ジェネリック制約、Fiber/Channel、C FFI 型安全性"

--- a/src/analyzer/pure/review_guides/tier3/dockerfile.py
+++ b/src/analyzer/pure/review_guides/tier3/dockerfile.py
@@ -1,6 +1,21 @@
-"""Dockerfile review guide — Tier 3."""
+"""Dockerfile review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Dockerfile review checklist
+- **Base image**: No `latest` tag → pin versions (`python:3.12-slim`); use `slim` / `alpine` for size
+- **Multi-stage**: Separate build deps from runtime; minimize final image size
+- **Layer cache**: Order `COPY requirements.txt` → `RUN pip install` → `COPY . .` (cache efficient)
+- **Security**: `USER` non-root; never hardcode secrets in `ENV` / `ARG` (use `--secret`)
+- **Cleanup**: `RUN apt-get update && apt-get install -y ... && rm -rf /var/lib/apt/lists/*` in one line
+- **HEALTHCHECK**: Required for production containers; document `EXPOSE`
+"""
+
+COMPACT = "## Dockerfile: no latest, multi-stage, COPY cache order, USER non-root, no ENV secrets, HEALTHCHECK"
+
+FULL_KO = """\
 ## Dockerfile 검토 기준
 - **베이스 이미지**: `latest` 태그 금지 → 버전 명시(`python:3.12-slim`), `slim`/`alpine` 경량 이미지
 - **멀티스테이지**: 빌드 의존성과 런타임 분리, 최종 이미지 크기 최소화
@@ -10,4 +25,16 @@ FULL = """\
 - **HEALTHCHECK**: 프로덕션 컨테이너 헬스체크 필수, `EXPOSE` 문서화
 """
 
-COMPACT = "## Dockerfile: latest 금지, 멀티스테이지, COPY 캐시 순서, USER 비-root, 시크릿 ENV 금지, HEALTHCHECK"
+COMPACT_KO = "## Dockerfile: latest 금지, 멀티스테이지, COPY 캐시 순서, USER 비-root, 시크릿 ENV 금지, HEALTHCHECK"
+
+FULL_JA = """\
+## Dockerfile レビュー基準
+- **ベースイメージ**: `latest` タグ禁止 → バージョン明示 (`python:3.12-slim`)、`slim` / `alpine` 軽量イメージ
+- **マルチステージ**: ビルド依存とランタイムを分離、最終イメージサイズを最小化
+- **レイヤーキャッシュ**: `COPY requirements.txt` → `RUN pip install` → `COPY . .` の順序 (キャッシュ効率)
+- **セキュリティ**: `USER` 非 root 実行、シークレットを `ENV` / `ARG` にハードコード禁止 (`--secret` 活用)
+- **クリーンアップ**: `RUN apt-get update && apt-get install -y ... && rm -rf /var/lib/apt/lists/*` を 1 行に
+- **HEALTHCHECK**: 本番コンテナに必須、`EXPOSE` を文書化
+"""
+
+COMPACT_JA = "## Dockerfile: latest 禁止、マルチステージ、COPY キャッシュ順、USER 非 root、ENV シークレット禁止、HEALTHCHECK"

--- a/src/analyzer/pure/review_guides/tier3/elm.py
+++ b/src/analyzer/pure/review_guides/tier3/elm.py
@@ -1,6 +1,20 @@
-"""Elm review guide — Tier 3."""
+"""Elm review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Elm review checklist
+- **Architecture**: Clear Model-Update-View pattern; exhaustive Msg union type handling
+- **Types**: Handle all `Maybe` / `Result` (compiler-enforced); clear type aliases
+- **Side effects**: Only via Cmd/Sub; JS interop through Ports
+- **Performance**: Use `Html.Lazy.lazy` to minimize re-renders; `Html.Keyed`
+- **Packages**: `elm.json` dependency version constraints; follow `elm-review` rules
+"""
+
+COMPACT = "## Elm: MVU pattern, exhaustive Maybe/Result, Cmd/Sub side effects, Port JS interop, elm-review"
+
+FULL_KO = """\
 ## Elm 검토 기준
 - **아키텍처**: Model-Update-View 패턴 명확성, Msg 유니온 타입 완전 처리
 - **타입**: 모든 `Maybe`/`Result` 처리 누락 금지(컴파일러 강제), 타입 별칭 명확성
@@ -9,4 +23,15 @@ FULL = """\
 - **패키지**: `elm.json` 의존성 버전 제약, `elm-review` 규칙 준수
 """
 
-COMPACT = "## Elm: MVU 패턴, Maybe/Result 완전 처리, Cmd/Sub 부작용, Port JS 상호운용, elm-review"
+COMPACT_KO = "## Elm: MVU 패턴, Maybe/Result 완전 처리, Cmd/Sub 부작용, Port JS 상호운용, elm-review"
+
+FULL_JA = """\
+## Elm レビュー基準
+- **アーキテクチャ**: Model-Update-View パターンの明確性、Msg 共用体型の網羅処理
+- **型**: 全ての `Maybe` / `Result` 処理 (コンパイラ強制)、型エイリアスの明確性
+- **副作用**: Cmd/Sub 経由のみで副作用、JS 相互運用は Port 経由
+- **パフォーマンス**: `Html.Lazy.lazy` で再レンダリング最小化、`Html.Keyed`
+- **パッケージ**: `elm.json` 依存バージョン制約、`elm-review` ルール遵守
+"""
+
+COMPACT_JA = "## Elm: MVU パターン、Maybe/Result 網羅処理、Cmd/Sub 副作用、Port JS 相互運用、elm-review"

--- a/src/analyzer/pure/review_guides/tier3/erlang.py
+++ b/src/analyzer/pure/review_guides/tier3/erlang.py
@@ -1,6 +1,20 @@
-"""Erlang review guide — Tier 3."""
+"""Erlang review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Erlang review checklist
+- **Processes**: "Let it crash" philosophy — design supervisor trees; minimize gen_server state
+- **Pattern matching**: Exhaustive function clauses; no variable rebinding (single assignment)
+- **Errors**: `{ok, Val}` / `{error, Reason}` tuples; appropriate `catch` / `try`
+- **Messages**: Prevent message queue overflow; minimize selective receive patterns
+- **OTP**: Complete behaviour callbacks (`gen_server` / `supervisor` / `gen_statem`)
+"""
+
+COMPACT = "## Erlang: let it crash + supervisor, single assignment, {ok/error} tuples, OTP behaviour"
+
+FULL_KO = """\
 ## Erlang 검토 기준
 - **프로세스**: "let it crash" 철학 — supervisor 트리 설계, gen_server 상태 최소화
 - **패턴 매칭**: 함수 절 완전성, 변수 재바인딩 금지(단일 할당)
@@ -9,4 +23,15 @@ FULL = """\
 - **OTP**: behaviour(`gen_server`/`supervisor`/`gen_statem`) 콜백 완성도
 """
 
-COMPACT = "## Erlang: let it crash + supervisor, 단일 할당, {ok/error} 튜플, 메시지 큐 관리, OTP behaviour"
+COMPACT_KO = "## Erlang: let it crash + supervisor, 단일 할당, {ok/error} 튜플, 메시지 큐 관리, OTP behaviour"
+
+FULL_JA = """\
+## Erlang レビュー基準
+- **プロセス**: "let it crash" 哲学 — supervisor ツリー設計、gen_server 状態を最小化
+- **パターンマッチ**: 関数節の網羅性、変数再バインド禁止 (単一代入)
+- **エラー**: `{ok, Val}` / `{error, Reason}` タプル、`catch` / `try` の適切性
+- **メッセージ**: メッセージキューオーバーフロー防止、選択的 receive パターンを最小化
+- **OTP**: behaviour (`gen_server` / `supervisor` / `gen_statem`) コールバック完成度
+"""
+
+COMPACT_JA = "## Erlang: let it crash + supervisor、単一代入、{ok/error} タプル、メッセージキュー管理、OTP"

--- a/src/analyzer/pure/review_guides/tier3/gdscript.py
+++ b/src/analyzer/pure/review_guides/tier3/gdscript.py
@@ -1,6 +1,21 @@
-"""GDScript (Godot) review guide — Tier 3."""
+"""GDScript (Godot) review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## GDScript review checklist
+- **Type hints**: Explicit `: Type` for static typing (performance + readability); `@export` variable types
+- **Node references**: `@onready var` for initialization; consistent `get_node()` vs `$`; null checks
+- **Signals**: `signal` declaration + `emit` / `connect` pair; signals over polling
+- **_process vs _physics_process**: Separate game logic; `delta`-based time movement
+- **Memory**: `queue_free()` to release nodes; `preload` vs `load` (compile-time vs runtime)
+- **Godot 4**: `await` signals; `Resource` immutability; minimize `Node` scene tree dependencies
+"""
+
+COMPACT = "## GDScript: type hints, @onready, signal emit/connect, delta movement, queue_free, await signal"
+
+FULL_KO = """\
 ## GDScript 검토 기준
 - **타입 힌트**: `: Type` 정적 타입 명시(성능 + 가독성), `@export` 변수 타입
 - **노드 참조**: `@onready var` 초기화, `get_node()` vs `$` 일관성, null 체크
@@ -10,4 +25,16 @@ FULL = """\
 - **Godot 4**: `await` 시그널, `Resource` 불변성, `Node` 씬 트리 의존성 최소화
 """
 
-COMPACT = "## GDScript: 타입 힌트, @onready, signal emit/connect, delta 이동, queue_free, await 시그널"
+COMPACT_KO = "## GDScript: 타입 힌트, @onready, signal emit/connect, delta 이동, queue_free, await 시그널"
+
+FULL_JA = """\
+## GDScript レビュー基準
+- **型ヒント**: `: Type` で静的型を明示 (パフォーマンス + 可読性)、`@export` 変数の型
+- **ノード参照**: `@onready var` で初期化、`get_node()` vs `$` の一貫性、null チェック
+- **シグナル**: `signal` 宣言 + `emit` / `connect` ペア、ポーリングよりシグナル
+- **_process vs _physics_process**: ゲームロジックを分離、`delta` 時間ベース移動
+- **メモリ**: `queue_free()` でノード解放、`preload` / `load` 選択 (コンパイル時 vs 実行時)
+- **Godot 4**: `await` シグナル、`Resource` 不変性、`Node` シーンツリー依存を最小化
+"""
+
+COMPACT_JA = "## GDScript: 型ヒント、@onready、signal emit/connect、delta 移動、queue_free、await シグナル"

--- a/src/analyzer/pure/review_guides/tier3/gleam.py
+++ b/src/analyzer/pure/review_guides/tier3/gleam.py
@@ -1,6 +1,20 @@
-"""Gleam review guide — Tier 3."""
+"""Gleam review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Gleam review checklist
+- **Types**: Exhaustive pattern matching (compiler-enforced); `Result(a, e)` for errors
+- **Pipelines**: `|>` operator for functional style; single-direction data flow
+- **Immutability**: All values immutable; record update syntax
+- **BEAM interop**: Erlang/Elixir FFI via `external fn`; verify type boundaries
+- **Modules**: Mark visibility (`pub`); explicit import selection
+"""
+
+COMPACT = "## Gleam: exhaustive matching, Result type, |> pipe, immutability, BEAM FFI boundaries"
+
+FULL_KO = """\
 ## Gleam 검토 기준
 - **타입**: 완전한 패턴 매칭(컴파일러 강제), `Result(a, e)` 에러 처리
 - **파이프라인**: `|>` 연산자 함수형 스타일, 단방향 데이터 흐름
@@ -9,4 +23,15 @@ FULL = """\
 - **모듈**: 공개/비공개 명시(`pub`), import 명시적 선택
 """
 
-COMPACT = "## Gleam: 완전 패턴 매칭, Result 타입, |> 파이프, 불변성, BEAM FFI 타입 경계"
+COMPACT_KO = "## Gleam: 완전 패턴 매칭, Result 타입, |> 파이프, 불변성, BEAM FFI 타입 경계"
+
+FULL_JA = """\
+## Gleam レビュー基準
+- **型**: 網羅的パターンマッチ (コンパイラ強制)、`Result(a, e)` でエラー処理
+- **パイプライン**: `|>` 演算子の関数型スタイル、単一方向のデータフロー
+- **不変性**: 全ての値が不変、レコード更新構文
+- **BEAM 相互運用**: Erlang/Elixir FFI を `external fn` で、型境界を検証
+- **モジュール**: 可視性 (`pub`) 明示、import の明示的選択
+"""
+
+COMPACT_JA = "## Gleam: 網羅マッチ、Result 型、|> パイプ、不変性、BEAM FFI 境界"

--- a/src/analyzer/pure/review_guides/tier3/graphql.py
+++ b/src/analyzer/pure/review_guides/tier3/graphql.py
@@ -1,6 +1,21 @@
-"""GraphQL review guide — Tier 3."""
+"""GraphQL review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## GraphQL review checklist
+- **Schema design**: Noun-style type names; appropriate `!` non-null; distinguish Input vs Object types
+- **N+1**: Required DataLoader pattern; avoid direct DB N+1 inside resolvers
+- **Security**: Limit query depth; limit query complexity; disable introspection in production
+- **Pagination**: Cursor-based (`edges/node/pageInfo`) vs offset; `first` / `after` args
+- **Errors**: Consistent `errors` array vs `null` returns; don't expose sensitive info in error messages
+- **Mutations**: Consider idempotency; validate input types; include sufficient info in return types
+"""
+
+COMPACT = "## GraphQL: DataLoader N+1, depth/complexity limits, prod introspection off, cursor pagination"
+
+FULL_KO = """\
 ## GraphQL 검토 기준
 - **스키마 설계**: 명사 타입 명명, `!` non-null 적절성, Input vs Object 타입 구분
 - **N+1**: DataLoader 패턴 필수, Resolver 내 DB 직접 N+1 조회 방지
@@ -10,4 +25,16 @@ FULL = """\
 - **Mutation**: 멱등성 고려, 입력 타입 검증, 반환 타입 충분한 정보 포함
 """
 
-COMPACT = "## GraphQL: DataLoader N+1, 쿼리 깊이/복잡도 제한, introspection 프로덕션 비활성, cursor 페이지네이션"
+COMPACT_KO = "## GraphQL: DataLoader N+1, 쿼리 깊이/복잡도 제한, introspection 프로덕션 비활성, cursor 페이지네이션"
+
+FULL_JA = """\
+## GraphQL レビュー基準
+- **スキーマ設計**: 名詞型の命名、`!` non-null の適切性、Input vs Object 型の区別
+- **N+1**: DataLoader パターン必須、Resolver 内の DB 直接 N+1 クエリ防止
+- **セキュリティ**: クエリ深さ制限、クエリ複雑度制限、本番で introspection 無効化
+- **ページネーション**: Cursor ベース (`edges/node/pageInfo`) vs offset 選択、`first` / `after` 引数
+- **エラー**: `errors` 配列 vs `null` 戻り値の一貫性、エラーメッセージへの機密情報露出禁止
+- **Mutation**: 冪等性を考慮、入力型検証、戻り型に十分な情報を含める
+"""
+
+COMPACT_JA = "## GraphQL: DataLoader N+1、深さ/複雑度制限、本番 introspection オフ、cursor ページネーション"

--- a/src/analyzer/pure/review_guides/tier3/json_schema.py
+++ b/src/analyzer/pure/review_guides/tier3/json_schema.py
@@ -1,6 +1,21 @@
-"""JSON Schema review guide — Tier 3."""
+"""JSON Schema review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## JSON Schema review checklist
+- **Version**: Specify draft via `$schema` (`draft-07`, `2020-12`)
+- **Type constraints**: Explicit `type`; strict `additionalProperties: false`; list `required` fields
+- **Reuse**: Extract common schemas via `$defs` / `definitions`; watch `$ref` circular references
+- **Validation**: Constrain with `minLength` / `maxLength` / `pattern` / `format`; allowed values via `enum` / `const`
+- **Security**: Avoid overly permissive schemas (`{}` allows anything); validate inputs with `format: "uri"`
+- **Documentation**: `title` / `description` required for public APIs; include `examples`
+"""
+
+COMPACT = "## JSON Schema: $schema version, additionalProperties:false, $defs reuse, required, format validation"
+
+FULL_KO = """\
 ## JSON Schema 검토 기준
 - **버전**: `$schema` 키워드로 draft 버전 명시(`draft-07`, `2020-12`)
 - **타입 제약**: `type` 명시, `additionalProperties: false` 엄격 검증, `required` 필드 목록
@@ -10,4 +25,16 @@ FULL = """\
 - **문서화**: `title`/`description` 필드 공개 API 필수, 예시(`examples`) 포함
 """
 
-COMPACT = "## JSON Schema: $schema 버전, additionalProperties:false, $defs 재사용, required 명시, format 검증"
+COMPACT_KO = "## JSON Schema: $schema 버전, additionalProperties:false, $defs 재사용, required 명시, format 검증"
+
+FULL_JA = """\
+## JSON Schema レビュー基準
+- **バージョン**: `$schema` キーワードで draft バージョン明示 (`draft-07`、`2020-12`)
+- **型制約**: `type` 明示、`additionalProperties: false` で厳密検証、`required` フィールドリスト
+- **再利用**: `$defs` / `definitions` で共通スキーマ抽出、`$ref` 循環参照に注意
+- **検証**: `minLength` / `maxLength` / `pattern` / `format` 制約、`enum` / `const` 許容値
+- **セキュリティ**: 過度に寛容なスキーマ (`{}` 全許可) 禁止、`format: "uri"` で入力検証
+- **文書化**: `title` / `description` フィールドは公開 API で必須、`examples` 含める
+"""
+
+COMPACT_JA = "## JSON Schema: $schema バージョン、additionalProperties:false、$defs 再利用、required、format 検証"

--- a/src/analyzer/pure/review_guides/tier3/julia.py
+++ b/src/analyzer/pure/review_guides/tier3/julia.py
@@ -1,6 +1,20 @@
-"""Julia review guide — Tier 3."""
+"""Julia review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Julia review checklist
+- **Type stability**: Avoid type-unstable functions (`@code_warntype`); avoid abstract-type containers
+- **Performance**: Declare globals `const`; minimize allocations in loops; use `@view` for slices
+- **Multiple dispatch**: Clear method signatures; avoid ambiguity; `!` mutation convention
+- **Broadcasting**: Use `.` dot broadcasting; avoid unnecessary vectorization
+- **Packages**: Distinguish `using` vs `import`; pin deps via `Project.toml`
+"""
+
+COMPACT = "## Julia: type stability, const globals, @view slices, multiple-dispatch clarity, Project.toml"
+
+FULL_KO = """\
 ## Julia 검토 기준
 - **타입 안정성**: 타입 불안정 함수 회피(`@code_warntype`), 추상 타입 컨테이너 지양
 - **성능**: 전역 변수 `const` 선언, 루프 내 메모리 할당 최소화, `@view` 슬라이스
@@ -9,4 +23,15 @@ FULL = """\
 - **패키지**: `using` vs `import` 구분, 의존성 `Project.toml` 명시
 """
 
-COMPACT = "## Julia: 타입 안정성, const 전역, @view 슬라이스, 멀티플 디스패치 명확성, Project.toml"
+COMPACT_KO = "## Julia: 타입 안정성, const 전역, @view 슬라이스, 멀티플 디스패치 명확성, Project.toml"
+
+FULL_JA = """\
+## Julia レビュー基準
+- **型安定性**: 型不安定な関数を回避 (`@code_warntype`)、抽象型コンテナを避ける
+- **パフォーマンス**: グローバル変数を `const` 宣言、ループ内アロケーションを最小化、`@view` スライス
+- **多重ディスパッチ**: メソッドシグネチャを明確化、曖昧性 (ambiguity) 回避、`!` 変更関数の規約
+- **ブロードキャスト**: `.` ドットブロードキャスト活用、不要なベクトル化回避
+- **パッケージ**: `using` vs `import` の区別、依存を `Project.toml` で明示
+"""
+
+COMPACT_JA = "## Julia: 型安定性、const グローバル、@view スライス、多重ディスパッチ明確性、Project.toml"

--- a/src/analyzer/pure/review_guides/tier3/latex.py
+++ b/src/analyzer/pure/review_guides/tier3/latex.py
@@ -1,6 +1,21 @@
-"""LaTeX review guide — Tier 3."""
+"""LaTeX review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## LaTeX review checklist
+- **Packages**: Remove unused packages; mind package conflict order (load `hyperref` last)
+- **References**: No unresolved `\\label{}` / `\\ref{}` / `\\cite{}`; consistent BibTeX/BibLaTeX
+- **Math**: Consistent `$...$` vs `\\(...\\)`; decide if `equation` numbering is needed
+- **Portability**: No absolute image paths → relative paths; image formats (PDF/EPS/PNG) by compiler compat
+- **Build**: Automate via `latexmk`; include `.aux`, `.log` in `.gitignore`
+- **Security**: Disable `\\write18` (shell escape) — recommended `-no-shell-escape`
+"""
+
+COMPACT = "## LaTeX: hyperref last, no unresolved refs, relative image paths, latexmk, no shell-escape"
+
+FULL_KO = """\
 ## LaTeX 검토 기준
 - **패키지**: 불필요한 패키지 제거, 패키지 충돌 순서 주의(`hyperref` 마지막 로드)
 - **참조**: `\\label{}`/`\\ref{}`/`\\cite{}` 미해결 참조 없음, BibTeX/BibLaTeX 일관성
@@ -10,4 +25,16 @@ FULL = """\
 - **보안**: `\\write18`(셸 탈출) 비활성화 권장(`-no-shell-escape`)
 """
 
-COMPACT = "## LaTeX: hyperref 마지막, 미해결 참조 없음, 상대 경로 이미지, latexmk, shell-escape 비활성"
+COMPACT_KO = "## LaTeX: hyperref 마지막, 미해결 참조 없음, 상대 경로 이미지, latexmk, shell-escape 비활성"
+
+FULL_JA = """\
+## LaTeX レビュー基準
+- **パッケージ**: 不要なパッケージを削除、パッケージ競合順序に注意 (`hyperref` を最後にロード)
+- **参照**: `\\label{}` / `\\ref{}` / `\\cite{}` の未解決参照なし、BibTeX/BibLaTeX の一貫性
+- **数式**: `$...$` vs `\\(...\\)` の一貫性、`equation` 環境の番号付けの必要性
+- **可搬性**: 画像の絶対パス禁止 → 相対パス、画像形式 (PDF/EPS/PNG) のコンパイラ互換
+- **ビルド**: `latexmk` で自動化、一時ファイル (`.aux`、`.log`) を `.gitignore` に含める
+- **セキュリティ**: `\\write18` (シェルエスケープ) 無効化推奨 (`-no-shell-escape`)
+"""
+
+COMPACT_JA = "## LaTeX: hyperref 最後、未解決参照なし、相対パス画像、latexmk、shell-escape 無効"

--- a/src/analyzer/pure/review_guides/tier3/makefile.py
+++ b/src/analyzer/pure/review_guides/tier3/makefile.py
@@ -1,6 +1,21 @@
-"""Makefile review guide — Tier 3."""
+"""Makefile review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Makefile review checklist
+- **PHONY**: `.PHONY: clean test build` — required to avoid file-name conflicts
+- **Variables**: `$(VAR)` reference; distinguish `:=` immediate vs `=` deferred expansion
+- **Errors**: Cautious use of `-` to ignore errors; differs from `set -e` shell semantics
+- **Portability**: Avoid bash-specific syntax (`SHELL := /bin/bash` if needed); tabs vs spaces
+- **Dependencies**: Accurate target dependencies (build order); use automatic variables (`$@`, `$<`, `$^`)
+- **Parallel**: `-j` flag compatibility; explicit `order-only prerequisites` when needed
+"""
+
+COMPACT = "## Makefile: .PHONY required, := vs =, tab indent, automatic vars $@/$<, -j parallel compat"
+
+FULL_KO = """\
 ## Makefile 검토 기준
 - **PHONY**: `.PHONY: clean test build` — 파일명과 충돌 방지 필수
 - **변수**: `$(VAR)` 참조, `:=` 즉시 확장 vs `=` 지연 확장 구분
@@ -10,4 +25,16 @@ FULL = """\
 - **병렬화**: `-j` 플래그 호환성, 순서 의존성 명시(`order-only prerequisites`)
 """
 
-COMPACT = "## Makefile: .PHONY 필수, := vs = 구분, tab 들여쓰기, 자동변수 $@/$<, -j 병렬화 호환"
+COMPACT_KO = "## Makefile: .PHONY 필수, := vs = 구분, tab 들여쓰기, 자동변수 $@/$<, -j 병렬화 호환"
+
+FULL_JA = """\
+## Makefile レビュー基準
+- **PHONY**: `.PHONY: clean test build` — ファイル名との競合防止に必須
+- **変数**: `$(VAR)` 参照、`:=` 即時展開 vs `=` 遅延展開を区別
+- **エラー**: コマンド前の `-` でのエラー無視を濫用しない、`set -e` シェルとは異なる
+- **可搬性**: bash 特有構文を回避 (`SHELL := /bin/bash` を明示)、tab vs space
+- **依存**: ターゲット依存の正確性 (ビルド順)、自動変数 (`$@`、`$<`、`$^`) 活用
+- **並列化**: `-j` フラグ互換性、順序依存を明示 (`order-only prerequisites`)
+"""
+
+COMPACT_JA = "## Makefile: .PHONY 必須、:= vs = 区別、tab インデント、自動変数 $@/$<、-j 並列互換"

--- a/src/analyzer/pure/review_guides/tier3/nim.py
+++ b/src/analyzer/pure/review_guides/tier3/nim.py
@@ -1,6 +1,20 @@
-"""Nim review guide — Tier 3."""
+"""Nim review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Nim review checklist
+- **Memory**: Choose GC mode (prefer ORC/ARC); `owned ref` lifetimes; `=destroy` hooks
+- **Errors**: `Result[T, E]` (from `results` package) vs exceptions; `try` / `except` / `finally`
+- **Pragmas**: `{.raises: [].}` for exception tracking; `{.noSideEffect.}`; `{.pure.}` enums
+- **Macros**: Hygienic macros/templates (gensym); cap excessive macro complexity
+- **Backends**: Consider C/JS backend targets; verify FFI `{.importc.}` type mapping
+"""
+
+COMPACT = "## Nim: ORC/ARC GC, Result type, {.raises.} pragma, hygienic macros, FFI type mapping"
+
+FULL_KO = """\
 ## Nim 검토 기준
 - **메모리**: GC 모드 선택(ORC/ARC 선호), `owned ref` 수명, `=destroy` 훅
 - **에러**: `Result[T, E]` 타입(`results` 패키지) vs 예외, `try`/`except`/`finally`
@@ -9,4 +23,15 @@ FULL = """\
 - **백엔드**: C/JS 백엔드 타겟 고려, FFI `{.importc.}` 타입 매핑 검증
 """
 
-COMPACT = "## Nim: ORC/ARC GC, Result 타입, {.raises.} pragma, 위생 매크로, FFI 타입 매핑"
+COMPACT_KO = "## Nim: ORC/ARC GC, Result 타입, {.raises.} pragma, 위생 매크로, FFI 타입 매핑"
+
+FULL_JA = """\
+## Nim レビュー基準
+- **メモリ**: GC モードの選択 (ORC/ARC 推奨)、`owned ref` 寿命、`=destroy` フック
+- **エラー**: `Result[T, E]` 型 (`results` パッケージ) vs 例外、`try` / `except` / `finally`
+- **pragma**: `{.raises: [].}` 例外追跡、`{.noSideEffect.}`、`{.pure.}` enum
+- **マクロ**: マクロ/テンプレートの衛生性 (gensym)、過度なマクロ複雑度を制限
+- **バックエンド**: C/JS バックエンドのターゲット考慮、FFI `{.importc.}` 型マッピング検証
+"""
+
+COMPACT_JA = "## Nim: ORC/ARC GC、Result 型、{.raises.} pragma、衛生マクロ、FFI 型マッピング"

--- a/src/analyzer/pure/review_guides/tier3/ocaml.py
+++ b/src/analyzer/pure/review_guides/tier3/ocaml.py
@@ -1,6 +1,20 @@
-"""OCaml review guide — Tier 3."""
+"""OCaml review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## OCaml review checklist
+- **Types**: Trust inference but make public signatures explicit; `option` / `result` for errors
+- **Pattern matching**: Exhaustive `match` (compiler warning); minimize `_` wildcard
+- **Immutability**: Default immutable — comment justifications for `ref` / `mutable` fields
+- **Modules**: Manage functor complexity; avoid `include` overuse; maintain `mli` interface files
+- **Exceptions**: Prefer `result` types over `exception` (functional error handling); narrow `try/with` scope
+"""
+
+COMPACT = "## OCaml: option/result, exhaustive match, minimize ref, keep mli, result > exception"
+
+FULL_KO = """\
 ## OCaml 검토 기준
 - **타입**: 타입 추론 신뢰하되 공개 함수 시그니처 명시, `option`/`result` 에러 처리
 - **패턴 매칭**: 완전한 match(컴파일러 경고), `_` 와일드카드 최소화
@@ -9,4 +23,15 @@ FULL = """\
 - **예외**: `exception`보다 `result` 타입 선호(함수형 에러 처리), `try/with` 범위 최소화
 """
 
-COMPACT = "## OCaml: option/result, 완전 match, ref 최소화, mli 인터페이스 유지, result > exception"
+COMPACT_KO = "## OCaml: option/result, 완전 match, ref 최소화, mli 인터페이스 유지, result > exception"
+
+FULL_JA = """\
+## OCaml レビュー基準
+- **型**: 型推論を信頼しつつ公開関数のシグネチャを明示、`option` / `result` でエラー処理
+- **パターンマッチ**: `match` の網羅性 (コンパイラ警告)、`_` ワイルドカードを最小化
+- **不変性**: デフォルトで不変 — `ref` / `mutable` フィールド使用時は根拠コメント
+- **モジュール**: functor 複雑度を管理、`include` の濫用注意、`mli` インターフェースファイル維持
+- **例外**: `exception` より `result` 型推奨 (関数的エラー処理)、`try/with` 範囲を最小化
+"""
+
+COMPACT_JA = "## OCaml: option/result、網羅 match、ref 最小化、mli 維持、result > exception"

--- a/src/analyzer/pure/review_guides/tier3/protobuf.py
+++ b/src/analyzer/pure/review_guides/tier3/protobuf.py
@@ -1,6 +1,21 @@
-"""Protocol Buffers review guide — Tier 3."""
+"""Protocol Buffers review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Protocol Buffers review checklist
+- **Field numbers**: Don't change/reuse existing numbers (breaks compatibility); use `reserved` to protect removed numbers
+- **Type choice**: `int32` vs `sint32` (negative efficiency); `bytes` vs `string` (UTF-8 guarantee)
+- **Backward compat**: Add fields as optional only; no new `required` (proto2); careful with default reliance
+- **Packages**: Explicit `package` namespace; absolute import paths
+- **gRPC**: Justify streaming vs unary; semantic accuracy of error status codes
+- **Performance**: Paginate large repeated fields; type safety of `google.protobuf.Any`
+"""
+
+COMPACT = "## Protobuf: stable field numbers, reserved protection, sint32 negatives, additions optional only, gRPC status"
+
+FULL_KO = """\
 ## Protocol Buffers 검토 기준
 - **필드 번호**: 기존 번호 변경/재사용 금지(하위 호환성 파괴), reserved 선언으로 제거된 번호 보호
 - **타입 선택**: `int32` vs `sint32`(음수 효율), `bytes` vs `string`(UTF-8 보장 여부)
@@ -10,4 +25,16 @@ FULL = """\
 - **성능**: 대용량 repeated 필드 페이지네이션, `google.protobuf.Any` 타입 안전성
 """
 
-COMPACT = "## Protobuf: 필드 번호 불변, reserved 보호, sint32 음수, 하위 호환 optional만 추가, gRPC status"
+COMPACT_KO = "## Protobuf: 필드 번호 불변, reserved 보호, sint32 음수, 하위 호환 optional만 추가, gRPC status"
+
+FULL_JA = """\
+## Protocol Buffers レビュー基準
+- **フィールド番号**: 既存番号の変更/再利用禁止 (後方互換性破壊)、`reserved` で削除済み番号を保護
+- **型選択**: `int32` vs `sint32` (負数効率)、`bytes` vs `string` (UTF-8 保証)
+- **後方互換**: フィールド追加は optional のみ、新規 `required` (proto2) 禁止、デフォルト値依存に注意
+- **パッケージ**: `package` 名前空間を明示、import パスは絶対パス
+- **gRPC**: streaming vs unary の選択根拠、エラー status code の意味的正確性
+- **パフォーマンス**: 大量 repeated フィールドのページネーション、`google.protobuf.Any` の型安全性
+"""
+
+COMPACT_JA = "## Protobuf: フィールド番号不変、reserved 保護、sint32 負数、互換は optional のみ、gRPC status"

--- a/src/analyzer/pure/review_guides/tier3/terraform.py
+++ b/src/analyzer/pure/review_guides/tier3/terraform.py
@@ -1,6 +1,22 @@
-"""Terraform/HCL review guide — Tier 3."""
+"""Terraform/HCL review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Terraform review checklist
+- **Security**: No hardcoded secrets → `var.` / env vars / Vault; block S3 public access
+- **State**: Remote state backend required (no local tfstate); state locking (DynamoDB)
+- **Modules**: Pin module versions (`source = "... version = ..."`); minimal reusable interfaces
+- **Variables**: Constrain `variable` types (`type = string`); `sensitive = true` for sensitive vars
+- **Naming**: Resource naming convention (`{env}_{service}_{resource}`); common `tags`
+- **Idempotency**: Review `plan` output — verify no unintended destroy/replace (force-new resource)
+- **Security groups**: Least privilege; minimize `0.0.0.0/0` ingress
+"""
+
+COMPACT = "## Terraform: no hardcoded secrets, remote state+lock, pin modules, sensitive vars, review plan"
+
+FULL_KO = """\
 ## Terraform 검토 기준
 - **보안**: 시크릿 하드코딩 금지 → `var.`/환경변수/Vault, S3 버킷 퍼블릭 접근 차단
 - **상태**: remote state backend 필수(로컬 tfstate 금지), state locking(DynamoDB)
@@ -11,4 +27,17 @@ FULL = """\
 - **보안 그룹**: 최소 권한 원칙, `0.0.0.0/0` ingress 최소화
 """
 
-COMPACT = "## Terraform: 시크릿 하드코딩 금지, remote state+locking, 모듈 버전 고정, sensitive 변수, plan 검토"
+COMPACT_KO = "## Terraform: 시크릿 하드코딩 금지, remote state+locking, 모듈 버전 고정, sensitive 변수, plan 검토"
+
+FULL_JA = """\
+## Terraform レビュー基準
+- **セキュリティ**: シークレットのハードコード禁止 → `var.` / 環境変数 / Vault、S3 バケットの公開アクセスをブロック
+- **状態**: remote state backend 必須 (ローカル tfstate 禁止)、state locking (DynamoDB)
+- **モジュール**: モジュールバージョン固定 (`source = "... version = ..."`)、再利用可能な最小インターフェース
+- **変数**: `variable` 型制約 (`type = string`)、機密変数に `sensitive = true`
+- **命名**: リソース命名規則 (`{env}_{service}_{resource}`)、共通の `tags`
+- **冪等性**: `plan` 結果のレビュー — 意図しない削除/置換 (force new resource) を確認
+- **セキュリティグループ**: 最小権限原則、`0.0.0.0/0` ingress を最小化
+"""
+
+COMPACT_JA = "## Terraform: シークレット禁止、remote state+locking、モジュールバージョン固定、sensitive 変数、plan レビュー"

--- a/src/analyzer/pure/review_guides/tier3/toml.py
+++ b/src/analyzer/pure/review_guides/tier3/toml.py
@@ -1,6 +1,20 @@
-"""TOML review guide — Tier 3."""
+"""TOML review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## TOML review checklist
+- **Types**: String quotes `"..."`, literal strings `'...'` (no escapes), ISO 8601 dates
+- **pyproject.toml**: Complete `[project]` (name/version/dependencies/requires-python); separate `[tool.XX]` config
+- **Cargo.toml**: Dependency version ranges (`^1.0`, `~1.0.3`); separate `[dev-dependencies]`; clear features
+- **Duplicate keys**: Forbidden within a table (parser error); `[[array]]` table order matters
+- **Inline tables**: One line (`{key = "value"}`) — prefer standard tables when complex
+"""
+
+COMPACT = "## TOML: type literals, pyproject required fields, Cargo version ranges, no duplicate keys, inline tables"
+
+FULL_KO = """\
 ## TOML 검토 기준
 - **타입**: 문자열 따옴표 `"..."`, 리터럴 문자열 `'...'`(이스케이프 없음), 날짜 ISO 8601
 - **pyproject.toml**: `[project]` 필드 완성도(name/version/dependencies/requires-python), `[tool.XX]` 설정 분리
@@ -9,4 +23,15 @@ FULL = """\
 - **인라인 테이블**: 한 줄(`{key = "value"}`) — 복잡하면 표준 테이블 선호
 """
 
-COMPACT = "## TOML: 타입 리터럴, pyproject 필수 필드, Cargo 버전 범위, 중복 키 금지, 인라인 테이블 최소화"
+COMPACT_KO = "## TOML: 타입 리터럴, pyproject 필수 필드, Cargo 버전 범위, 중복 키 금지, 인라인 테이블 최소화"
+
+FULL_JA = """\
+## TOML レビュー基準
+- **型**: 文字列クォート `"..."`、リテラル文字列 `'...'` (エスケープなし)、ISO 8601 日付
+- **pyproject.toml**: `[project]` フィールド完成度 (name/version/dependencies/requires-python)、`[tool.XX]` 設定分離
+- **Cargo.toml**: 依存バージョン範囲 (`^1.0`、`~1.0.3`)、`[dev-dependencies]` 分離、features 明確性
+- **重複キー**: 同一テーブル内の重複キー禁止 (パーサーエラー)、`[[array]]` 配列テーブル順序
+- **インラインテーブル**: 1 行 (`{key = "value"}`) — 複雑な場合は標準テーブル推奨
+"""
+
+COMPACT_JA = "## TOML: 型リテラル、pyproject 必須フィールド、Cargo バージョン範囲、重複キー禁止、インラインテーブル最小化"

--- a/src/analyzer/pure/review_guides/tier3/vimscript.py
+++ b/src/analyzer/pure/review_guides/tier3/vimscript.py
@@ -1,6 +1,20 @@
-"""Vimscript review guide — Tier 3."""
+"""Vimscript review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Vimscript review checklist
+- **Scope**: Mark `s:` script-local, `g:` global, `l:` function-local variables
+- **Functions**: `function!` (redefine), `abort` flag (stop on error), namespace prefixes
+- **Autocomplete**: Distinguish `setlocal` vs `set`; prevent plugin option conflicts
+- **Performance**: Minimize slow `system()`; conditional `has('nvim')` code; regex compile (`\\V`)
+- **Neovim**: Consider migration to `vim.api` / `vim.fn` Lua; `autoload` lazy loading
+"""
+
+COMPACT = "## Vimscript: s:/g:/l: scope, function! abort, setlocal vs set, autoload lazy"
+
+FULL_KO = """\
 ## Vimscript 검토 기준
 - **범위**: `s:` 스크립트 로컬, `g:` 전역, `l:` 함수 로컬 변수 명시
 - **함수**: `function!`(재정의), `abort` 플래그(에러 시 중단), 네임스페이스 접두사
@@ -9,4 +23,15 @@ FULL = """\
 - **Neovim**: `vim.api`/`vim.fn` Lua 마이그레이션 고려, `autoload` 지연 로딩
 """
 
-COMPACT = "## Vimscript: s:/g:/l: 범위, function! abort, setlocal vs set, autoload 지연 로딩"
+COMPACT_KO = "## Vimscript: s:/g:/l: 범위, function! abort, setlocal vs set, autoload 지연 로딩"
+
+FULL_JA = """\
+## Vimscript レビュー基準
+- **スコープ**: `s:` スクリプトローカル、`g:` グローバル、`l:` 関数ローカル変数を明示
+- **関数**: `function!` (再定義)、`abort` フラグ (エラー時停止)、名前空間プレフィックス
+- **オートコンプリート**: `setlocal` vs `set` の区別、プラグインオプション衝突防止
+- **パフォーマンス**: 遅い `system()` を最小化、`has('nvim')` 条件付きコード、正規表現コンパイル (`\\V`)
+- **Neovim**: `vim.api` / `vim.fn` Lua への移行検討、`autoload` 遅延ロード
+"""
+
+COMPACT_JA = "## Vimscript: s:/g:/l: スコープ、function! abort、setlocal vs set、autoload 遅延"

--- a/src/analyzer/pure/review_guides/tier3/xml.py
+++ b/src/analyzer/pure/review_guides/tier3/xml.py
@@ -1,6 +1,21 @@
-"""XML review guide — Tier 3."""
+"""XML review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## XML review checklist
+- **Security**: XXE (XML External Entity) attacks — disable external DTD/entity in parsers
+- **Schema**: Use XSD/DTD validation; explicit namespace declaration
+- **Encoding**: `<?xml version="1.0" encoding="UTF-8"?>` declaration required
+- **Parsing**: SAX (streaming) vs DOM (load all) — use SAX/StAX for large files
+- **XSLT**: Don't run untrusted XSLT (can execute code); validate user-provided params
+- **Namespaces**: Avoid prefix collisions; concentrate `xmlns:` declarations at the top
+"""
+
+COMPACT = "## XML: XXE defense, XSD validation, encoding declaration, SAX vs DOM, trusted XSLT only"
+
+FULL_KO = """\
 ## XML 검토 기준
 - **보안**: XXE(XML External Entity) 공격 — 외부 DTD/엔티티 파서 비활성화 필수
 - **스키마**: XSD/DTD 검증 활용, namespace 명시적 선언
@@ -10,4 +25,16 @@ FULL = """\
 - **네임스페이스**: 접두사 충돌 방지, `xmlns:` 선언 최상위 집중
 """
 
-COMPACT = "## XML: XXE 방어(외부 엔티티 비활성), XSD 검증, encoding 선언, SAX vs DOM, XSLT 신뢰 입력만"
+COMPACT_KO = "## XML: XXE 방어(외부 엔티티 비활성), XSD 검증, encoding 선언, SAX vs DOM, XSLT 신뢰 입력만"
+
+FULL_JA = """\
+## XML レビュー基準
+- **セキュリティ**: XXE (XML External Entity) 攻撃 — パーサーで外部 DTD/エンティティを無効化必須
+- **スキーマ**: XSD/DTD 検証を活用、namespace を明示的に宣言
+- **エンコーディング**: `<?xml version="1.0" encoding="UTF-8"?>` 宣言必須
+- **パース**: SAX (ストリーミング) vs DOM (全ロード) 選択 — 大容量は SAX/StAX
+- **XSLT**: 信頼できない XSLT 実行禁止 (コード実行可能)、ユーザー入力パラメータを検証
+- **ネームスペース**: プレフィックス衝突防止、`xmlns:` 宣言を最上位に集中
+"""
+
+COMPACT_JA = "## XML: XXE 防御、XSD 検証、encoding 宣言、SAX vs DOM、信頼 XSLT のみ"

--- a/src/analyzer/pure/review_guides/tier3/yaml.py
+++ b/src/analyzer/pure/review_guides/tier3/yaml.py
@@ -1,6 +1,22 @@
-"""YAML review guide — Tier 3."""
+"""YAML review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## YAML review checklist
+- **Indentation**: Spaces only (no tabs); consistent indentation (2 spaces recommended)
+- **Type gotchas**: `yes` / `no` / `on` / `off` parse as bool — quote strings
+- **Anchors/aliases**: Clear `&anchor` / `*alias` reuse; deep nesting hurts readability
+- **Secrets**: No hardcoded secrets in YAML — reference env vars or external secret stores
+- **GitHub Actions**: Least-privilege `permissions`; understand `pull_request_target` risks
+- **Kubernetes**: Set resource limits; no `latest` image tags; least-privilege RBAC
+- **Validation**: Validate with `yamllint` / `kustomize build` / `helm lint`
+"""
+
+COMPACT = "## YAML: no tabs, yes/no bool gotcha, no secrets, GitHub Actions perms, K8s limits"
+
+FULL_KO = """\
 ## YAML 검토 기준
 - **들여쓰기**: 스페이스만 사용(탭 금지), 일관된 들여쓰기(2칸 권장)
 - **타입 주의**: `yes`/`no`/`on`/`off`는 bool로 파싱됨 — 문자열은 따옴표로 감싸기
@@ -11,4 +27,17 @@ FULL = """\
 - **검증**: `yamllint` / `kustomize build` / `helm lint` 도구 검증
 """
 
-COMPACT = "## YAML: 탭 금지, yes/no bool 주의, 시크릿 하드코딩 금지, GitHub Actions permissions, K8s limits"
+COMPACT_KO = "## YAML: 탭 금지, yes/no bool 주의, 시크릿 하드코딩 금지, GitHub Actions permissions, K8s limits"
+
+FULL_JA = """\
+## YAML レビュー基準
+- **インデント**: スペースのみ (タブ禁止)、一貫したインデント (2 スペース推奨)
+- **型注意**: `yes` / `no` / `on` / `off` は bool としてパース — 文字列はクォートで囲む
+- **アンカー/エイリアス**: `&anchor` / `*alias` の再利用を明確化、深いネストで可読性低下
+- **シークレット**: YAML へのシークレットハードコード禁止 — 環境変数参照または外部シークレットストア
+- **GitHub Actions**: `permissions` 最小権限、`pull_request_target` のリスクを理解
+- **Kubernetes**: リソースリミット設定、`latest` イメージタグ禁止、RBAC 最小権限
+- **検証**: `yamllint` / `kustomize build` / `helm lint` で検証
+"""
+
+COMPACT_JA = "## YAML: タブ禁止、yes/no bool 注意、シークレット禁止、GitHub Actions permissions、K8s limits"

--- a/src/analyzer/pure/review_guides/tier3/zig.py
+++ b/src/analyzer/pure/review_guides/tier3/zig.py
@@ -1,6 +1,20 @@
-"""Zig review guide — Tier 3."""
+"""Zig review guide — Tier 3.
+
+Phase 4 PR-15 (사이클 84) — i18n: en (default) / ko / ja.
+"""
 
 FULL = """\
+## Zig review checklist
+- **Error handling**: `try` / `catch` / `errdefer`; explicit error union types; bounded error sets
+- **Memory**: Pass allocators explicitly (Allocator pattern); `defer allocator.free(...)`; prefer comptime stack
+- **comptime**: Use compile-time computation; generic types; cap comptime complexity
+- **undefined**: Verify initialization; document `undefined` usage scope; debug/release differences
+- **Safety**: `@intCast` / `@floatCast` overflow; bounds checks; pointer lifetimes
+"""
+
+COMPACT = "## Zig: errdefer, explicit Allocator, comptime generics, init undefined, @intCast overflow"
+
+FULL_KO = """\
 ## Zig 검토 기준
 - **에러 처리**: `try`/`catch`/`errdefer`, 에러 유니온 타입 명시, 에러 집합 범위
 - **메모리**: 할당자 명시적 전달(Allocator 패턴), `defer allocator.free(...)`, comptime 스택 선호
@@ -9,4 +23,15 @@ FULL = """\
 - **안전성**: `@intCast`/`@floatCast` 오버플로, 경계 검사, 포인터 수명
 """
 
-COMPACT = "## Zig: errdefer, 명시적 Allocator, comptime 제네릭, undefined 초기화, @intCast 오버플로"
+COMPACT_KO = "## Zig: errdefer, 명시적 Allocator, comptime 제네릭, undefined 초기화, @intCast 오버플로"
+
+FULL_JA = """\
+## Zig レビュー基準
+- **エラー処理**: `try` / `catch` / `errdefer`、エラー共用体型を明示、エラー集合の範囲
+- **メモリ**: アロケータを明示的に渡す (Allocator パターン)、`defer allocator.free(...)`、comptime スタック推奨
+- **comptime**: コンパイル時演算活用、ジェネリック型実装、comptime 過度な複雑度を制限
+- **undefined**: 初期化検証、`undefined` 使用範囲を文書化、デバッグ/リリースの違い
+- **安全性**: `@intCast` / `@floatCast` オーバーフロー、境界チェック、ポインタ寿命
+"""
+
+COMPACT_JA = "## Zig: errdefer、明示的 Allocator、comptime ジェネリック、undefined 初期化、@intCast オーバーフロー"

--- a/tests/unit/analyzer/pure/test_review_guides_tier1_i18n.py
+++ b/tests/unit/analyzer/pure/test_review_guides_tier1_i18n.py
@@ -103,12 +103,12 @@ def test_tier2_now_supports_korean_after_pr14():
     assert ko != ja
 
 
-def test_tier3_falls_back_to_english_for_japanese():
-    """Tier3 (julia) — output_language='ja' 요청 시 영문 fallback (PR-15 미적용 영역)."""
+def test_tier3_now_supports_japanese_after_pr15():
+    """Tier3 (julia) — PR-15 적용 후 일본어 지원 (영문/한국어/일본어 distinct)."""
     en = get_guide("julia", "full", output_language="en")
     ja = get_guide("julia", "full", output_language="ja")
-    # PR-15 미적용 → 동일 영문 (fallback)
-    assert en == ja
+    # Phase 4 PR-15 적용 후 — Tier3 도 다국어 지원
+    assert en != ja
 
 
 # ── build_review_prompt + build_review_blocks — language 전달 ─────────────

--- a/tests/unit/analyzer/pure/test_review_guides_tier3_generic_i18n.py
+++ b/tests/unit/analyzer/pure/test_review_guides_tier3_generic_i18n.py
@@ -1,0 +1,111 @@
+"""Phase 4 PR-15 회귀 가드 — Tier3 20 가이드 + generic 다국어.
+
+Phase 4 PR-15 regression guards — Tier3 20 guides + generic i18n.
+
+검증 범위 (Coverage):
+1. Tier3 20 언어 모든 가이드 — FULL/COMPACT × en/ko/ja 변형 보유 검증
+2. generic.py — FULL/COMPACT × en/ko/ja 변형 검증
+3. output_language='en' (default) — 영문 반환
+4. output_language='ko' / 'ja' → 해당 언어 반환
+5. 각 가이드 헤더 일관성 (review checklist / 검토 기준 / レビュー基準)
+6. unknown language → generic fallback (3 언어)
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.analyzer.pure.review_guides import get_guide
+
+_TIER3 = [
+    "erlang", "ocaml", "julia", "zig", "nim", "crystal", "gleam",
+    "elm", "vimscript", "gdscript", "dockerfile", "makefile",
+    "terraform", "yaml", "toml", "graphql", "protobuf", "xml",
+    "latex", "json_schema",
+]
+
+
+# ── Tier3 20 언어 × 3 출력 언어 헤더 검증 ──────────────────────────────
+
+
+@pytest.mark.parametrize("lang", _TIER3)
+def test_tier3_full_english(lang):
+    """Tier3 20 언어 — FULL 영문 반환 + `review checklist` 헤더."""
+    guide = get_guide(lang, "full", output_language="en")
+    assert isinstance(guide, str)
+    assert len(guide) > 50
+    assert "review checklist" in guide.lower()
+    # 한국어 헤더 부재 확인 (영문 default)
+    assert "검토 기준" not in guide
+
+
+@pytest.mark.parametrize("lang", _TIER3)
+def test_tier3_full_korean(lang):
+    """Tier3 20 언어 — FULL 한국어 반환 + `검토 기준` 헤더."""
+    guide = get_guide(lang, "full", output_language="ko")
+    assert isinstance(guide, str)
+    assert len(guide) > 50
+    assert "검토 기준" in guide
+
+
+@pytest.mark.parametrize("lang", _TIER3)
+def test_tier3_full_japanese(lang):
+    """Tier3 20 언어 — FULL 일본어 반환 + `レビュー基準` 헤더."""
+    guide = get_guide(lang, "full", output_language="ja")
+    assert isinstance(guide, str)
+    assert len(guide) > 50
+    assert "レビュー基準" in guide
+
+
+# ── COMPACT 3 언어 distinct ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("lang", _TIER3)
+def test_tier3_compact_3_languages_distinct(lang):
+    """Tier3 20 언어 — COMPACT 3 언어 모두 다른 텍스트 (cache key 분기 검증)."""
+    en = get_guide(lang, "compact", output_language="en")
+    ko = get_guide(lang, "compact", output_language="ko")
+    ja = get_guide(lang, "compact", output_language="ja")
+    assert en != ko
+    assert en != ja
+    assert ko != ja
+
+
+# ── generic.py i18n ──────────────────────────────────────────────────────
+
+
+def test_generic_full_3_languages_distinct():
+    """generic.py — FULL 3 언어 distinct."""
+    en = get_guide("unknown_xyz", "full", output_language="en")
+    ko = get_guide("unknown_xyz", "full", output_language="ko")
+    ja = get_guide("unknown_xyz", "full", output_language="ja")
+    assert "Generic code review checklist" in en
+    assert "일반 코드 검토 기준" in ko
+    assert "一般コードレビュー基準" in ja
+    assert en != ko != ja != en
+
+
+def test_generic_compact_3_languages_distinct():
+    """generic.py — COMPACT 3 언어 distinct."""
+    en = get_guide("unknown_xyz", "compact", output_language="en")
+    ko = get_guide("unknown_xyz", "compact", output_language="ko")
+    ja = get_guide("unknown_xyz", "compact", output_language="ja")
+    assert en != ko
+    assert en != ja
+    assert ko != ja
+
+
+# ── Tier3 fallback ──────────────────────────────────────────────────────
+
+
+def test_tier3_invalid_output_language_falls_to_english():
+    """invalid output_language → 영문 fallback."""
+    en = get_guide("erlang", "full", output_language="en")
+    invalid = get_guide("erlang", "full", output_language="zh")
+    assert en == invalid
+
+
+def test_tier3_default_output_language_is_english():
+    """get_guide — output_language default = 'en' (Tier3)."""
+    en_explicit = get_guide("erlang", "full", output_language="en")
+    en_default = get_guide("erlang", "full")
+    assert en_explicit == en_default


### PR DESCRIPTION
…4 종결 (PR-15)

## Summary
Phase 4 PR-15 — Tier3 review_guides 20 언어 + generic.py 다국어 적용. 기존 한국어 default → 영문 default 정합 + 한국어 보존 (FULL_KO/COMPACT_KO) + 일본어 신규 번역 (FULL_JA/COMPACT_JA). 63 영역 (21 영역 × 3 출력 언어) 신설. **Phase 4 (코드리뷰 다국어 4 PR) 종결 — PR-12/13/14/15 모두 완료, 50 언어 + generic = 153 영역 전체 다국어 지원.** 단위 +84 회귀 가드 (2728→2812).

## Changes (23 files)

### 1. Tier3 20 가이드 i18n 적용 (20 파일)
- erlang / ocaml / julia / zig / nim / crystal / gleam / elm / vimscript / gdscript
- dockerfile / makefile / terraform / yaml / toml / graphql / protobuf / xml / latex / json_schema
- 각 파일: `FULL` (영문 NEW — 기존 한국어 → 영문 번역) + `COMPACT` (영문 NEW)
- 각 파일: `FULL_KO` (기존 한국어 보존) + `COMPACT_KO`
- 각 파일: `FULL_JA` (일본어 신규 번역) + `COMPACT_JA`
- PR-13/14 패턴 동일 (Tier1/Tier2 컨벤션 그대로)

### 2. generic.py i18n 적용
- unknown 언어 fallback — 영문/한국어/일본어 3 언어 지원
- get_guide("unknown_xyz", "full", output_language=...) → generic 반환

### 3. 회귀 가드 84건 (tests/unit/analyzer/pure/test_review_guides_tier3_generic_i18n.py — 신설)
- Tier3 20 언어 × 3 output_language (en/ko/ja) FULL 헤더 검증 = 60 tests
- Tier3 20 언어 × COMPACT 3 언어 distinct = 20 tests
- generic.py × 3 언어 FULL + COMPACT distinct = 2 tests
- Tier3 invalid → 영문 fallback + default = 2 tests

### 4. 기존 테스트 정정 (test_review_guides_tier1_i18n.py — 1건)
- test_tier3_falls_back_to_english_for_japanese → test_tier3_now_supports_japanese_after_pr15
  - PR-13 시점: Tier3 미적용 → 영문 fallback
  - PR-15 시점: Tier3 적용 후 영문/일본어 distinct

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 Tier3 20 언어 (Erlang/OCaml/Julia/Zig/Nim/Crystal/Gleam/Elm/VimScript/GDScript/Dockerfile/Makefile/Terraform/YAML/TOML/GraphQL/Protobuf/XML/LaTeX/JSON Schema) AI 리뷰 출력 — 다른 preferred_language 사용자별 확인
- [ ] unknown 언어 (예: assembly/cobol) 분석 시 generic.py fallback 다국어 확인
- [ ] **50 언어 + generic 전체 영역** 영문/한국어/일본어 일관성 확인 (Phase 4 종결 검증)

## 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 적용 영역)

⚠️ **architecture 영향** (정책 3 강화 정량 기준 2번):
- Tier3 20 + generic = 21 가이드 파일 컨벤션 변경 — `FULL` 의미가 한국어 → 영문 default
- PR-13/14 시그니처 (output_language='en') 그대로 재사용 — 시그니처 변경 0
- **50 언어 + generic = 153 영역 전체 다국어 지원** (Phase 4 종결)

⚠️ **AI 리뷰 품질 영향 영역** (메모리 `feedback-ai-review-quality-protect.md` High tier):
- Tier3 20 언어 영문/한국어/일본어 가이드 본문 — 사용자 사전 결정 영역. 본 사이클 사용자 명시 진행 결정 ("머지했습니다. 다음 작업 진행해주세요")
- 영문 가이드 본문 = 기존 한국어에서 직역 (의미 보존 의무) — 단위 가드 84건이 헤더 일관성 + 텍스트 무결성 검증

자율 진입 보고:
- PR-15 응집 단위 = "Tier3 20 가이드 + generic" (정책 7 강화 응집 부합)
- **Phase 4 (코드리뷰 다국어 4 PR) 종결** — PR-12 (인프라) + PR-13 (Tier1 10) + PR-14 (Tier2 20) + PR-15 (Tier3 20 + generic)
- 회귀 가드 84건 = parametrized × 3 output_language 효율 (1 fixture 60 영역 동시 검증)

## 검증 (사이클 84 sync 실측)
- 단위 = `pytest tests/unit -q` → 2621 passed (+84 회귀 가드 + 1 PR-13 정정)
- 통합 = `pytest tests/integration -q` → 191 passed
- 합계 = 2812 passed / 5 skipped / 0 failed (105s)

## Phase 4 종결 선언

| Phase 4 PR | 영역 | LOC | 회귀 가드 | 핵심 결정 |
|-----------|------|-----|----------|----------|
| PR-12 (#298) | review_prompt + ai_review + caching 인프라 | ~400 | +12 | system prompt 3 언어 분기 + cache key 자동 분기 | | PR-13 (#299) | Tier1 10 가이드 (Python/JS/TS/Java/Go/Rust/C/C++/C#/Ruby) | ~1,500 | +80 | get_guide(output_language) 시그니처 확장 | | PR-14 (#300) | Tier2 20 가이드 (PHP/Swift/Kotlin/Scala/Shell/...) | ~2,000 | +82 | PR-13 패턴 그대로 재사용 | | PR-15 (본) | Tier3 20 가이드 + generic.py | ~2,000 | +84 | Phase 4 종결 — 50 언어 + generic = 153 영역 | | **합계** | **4 PR** | **~5,900 LOC** | **+258 단위** | **Phase 4 종결** |

다음 작업 = **Phase 5 진입** (PR-16 E2E 시각 회귀 가드 — 3 언어 × 4 테마 × 2 device = 24 조합).

## cross-verify 결과
- 1차 5 에이전트 디스패치 = 본 사이클 미수행 (단일 응집 PR-15 — Tier3 20 + generic)
- 통합 fail 0 (PR push 직전 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
