### PR TITLE
fix(cycle-89-pra): P0-1 통합 fixture import + P0-3 flake8 noqa + 메모리 진화…

### DIFF
--- a/src/gate/native_automerge.py
+++ b/src/gate/native_automerge.py
@@ -37,7 +37,7 @@ from src.gate.github_review import (
     get_pr_mergeable_state,
     merge_pr,
 )
-from src.github_client.graphql import (  # pylint: disable=unused-import
+from src.github_client.graphql import (  # noqa: F401  # pylint: disable=unused-import
     # ENABLE_DISABLED_IN_REPO + ENABLE_PERMISSION_DENIED 는 외부 (tests/unit/gate/test_native_automerge.py
     # + tests/unit/gate/test_engine_defensive_guards.py) 에서 본 모듈 경로로 import 하는 re-export 영역.
     # 메모리 `feedback-copilot-autofix-noqa-trap.md` 페어 — side-effect re-export 패턴.

--- a/tests/integration/test_insight_caching.py
+++ b/tests/integration/test_insight_caching.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import Session
 # Top-level ORM imports register Base.metadata (no lazy imports allowed)
 from src.database import Base
 from src.models.analysis import Analysis
+from src.models.insight_narrative_cache import InsightNarrativeCache  # noqa: F401  (register on metadata)
 from src.models.merge_attempt import MergeAttempt  # noqa: F401  (register on metadata)
 from src.models.repository import Repository
 from src.models.user import User


### PR DESCRIPTION
… — 사이클 89 검증 P0 단순 묶음

사이클 89 정기 5+1 다중 에이전트 검증 (Round 1+2+3) 결과 P0 3건 중 단순 영역 2건 + 메모리 학습 영역 통합.

## P0-1: 통합 fixture metadata 모델 sync

`tests/integration/test_insight_caching.py:33` `InsightNarrativeCache` import 1줄 추가.

- 원인: fixture `db()` (L40-50) 가 `Base.metadata.create_all(engine)` 호출하지만 `InsightNarrativeCache` 모델 import 누락 → metadata 미등록 → `no such table` SQL 에러 (C.2 user_id=user_a.id 분기만 fail)
- fix: 모듈 최상단 import + `# noqa: F401  (register on metadata)` 마커 (re-export 영역 의도 명시)
- 회귀 분류: fixture 결함 (운영 영향 0) — 사이클 74 #248 도입 후 잠재 결함 (정기 5+1 검증으로 발견)
- 검증: 통합 125 → 126 passed (1 fail → 0)

## P0-3: flake8 F401 noqa 추가

`src/gate/native_automerge.py:40` multi-line import 첫 line 에 `# noqa: F401` + 기존 `# pylint: disable=unused-import` 보존.

- 원인: 사이클 86 #335 = pylint disable 마커만 추가, flake8 별도 룰 → F401 2건 보고 (`ENABLE_DISABLED_IN_REPO` + `ENABLE_PERMISSION_DENIED` re-export 영역)
- fix: import 첫 line 에 noqa 동시 부착 (multi-line import 영역 flake8 컨벤션)
- 검증: flake8 40 → 38 issues (F401 2건 해소)

## 메모리 신설: feedback-fixture-model-sync-discipline.md

신규 ORM 모델 추가 시 fixture metadata 등록 sync 의무 (사용처 ≥ 2 도달 — 사이클 74 InsightNarrativeCache + 사이클 84 i18n locale 컬럼).

- 모듈 최상단 import 의무 (lazy import 금지)
- `Base.metadata.create_all(engine)` 호출 fixture 가 있는 테스트 파일에 모델 import 의무
- `# noqa: F401  (register on metadata)` 마커 부착
- PR push 직전 `grep -rn "Base.metadata.create_all" tests/` 검증 default

카테고리: 🧪 TDD/CI 7 → 8 (MEMORY.md 인덱스 sync).

## 메모리 진화: feedback-pr-push-direct-validation.md

§"환경 차이 영역 누적" 표에 사이클 89 행 추가 (시간차 결함 누적 — E2E + fixture sync 도입 시점 미발견 → 정기 5+1 검증으로 발견).

§"How to apply" 4번 신설: 신규 i18n 영역 / ORM 모델 도입 시 PR push 직전 단위+통합+E2E 3종 동시 실행 의무 (시간 비용 ↑ but 시간차 결함 차단).

Cross-ref 추가: `feedback-fixture-model-sync-discipline.md` (신설) + 정책 17 (사이클 88) 페어.

## 자율 판단 보고 (정책 3 ⚠️ 마커)

- ⚠️ PR 응집 단위 = 단순 영역 묶음 (정책 7 강화 정합 — P0-1 + P0-3 + 메모리 영역 동질). P0-2 (E2E i18n) 별도 PR (시각 검증 영역 페어 — 정책 11 의무).
- ⚠️ 정기 5+1 다중 에이전트 검증 효과 검증 — 사이클 86~88 운영 영향 0 가운데 누적 결함 3건 발견 (Round 1+2 점수 93.50/100 A 등급 + Tier A 2건 즉시 정정).
- ⚠️ 정책 17 (사이클 88 신설) 4 default 정합 — 안정성 우선 ✅ + default rule 보존 ✅ + 단계 분할 ✅ + 분리 위험 사전 확인 ✅

## 검증

- ✅ `pytest tests/integration -q` → 126 passed (125 → 126), 3 skipped, 0 failed (57.37s)
- ✅ `pytest tests/unit -q` → 2668 passed (변동 0), 1 skipped (47.18s)
- ✅ `flake8 src/` → 38 issues (40 → 38, F401 2건 해소)
- ✅ `make lint-strict` exit 0 (pylint 9.94/10 보존 ≥ 9.90 baseline)

## 사이클 89 Round 1+2+3 회의 결과 페어

5+1 다중 에이전트 회의 (Round 1: 6 영역 정밀 검증 + Round 2: 점수 환산 + 재검증 + Round 3: 수행 계획 6 관점):
- 종합 점수 = 93.50/100 (A 등급 — 운영 배포 안정 영역)
- R0 운영 영향 96.5/100 (A+) / R1 개발/테스트 89.7/100 (B+)
- false-positive 사전 차단 5건 + PR 응집 단위 정정 1건

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
