### PR TITLE
feat(i18n-phase5-pr16): E2E i18n 시각 회귀 가드 — 3 언어 × 4 페이지 + Cookie fal…

### DIFF
--- a/e2e/test_i18n_visual_regression.py
+++ b/e2e/test_i18n_visual_regression.py
@@ -1,0 +1,221 @@
+"""Phase 5 PR-16 — i18n E2E 시각 회귀 가드 (3 언어 × 주요 페이지).
+
+Phase 5 PR-16 — i18n E2E visual regression guards (3 languages × main pages).
+
+검증 범위 (Coverage):
+1. 3 언어 (en/ko/ja) × 4 주요 페이지 (login/overview/dashboard/settings) 렌더링
+2. preferred_language Cookie 설정 시 LocaleMiddleware 가 해당 언어 적용
+3. 언어별 핵심 텍스트 (header/title/nav) 표시 검증
+4. Cookie 미설정 시 default locale ('en') fallback 검증
+5. base.html nav 메뉴 (Overview/Dashboard/Logout) 다국어 적용 검증
+
+본 가이드는 정책 11 페어 (UI/시각 변경 PR 8 조합 시각 체크리스트 의무) 자동화 보조 가드.
+사용자 시각 검증 책임은 보존 — 본 가드는 정적 text + nav structure 회귀 차단만.
+
+This guard supports Policy 11 (8-combination visual checklist obligation for UI changes) but
+DOES NOT replace user manual visual verification — only prevents text/structure regression.
+"""
+import pytest
+
+
+# ── 언어별 키 텍스트 매트릭스 (anchor texts for visual regression) ───────────
+
+
+_I18N_ANCHORS = {
+    "en": {
+        "nav_overview": "Overview",
+        "nav_dashboard": "Dashboard",
+        "nav_logout": "Logout",
+        "login_subtitle": "Claude reviews your PR",
+        "login_button": "Sign in with GitHub",
+        "overview_title": "Today's Analyses",
+        "overview_title_empty": "Repository Status",
+        "dashboard_title": "Dashboard",
+        "settings_save": "Save settings",
+        "settings_page_title": "Repository Settings",
+    },
+    "ko": {
+        "nav_overview": "개요",
+        "nav_dashboard": "대시보드",
+        "nav_logout": "로그아웃",
+        "login_subtitle": "PR이 들어오면 Claude가 검토",
+        "login_button": "GitHub로 로그인",
+        "overview_title": "오늘의 분석",
+        "overview_title_empty": "리포지토리 현황",
+        "dashboard_title": "대시보드",
+        "settings_save": "설정 저장",
+        "settings_page_title": "리포지토리 설정",
+    },
+    "ja": {
+        "nav_overview": "概要",
+        "nav_dashboard": "ダッシュボード",
+        "nav_logout": "ログアウト",
+        "login_subtitle": "PRが入ってきたらClaude",
+        "login_button": "GitHubでログイン",
+        "overview_title": "本日の分析",
+        "overview_title_empty": "リポジトリ状況",
+        "dashboard_title": "ダッシュボード",
+        "settings_save": "設定を保存",
+        "settings_page_title": "リポジトリ設定",
+    },
+}
+
+
+def _set_locale_cookie(page, base_url: str, locale: str) -> None:
+    """preferred_language Cookie 설정 — LocaleMiddleware 가 Layer 1 (Cookie) 우선 감지.
+
+    Set preferred_language cookie — LocaleMiddleware Layer 1 takes priority.
+    """
+    page.context.add_cookies([{
+        "name": "preferred_language",
+        "value": locale,
+        "url": base_url,
+    }])
+
+
+# ── /login (비로그인 진입 페이지) ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize("locale", ["en", "ko", "ja"])
+def test_login_page_i18n_render(page, base_url, locale):
+    """/login 페이지 — 3 언어 (en/ko/ja) 텍스트 렌더링 검증.
+
+    /login is unauthenticated, so Cookie-based locale must be respected.
+    """
+    _set_locale_cookie(page, base_url, locale)
+    page.goto(f"{base_url}/login")
+    body = page.content()
+
+    anchors = _I18N_ANCHORS[locale]
+    assert anchors["login_subtitle"] in body, (
+        f"login subtitle missing for locale={locale}"
+    )
+    assert anchors["login_button"] in body, (
+        f"login button missing for locale={locale}"
+    )
+
+    # HTML lang attribute 동적 검증
+    html_tag_re = page.locator("html")
+    actual_lang = html_tag_re.get_attribute("lang")
+    assert actual_lang == locale, (
+        f"<html lang='{actual_lang}'> doesn't match expected '{locale}'"
+    )
+
+
+# ── / (overview — 로그인 후) ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("locale", ["en", "ko", "ja"])
+def test_overview_page_i18n_render(page, base_url, locale):
+    """/ overview 페이지 — 3 언어 nav + title 렌더링 검증."""
+    _set_locale_cookie(page, base_url, locale)
+    page.goto(f"{base_url}/")
+    body = page.content()
+
+    anchors = _I18N_ANCHORS[locale]
+    # base.html nav 검증
+    assert anchors["nav_overview"] in body, (
+        f"nav 'Overview' missing for locale={locale}"
+    )
+    assert anchors["nav_dashboard"] in body, (
+        f"nav 'Dashboard' missing for locale={locale}"
+    )
+    assert anchors["nav_logout"] in body, (
+        f"nav 'Logout' missing for locale={locale}"
+    )
+
+    # overview title — 리포 0 vs ≥1 분기 모두 포괄
+    assert (
+        anchors["overview_title"] in body
+        or anchors["overview_title_empty"] in body
+    ), f"overview title missing for locale={locale}"
+
+
+# ── /dashboard ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("locale", ["en", "ko", "ja"])
+def test_dashboard_page_i18n_render(page, base_url, locale):
+    """/dashboard 페이지 — 3 언어 title + nav 렌더링 검증."""
+    _set_locale_cookie(page, base_url, locale)
+    page.goto(f"{base_url}/dashboard")
+    body = page.content()
+
+    anchors = _I18N_ANCHORS[locale]
+    assert anchors["dashboard_title"] in body, (
+        f"dashboard title missing for locale={locale}"
+    )
+    assert anchors["nav_overview"] in body
+    assert anchors["nav_dashboard"] in body
+
+
+# ── /repos/{name}/settings (settings 페이지 — repo 시드 의무) ─────────────
+
+
+@pytest.mark.parametrize("locale", ["en", "ko", "ja"])
+def test_settings_page_i18n_render(seeded_page, base_url, locale):
+    """/repos/{owner}/{repo}/settings 페이지 — 3 언어 title + save button 검증.
+
+    seeded_page fixture = repo 시드 + 신규 page (격리 context). Cookie 는 본 함수에서 추가.
+    seeded_page fixture seeds owner/testrepo + a fresh page; we add the cookie locally.
+    """
+    seeded_page.context.add_cookies([{
+        "name": "preferred_language",
+        "value": locale,
+        "url": base_url,
+    }])
+    seeded_page.goto(f"{base_url}/repos/owner/testrepo/settings")
+    body = seeded_page.content()
+
+    anchors = _I18N_ANCHORS[locale]
+    # 페이지 헤더 (`리포지토리 설정` 등)
+    assert anchors["settings_page_title"] in body, (
+        f"settings page title missing for locale={locale}"
+    )
+    # 저장 버튼 — 페이지 하단 의무 노출
+    assert anchors["settings_save"] in body, (
+        f"settings save button missing for locale={locale}"
+    )
+
+
+# ── default locale fallback (Cookie 미설정) ────────────────────────────────
+
+
+def test_no_cookie_falls_to_default_locale(page, base_url):
+    """Cookie 미설정 시 settings.default_locale ('en') fallback 검증."""
+    # Cookie 미설정 — 기존 컨텍스트 cookies 모두 삭제
+    page.context.clear_cookies()
+    page.goto(f"{base_url}/login")
+    body = page.content()
+
+    # default = 'en'
+    anchors_en = _I18N_ANCHORS["en"]
+    assert anchors_en["login_subtitle"] in body, (
+        "default locale fallback failed — expected English subtitle"
+    )
+
+    actual_lang = page.locator("html").get_attribute("lang")
+    assert actual_lang == "en", f"expected default lang='en', got '{actual_lang}'"
+
+
+# ── 언어 전환 일관성 (Cookie 변경 시 즉시 반영) ─────────────────────────
+
+
+def test_locale_switch_via_cookie_takes_effect(page, base_url):
+    """preferred_language Cookie 변경 시 다음 요청에서 즉시 다른 언어 표시."""
+    # 1차: en
+    _set_locale_cookie(page, base_url, "en")
+    page.goto(f"{base_url}/login")
+    assert "Sign in with GitHub" in page.content()
+
+    # 2차: ko 로 전환
+    page.context.clear_cookies()
+    _set_locale_cookie(page, base_url, "ko")
+    page.goto(f"{base_url}/login")
+    assert "GitHub로 로그인" in page.content()
+
+    # 3차: ja 로 전환
+    page.context.clear_cookies()
+    _set_locale_cookie(page, base_url, "ja")
+    page.goto(f"{base_url}/login")
+    assert "GitHubでログイン" in page.content()


