### PR TITLE
Potential fix for code scanning alert no. 370: Unused import

### DIFF
--- a/tests/unit/services/test_operations_i18n_kpi.py
+++ b/tests/unit/services/test_operations_i18n_kpi.py
@@ -11,8 +11,6 @@ Phase 5 PR-17 regression guards — operations_service i18n KPI (language_distri
 """
 from __future__ import annotations
 
-from unittest.mock import MagicMock
-
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker


### PR DESCRIPTION
Potential fix for [https://github.com/xzawed/SCAManager/security/code-scanning/370](https://github.com/xzawed/SCAManager/security/code-scanning/370)

미사용 import 문제의 가장 좋은 해결 방법은 **해당 import 문을 삭제**하는 것입니다. 기능 변경 없이 코드 가독성을 높이고 불필요한 의존성을 제거합니다.

구체적으로 `tests/unit/services/test_operations_i18n_kpi.py`의 import 섹션에서 다음 한 줄을 제거하면 됩니다.

- 제거 대상: `from unittest.mock import MagicMock` (현재 14번 줄)

그 외 로직/테스트 본문은 수정할 필요가 없습니다. 새로운 메서드, 정의, 외부 패키지 추가도 필요 없습니다.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
