### PR TITLE
fix(cycle-86-pylint-drift-recovery): pylint 9.92→9.94 회복 — Tier A 13건…

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -44,7 +44,7 @@ class AiReviewResult:  # pylint: disable=too-many-instance-attributes
     detected_languages: list[str] = field(default_factory=list)  # 감지된 언어 목록
 
 
-async def review_code(
+async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching + 예외 분기로 인한 누적 (사이클 84 i18n)
     api_key: str,
     commit_message: str,
     patches: list[tuple[str, str]],

--- a/src/auth/github.py
+++ b/src/auth/github.py
@@ -31,7 +31,7 @@ templates = Jinja2Templates(directory="src/templates")
 # Phase 2 PR-5 (Cycle 84) — Register Jinja2 i18n filters (pairs with login.html i18n)
 # auth/github.py 는 자체 Jinja2Templates 인스턴스 사용 — _helpers.templates 와 분리
 # auth/github.py uses its own Jinja2Templates instance — separate from _helpers.templates
-from src.i18n.filters import register_i18n_filters  # noqa: E402
+from src.i18n.filters import register_i18n_filters  # noqa: E402  # pylint: disable=wrong-import-position
 register_i18n_filters(templates.env)
 
 

--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -489,7 +489,7 @@ async def _enqueue_merge_retry(  # pylint: disable=too-many-arguments
         )
 
 
-async def _run_auto_merge_legacy(  # pylint: disable=too-many-arguments
+async def _run_auto_merge_legacy(  # pylint: disable=too-many-arguments,too-many-locals
     config: RepoConfigData,
     github_token: str,
     repo_name: str,

--- a/src/gate/native_automerge.py
+++ b/src/gate/native_automerge.py
@@ -37,7 +37,11 @@ from src.gate.github_review import (
     get_pr_mergeable_state,
     merge_pr,
 )
-from src.github_client.graphql import (
+from src.github_client.graphql import (  # pylint: disable=unused-import
+    # ENABLE_DISABLED_IN_REPO + ENABLE_PERMISSION_DENIED 는 외부 (tests/unit/gate/test_native_automerge.py
+    # + tests/unit/gate/test_engine_defensive_guards.py) 에서 본 모듈 경로로 import 하는 re-export 영역.
+    # 메모리 `feedback-copilot-autofix-noqa-trap.md` 페어 — side-effect re-export 패턴.
+    # ENABLE_DISABLED_IN_REPO + ENABLE_PERMISSION_DENIED are re-exported for external test consumers.
     ENABLE_DISABLED_IN_REPO,
     ENABLE_FORCE_PUSHED,
     ENABLE_OK,

--- a/src/notifier/email.py
+++ b/src/notifier/email.py
@@ -21,7 +21,7 @@ from src.notifier._common import format_ref, get_all_issues, truncate_issue_msg
 logger = logging.getLogger(__name__)
 
 
-def _build_html_body(  # pylint: disable=too-many-positional-arguments
+def _build_html_body(  # pylint: disable=too-many-positional-arguments,too-many-locals
     repo_name: str,
     commit_sha: str,
     score_result: ScoreResult,

--- a/src/notifier/github_issue.py
+++ b/src/notifier/github_issue.py
@@ -27,7 +27,7 @@ def _bandit_high_issues(result: dict) -> list[dict]:
     return [i for i in issues if i.get("tool") == "bandit" and i.get("severity") == "HIGH"]
 
 
-def _build_issue_body(
+def _build_issue_body(  # pylint: disable=too-many-locals
     repo_name: str,
     commit_sha: str,
     analysis_id: int,

--- a/src/notifier/telegram.py
+++ b/src/notifier/telegram.py
@@ -98,7 +98,7 @@ def _parse_retry_after(response) -> int:
     return min(max(retry_after, 1), TELEGRAM_RETRY_AFTER_MAX_SECONDS)
 
 
-def _build_message(  # pylint: disable=too-many-positional-arguments
+def _build_message(  # pylint: disable=too-many-positional-arguments,too-many-locals
     repo_name: str,
     commit_sha: str,
     score_result: ScoreResult,

--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -618,7 +618,7 @@ def _parse_insight_cards(text: str) -> dict[str, list] | None:
     }
 
 
-async def insight_narrative(
+async def insight_narrative(  # pylint: disable=too-many-locals
     db: Session,
     days: int = 7,
     *,

--- a/src/shared/merge_metrics.py
+++ b/src/shared/merge_metrics.py
@@ -40,7 +40,7 @@ def parse_reason_tag(reason: str | None) -> str | None:
     return head or None
 
 
-def log_merge_attempt(  # pylint: disable=too-many-arguments
+def log_merge_attempt(  # pylint: disable=too-many-arguments,too-many-locals
     db: Session,
     *,
     analysis_id: int,

--- a/src/ui/_helpers.py
+++ b/src/ui/_helpers.py
@@ -25,7 +25,7 @@ templates = Jinja2Templates(directory="src/templates")
 
 # Phase 2 PR-5 (사이클 84) — Jinja2 i18n 필터 등록 (i18n + i18n_args 사용 가능)
 # Phase 2 PR-5 (Cycle 84) — Register Jinja2 i18n filters (i18n + i18n_args available)
-from src.i18n.filters import register_i18n_filters  # noqa: E402
+from src.i18n.filters import register_i18n_filters  # noqa: E402  # pylint: disable=wrong-import-position
 
 register_i18n_filters(templates.env)
 

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -63,7 +63,7 @@ def _detect_initial_dashboard_mode(db: Session, user_id: int | None = None) -> s
 
 
 @router.get("/dashboard", response_class=HTMLResponse)
-async def dashboard(
+async def dashboard(  # pylint: disable=too-many-locals
     request: Request,
     current_user: Annotated[CurrentUser, Depends(require_login)],
     days: int = 7,

--- a/src/ui/routes/settings.py
+++ b/src/ui/routes/settings.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 
 import ipaddress
 import secrets
+from dataclasses import fields as dataclass_fields
 from typing import Annotated
 from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
-
-from dataclasses import fields as dataclass_fields
 
 from src.auth.session import CurrentUser, require_login
 from src.config_manager.manager import RepoConfigData, get_repo_config, upsert_repo_config


### PR DESCRIPTION
… (W0611/C0411/C0413 5 + R0914 8)

## Summary

사이클 85 회고 관점 2 P0 finding (pylint 10.00 → 9.92 drift) 회복 1차 단계. 사이클 84 i18n + 사이클 85 cleanup 후속 누적 violations 정정.

## 변경 영역 (Tier A 안전 fix)

### 1. W0611 unused-import (2건 → re-export 패턴 명시)

`src/gate/native_automerge.py:40-47`:
- `ENABLE_DISABLED_IN_REPO` + `ENABLE_PERMISSION_DENIED` 는 외부 (tests/unit/gate/test_native_automerge.py + tests/unit/gate/test_engine_defensive_guards.py) 에서 본 모듈 경로로 import 하는 **re-export 영역**
- `# pylint: disable=unused-import` 추가 + 사유 주석 (한국어/영어 병행) — 메모리 `feedback-copilot-autofix-noqa-trap.md` 페어
- 기존 imports 보존 (회귀 위험 차단)

### 2. C0413 wrong-import-position (2건 → 의도된 placement 명시)

`src/auth/github.py:34` + `src/ui/_helpers.py:28`:
- `from src.i18n.filters import register_i18n_filters` 가 `templates = Jinja2Templates(...)` 후 placement (i18n filter 등록 의도된 순서)
- `# pylint: disable=wrong-import-position` 추가 (기존 `# noqa: E402` 와 페어)

### 3. C0411 wrong-import-order (1건 → 표준 lib 순서 정정)

`src/ui/routes/settings.py:13`:
- `from dataclasses import fields` 를 third-party imports (httpx/fastapi) 위로 이동 (PEP 8 정합)
- 코드 동작 영향 0

### 4. R0914 too-many-locals (8건 → CLAUDE.md inline disable default 페어)

CLAUDE.md `.claude/rules/testing.md` 의 R0914 결정 트리 정합 — signature 확장 default 영역에 inline disable + 사유:
- `src/analyzer/io/ai_review.py:47` review_code (다국어 + caching 누적)
- `src/gate/engine.py:492` _run_auto_merge_legacy
- `src/notifier/email.py:24` _build_html_body
- `src/notifier/github_issue.py:30` _build_issue_body
- `src/notifier/telegram.py:101` _build_message
- `src/services/dashboard_service.py:621` insight_narrative
- `src/shared/merge_metrics.py:43` log_merge_attempt
- `src/ui/routes/dashboard.py:66` dashboard

기존 `# pylint: disable=too-many-arguments`/`too-many-positional-arguments` 와 페어 (메서드별 누적).

## 정량 효과

| 지표 | 이전 | 이후 | 차이 |
|------|------|------|------|
| pylint | 9.92/10 | **9.94/10** | +0.02 |
| 정정된 violations | 0 | **13건** | -13 |
| 잔여 violations | 49 | 36 | (사이클 87+ 영역) |

## 잔여 영역 (사이클 87+ 점진 default)

- **C0415 import-outside-toplevel (21건)** — i18n notifier `_language` lazy import 14건 + dashboard_service repository lazy import 4건 등 = 의도된 circular import 회피 패턴. inline disable 또는 setup.cfg 영역 결정 필요 (사이클 87+ 결정)
- **C0301 line-too-long (8건)** — saas_service.py SQL 쿼리 + add_repo.py URL 등 = 가독성 vs 정정 결정 필요
- **W0718 broad-exception (2건)** — 의도된 graceful handler (이미 메모리 페어)
- **W0613 unused-argument (2건)** — 인터페이스 호환성 (signature 보존)
- **R0913/R0917 too-many-arguments (3건)** — signature 확장 (inline disable 페어)

## 검증

- `pytest tests/unit -q` → **2668 passed / 1 skipped / 0 failed (50.12s)** ✅
- 코드 동작 영향 0 (inline disable + import order 정정만)

## 자율 판단 보고 (정책 3 강화 — ⚠️ 마커 적용)

- ⚠️ **Tier A 안전 영역 한정** = code 동작 영향 0 (inline annotation only). architecture/UX/데이터 영향 X — High tier 영역 X
- ⚠️ **잔여 36건 = 사이클 87+ 점진 default** — 1 PR 에 49건 일괄 fix 시 변경 범위 ↑ + 검증 부담 ↑. 정책 16 단순화 default + 정책 7 강화 응집 단위 페어
- ⚠️ **pylint 10.00 회귀 가드 부재** — STATE.md 헤더 "pylint 10.00" 표기와 9.94 실측 불일치. 사이클 87+ 회복 의무

## Code Scanning open alert (정책 14)

- ✅ open 0건 (마지막 확인 시점: 사이클 86 pylint drift 회복, 2026-05-06)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
