### PR TITLE
Potential fix for code scanning alert no. 368: Unused import

### DIFF
--- a/tests/unit/notifier/test_telegram_i18n.py
+++ b/tests/unit/notifier/test_telegram_i18n.py
@@ -14,8 +14,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from src.notifier._language import resolve_notification_language
 from src.notifier.telegram import _build_message
 from src.notifier.telegram_commands import (


### PR DESCRIPTION
Potential fix for [https://github.com/xzawed/SCAManager/security/code-scanning/368](https://github.com/xzawed/SCAManager/security/code-scanning/368)

The best fix is to delete the unused `import pytest` line from `tests/unit/notifier/test_telegram_i18n.py` to eliminate an unnecessary dependency and satisfy CodeQL without changing behavior.

Specifically:
- Edit the import section near lines 14–20.
- Remove only `import pytest`.
- Keep all other imports unchanged.

No new methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