### PR DESCRIPTION
…lback (Phase 5 PR-16)

## Summary
Phase 5 PR-16 — E2E 시각 회귀 가드 (Playwright + Chromium). 3 언어 (en/ko/ja) × 4 주요 페이지 (login/overview/dashboard/settings) + Cookie fallback + locale switch 정합. 정책 11 페어 자동화 보조 가드 (사용자 수동 시각 검증 의무 보존). e2e +14 회귀 가드 신설.

## Changes (1 file)

### 1. e2e/test_i18n_visual_regression.py (신설)
- Phase 1 PR-1b LocaleMiddleware Cookie 우선 감지 페어 검증
- `_I18N_ANCHORS` 매트릭스 (en/ko/ja × 10 anchor 텍스트)
- `_set_locale_cookie` 헬퍼 — preferred_language Cookie 직접 설정 (LocaleMiddleware Layer 1 트리거)

#### 검증 14건
- `test_login_page_i18n_render` × 3 (en/ko/ja) — 비로그인 진입 + HTML lang 동적 검증
- `test_overview_page_i18n_render` × 3 (en/ko/ja) — base.html nav + overview title (리포 0/≥1 분기)
- `test_dashboard_page_i18n_render` × 3 (en/ko/ja) — dashboard title + nav
- `test_settings_page_i18n_render` × 3 (en/ko/ja) — `seeded_page` fixture 활용 (repo 시드 + Cookie 추가)
- `test_no_cookie_falls_to_default_locale` — Cookie 부재 시 settings.default_locale ('en') fallback
- `test_locale_switch_via_cookie_takes_effect` — Cookie 변경 시 다음 요청 즉시 반영 (en→ko→ja)

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 manual 시각 검증 (정책 11 8 조합 의무 보존):
  - 4 테마 (dark/light/glass/claude-dark) × 모바일/데스크탑 = 8 조합
  - 3 언어 (en/ko/ja) × 4 페이지 = 12 페이지 — 본 자동화는 텍스트만, 시각 정합 (폰트/줄바꿈/오버플로) 사용자 책임
