### PR TITLE
Potential fix for code scanning alert no. 367: Unused import

### DIFF
--- a/tests/unit/notifier/test_telegram_i18n.py
+++ b/tests/unit/notifier/test_telegram_i18n.py
@@ -12,7 +12,7 @@ Phase 3 PR-9 regression guards — Telegram + telegram_commands i18n + 3-layer f
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 


### PR DESCRIPTION
Potential fix for [https://github.com/xzawed/SCAManager/security/code-scanning/367](https://github.com/xzawed/SCAManager/security/code-scanning/367)

사용되지 않는 import를 제거하면 됩니다.  
이 경우 `tests/unit/notifier/test_telegram_i18n.py`의 import 구문에서 `patch`만 삭제하고, 실제로 사용 중인 `MagicMock`은 유지합니다. 기능 변경 없이 가독성과 유지보수성을 개선하는 최소 수정입니다.

수정 위치:
- 파일: `tests/unit/notifier/test_telegram_i18n.py`
- 상단 import 영역 (현재 15행)

필요 변경:
- `from unittest.mock import MagicMock, patch`  
  → `from unittest.mock import MagicMock`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
