### PR TITLE
Potential fix for code scanning alert no. 366: Unused import

### DIFF
--- a/tests/unit/notifier/test_telegram_i18n.py
+++ b/tests/unit/notifier/test_telegram_i18n.py
@@ -11,7 +11,6 @@ Phase 3 PR-9 regression guards — Telegram + telegram_commands i18n + 3-layer f
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest


### PR DESCRIPTION
Potential fix for [https://github.com/xzawed/SCAManager/security/code-scanning/366](https://github.com/xzawed/SCAManager/security/code-scanning/366)

To fix this without changing functionality, delete the unused import statement in `tests/unit/notifier/test_telegram_i18n.py`:

- Remove `from datetime import datetime, timezone` (line 14 in the provided snippet).
- Keep all other imports and test code unchanged.

This single edit resolves both alert variants at once (`datetime` unused and `timezone` unused), since both names come from the same import line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
