### PR TITLE
chore(cycle-88-phase-a): CLAUDE.md Anthropic 200줄 정합 정정 Phase A — 정책 …

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,176 +358,39 @@ git push -u origin <branch>
 - **정책 7 강화**: PR 단위 = **응집 단위 분할** ("작게 분할" 아님). **응집 = URL + 화면 + 데이터 3종 동시 묶음**. 단일 PR > 1500 LOC = 사용자 사전 확인 의무 (architecture/migration/RLS 예외 — 사용자 명시 시 단일 PR OK). 상세: [docs/policies/history.md#정책-7-강화](docs/policies/history.md#정책-7-강화).
 - **정책 3 강화** (MCP): MCP 자율 실행 결과 PR 본문 §"MCP 자율 실행 결과" 별도 섹션 분리 (실행 SQL/도구 + 해석 + acknowledge 요청). 정책 12 페어.
 
-#### 정책 12 신설 (2026-05-02 Phase 1+2 회고 후속): **MCP scope 제한 의무**
-
-회고 발견: Phase 2 진입 검증 시 Supabase MCP 직접 실행 = 사용자 부담 87% 절감 (15분 → 2분). 그러나 INSERT/DELETE 권한 misuse 위험 명시 의무.
-
-**default scope 제한**:
-- **SELECT-only 자율 실행 OK** — 통계/검증/조회 SQL
-- **INSERT / UPDATE / DELETE / DROP / ALTER 사용자 사전 승인 의무** — 운영 데이터 변경 가능 SQL
-- **MCP 도구 호출 시 PR 본문 §"MCP 자율 실행 결과" 에 호출 도구 + 영향 범위 명시** (정책 3 강화 페어)
-- **읽기 전용이지만 PII / credential 노출 가능 SQL 도 사전 승인** (예: `SELECT * FROM users`, secret 컬럼 SELECT)
-
-**검증 사례** (Phase 1+2 사이클):
-- ✅ `mcp__claude_ai_Supabase__list_projects` (메타데이터 — OK)
-- ✅ `mcp__claude_ai_Supabase__list_tables` (스키마 메타 — OK)
-- ✅ 5 SELECT (count/avg/group by — PII 0건 — OK)
-- (없음) INSERT/DELETE — 본 사이클 미적용
-
-**금지**: `mcp__*__execute_sql` 의 SQL 자체 사용자 사전 노출 없이 INSERT/DELETE 실행. PII 컬럼 (`users.email`, `users.github_access_token`, `repo_configs.*_token` 등) SELECT 도 사전 승인.
-
-#### 정책 13 신설 (2026-05-02 P0 OAuth 사고 후속): **운영 endpoint smoke check 의무**
-
-회고 P0 #4 자기 예언 ("운영 사고 0 = 운 + Copilot Autofix + Railway CI") 무시 → 본 사고 발생. 사고 회고: [`docs/reports/2026-05-02-oauth-redirect-uri-incident.md`](docs/reports/2026-05-02-oauth-redirect-uri-incident.md).
-
-**default 의무** — 매 사이클 종료 시 (또는 Phase 종료 시) 최소 3-endpoint smoke check:
-- `GET /health` → 200 (lifeness)
-- `GET /auth/github` → 302 + Location 헤더의 `redirect_uri=` 정합성 검증
-- `GET /login` → 200 (또는 302 — 로그인 상태 의존)
-
-**확장 권장** (인증/외부 통합 변경 PR 시):
-- `GET /auth/callback` (state 검증으로 401 또는 302 — 직접 호출 시 의도된 거부 OK)
-- `POST /webhooks/github` (서명 헤더 누락 → 401, 정상)
-
-**실행 방법**:
-- Claude MCP 가용 시 자율 실행 (정책 12 SELECT-only 패턴 차용)
-- curl 직접 호출 — `curl -sf -o /dev/null -w "%{http_code}\n" https://<APP_BASE_URL>/<endpoint>`
-- 사용자 운영 환경 (Railway production) 직접 호출
-
-**PR 본문 §"운영 smoke check 결과" 섹션 의무**:
-```markdown
-## 운영 smoke check (정책 13)
-- ✅ /health 200
-- ✅ /auth/github 302 redirect_uri = https://...up.railway.app/auth/callback (정합)
-- ✅ /login 200
-```
-
-**금지**: 인증/외부 통합 변경 PR 본문에 본 섹션 누락 후 머지. 빌드 성공 = 운영 정상 가정 X.
-
-**자동화 가드 (그룹 61 PR #208 + 사이클 62 PR #212)** — manual smoke 와 페어:
-- `tests/integration/test_oauth_flow_smoke.py` (10건): 3-endpoint smoke + 인증 flow 4 endpoint 정합 + insights redirect + 성능
-- `e2e/test_dashboard.py` (14건): 페이지 로드 + KPI 5 카드 + range toggle + chart vendoring + JS 런타임 + insights redirect + nav Dashboard
-- `e2e/test_theme_mobile_guards.py` (7건, PR #212): claude-dark 8 토큰 정의 가드 + dashboard body 비-투명 + 등급 alias + WCAG 2.5.5 모바일 (.btn ≥44px / .btn--sm ≥40px / .nav-hamburger ≥44x44 / 데스크탑 누수 회귀)
-- `tests/integration/conftest.py` autouse fixture (PR #209): webhook secret 환경 의존성 격리 (24 fail 해소)
-- 상세: `docs/runbooks/operational-smoke-checks.md` §8
-
-🔴 **자동화 가드는 manual smoke check 의무를 대체하지 않는다** — CI 통과 ≠ 운영 정상. PR 본문 §"운영 smoke check 결과" 섹션은 인증/외부 통합 변경 PR 마다 여전히 의무 (정책 13 default). 자동화는 회귀 차단 보조이며 외부 의존 (GitHub OAuth App callback URL 등) 검증은 manual / 사용자 영역.
-
 #### 정책 11 강화 (사이클 62 P0 OAuth 사고 후속): 인증 flow 검증 추가
 
 🔴 **진화 default 요약**: 인증/외부 통합 변경 PR 시 8 조합 시각 체크리스트 + **인증 flow 4 endpoint 종단간 검증** 의무 — `/login` 200 + `/auth/github` 302 + `/auth/callback` redirect + `/auth/logout` redirect. 상세: [docs/policies/history.md#정책-11-강화](docs/policies/history.md#정책-11-강화).
 
-#### 정책 14 신설 (2026-05-03 사이클 62 후속): **GitHub Code Scanning 알림 운영 체크 의무**
+#### 정책 12: MCP scope 제한 의무
 
-사용자 발화 (2026-05-03): *"시큐리티에서 감지하는 내용도 앞으로 프로젝트 운영시 체크사항으로 부탁드립니다."*
+**default**: SELECT-only 자율 실행 OK / **INSERT/UPDATE/DELETE/DROP/ALTER + PII·credential SELECT = 사용자 사전 승인 의무** (운영 데이터 변경 + secret 노출 차단). MCP 호출 시 PR 본문 §"MCP 자율 실행 결과" 명시 (정책 3 강화 페어). 상세 + 검증 사례 + 금지 패턴: [docs/policies/active.md#정책-12](docs/policies/active.md#정책-12).
 
-회고 배경: GitHub Security 탭의 Code Scanning Alert #324 (`'break' or 'return' statement in finally`) + #325 (`Unused import`) 직접 확인 (참조 메타 Issue #213 / #214 는 단순 추적 수단). SCAManager 자체 정적분석 (pylint / flake8 / bandit) 은 통과 (위반 0건) 하지만 GitHub Security 탭 (CodeQL 또는 추가 도구) 이 별도 룰셋으로 감지하는 영역이 있음. **빌드 통과 + SCAManager lint 통과 ≠ Security 탭 0 alert**. 외부 가시성 부재 시 alert 누적 → 운영 책임 이전 위험.
+#### 정책 13: 운영 endpoint smoke check 의무
 
-**default 의무**:
-- **작업 시작 전 30초 체크리스트** (CLAUDE.md L891~) 에 GitHub Security 탭 Code Scanning open alert 카운트 1줄 추가 (이미 적용)
-- **매 사이클 종료 시** (또는 Phase 종료 시) — 정책 13 smoke check 와 페어로 GitHub Security 탭 등록된 alert 직접 검토 (Issue 추적 수단 의존 X — Security 탭 자체가 단일 진실 소스)
-- **GitHub Security 탭에 신규 alert 등록 시** — 분류 처리 (1회 의무):
-  - (a) 실제 위반 → 코드 fix PR (정책 7 단위)
-  - (b) false-positive → GitHub Security 탭에서 dismiss + 사유 기록
-  - (c) 의도된 패턴 → suppress 룰 추가 + 회고에 사유 명시
+**default**: 매 사이클/Phase 종료 시 3-endpoint smoke check — `/health` 200 + `/auth/github` 302 + Location `redirect_uri=` 정합 + `/login` 200. PR 본문 §"운영 smoke check 결과" 섹션 의무 (인증/외부 통합 변경 PR). **자동화 가드 (oauth_flow_smoke 10 + dashboard 14 + theme_mobile 7) ≠ manual smoke check 대체** — CI 통과 ≠ 운영 정상. 상세: [docs/policies/active.md#정책-13](docs/policies/active.md#정책-13).
 
-**실행 방법**:
-- gh CLI 가용 시: `gh api repos/<owner>/<repo>/code-scanning/alerts --jq '[.[] | select(.state=="open")] | length'`
-- gh 부재 시: 사용자 GitHub `Security → Code scanning alerts` 탭 직접 확인 → Claude 에 카운트 + alert 제목 공유 의무 (현 SCAManager 환경 default — 정책 10 옵션 🅒 와 동일 폴백 패턴)
-- API 인증 필요 (Code Scanning API 는 미인증 호출 차단) — 사용자 PAT 발급 시점에 자동화 가능
+#### 정책 14: GitHub Code Scanning 알림 운영 체크 의무
 
-**PR 본문 §"Code Scanning open alert 결과" 섹션 의무** (인증/외부 통합 변경 PR 외에는 사이클 종료 PR 일괄 회신 OK — 정책 2 진화 패턴):
-```markdown
-## Code Scanning open alert (정책 14)
-- ✅ open 0건 (마지막 확인 시점: 사이클 N 종료, YYYY-MM-DD)
-- (또는 [N]건 — 분류 처리 결과 명시)
-```
+사용자 발화: *"시큐리티에서 감지하는 내용도 앞으로 프로젝트 운영시 체크사항으로 부탁드립니다."*
 
-**금지**:
-- ❌ alert 누적 무시 (SCAManager lint 통과만으로 "Security A" 라고 단정)
-- ❌ 추측 기반 alert dismiss (룰 본문 미확인 상태에서 false-positive 단정)
+**default**: 매 사이클 종료 시 Security 탭 Code Scanning open alert 직접 검토. 신규 alert = (a) 실제 위반 → fix PR / (b) false-positive → dismiss + 사유 / (c) 의도 패턴 → suppress + 회고. PR 본문 §"Code Scanning open alert" 일괄 회신 OK. **SCAManager lint (pylint/flake8/bandit) 통과 ≠ Security 탭 0 alert** (CodeQL 별도 룰셋). 상세: [docs/policies/active.md#정책-14](docs/policies/active.md#정책-14).
 
-**상호 보완**:
-- SCAManager 자체 lint (pylint / flake8 / bandit) = src/ 직접 분석
-- GitHub Code Scanning (CodeQL + 추가 룰셋) = 다른 룰셋 + 의존성 그래프 분석
-- 두 영역 합집합 = 진정한 "보안/품질 0 alert" 상태
-- detail 절차 + 운영 통합 = `docs/runbooks/operational-smoke-checks.md` §9
+#### 정책 15: 코드 작업 (add/edit/delete) 전 사전 사고 의무
 
-#### 정책 15 신설 (2026-05-04 사이클 70 진입): **코드 작업 (add/edit/delete) 전 사전 사고 의무 + 이해 부족 시 중단/질문 의무**
+사용자 발화: *"앞으로 코드를 추가, 수정, 삭제 작업을 실행하기 이전에 항상 생각을 먼저 하고 진행을 합니다. 이해가 안되면 멈추거나 물어보고 하세요."*
 
-사용자 발화 (2026-05-04, 사이클 69 머지 후): *"앞으로 코드를 추가, 수정, 삭제 작업을 실행하기 이전에 항상 생각을 먼저 하고 진행을 합니다. 이해가 안되면 멈추거나 물어보고 하세요."*
+**default**: 모든 Edit/Write/MCP destructive 직전 3 자문 의무 — (a) 목적 = 사용자 의도 정합? (b) 영향 범위 인지? (c) 검증 방법 명확? 이해 부족 시 즉시 중단 (옵션 표 또는 yes/no 사전 확인). **위임 분류 3-tier**: **High** (사전 확인 의무 — DB 스키마/API/권한/데이터 모델) / **Medium** (자율+보고 — 헬퍼/정책 진화) / **Low** (즉시 진입 — 회귀 가드/docstring/typo). 상세: [docs/policies/active.md#정책-15](docs/policies/active.md#정책-15).
 
-**default 의무**:
-1. **모든 코드 작업 (Edit/Write/MCP `*_sql` INSERT/DELETE 등) 직전 사전 사고 의무** — 즉각 도구 호출 X. 다음 3 질문 자문 의무:
-   - (a) 본 변경의 **목적** 이 사용자 의도와 정합한가? (요청 발화 vs 내 해석)
-   - (b) 본 변경이 영향 범위 (다른 파일 / 운영 / 테스트) 를 **모두 인지** 한 상태인가?
-   - (c) 본 변경 후 **검증 방법** 이 명확한가? (테스트 / smoke / 사용자 의무)
-2. **이해 부족 시 즉시 중단**:
-   - 사용자 의도 모호 → "본 작업 의도 = X 로 해석. OK?" 1줄 사전 확인 (정책 1 옵션 표 또는 단순 yes/no)
-   - 영향 범위 불명 → 영향 범위 조사 후 보고 → 사용자 결정 회신 의무
-   - 검증 방법 부재 → 회귀 가드 추가 의무 또는 사용자 명시 검증 요청
-3. **위반 시 회복**: 사전 사고 누락 후 진행 시 사용자 발견 → 즉시 사과 + 영향 범위 분석 + revert 결정 회신.
+#### 정책 16: 코드 단순화 default + 가독성 우선
 
-**위임 분류 3-tier 통합** (`feedback-architecture-decision-pre-confirm.md`):
-- **High (사전 확인 의무)** = 정책 15 적용 (DB 스키마 / API / 권한 / 데이터 모델) — 옵션 표 + 사용자 1줄 명시
-- **Medium (자율 + 보고)** = 정책 15 적용 (헬퍼 함수 / 정책 본문 진화) — Claude 사전 사고 후 자율 진입 + PR 본문 자율 판단 보고
-- **Low (즉시 진입)** = 정책 15 면제 OK (회귀 가드 / docstring / typo) — 단 (b)/(c) 자문은 의무
+사용자 발화: *"코드를 단순화 하여 작성을 해주세요. 단 정확성과 성능은 유지가 되야합니다. 되도록 코드는 이해하기가 쉽게 작성을 해주세요."*
 
-**검증 사례 (사이클 69)**:
-- ✅ 5+1 에이전트 정밀 검증 시 cross-verify 의 false-positive 1건 차단 = 사전 사고 의무 효과 (Claude 단독 진행 시 잘못된 fix 적용 위험 차단)
-- ✅ PR # 카운트 산식 모호 → 실측 검증 후 정정 = 영향 범위 인지 의무 적용
+**default 의무 5 원칙** (우선순위 순): 1. 정확성 / 2. 성능 / 3. 가독성 / 4. 최소 추상화 (사용처 ≥ 3 시 도입) / 5. **🔴 토큰 비용 효율** (caching + 분산 + 호출 빈도 제한 — caching 4 단계 사이클 63→74 활성화).
 
-**Why**: 사이클 64~69 누적 회고 결과 — Claude 의 "즉각 도구 호출" 패턴이 사용자 위임 신호 (75%) 와 결합 시 잘못된 결정 누적 위험. 사전 사고 1단계로 75% → 0% 위임 위험 차단 (사이클 64 → 사이클 66 검증 효과).
+**🚫 명시 제외 영역** (AI 리뷰 품질 보존 — 사이클 72 사용자 명시 보류): `build_review_prompt` 토큰 예산 8000 축소 / `review_guides/` Tier1 full 압축. 신규 토큰 절약 영역 도입 시 사용자 사전 확인 의무 (정책 15 High tier 페어).
 
-**How to apply**: 모든 Edit/Write/Bash (destructive) 도구 호출 직전 1줄 자문 → 명확하면 진행, 불명하면 사용자 회신 대기. PR 본문 §"자율 판단 보고" (정책 3) 페어.
-
-#### 정책 16 신설 (2026-05-04 사이클 70 진입): **코드 단순화 default + 가독성 우선 (정확성/성능 유지)**
-
-사용자 발화 (2026-05-04, 사이클 69 머지 후): *"코드를 단순화 하여 작성을 해주세요. 단 정확성과 성능은 유지가 되야합니다. 되도록 코드는 이해하기가 쉽게 작성을 해주세요."*
-
-**default 의무** (5 원칙 — 우선순위 순):
-1. **정확성 우선** — 단순화가 동작 변경/회귀 유발 시 단순화 포기 (회귀 0 default)
-2. **성능 유지** — 단순화로 hot-path latency / memory 증가 시 단순화 포기 (실측 의무)
-3. **가독성 우선** — 위 두 조건 충족 시 가독성 ↑ 패턴 채택
-4. **최소 추상화** — 시스템 프롬프트 "Don't add features, refactor, or introduce abstractions beyond what the task requires" 강화
-5. **🔴 토큰 비용 효율** (사이클 72 추가 — 사용자 의도 정합) — 운영 토큰 사용량 ↓ + 분산 + caching 활용. 단, **AI 리뷰 품질 영향 영역 = 단순화 금지** (사용자 명시 제외 — 아래 명시 제외 영역). **caching 4 단계 활성화 사례 (사이클 63 → 74 — 사이클 75 진화)**: 1단계 인프라 도입 (사이클 63 #218 — `build_cached_system_param`) → 2단계 baseline 정확화 (사이클 72 #242 — cache 비용 모델 + `get_cache_stats` + silent fallback streak) → 3단계 활성화 (사이클 74 #247 — 1024 토큰 패딩 + Haiku 모델 분기) → 4단계 호출 빈도 제한 (사이클 74 #248 — DB 캐싱 1h TTL). 운영 baseline 측정 의무 (1주 후 cache_hit_rate / silent_cache_fallback streak 검증).
-
-**🚫 명시 제외 영역 (사용자 결정 — AI 리뷰 품질 보존 의무)**:
-- ❌ `build_review_prompt` 토큰 예산 8000 → 축소 (사이클 72 사용자 명시 보류 — 품질 저하 원치 않음)
-- ❌ `review_guides/` 50개 언어 Tier1 full ~500 토큰 압축 (사이클 72 사용자 명시 보류 — 체크리스트 ↓ → 리뷰 깊이 ↓ 위험)
-- ✅ 진행 OK 영역 (사이클 72 검증): `review_code` prompt caching = **이미 100% 적용** (사이클 63 #218 — `src/analyzer/io/ai_review.py:79,89`) — multi-block 확장 (system + lang_guides 분리) 만 Phase 3 후보 (단 `build_review_prompt` 시그니처 변경 = High tier 사전 확인 의무) / 모델 분기 (Haiku/Sonnet/Opus) — Phase 2 (1주 운영 데이터 후 결정, AI 리뷰 품질 영향 = High tier) / 동일 SHA 결과 재사용 = **이미 100% 적용** (3-tier dedup — `src/worker/pipeline.py:178-181`) / Insight narrative 호출 빈도 제한 — Phase 2 (DB 캐싱 1h TTL 후보) / **cache hit rate 모니터링 인프라 = 사이클 72 PR 2 (#242) 도입** (`src/shared/claude_metrics.py::get_cache_stats` + cache 비용 모델 정확화 + silent fallback streak WARNING)
-- 신규 토큰 절약 영역 도입 시 사용자 사전 확인 의무 (정책 15 + High tier — `feedback-architecture-decision-pre-confirm.md` 페어)
-
-**default 적용 패턴**:
-- **변수명** = 의도 명시 (예: `data` X → `repository_user_id` ○)
-- **함수 시그니처** = 인자 ≤ 5 (R0913 임계 default)
-- **함수 본문** = 단일 책임 (R0915 / R0912 임계 default)
-- **타입 힌트** = 모든 public 함수/메서드 의무 (이미 default — 정책 16 강화)
-- **주석** = 시스템 프롬프트 default (WHY 비명확 시만) + CLAUDE.md L7~L18 한국어/영어 병행 default
-- **early return** = 중첩 깊이 ≤ 3 (R0911 임계 default)
-
-**금지 패턴** (단순화 위반):
-- ❌ 추상 베이스 클래스 / Protocol — 사용처 ≥ 3 일 때만 도입 (`feedback-architecture-decision-pre-confirm.md` Medium tier 기준 페어)
-- ❌ Generic 타입 매개변수 — 사용처 ≥ 3 시점 도입
-- ❌ 메타클래스 / 데코레이터 체인 — 표준 라이브러리 (functools/contextlib) 외 자체 작성 금지 (사용자 명시 시만 OK)
-- ❌ "다음 확장 대비" 분기 — 현재 요건만 구현 (정책 7 강화 응집 단위 부합)
-
-**리뷰 체크 포인트** (PR 작성 시 자가 검토 의무):
-1. **줄 수 감소 가능?** — 동일 동작을 더 짧게 표현 가능 시 적용 (단 가독성 ↓ 시 보존)
-2. **분기 합치 가능?** — `if/elif/else` 가 동일 결과 분기 시 합치
-3. **중간 변수 제거 가능?** — 단일 사용 임시 변수 inline 가능 시 적용
-4. **표준 라이브러리 활용 가능?** — `itertools / collections / functools / dataclasses` 우선 (자체 구현 금지)
-
-**검증 사례** (사이클 64~67 — 정책 16 사후 검증):
-- ✅ Phase 3 PR 5 (#223) RLS 격리 헬퍼 2건 (`_apply_*_user_filter`) — 함수 ≤ 10 줄 + 단일 책임 + 인자 3 (정합)
-- ✅ 사이클 66 #228 RLS middleware ASGI 직접 작성 (BaseHTTPMiddleware 우회) — 추상화 0 + 흐름 직선 (정합)
-- ⚠️ 사이클 64 회고 R0914 결정 트리 (CLAUDE.md L988~) — `dashboard_kpi` / `frequent_issues_v2` user_id 인자 추가 시 R0914 inline disable 채택 (헬퍼 추출 over-engineering 회피) — 정책 16 default 사례
-
-**Why**: 사이클 65~67 정합성 cleanup 누적 = 100+ 줄 변경 / 10+ 패턴 — 코드량 ↑ 자체가 미래 회고 부담. 단순화 default 로 다음 cleanup 부담 ↓.
-
-**Why (5 원칙 추가 — 사이클 72)**: 사이클 70~71 진행 후 사용자 의도 검증 = "토큰 비용 효율" 이 본래 목적이었음 (사이클 70 정책 15 위반 사례 — Claude 가 "단순화" 의도 모호 검증 안 함). 사이클 72 회고 정정으로 5번째 원칙 신설. **운영 Anthropic API 비용 ↓** 가 실 가치 — 가독성 단순화는 부가 효과.
-
-**How to apply**: Edit/Write 도구 호출 직전 정책 15 사전 사고와 페어 — "이 변경이 가장 단순한 형태인가?" + "토큰 비용 영향은?" 2 자문 의무. CI lint (pylint R0911~R0917) 가 1차 가드, PR 본문 §"자율 판단 보고" 의 자가 리뷰 4 체크포인트 + 토큰 영향 추정이 2차 가드.
+**금지 패턴**: 추상 베이스 클래스 / Generic 타입 / 메타클래스 / 데코레이터 체인 / "확장 대비" 분기. 상세 + 검증 사례 + 리뷰 체크포인트: [docs/policies/active.md#정책-16](docs/policies/active.md#정책-16).
 
 ---
 
@@ -677,10 +540,10 @@ PreToolUse Hook(`.claude/hooks/check_edit_allowed.py`)이 자동으로 차단한
 
 ## 현재 상태
 
-최신 수치는 [docs/STATE.md](docs/STATE.md) 참조 — 단위 테스트 2669개 | 통합 129개 | E2E 96개 | pylint **9.94/10** (사이클 86 #335 = 9.92→9.94 1차, 잔여 36건 사이클 87+ → 10.00 / 사이클 87 `make lint-strict` 회귀 가드) | 커버리지 95% | SonarCloud QG OK · Security A · Reliability A · Maintainability A · Tier1 정적분석 10종 · Observability (Claude metrics + stage timing + MergeAttempt — Sentry 통합은 사이클 85 #317 폐기 완료) · AI 점수 피드백 루프 · Settings Minimal Mode · Onboarding 3단계 튜토리얼 · **사이클 60~82 historical**: [`docs/cycle-history.md`](docs/cycle-history.md) (archive). **직전 5 사이클 (2026-05-05 ~ 2026-05-06)**:
+최신 수치는 [docs/STATE.md](docs/STATE.md) 참조 — 단위 테스트 2669개 | 통합 129개 | E2E 96개 | pylint **9.94/10** (`make lint-strict` 회귀 가드 baseline 9.90) | 커버리지 95% | SonarCloud QG OK · Security A · Reliability A · Maintainability A · Tier1 정적분석 10종 · Observability (Claude metrics + stage timing + MergeAttempt — Sentry 사이클 85 #317 폐기) · AI 점수 피드백 루프 · Settings Minimal Mode · Onboarding 3단계 튜토리얼 · **사이클 60~83 historical**: [`docs/cycle-history.md`](docs/cycle-history.md) (archive). **직전 5 사이클 (2026-05-05 ~ 2026-05-06)**:
 
-- **사이클 83 (Tier B 11건 정책 진화 묶음, 2026-05-05)** — 정책 9 완화 + 정책 8 진화 (단일 작업일 ≥ 5 dispatch 사전 확인) + 정책 3 ⚠️ 마커 정량 기준 + 정책 1 진화 + 정책 5 cross-reference 강화 + 메모리 cross-reference (#279).
 - **사이클 84 (다국어 i18n 18 PR + 회고 + Tier B, 2026-05-05~06)** — Phase 1~5 18 PR (#283~#304) — 영어/한국어/일본어 + UI/알림/AI 리뷰 전 영역. 단위 2236→2709 (+473) | 통합 118→129 | E2E 82→96. 회고+sync (#306) + Tier B Q3+Q5 (#307) + Tier B Q1+Q2+Q4 (#308) — 정책 1 진화 강화 (≥ 10회 빠른 진행 신호) + 정책 8 강화 (dispatch vs invocation 구분) + 메모리 신설 2 (i18n locale fallback + 메모리 카운터 패턴). 메모리 27→29.
-- **사이클 85 (Sentry 제거 + GitHub 정리 + CLAUDE.md Anthropic 200줄 정합 정정, 2026-05-06)** — Sentry 통합 완전 폐기 (40 테스트 + 105 LOC + 의존성 제거). GitHub 정리 62 branch 일괄 삭제. **CLAUDE.md cleanup**: 5+1 다중 에이전트 검토 (Anthropic 권고 6배 초과 → 3.5배) → 권장 default Q1=🅒 + Q2=🅐 + Q3=🅑 + Q4=🅑 채택 → src/ 트리 → `docs/architecture.md` / 9 카테고리 → `.claude/rules/<area>.md` (path-scoped, Anthropic 공식 패턴) / tail entry 사이클 60~80 → `docs/cycle-history.md` / Railway 배포 → `docs/runbooks/railway.md` / 점수 체계 → `docs/reference/scoring.md` / 정책 진화 history archive 영역 신설 → `docs/policies/history.md` (사이클 86+ 점진적 작업 default). LOC 1271 → ~700 (-45%) / 토큰 ~57K → ~25K (-56%).
-- **사이클 86 (정책 진화 + CI 사고 대응 + dependabot 자동화 + pylint drift 회복 + 5+1 회고, 2026-05-06 · #336)** — Q3 (#321 정책 본문 진화 → `docs/policies/history.md`) + Tier B Q1+Q2+Q3+Q4 묶음 #322 (정책 1 진화 회귀 가드 + `.claude/rules/` sync 의무 + CLAUDE 추가 cleanup). **CI submit-pypi 대응 #324**: 5+1 → GitHub Auto-Injected workflow 영구 timeout (코드 영역 X) → `dependabot.yml` 신설 (2026-04-23 changelog supersede 트리거). **dependabot 자동 8 PR ROI 100%** (#325-#332 — sonarqube/setup-node/playwright/codeql/authlib/flake8/itsdangerous/uvicorn). #332 conflict = Claude rebase + force-with-lease 해결. **pylint #335**: 9.92 → 9.94 (Tier A 13건). 잔여 36건 사이클 87+. **5+1 회고 (#336)**: P0 6건 + P1 8건 + P2 17건 — Tier A 2건 즉시 정정 (README 배지 + CLAUDE 직전 5 사이클 정합 = 사이클 81 → cycle-history.md 이전) + Tier B 3건 사이클 87+. LOC 762 → 677 (-11%).
-- **사이클 87 (Tier B 3건 단일 응집 묶음, 2026-05-06)** — 사이클 86 회고 후속 (사용자 옵션 🅐 명시 결정 — 사이클 83 #279 / 사이클 84 #308 패턴 정합). **Tier B-1**: Makefile `lint-strict` target (`pylint --fail-under=9.90`) — pylint drift 자동 감지 회귀 가드, baseline 9.94 보수적 floor. 기존 `make lint` 보존 (정책 12 destructive 영역 사용자 명시 페어 — CI workflow 통합은 사용자 영역). **Tier B-2**: dependabot.yml `groups` 분리 (production-deps minor/patch + development-deps minor/patch + actions-minor-patch — major bump + security update 개별 PR 보존). **Tier B-3**: 정책 8 본문 진화 — cross-verify 6차 생략 시 PR 본문 §"cross-verify 생략 사유" 사이클 69 정량 3 조건 대조 표 형식 default. 사이클 86 #324 commit body 누락 사례 학습 페어. 사이클 82 entry → cycle-history.md 이전 (직전 5 사이클 정합 회복 default).
+- **사이클 85 (Sentry 제거 + GitHub 정리 + CLAUDE.md Anthropic 200줄 정합 정정, 2026-05-06)** — Sentry 통합 완전 폐기 (40 테스트 + 105 LOC + 의존성 제거). GitHub 정리 62 branch 일괄 삭제. **CLAUDE.md cleanup**: 5+1 다중 에이전트 검토 → src/ 트리 → `docs/architecture.md` / 9 카테고리 → `.claude/rules/<area>.md` / tail entry → `docs/cycle-history.md` / Railway → `docs/runbooks/railway.md` / 점수 → `docs/reference/scoring.md` / 정책 진화 history → `docs/policies/history.md`. LOC 1271 → 865 (-32%) / 토큰 ~57K → ~22K (-61%).
+- **사이클 86 (정책 진화 + CI 사고 + dependabot 자동화 + pylint drift + 5+1 회고, 2026-05-06 · #336)** — Q3 (#321) + Tier B Q1+Q2+Q3+Q4 (#322) + CI submit-pypi 대응 #324 (`dependabot.yml` supersede) + dependabot 자동 8 PR (#325-#332, ROI 100%, #332 conflict Claude rebase) + pylint #335 (9.92→9.94) + 5+1 회고 #336 (P0 6 + P1 8 + P2 17, Tier A 2 정정). LOC 762 → 677 (-11%).
+- **사이클 87 (Tier B 3건 단일 응집 묶음, 2026-05-06 · #337)** — 사이클 86 회고 후속 (옵션 🅐). **Tier B-1**: Makefile `lint-strict` (`pylint --fail-under=9.90`) drift 회귀 가드. **Tier B-2**: dependabot.yml `groups` 분리 (production-deps + development-deps + actions-minor-patch). **Tier B-3**: 정책 8 본문 진화 — cross-verify 생략 시 PR 본문 §"cross-verify 생략 사유" 사이클 69 정량 3 조건 대조 표 default.
+- **사이클 88 Phase A (CLAUDE.md Anthropic 200줄 정합 — 2026-05-06)** — 사이클 85 보류 영역 (C2) 진입. 5+1 다중 에이전트 회의 (관점 1~5 + cross-verify 6차) → 옵션 🅑 균형 default 채택. **Phase A**: 정책 12~16 + 11 강화 본문 → `docs/policies/active.md` 분리 (default rule + 진화 default 보존, detail 외부화). CLAUDE.md 686 → 549 LOC (-20%, Anthropic 권고 3.4배 → 2.7배). Phase B (정책 1~11) = 별도 PR 진행 default. Cross-verify ROI: false-positive 차단 5 / 신규 발견 4. 사이클 83 entry → cycle-history.md 이전.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,7 +2,7 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-05-06 기준 — **사이클 87 진입: Tier B 3건 단일 응집 묶음**: 112+ PR #188~#336+ — 누적 정책 본문 17건 (정책 8 본문 진화 +1 cross-verify 정량 표 default) + 메모리 29건 (활성 27 + deprecated 2). **사이클 86 종결 회고 (#336)**: 5+1 다중 에이전트 (P0 6건 + P1 8건 + P2 17건) + Tier A 2건 (README 배지 9.94 + CLAUDE.md 직전 5 사이클 정합). **사이클 87**: 회고 Tier B 3건 = Makefile `lint-strict` target (pylint --fail-under=9.90 회귀 가드) + dependabot.yml `groups` 분리 + 정책 8 본문 진화 (cross-verify 생략 정량 표 default). 단위 2669 / 통합 129 / E2E 96 / pylint **9.94/10** (잔여 36건 사이클 87+ 점진)
+## 현재 수치 (2026-05-06 기준 — **사이클 88 진입: CLAUDE.md Anthropic 200줄 정합 정정 Phase A** (정책 12~16 분리)): 113+ PR #188~#337+ — 누적 정책 본문 17건 + 메모리 29건 (활성 27 + deprecated 2). **사이클 87 종결**: Tier B 3건 단일 응집 (#337 — Makefile `lint-strict` + dependabot.yml `groups` + 정책 8 본문 진화). **사이클 88 Phase A (본 PR)**: 5+1 다중 에이전트 회의 (관점 1~5 + cross-verify 6차) → 옵션 🅑 균형 default 채택 → 정책 12~16 + 11 강화 본문 → `docs/policies/active.md` 분리 (CLAUDE.md 686 → 549 LOC, -20%). Phase B (정책 1~11 분리) = 별도 PR 진행 default. 단위 2669 / 통합 129 / E2E 96 / pylint **9.94/10**
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
@@ -111,6 +111,40 @@
 | **#232** Docs/cycle-67-end multi-agent retrospective | **4 사이클 종결 회고** — 1차 5 에이전트 (cross-verify 생략 — 사용자 빠른 진행 신호 + 1차 결과 충분). P0 13 + P1 7 + P2 3 식별. **메모리 4건** (3 신설: stale-blocker / asgi-middleware / conftest-direct-env-set + 1 갱신: architecture-pre-confirm 위임 분류 3-tier 정밀화). MEMORY 인덱스 8→11건. 회고 보고서 + 자유 발언 (정책 9) + 회고 질문 (사용자 회신 의무) |
 | **#233** Docs/policy-evolution cycle-67 P0 bundle | **사이클 67 회고 P0 4건 정책 본문 진화** (정책 7 강화 응집): (1) 정책 7 강화 — 단일 PR > 1500 LOC 사전 확인 + architecture 단일 OK 정정 (관점 1 P0-1+P0-2) (2) 정책 8 — cross-verify 생략 조건 + 회고 PR 패턴 3 분기 (관점 1 P0-3) (3) 정책 2 진화 — 모든 sync PR commit body 실측 1줄 의무 (관점 2 P0-1) (4) 30초 체크리스트 — 메모리 11건 사례 + 트랩 차단 효과 (관점 2 P0-2). 카테고리 분류 (관점 4 P0-2) = 별도 PR (High tier 사용자 결정 의무) |
 | **#234** Docs/cycle-68 end state sync | **사이클 68 종료 sync** — STATE 헤더 38→41 PR + 사이클 68 행 신설 + CLAUDE.md L1052 tail. 단위 2055 / 통합 84 / E2E 82 변화 0 (docs only). 정책 2 진화 default 첫 적용 — 실측 1줄 의무 명시 |
+
+---
+
+### 사이클 88 — CLAUDE.md Anthropic 200줄 정합 정정 Phase A (2026-05-06 · 5+1 다중 에이전트 회의 + 사용자 옵션 🅑 균형 default 채택)
+
+사이클 85 회고 보류 영역 (C2 Anthropic 200줄 추가 cleanup) 진입. 사용자 발화 = *"Claude.md 를 Anthropic 에서 권장하는 수준으로 정리... 최적의 방안과 안정적인 방안 모두 만족하는 내용으로 정리"* — 균형 default 의무.
+
+**5+1 다중 에이전트 회의 결과** (관점 1~5 + cross-verify 6차):
+- 관점 1 (Anthropic 공식): HumanLayer 60줄 / 권장 300줄 / `@file` import 트랩 / advisory 80% vs hooks 100%
+- 관점 2 (본문 분석): 정책 본문 = 686의 62% (~422 LOC) — 가장 큰 영역
+- 관점 3 (안정성): 보존 의무 = 30초 체크리스트 / 필수 원칙 / 모바일 환경 / tail entry / 도구 사용 표 / 코드 주석 원칙
+- 관점 4 (분리 후보): 단일 `docs/policies/active.md` 권장 (디렉토리 폭발 회피) + `@file` import 미사용 + `.claude/skills/` 부적합
+- 관점 5 (사용자 패턴): 단계 분할 default (사이클 85 #320 검증 패턴 정합)
+- Cross-verify 6차: Phase A/B/C 분할 default + 200줄 hard X (1.5배 영역 균형)
+
+**Phase A (본 PR)**: 정책 12~16 + 정책 11 강화 본문 → `docs/policies/active.md` 분리. CLAUDE.md 본문 = 정책 N 표제 + default rule 1줄 + 진화 default 1~2줄 + reference link.
+
+| 영역 | 분리 전 | 분리 후 (CLAUDE.md) | 외부화 (active.md) |
+|------|--------|---------------------|---------------------|
+| 정책 11 강화 (사이클 62 OAuth) | 3 LOC (이미 짧음) | 3 LOC (보존) | history.md cross-ref |
+| 정책 12 (MCP scope) | 17 LOC | 3 LOC | 14 LOC |
+| 정책 13 (운영 smoke check) | 36 LOC | 4 LOC | 32 LOC |
+| 정책 14 (Code Scanning) | 35 LOC | 5 LOC | 30 LOC |
+| 정책 15 (사전 사고) | 27 LOC | 5 LOC | 22 LOC |
+| 정책 16 (코드 단순화) | 49 LOC | 8 LOC | 41 LOC |
+| **합계** | **167 LOC** | **28 LOC (-83%)** | **139 LOC archive** |
+
+**누적 효과**: CLAUDE.md 686 → **549 LOC (-20%)** / Anthropic 권고 200줄 대비 3.4배 → 2.7배.
+
+**자율 판단 보고 (정책 3 ⚠️ 마커)**:
+- ⚠️ Phase A = 정책 본문 default rule + 진화 default 보존 (사이클 85/86 검증 패턴 — 행동 영향 0 검증 반복)
+- ⚠️ Phase B (정책 1~11 본문 분리) = 별도 PR 진행 default (정책 7 강화 응집 단위 + 사용자 단계 검증 의무)
+- ⚠️ Phase C (workflows + checklist detail 분리) = 사이클 89+ 보류 (관점 3 보존 의무 영역 일부 — 사용자 명시 결정 의무)
+- ⚠️ Cross-verify ROI: false-positive 사전 차단 5건 / 신규 발견 4건 (P0 1 + P1 2 + P2 1) / Tier A 정정 후보 = Phase A 진입 의무 + 정책 1 회귀 가드 default 적용
 
 ---
 

--- a/docs/cycle-history.md
+++ b/docs/cycle-history.md
@@ -1,7 +1,7 @@
-# SCAManager 사이클 작업 이력 (사이클 60~82 archive)
+# SCAManager 사이클 작업 이력 (사이클 60~83 archive)
 
-> CLAUDE.md tail entry 분리본 (사이클 85 정리 → 사이클 86 회고 사이클 81 추가 → 사이클 87 진입 사이클 82 추가). 사이클 60~82 historical entries.
-> 사이클 83~87+ 직전 5 사이클은 CLAUDE.md tail 보존.
+> CLAUDE.md tail entry 분리본 (사이클 85 정리 → 사이클 86 사이클 81 추가 → 사이클 87 사이클 82 추가 → 사이클 88 Phase A 사이클 83 추가). 사이클 60~83 historical entries.
+> 사이클 84~88+ 직전 5 사이클은 CLAUDE.md tail 보존.
 > 본 파일은 회고 시점 (정책 8 5+1 패턴) 또는 영역 reference 시 read 의무.
 
 ## 목차
@@ -18,6 +18,7 @@
 - [사이클 78~80 (Phase 4 5 영역 분할 — Telegram + SaaS + 운영 모니터링)](#사이클-7880)
 - [사이클 81 (모바일 Phase 1 MVP)](#사이클-81)
 - [사이클 82 (Tier B 묶음 + NEW-P0-1)](#사이클-82)
+- [사이클 83 (Tier B 11건 정책 진화 묶음)](#사이클-83)
 
 ---
 
@@ -98,3 +99,7 @@
 ## 사이클 82
 
 - **사이클 82 (Tier B 묶음 + NEW-P0-1, 2026-05-05)** — alembic dialect 헬퍼 추출 (사용처 12) + 메모리 신설 2건 + Telegram 봇 차단 silent skip (NEW-P0-1) (#272/#274). 메모리 25→27.
+
+## 사이클 83
+
+- **사이클 83 (Tier B 11건 정책 진화 묶음, 2026-05-05)** — 정책 9 완화 + 정책 8 진화 (단일 작업일 ≥ 5 dispatch 사전 확인) + 정책 3 ⚠️ 마커 정량 기준 + 정책 1 진화 + 정책 5 cross-reference 강화 + 메모리 cross-reference (#279).

--- a/docs/policies/active.md
+++ b/docs/policies/active.md
@@ -1,0 +1,187 @@
+# SCAManager 사용자 협업 정책 본문 detail (사이클 88+ active archive)
+
+> CLAUDE.md tail entry / 정책 본문 detail 분리본 (사이클 88 #338 진입, 2026-05-06).
+> 본 파일 = **활성 정책 본문 detail** (default rule 외 검증 사례 / Why / How to apply / 금지 패턴 등).
+> CLAUDE.md 본문 = 정책 N 표제 + 핵심 default rule 1줄 + 진화 default 1~2줄 + 본 파일 reference link.
+> 정책 진화 history (이전 사이클 진화 entry) = `docs/policies/history.md` (사이클 85 #320 + 사이클 86 #321 분리).
+
+## 정책 11 강화 (사이클 62 P0 OAuth 사고 후속): 인증 flow 검증 추가
+
+🔴 **진화 default 요약**: 인증/외부 통합 변경 PR 시 8 조합 시각 체크리스트 + **인증 flow 4 endpoint 종단간 검증** 의무 — `/login` 200 + `/auth/github` 302 + `/auth/callback` redirect + `/auth/logout` redirect. 상세: [docs/policies/history.md#정책-11-강화](history.md#정책-11-강화).
+
+---
+
+## 정책 12 신설 (2026-05-02 Phase 1+2 회고 후속): MCP scope 제한 의무
+
+회고 발견: Phase 2 진입 검증 시 Supabase MCP 직접 실행 = 사용자 부담 87% 절감 (15분 → 2분). 그러나 INSERT/DELETE 권한 misuse 위험 명시 의무.
+
+**default scope 제한**:
+- **SELECT-only 자율 실행 OK** — 통계/검증/조회 SQL
+- **INSERT / UPDATE / DELETE / DROP / ALTER 사용자 사전 승인 의무** — 운영 데이터 변경 가능 SQL
+- **MCP 도구 호출 시 PR 본문 §"MCP 자율 실행 결과" 에 호출 도구 + 영향 범위 명시** (정책 3 강화 페어)
+- **읽기 전용이지만 PII / credential 노출 가능 SQL 도 사전 승인** (예: `SELECT * FROM users`, secret 컬럼 SELECT)
+
+**검증 사례** (Phase 1+2 사이클):
+- ✅ `mcp__claude_ai_Supabase__list_projects` (메타데이터 — OK)
+- ✅ `mcp__claude_ai_Supabase__list_tables` (스키마 메타 — OK)
+- ✅ 5 SELECT (count/avg/group by — PII 0건 — OK)
+- (없음) INSERT/DELETE — 본 사이클 미적용
+
+**금지**: `mcp__*__execute_sql` 의 SQL 자체 사용자 사전 노출 없이 INSERT/DELETE 실행. PII 컬럼 (`users.email`, `users.github_access_token`, `repo_configs.*_token` 등) SELECT 도 사전 승인.
+
+---
+
+## 정책 13 신설 (2026-05-02 P0 OAuth 사고 후속): 운영 endpoint smoke check 의무
+
+회고 P0 #4 자기 예언 ("운영 사고 0 = 운 + Copilot Autofix + Railway CI") 무시 → 본 사고 발생. 사고 회고: [`docs/reports/2026-05-02-oauth-redirect-uri-incident.md`](../reports/2026-05-02-oauth-redirect-uri-incident.md).
+
+**default 의무** — 매 사이클 종료 시 (또는 Phase 종료 시) 최소 3-endpoint smoke check:
+- `GET /health` → 200 (lifeness)
+- `GET /auth/github` → 302 + Location 헤더의 `redirect_uri=` 정합성 검증
+- `GET /login` → 200 (또는 302 — 로그인 상태 의존)
+
+**확장 권장** (인증/외부 통합 변경 PR 시):
+- `GET /auth/callback` (state 검증으로 401 또는 302 — 직접 호출 시 의도된 거부 OK)
+- `POST /webhooks/github` (서명 헤더 누락 → 401, 정상)
+
+**실행 방법**:
+- Claude MCP 가용 시 자율 실행 (정책 12 SELECT-only 패턴 차용)
+- curl 직접 호출 — `curl -sf -o /dev/null -w "%{http_code}\n" https://<APP_BASE_URL>/<endpoint>`
+- 사용자 운영 환경 (Railway production) 직접 호출
+
+**PR 본문 §"운영 smoke check 결과" 섹션 의무**:
+```markdown
+## 운영 smoke check (정책 13)
+- ✅ /health 200
+- ✅ /auth/github 302 redirect_uri = https://...up.railway.app/auth/callback (정합)
+- ✅ /login 200
+```
+
+**금지**: 인증/외부 통합 변경 PR 본문에 본 섹션 누락 후 머지. 빌드 성공 = 운영 정상 가정 X.
+
+**자동화 가드 (그룹 61 PR #208 + 사이클 62 PR #212)** — manual smoke 와 페어:
+- `tests/integration/test_oauth_flow_smoke.py` (10건): 3-endpoint smoke + 인증 flow 4 endpoint 정합 + insights redirect + 성능
+- `e2e/test_dashboard.py` (14건): 페이지 로드 + KPI 5 카드 + range toggle + chart vendoring + JS 런타임 + insights redirect + nav Dashboard
+- `e2e/test_theme_mobile_guards.py` (7건, PR #212): claude-dark 8 토큰 정의 가드 + dashboard body 비-투명 + 등급 alias + WCAG 2.5.5 모바일 (.btn ≥44px / .btn--sm ≥40px / .nav-hamburger ≥44x44 / 데스크탑 누수 회귀)
+- `tests/integration/conftest.py` autouse fixture (PR #209): webhook secret 환경 의존성 격리 (24 fail 해소)
+- 상세: `docs/runbooks/operational-smoke-checks.md` §8
+
+🔴 **자동화 가드는 manual smoke check 의무를 대체하지 않는다** — CI 통과 ≠ 운영 정상. PR 본문 §"운영 smoke check 결과" 섹션은 인증/외부 통합 변경 PR 마다 여전히 의무 (정책 13 default). 자동화는 회귀 차단 보조이며 외부 의존 (GitHub OAuth App callback URL 등) 검증은 manual / 사용자 영역.
+
+---
+
+## 정책 14 신설 (2026-05-03 사이클 62 후속): GitHub Code Scanning 알림 운영 체크 의무
+
+사용자 발화 (2026-05-03): *"시큐리티에서 감지하는 내용도 앞으로 프로젝트 운영시 체크사항으로 부탁드립니다."*
+
+회고 배경: GitHub Security 탭의 Code Scanning Alert #324 (`'break' or 'return' statement in finally`) + #325 (`Unused import`) 직접 확인 (참조 메타 Issue #213 / #214 는 단순 추적 수단). SCAManager 자체 정적분석 (pylint / flake8 / bandit) 은 통과 (위반 0건) 하지만 GitHub Security 탭 (CodeQL 또는 추가 도구) 이 별도 룰셋으로 감지하는 영역이 있음. **빌드 통과 + SCAManager lint 통과 ≠ Security 탭 0 alert**. 외부 가시성 부재 시 alert 누적 → 운영 책임 이전 위험.
+
+**default 의무**:
+- **작업 시작 전 30초 체크리스트** (CLAUDE.md L891~) 에 GitHub Security 탭 Code Scanning open alert 카운트 1줄 추가 (이미 적용)
+- **매 사이클 종료 시** (또는 Phase 종료 시) — 정책 13 smoke check 와 페어로 GitHub Security 탭 등록된 alert 직접 검토 (Issue 추적 수단 의존 X — Security 탭 자체가 단일 진실 소스)
+- **GitHub Security 탭에 신규 alert 등록 시** — 분류 처리 (1회 의무):
+  - (a) 실제 위반 → 코드 fix PR (정책 7 단위)
+  - (b) false-positive → GitHub Security 탭에서 dismiss + 사유 기록
+  - (c) 의도된 패턴 → suppress 룰 추가 + 회고에 사유 명시
+
+**실행 방법**:
+- gh CLI 가용 시: `gh api repos/<owner>/<repo>/code-scanning/alerts --jq '[.[] | select(.state=="open")] | length'`
+- gh 부재 시: 사용자 GitHub `Security → Code scanning alerts` 탭 직접 확인 → Claude 에 카운트 + alert 제목 공유 의무 (현 SCAManager 환경 default — 정책 10 옵션 🅒 와 동일 폴백 패턴)
+- API 인증 필요 (Code Scanning API 는 미인증 호출 차단) — 사용자 PAT 발급 시점에 자동화 가능
+
+**PR 본문 §"Code Scanning open alert 결과" 섹션 의무** (인증/외부 통합 변경 PR 외에는 사이클 종료 PR 일괄 회신 OK — 정책 2 진화 패턴):
+```markdown
+## Code Scanning open alert (정책 14)
+- ✅ open 0건 (마지막 확인 시점: 사이클 N 종료, YYYY-MM-DD)
+- (또는 [N]건 — 분류 처리 결과 명시)
+```
+
+**금지**:
+- ❌ alert 누적 무시 (SCAManager lint 통과만으로 "Security A" 라고 단정)
+- ❌ 추측 기반 alert dismiss (룰 본문 미확인 상태에서 false-positive 단정)
+
+**상호 보완**:
+- SCAManager 자체 lint (pylint / flake8 / bandit) = src/ 직접 분석
+- GitHub Code Scanning (CodeQL + 추가 룰셋) = 다른 룰셋 + 의존성 그래프 분석
+- 두 영역 합집합 = 진정한 "보안/품질 0 alert" 상태
+- detail 절차 + 운영 통합 = `docs/runbooks/operational-smoke-checks.md` §9
+
+---
+
+## 정책 15 신설 (2026-05-04 사이클 70 진입): 코드 작업 (add/edit/delete) 전 사전 사고 의무
+
+사용자 발화 (2026-05-04, 사이클 69 머지 후): *"앞으로 코드를 추가, 수정, 삭제 작업을 실행하기 이전에 항상 생각을 먼저 하고 진행을 합니다. 이해가 안되면 멈추거나 물어보고 하세요."*
+
+**default 의무**:
+1. **모든 코드 작업 (Edit/Write/MCP `*_sql` INSERT/DELETE 등) 직전 사전 사고 의무** — 즉각 도구 호출 X. 다음 3 질문 자문 의무:
+   - (a) 본 변경의 **목적** 이 사용자 의도와 정합한가? (요청 발화 vs 내 해석)
+   - (b) 본 변경이 영향 범위 (다른 파일 / 운영 / 테스트) 를 **모두 인지** 한 상태인가?
+   - (c) 본 변경 후 **검증 방법** 이 명확한가? (테스트 / smoke / 사용자 의무)
+2. **이해 부족 시 즉시 중단**:
+   - 사용자 의도 모호 → "본 작업 의도 = X 로 해석. OK?" 1줄 사전 확인 (정책 1 옵션 표 또는 단순 yes/no)
+   - 영향 범위 불명 → 영향 범위 조사 후 보고 → 사용자 결정 회신 의무
+   - 검증 방법 부재 → 회귀 가드 추가 의무 또는 사용자 명시 검증 요청
+3. **위반 시 회복**: 사전 사고 누락 후 진행 시 사용자 발견 → 즉시 사과 + 영향 범위 분석 + revert 결정 회신.
+
+**위임 분류 3-tier 통합** (`feedback-architecture-decision-pre-confirm.md`):
+- **High (사전 확인 의무)** = 정책 15 적용 (DB 스키마 / API / 권한 / 데이터 모델) — 옵션 표 + 사용자 1줄 명시
+- **Medium (자율 + 보고)** = 정책 15 적용 (헬퍼 함수 / 정책 본문 진화) — Claude 사전 사고 후 자율 진입 + PR 본문 자율 판단 보고
+- **Low (즉시 진입)** = 정책 15 면제 OK (회귀 가드 / docstring / typo) — 단 (b)/(c) 자문은 의무
+
+**검증 사례 (사이클 69)**:
+- ✅ 5+1 에이전트 정밀 검증 시 cross-verify 의 false-positive 1건 차단 = 사전 사고 의무 효과 (Claude 단독 진행 시 잘못된 fix 적용 위험 차단)
+- ✅ PR # 카운트 산식 모호 → 실측 검증 후 정정 = 영향 범위 인지 의무 적용
+
+**Why**: 사이클 64~69 누적 회고 결과 — Claude 의 "즉각 도구 호출" 패턴이 사용자 위임 신호 (75%) 와 결합 시 잘못된 결정 누적 위험. 사전 사고 1단계로 75% → 0% 위임 위험 차단 (사이클 64 → 사이클 66 검증 효과).
+
+**How to apply**: 모든 Edit/Write/Bash (destructive) 도구 호출 직전 1줄 자문 → 명확하면 진행, 불명하면 사용자 회신 대기. PR 본문 §"자율 판단 보고" (정책 3) 페어.
+
+---
+
+## 정책 16 신설 (2026-05-04 사이클 70 진입): 코드 단순화 default + 가독성 우선
+
+사용자 발화 (2026-05-04, 사이클 69 머지 후): *"코드를 단순화 하여 작성을 해주세요. 단 정확성과 성능은 유지가 되야합니다. 되도록 코드는 이해하기가 쉽게 작성을 해주세요."*
+
+**default 의무** (5 원칙 — 우선순위 순):
+1. **정확성 우선** — 단순화가 동작 변경/회귀 유발 시 단순화 포기 (회귀 0 default)
+2. **성능 유지** — 단순화로 hot-path latency / memory 증가 시 단순화 포기 (실측 의무)
+3. **가독성 우선** — 위 두 조건 충족 시 가독성 ↑ 패턴 채택
+4. **최소 추상화** — 시스템 프롬프트 "Don't add features, refactor, or introduce abstractions beyond what the task requires" 강화
+5. **🔴 토큰 비용 효율** (사이클 72 추가 — 사용자 의도 정합) — 운영 토큰 사용량 ↓ + 분산 + caching 활용. 단, **AI 리뷰 품질 영향 영역 = 단순화 금지** (사용자 명시 제외 — 아래 명시 제외 영역). **caching 4 단계 활성화 사례 (사이클 63 → 74 — 사이클 75 진화)**: 1단계 인프라 도입 (사이클 63 #218 — `build_cached_system_param`) → 2단계 baseline 정확화 (사이클 72 #242 — cache 비용 모델 + `get_cache_stats` + silent fallback streak) → 3단계 활성화 (사이클 74 #247 — 1024 토큰 패딩 + Haiku 모델 분기) → 4단계 호출 빈도 제한 (사이클 74 #248 — DB 캐싱 1h TTL). 운영 baseline 측정 의무 (1주 후 cache_hit_rate / silent_cache_fallback streak 검증).
+
+**🚫 명시 제외 영역 (사용자 결정 — AI 리뷰 품질 보존 의무)**:
+- ❌ `build_review_prompt` 토큰 예산 8000 → 축소 (사이클 72 사용자 명시 보류 — 품질 저하 원치 않음)
+- ❌ `review_guides/` 50개 언어 Tier1 full ~500 토큰 압축 (사이클 72 사용자 명시 보류 — 체크리스트 ↓ → 리뷰 깊이 ↓ 위험)
+- ✅ 진행 OK 영역 (사이클 72 검증): `review_code` prompt caching = **이미 100% 적용** (사이클 63 #218 — `src/analyzer/io/ai_review.py:79,89`) — multi-block 확장 (system + lang_guides 분리) 만 Phase 3 후보 (단 `build_review_prompt` 시그니처 변경 = High tier 사전 확인 의무) / 모델 분기 (Haiku/Sonnet/Opus) — Phase 2 (1주 운영 데이터 후 결정, AI 리뷰 품질 영향 = High tier) / 동일 SHA 결과 재사용 = **이미 100% 적용** (3-tier dedup — `src/worker/pipeline.py:178-181`) / Insight narrative 호출 빈도 제한 — Phase 2 (DB 캐싱 1h TTL 후보) / **cache hit rate 모니터링 인프라 = 사이클 72 PR 2 (#242) 도입** (`src/shared/claude_metrics.py::get_cache_stats` + cache 비용 모델 정확화 + silent fallback streak WARNING)
+- 신규 토큰 절약 영역 도입 시 사용자 사전 확인 의무 (정책 15 + High tier — `feedback-architecture-decision-pre-confirm.md` 페어)
+
+**default 적용 패턴**:
+- **변수명** = 의도 명시 (예: `data` X → `repository_user_id` ○)
+- **함수 시그니처** = 인자 ≤ 5 (R0913 임계 default)
+- **함수 본문** = 단일 책임 (R0915 / R0912 임계 default)
+- **타입 힌트** = 모든 public 함수/메서드 의무 (이미 default — 정책 16 강화)
+- **주석** = 시스템 프롬프트 default (WHY 비명확 시만) + CLAUDE.md L7~L18 한국어/영어 병행 default
+- **early return** = 중첩 깊이 ≤ 3 (R0911 임계 default)
+
+**금지 패턴** (단순화 위반):
+- ❌ 추상 베이스 클래스 / Protocol — 사용처 ≥ 3 일 때만 도입 (`feedback-architecture-decision-pre-confirm.md` Medium tier 기준 페어)
+- ❌ Generic 타입 매개변수 — 사용처 ≥ 3 시점 도입
+- ❌ 메타클래스 / 데코레이터 체인 — 표준 라이브러리 (functools/contextlib) 외 자체 작성 금지 (사용자 명시 시만 OK)
+- ❌ "다음 확장 대비" 분기 — 현재 요건만 구현 (정책 7 강화 응집 단위 부합)
+
+**리뷰 체크 포인트** (PR 작성 시 자가 검토 의무):
+1. **줄 수 감소 가능?** — 동일 동작을 더 짧게 표현 가능 시 적용 (단 가독성 ↓ 시 보존)
+2. **분기 합치 가능?** — `if/elif/else` 가 동일 결과 분기 시 합치
+3. **중간 변수 제거 가능?** — 단일 사용 임시 변수 inline 가능 시 적용
+4. **표준 라이브러리 활용 가능?** — `itertools / collections / functools / dataclasses` 우선 (자체 구현 금지)
+
+**검증 사례** (사이클 64~67 — 정책 16 사후 검증):
+- ✅ Phase 3 PR 5 (#223) RLS 격리 헬퍼 2건 (`_apply_*_user_filter`) — 함수 ≤ 10 줄 + 단일 책임 + 인자 3 (정합)
+- ✅ 사이클 66 #228 RLS middleware ASGI 직접 작성 (BaseHTTPMiddleware 우회) — 추상화 0 + 흐름 직선 (정합)
+- ⚠️ 사이클 64 회고 R0914 결정 트리 (CLAUDE.md L988~) — `dashboard_kpi` / `frequent_issues_v2` user_id 인자 추가 시 R0914 inline disable 채택 (헬퍼 추출 over-engineering 회피) — 정책 16 default 사례
+
+**Why**: 사이클 65~67 정합성 cleanup 누적 = 100+ 줄 변경 / 10+ 패턴 — 코드량 ↑ 자체가 미래 회고 부담. 단순화 default 로 다음 cleanup 부담 ↓.
+
+**Why (5 원칙 추가 — 사이클 72)**: 사이클 70~71 진행 후 사용자 의도 검증 = "토큰 비용 효율" 이 본래 목적이었음 (사이클 70 정책 15 위반 사례 — Claude 가 "단순화" 의도 모호 검증 안 함). 사이클 72 회고 정정으로 5번째 원칙 신설. **운영 Anthropic API 비용 ↓** 가 실 가치 — 가독성 단순화는 부가 효과.
+
+**How to apply**: Edit/Write 도구 호출 직전 정책 15 사전 사고와 페어 — "이 변경이 가장 단순한 형태인가?" + "토큰 비용 영향은?" 2 자문 의무. CI lint (pylint R0911~R0917) 가 1차 가드, PR 본문 §"자율 판단 보고" 의 자가 리뷰 4 체크포인트 + 토큰 영향 추정이 2차 가드.


### PR DESCRIPTION
…12~16 + 11 강화 본문 분리

5+1 다중 에이전트 회의 (관점 1~5 + cross-verify 6차) → 사용자 옵션 🅑 균형 default 채택.

## Phase A 영역 (본 PR)

정책 12~16 + 정책 11 강화 본문 → `docs/policies/active.md` 신설 분리. CLAUDE.md 본문 = 정책 N 표제 + default rule 1줄 + 진화 default 1~2줄 + reference link.

| 정책 | 분리 전 | 분리 후 (CLAUDE.md) |
|------|--------|---------------------|
| 정책 11 강화 | 3 LOC (이미 짧음) | 3 LOC (보존) |
| 정책 12 (MCP scope) | 17 → 3 (-14) |
| 정책 13 (운영 smoke) | 36 → 4 (-32) |
| 정책 14 (Code Scanning) | 35 → 5 (-30) |
| 정책 15 (사전 사고) | 27 → 5 (-22) |
| 정책 16 (코드 단순화) | 49 → 8 (-41) |
| **합계** | **167 → 28 (-83%)** |

**누적 효과**: CLAUDE.md 686 → **549 LOC (-20%)** / Anthropic 권고 200줄 대비 3.4배 → 2.7배.

## sync 변경 영역

- STATE.md 헤더 line 5 갱신 — 사이클 88 진입 명시 + 113+ PR
- STATE.md 사이클 88 row 신설 (사이클 87 row 위 시계열 정합)
- CLAUDE.md tail 사이클 83 entry → docs/cycle-history.md 이전 (직전 5 사이클 정합 회복 default — 매 사이클 N-5 이전)
- CLAUDE.md tail 사이클 88 entry 추가 (직전 5 사이클 = 84~88 정합)
- CLAUDE.md tail 헤더 "사이클 60~82" → "사이클 60~83"
- docs/cycle-history.md 헤더 60~82 → 60~83 + 목차 + 사이클 83 entry

## 5+1 다중 에이전트 회의 결과

- 관점 1 (Anthropic 공식): HumanLayer 60줄 / 권장 300줄 / @file import 트랩 / advisory 80% vs hooks 100%
- 관점 2 (본문 분석): 정책 본문 = 686의 62% (~422 LOC) — 가장 큰 영역
- 관점 3 (안정성): 보존 의무 = 30초 체크리스트 / 필수 원칙 / 모바일 환경 / tail entry / 도구 사용 표 / 코드 주석 원칙
- 관점 4 (분리 후보): 단일 docs/policies/active.md 권장 (디렉토리 폭발 회피)
- 관점 5 (사용자 패턴): 단계 분할 default (사이클 85 #320 패턴 정합)
- Cross-verify 6차: Phase A/B/C 분할 default + 200줄 hard X (1.5배 영역 균형)

## Cross-verify ROI 정량 (정책 8 진화 (2))

- false-positive 사전 차단: 5건 (각 관점 1건씩 — 관점 1 "200줄 절대" / 관점 2 "정책 전체 외부화" / 관점 3 "외부화 회귀 위험 과대" / 관점 4 "@file import 권장" / 관점 5 "공격적 default")
- 신규 발견: 4건 (P0 1: 사이클 88 진입 시 정책 1 회귀 가드 default + P1 2: 정책 본문 default rule 보존 안전 라인 + 메모리 인덱스 외부화 후보 + P2 1: cycle-history 정합 검증)
- Tier A 정정 후보: Phase A 진입 의무 + 정책 1 진화 회귀 가드 default 적용

## 자율 판단 보고 (정책 3 ⚠️ 마커)

- ⚠️ Phase A = 정책 본문 default rule + 진화 default 보존 (사이클 85/86 검증 패턴 — 행동 영향 0 검증 반복)
- ⚠️ Phase B (정책 1~11 본문 분리) = 별도 PR 진행 default (정책 7 강화 응집 단위 + 사용자 단계 검증 의무)
- ⚠️ Phase C (workflows + checklist detail 분리) = 사이클 89+ 보류 (관점 3 보존 의무 영역 일부)

## 검증

- ✅ `make lint-strict` → exit code 0 (pylint 9.94/10 ≥ 9.90)
- ✅ `pytest tests/unit -q` → 2668 passed, 1 skipped, 49.16s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
