### PR TITLE
fix(cycle-89-prb): P0-2 E2E i18n 회귀 fix — 영문 기대값 갱신 (옵션 🅑) + 메모리 진화 정정

### DIFF
--- a/e2e/test_dashboard.py
+++ b/e2e/test_dashboard.py
@@ -48,10 +48,13 @@ def test_dashboard_renders_5_kpi_cards(page, base_url):
 
 
 def test_dashboard_kpi_labels_present(page, base_url):
-    """KPI 5 라벨 모두 페이지에 노출."""
+    """KPI 5 라벨 모두 페이지에 노출.
+
+    사이클 84 i18n 18 PR 후 default locale 영문 — 영문 기대값 (사이클 89 P0-2 학습).
+    """
     page.goto(f"{base_url}/dashboard")
     content = page.content()
-    for label in ("평균 점수", "분석 건수", "보안 이슈", "활성 리포", "자동 머지 성공률"):
+    for label in ("Average Score", "Analyses", "Security Issues (HIGH)", "Active Repos", "Auto-Merge Success Rate"):
         assert label in content, f"KPI 라벨 누락: {label}"
 
 

--- a/e2e/test_settings.py
+++ b/e2e/test_settings.py
@@ -22,9 +22,12 @@ def _expand_advanced(page):
 
 
 def test_settings_page_loads(seeded_page, base_url):
-    """설정 페이지가 정상적으로 로드되어야 한다."""
+    """설정 페이지가 정상적으로 로드되어야 한다.
+
+    사이클 84 i18n 18 PR 후 default locale 영문 — 영문 기대값 (사이클 89 P0-2 학습).
+    """
     seeded_page.goto(f"{base_url}{SETTINGS_URL}")
-    assert seeded_page.title() == "설정 — owner/testrepo"
+    assert seeded_page.title() == "Settings — owner/testrepo"
 
 
 def test_preset_cards_exist(seeded_page, base_url):
@@ -504,10 +507,10 @@ def test_save_success_keeps_simple_mode(seeded_page, base_url):
 
 
 def test_auto_merge_in_pr_card(seeded_page, base_url):
-    """auto_merge 체크박스가 PR 동작 규칙 카드 안에 있어야 한다 (이벤트 후 자동화 카드 아님).
+    """auto_merge 체크박스가 PR Behavior Rules 카드 안에 있어야 한다 (이벤트 후 자동화 카드 아님).
 
-    Phase 2A Progressive 재설계: 카드명이 'PR 동작 규칙' 으로 갱신.
-    Phase 2A: card renamed to 'PR 동작 규칙'.
+    Phase 2A Progressive 재설계: 카드명이 'PR 동작 규칙' / 'PR Behavior Rules'.
+    사이클 84 i18n 18 PR 후 default locale 영문 — 영문 기대값 (사이클 89 P0-2 학습).
     """
     seeded_page.goto(f"{base_url}{SETTINGS_URL}")
     card_title = seeded_page.evaluate(
@@ -520,8 +523,8 @@ def test_auto_merge_in_pr_card(seeded_page, base_url):
             return title ? title.textContent.trim() : null;
         }"""
     )
-    assert card_title == "PR 동작 규칙", (
-        f"auto_merge 의 상위 카드 타이틀이 'PR 동작 규칙' 여야 하는데 '{card_title}' 임"
+    assert card_title == "PR Behavior Rules", (
+        f"auto_merge 의 상위 카드 타이틀이 'PR Behavior Rules' 여야 하는데 '{card_title}' 임"
     )
 
 


### PR DESCRIPTION
사이클 89 검증 P0-2 (E2E i18n 회귀 3건) — 사이클 84 i18n 18 PR 도입 시 default locale 영문화 → E2E 한글 hardcode 영역 미적용 결과.

## 옵션 결정 변경 사유 (사이클 89 사고 학습)

**Round 3 cross-verify 권장 default = 🅐 (한글 cookie autouse fixture)** 이었으나 적용 시 회귀 발견:
- `test_no_cookie_falls_to_default_locale` fail (i18n_visual_regression 명시 cookie 부재 검증 영역 침범)
- `test_overview_page_loads` / `test_dashboard_page_loads` / `test_nav_dashboard_link_present` 3건 신규 fail (영문 기대값 영역 한글 cookie 침범)

**autouse cookie 패턴 부적합 사유**: 광범위 영향 영역 (i18n_visual_regression / navigation / dashboard) 침범 → 영문 default 검증 영역 회귀 4건. 정책 17 4번 default (분리 위험 영역 사용자 사전 확인) 영역 = autouse 패턴은 광범위 영향 = High tier 영역 학습.

**최종 채택 = 옵션 🅑 영문 기대값 갱신** — E2E 의도 (default locale = 영문) 정합 + 회귀 0 검증.

## 변경 영역

| 영역 | 변경 | LOC delta |
|------|------|----------|
| `e2e/test_dashboard.py:50-58` | KPI 5 라벨 한글 → 영문 (`Average Score / Analyses / Security Issues (HIGH) / Active Repos / Auto-Merge Success Rate`) | +3 / -1 | | `e2e/test_settings.py:24-30` | `"설정 — owner/testrepo"` → `"Settings — owner/testrepo"` | +3 / -1 | | `e2e/test_settings.py:509-530` | `"PR 동작 규칙"` → `"PR Behavior Rules"` | +1 / -1 | | **메모리 진화** | `feedback-i18n-locale-fallback-pattern.md` §"How to apply" 6번 정정 (옵션 🅐 → 🅑 권장 변경 + autouse 패턴 부적합 학습) | (사용자 home — git 추적 외) |

## 검증

- ✅ E2E 91 → **94 passed (5 fail → 2 fail)**, settings UI 2건 P1 잔존 (정책 11 사용자 시각 검증 영역 — 사이클 90+ 후속)
- ✅ 단위 + 통합 2794 passed (변동 0), 4 skipped, 0 failed
- ✅ `make lint-strict` exit 0 (pylint 9.94 보존)

## 자율 판단 보고 (정책 3 ⚠️ 마커)

- ⚠️ **Round 3 cross-verify 권장 default 정정** — 적용 시점 검증으로 회귀 4건 발견 → 즉시 revert + 옵션 🅑 채택. 검증 단계의 정합성 확인 효과 (정책 13 페어).
- ⚠️ **autouse 패턴 광범위 영향 학습** — `e2e/conftest.py` `page` + `seeded_page` fixture autouse cookie 적용 시 모든 E2E 영역 침범 → 영문 default 검증 영역 회귀. 사이클 89+ 검증 default 강화.
- ⚠️ **잔여 settings UI 2건 (P1)** = `test_two_column_layout_on_desktop` (944px grid 1열) + `test_save_success_keeps_simple_mode` (`advanced` vs `simple`) — 정책 11 시각 검증 사용자 영역 (Claude 단독 fix X — 사이클 92 P1-3 후속).

## 사용자 검증 필요 (정책 2)

- [ ] E2E 영문 기대값 운영 시 영문 default 정합 검증 (Railway production / staging)
- [ ] settings UI 2건 (P1 잔존) 시각 검증 — 944px grid 1열 + Simple Mode 동작 영역 (정책 11 8 조합 영역)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
