### PR TITLE
test(cycle-91-p1-2): graphql slow test mock 2건 — github_client/test_g…

### DIFF
--- a/tests/unit/github_client/test_graphql.py
+++ b/tests/unit/github_client/test_graphql.py
@@ -247,13 +247,17 @@ async def test_enable_returns_permission_denied_on_403():
 
 
 async def test_enable_returns_api_error_on_500():
-    """HTTP 500 응답 → ENABLE_API_ERROR.
-    HTTP 500 response → ENABLE_API_ERROR.
+    """HTTP 500 응답 → ENABLE_API_ERROR (5xx exponential backoff retry 후).
+    HTTP 500 response → ENABLE_API_ERROR (after 5xx exponential backoff retry).
+
+    사이클 91 P1-2: asyncio.sleep mock — 5xx 재시도 backoff 3s 제거 (slow test mock).
+    Cycle 91 P1-2: asyncio.sleep mock — skip 3s 5xx retry backoff (slow test mock).
     """
     mock_client = AsyncMock()
     mock_client.post = AsyncMock(return_value=_make_status_response({}, 500))
 
-    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client), \
+         patch("src.github_client.graphql.asyncio.sleep", new_callable=AsyncMock):
         result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
 
     assert result.status == ENABLE_API_ERROR
@@ -261,13 +265,17 @@ async def test_enable_returns_api_error_on_500():
 
 
 async def test_enable_returns_api_error_on_network_failure():
-    """httpx.ConnectError → ENABLE_API_ERROR (network: prefix).
-    httpx.ConnectError → ENABLE_API_ERROR (network: prefix).
+    """httpx.ConnectError → ENABLE_API_ERROR (network: prefix, transient retry 후).
+    httpx.ConnectError → ENABLE_API_ERROR (network: prefix, after transient retry).
+
+    사이클 91 P1-2: asyncio.sleep mock — transient network error retry backoff 3s 제거.
+    Cycle 91 P1-2: asyncio.sleep mock — skip 3s transient retry backoff (slow test mock).
     """
     mock_client = AsyncMock()
     mock_client.post = AsyncMock(side_effect=httpx.ConnectError("DNS failure"))
 
-    with patch("src.github_client.graphql.get_http_client", return_value=mock_client):
+    with patch("src.github_client.graphql.get_http_client", return_value=mock_client), \
+         patch("src.github_client.graphql.asyncio.sleep", new_callable=AsyncMock):
         result = await enable_pull_request_auto_merge(TOKEN, NODE_ID)
 
     assert result.status == ENABLE_API_ERROR


### PR DESCRIPTION
…raphql.py 6s → 0.02s

사이클 89 검증 P1-2 (사용자 명시 OK 영역) 진입 — slow test mock 2건 자율 진입 + 단위 도메인 밀도 false-positive 식별.

## 변경 영역

### slow test mock 2건 (graphql 6s outlier)

**file**: `tests/unit/github_client/test_graphql.py:249-280`

| 테스트 | Before | After | 단축 |
|--------|--------|-------|------|
| `test_enable_returns_api_error_on_500` | 3.01s | 0.02s | 99.3% | | `test_enable_returns_api_error_on_network_failure` | 3.00s | 0.02s | 99.3% | | **합계** | **6.01s** | **0.02s** | **99.7%** |

**fix 패턴**: 5xx exponential backoff retry (`src/github_client/graphql.py:135 await asyncio.sleep(backoff)`) 영역 mock 추가:
```python
patch("src.github_client.graphql.asyncio.sleep", new_callable=AsyncMock)
```
기존 (사이클 H PR-1B-2 도입) 5xx 자동 재시도 영역 — `test_graphql_request_retries_on_5xx` (L386~) 등 다른 테스트는 이미 동일 mock 적용. 본 2건만 누락 — 사이클 91 회복.

## ⚠️ False-positive 영역 식별 (Round 1 보고 부정확)

**Round 1 관점 1 도메인 밀도 균형 영역** — 사이클 89 검증 보고 P1-1 (단위 도메인 밀도 균형) 영역의 수치 부정확 발견:

| 도메인 | Round 1 보고 | 실측 (사이클 91) |
|--------|-------------|-----------------|
| middleware | 5 | **17** (locale 12 + rls 5) |
| worker | 22 | **78** (6 file) |
| github_client | 15 | **74** |

**원인**: Round 1 관점 1 단위 도메인 밀도 분석 시 일부 영역만 카운트 추정. Round 2 cross-verify 미검증 영역.

**결론**: 단위 도메인 밀도 균형 작업 = **false-positive 영역 (불필요)**. 실측 결과 모든 영역 우수 밀도 — 추가 회귀 가드 PR 불요. 사이클 92 P1-3 영역으로 보류 default 변경.

## 사이클 91 P1-2 영역 (단순화)

원본 Round 3 권장 = (1) 단위 도메인 밀도 균형 + (2) slow test mock 2건 = 묶음 PR. 실제 진행 = (2) slow test mock 2건만 (1번 false-positive 식별).

## 검증

- ✅ 단위 + 통합 **2794 passed** (변동 0), 4 skipped, 0 failed (95.70s — 사이클 90 P1-1 후 129.68s 대비 -34s, slow test mock 2건 효과)
- ✅ slow test 6.01s → 0.02s (99.7% 단축 검증)
- ✅ `flake8 src/` → 18 issues (변동 0)
- ✅ `make lint-strict` exit 0 (pylint 9.94 보존)

## 자율 판단 보고 (정책 3 ⚠️ 마커)

- ⚠️ 정책 9 완화 default 적용 — Medium tier 영역 (test mock = architecture/destructive/NEW-P0-N 미적용)
- ⚠️ Round 1 false-positive 식별 — Round 2 cross-verify 미검증 영역. 사이클 89 검증 학습 영역 (다음 cross-verify default = 단위 테스트 분포 실측 의무)
- ⚠️ 단위 도메인 밀도 균형 작업 미진행 — 실측 검증 결과 우수 밀도 (Round 1 추정 1/3~1/5 정도 — 정확한 카운트 미실시)
- ⚠️ 잔여 P1 = 사이클 92 P1-3 (E2E settings UI 2건 + RLS legacy NULL — High tier 사전 확인 의무)

## 사이클 89~91 검증 누적 효과

| 영역 | 사이클 88 | 사이클 89 | 사이클 90 | **사이클 91** |
|------|----------|----------|----------|--------------| | 통합 | 99.2% | 100% | 100% | 100% |
| E2E | 94.8% | 97.9% | 97.9% | 97.9% |
| flake8 | 40 | 38 | 18 | 18 |
| slow test 누적 | 12s | 12s | 6s | **0.04s** |
| 단위 + 통합 시간 | ~110s | ~110s | 129.68s | **95.70s (-34s)** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