- [ ] Playwright headless = chromium 만 — Firefox/WebKit fallback 시 Cookie 동작 검증 (운영 사용자 브라우저 다양성)
- [ ] preferred_language Cookie 부재 시 Accept-Language q-weight 우선순위 동작 (E2E 자동화 미커버)

## 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 적용 영역)

⚠️ **architecture 영향** (정책 3 강화 정량 기준 2번):
- E2E i18n 자동화 가드 = 정책 11 (8 조합 시각 체크리스트) 자동화 보조 — 사용자 수동 검증 의무 대체 X
- `seeded_page` fixture 활용 (기존) + Cookie 추가 패턴 — context.add_cookies + context.clear_cookies 라이프사이클

⚠️ **사용자 인지 영향** (정책 3 강화 정량 기준 4번):
- 14 E2E 가드 통과 = 텍스트/구조 회귀 차단만. 시각 (폰트/spacing/색) 정합 = 사용자 시각 검증 의무 보존

자율 진입 보고:
- PR-16 응집 단위 = "E2E i18n 시각 회귀 가드" (정책 7 강화 응집 부합)
- PR-17 (운영 KPI — 사용자 언어 분포 + i18n fallback rate) = 별도 PR — 다음 작업
- PR-18 (다국어 smoke + 1주 baseline + 정책 진화 묶음) = Phase 5 마지막 PR
- 본 PR 회귀 가드 = 정적 text + html lang attr 검증만 (시각 픽셀 회귀 미포함 — 정책 11 8 조합 사용자 영역)

## 검증 (사이클 84 sync 실측)
- E2E i18n = `pytest e2e/test_i18n_visual_regression.py` → 14 passed (12.96s)
- 단위 = `pytest tests/unit -q` → 2537 passed
- 통합 = `pytest tests/integration -q` → 191 passed
- 합계 = 2728 unit+integration passed / 5 skipped / 0 failed (106s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
