### PR TITLE
Potential fix for code scanning alert no. 369: Unused import

### DIFF
--- a/tests/unit/notifier/test_external_channels_i18n.py
+++ b/tests/unit/notifier/test_external_channels_i18n.py
@@ -12,7 +12,7 @@ Phase 3 PR-10 regression guards — Discord + Slack + Email i18n + RFC 2047 base
 from __future__ import annotations
 
 from email.header import Header, decode_header
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 from src.notifier.discord import _build_embed
 from src.notifier.email import _build_html_body


### PR DESCRIPTION
Potential fix for [https://github.com/xzawed/SCAManager/security/code-scanning/369](https://github.com/xzawed/SCAManager/security/code-scanning/369)

Remove the unused `patch` symbol from the `unittest.mock` import in `tests/unit/notifier/test_external_channels_i18n.py`.

Best fix without changing behavior:
- Edit the import line near the top of the file.
- Change:
  - `from unittest.mock import MagicMock, patch`
- To:
  - `from unittest.mock import MagicMock`

No functionality changes are introduced; this only removes an unnecessary dependency in the module namespace and satisfies the static analysis warning.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
