### PR TITLE
chore(ui-foundation): Foundation 토큰 + 4-테마 외부화 + Crimson Pro 폐기 + Jet…

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,8 @@ src/
 ├── static/
 │   ├── vendor/chart.umd.min.js  # Chart.js 4.4.0 UMD min vendoring
 │   ├── manifest.json            # PWA manifest (Cycle 81 PR-A)
-│   └── icons/icon-{192,512}.svg # PWA maskable icons
+│   ├── icons/icon-{192,512}.svg # PWA maskable icons
+│   └── css/{tokens,themes}.css  # Foundation 디자인 토큰 + 4-테마 정의 (Cycle 93 Step 1, base.html 외부화)
 ├── config.py                    # pydantic-settings 환경변수 관리, postgres:// URL 자동 변환
 ├── constants.py                 # 전역 상수 단일 출처 — 점수배점/감점가중치/AI기본값/등급/알림한도/HTTP타임아웃/캐시TTL
 ├── crypto.py                    # encrypt_token()/decrypt_token() — TOKEN_ENCRYPTION_KEY

--- a/src/static/css/themes.css
+++ b/src/static/css/themes.css
@@ -1,0 +1,221 @@
+/* ============================================================================
+ * SCAManager — 4-Theme Definitions
+ * 외부화 일자: 2026-05-09 (사이클 93 Step 1 — UI Foundation PR)
+ * Externalized: 2026-05-09 (Cycle 93 Step 1 — UI Foundation PR)
+ *
+ * 4 테마: dark (Linear) / light (Vercel) / glass (frosted) / claude-dark (warm).
+ * 신규 토큰 추가 시 4 블록 모두에 정의 의무 (.claude/rules/ui.md L30).
+ *
+ * Phase 2 신규 (본 PR):
+ * - --mesh-bg-* (테마별 radial-gradient 배경 — consumer 적용은 Step 2)
+ * - --accent-glow (테마별 accent 톤 glow — consumer 적용은 Step 2)
+ * 본 PR 범위 = 토큰 정의만. consumer 적용 = Step 2 (별도 PR, 회귀 위험 격리).
+ * ========================================================================== */
+
+/* ── Phase 1A: Claude 톤 다크 모드 토큰 (warm black) ──────────────────────────
+ *  data-theme="claude-dark" 시 활성. 기존 [data-theme="dark"] 와 별도. */
+[data-theme="claude-dark"] {
+  --claude-bg-base:      #1F1E1B;  /* warm black */
+  --claude-bg-surface:   #2A2825;
+  --claude-bg-elevated:  #33302C;
+  --claude-text-primary: #F5F1E8;
+  --claude-text-muted:   #A8A29A;
+  --claude-accent:       #E08968;
+  --claude-accent-soft:  #5C3D2E;
+  --claude-border:       #3D3A35;
+  --claude-success:      #A8BA94;
+  --claude-warning:      #DDB585;
+  --claude-danger:       #D45F50;
+}
+
+/* ── 다크 테마 (Linear 스타일) ───────────────────────────────────────────── */
+[data-theme="dark"], body:not([data-theme]) {
+  --bg-page:        #111118;
+  --bg-card:        #1c1c23;
+  --bg-nav:         #111118;
+  --bg-input:       #2a2a34;
+  --bg-input-focus: #32323e;
+  --border:         #2c2c38;
+  --border-focus:   #5e6ad2;
+  --text-primary:   #e2e2e8;
+  --text-muted:     #73737c;
+  --text-nav:       #a8a8b2;
+  --accent:         #5e6ad2;
+  --accent-hover:   #8d95e0;
+  --accent-grad:    linear-gradient(135deg, #5e6ad2, #8d95e0);
+  --success:        #4ade80;
+  --danger:         #f87171;
+  --warning:        #f59e0b;
+  --shadow:         0 4px 24px rgba(0,0,0,.5);
+  --shadow-card:    0 1px 3px rgba(0,0,0,.25), 0 0 0 1px rgba(255,255,255,.04);
+  --table-head:     #1a1a21;
+  --table-row-hover: #21212a;
+  --code-bg:        #0f0f15;
+
+  /* 설정 페이지 호환 */
+  --grad-gate:           linear-gradient(135deg, #5e6ad2, #4a57c4);
+  --grad-merge:          linear-gradient(135deg, #06b6d4, #0891b2);
+  --grad-notify:         linear-gradient(135deg, #fbbf24, #f59e0b);
+  --grad-hook:           linear-gradient(135deg, #a78bfa, #8b5cf6);
+  --title-gradient:      linear-gradient(135deg, #8d95e0, #c084fc);
+  --btn-gate-active-bg:  rgba(94,106,210,.15);
+  --btn-gate-active-bd:  #5e6ad2;
+  --btn-gate-active-tx:  #8d95e0;
+  --save-btn-bg:         linear-gradient(135deg, #5e6ad2, #4a57c4);
+  --save-btn-shadow:     rgba(94,106,210,.4);
+  --hint-bg:             rgba(255,255,255,.03);
+  --hint-border:         rgba(255,255,255,.05);
+  --hook-btn-bg:         rgba(139,92,246,.1);
+  --hook-btn-bd:         rgba(139,92,246,.3);
+  --hook-btn-tx:         #a78bfa;
+
+  /* Phase 2 신규: mesh-bg + accent-glow (consumer 미적용 — 정의만) */
+  --mesh-bg:    radial-gradient(at 20% 0%, rgba(94,106,210,0.10) 0, transparent 50%),
+                radial-gradient(at 80% 100%, rgba(192,132,252,0.08) 0, transparent 50%),
+                #111118;
+  --accent-glow: 0 0 24px rgba(94,106,210,0.35);
+}
+
+/* ── 라이트 테마 (Vercel 스타일) ─────────────────────────────────────────── */
+[data-theme="light"] {
+  --bg-page:        #f5f5f7;
+  --bg-card:        #ffffff;
+  --bg-nav:         #000000;
+  --bg-input:       #f5f5f7;
+  --bg-input-focus: #ffffff;
+  --border:         #e5e5e8;
+  --border-focus:   #5e6ad2;
+  --text-primary:   #111118;
+  --text-muted:     #8a8a96;
+  --text-nav:       #e5e5e8;
+  --accent:         #5e6ad2;
+  --accent-hover:   #4a57c4;
+  --accent-grad:    linear-gradient(135deg, #5e6ad2, #4a57c4);
+  --success:        #16a34a;
+  --danger:         #dc2626;
+  --warning:        #d97706;
+  --shadow:         0 2px 8px rgba(0,0,0,.07), 0 0 0 1px rgba(0,0,0,.04);
+  --shadow-card:    0 1px 3px rgba(0,0,0,.05), 0 0 0 1px rgba(0,0,0,.05);
+  --table-head:     #f9f9fb;
+  --table-row-hover: #f5f5f7;
+  --code-bg:        #f5f5f7;
+
+  /* 설정 페이지 호환 */
+  --grad-gate:           linear-gradient(135deg, #8d95e0, #5e6ad2);
+  --grad-merge:          linear-gradient(135deg, #22d3ee, #0891b2);
+  --grad-notify:         linear-gradient(135deg, #fcd34d, #f59e0b);
+  --grad-hook:           linear-gradient(135deg, #c4b5fd, #8b5cf6);
+  --title-gradient:      linear-gradient(135deg, #4a57c4, #7c3aed);
+  --btn-gate-active-bg:  rgba(94,106,210,.08);
+  --btn-gate-active-bd:  #5e6ad2;
+  --btn-gate-active-tx:  #5e6ad2;
+  --save-btn-bg:         linear-gradient(135deg, #5e6ad2, #7c3aed);
+  --save-btn-shadow:     rgba(94,106,210,.25);
+  --hint-bg:             #f9f9fb;
+  --hint-border:         #e5e5e8;
+  --hook-btn-bg:         rgba(124,58,237,.06);
+  --hook-btn-bd:         rgba(124,58,237,.2);
+  --hook-btn-tx:         #7c3aed;
+
+  /* Phase 2 신규: mesh-bg + accent-glow (라이트 톤, 채도 ↓) */
+  --mesh-bg:    radial-gradient(at 20% 0%, rgba(94,106,210,0.05) 0, transparent 50%),
+                radial-gradient(at 80% 100%, rgba(124,58,237,0.04) 0, transparent 50%),
+                #f5f5f7;
+  --accent-glow: 0 0 16px rgba(94,106,210,0.18);
+}
+
+/* ── 글래스모피즘 ───────────────────────────────────────────────────────── */
+[data-theme="glass"] {
+  --bg-page:        #0c0e1a;
+  --bg-card:        rgba(255,255,255,0.06);
+  --bg-nav:         rgba(12,14,26,0.9);
+  --bg-input:       rgba(255,255,255,0.07);
+  --bg-input-focus: rgba(255,255,255,0.12);
+  --border:         rgba(255,255,255,0.12);
+  --border-focus:   #8d95e0;
+  --text-primary:   #e2e2e8;
+  --text-muted:     rgba(255,255,255,0.4);
+  --text-nav:       #c8c8d4;
+  --accent:         #8d95e0;
+  --accent-hover:   #b0b8f0;
+  --accent-grad:    linear-gradient(135deg, #5e6ad2, #ec4899);
+  --success:        #4ade80;
+  --danger:         #f87171;
+  --warning:        #f59e0b;
+  --shadow:         0 8px 32px rgba(0,0,0,.5);
+  --shadow-card:    0 4px 20px rgba(0,0,0,.4), 0 0 0 1px rgba(255,255,255,.06);
+  --table-head:     rgba(255,255,255,0.04);
+  --table-row-hover: rgba(255,255,255,0.04);
+  --code-bg:        rgba(0,0,0,0.3);
+
+  /* 설정 페이지 호환 */
+  --grad-gate:           linear-gradient(135deg, rgba(141,149,224,.9), rgba(94,106,210,.9));
+  --grad-merge:          linear-gradient(135deg, rgba(6,182,212,.9), rgba(8,145,178,.9));
+  --grad-notify:         linear-gradient(135deg, rgba(251,191,36,.9), rgba(245,158,11,.9));
+  --grad-hook:           linear-gradient(135deg, rgba(196,181,253,.9), rgba(139,92,246,.9));
+  --title-gradient:      linear-gradient(135deg, #c084fc, #f472b6);
+  --btn-gate-active-bg:  rgba(141,149,224,.18);
+  --btn-gate-active-bd:  #8d95e0;
+  --btn-gate-active-tx:  #c4b5fd;
+  --save-btn-bg:         linear-gradient(135deg, #8d95e0, #c084fc);
+  --save-btn-shadow:     rgba(192,132,252,.3);
+  --hint-bg:             rgba(255,255,255,.04);
+  --hint-border:         rgba(255,255,255,.07);
+  --hook-btn-bg:         rgba(196,181,253,.08);
+  --hook-btn-bd:         rgba(196,181,253,.25);
+  --hook-btn-tx:         #c4b5fd;
+
+  /* Phase 2 신규: mesh-bg = 기존 body[data-theme="glass"] 그라디언트 토큰화 + accent-glow */
+  --mesh-bg:    linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0c0e1a 100%);
+  --accent-glow: 0 0 32px rgba(141,149,224,0.40);
+}
+
+/* ── claude-dark (Phase 1B alias — claude-* 토큰 → 기존 토큰 매핑) ───────── */
+body[data-theme="claude-dark"] {
+  --bg-page:        var(--claude-bg-base);
+  --bg-card:        var(--claude-bg-surface);
+  --bg-nav:         var(--claude-bg-base);
+  --bg-input:       var(--claude-bg-elevated);
+  --bg-input-focus: var(--claude-accent-soft);
+  --border:         var(--claude-border);
+  --border-focus:   var(--claude-accent);
+  --text-primary:   var(--claude-text-primary);
+  --text-muted:     var(--claude-text-muted);
+  --text-nav:       var(--claude-text-muted);
+  --accent:         var(--claude-accent);
+  --accent-hover:   #F09578;
+  --accent-grad:    linear-gradient(135deg, #D97757, #F09578);
+
+  /* Phase 1C — 등급 색상 alias (sage/sand/muted-red/terracotta) */
+  --grade-a: var(--claude-grade-a);
+  --grade-b: var(--claude-grade-b);
+  --grade-c: var(--claude-grade-c);
+  --grade-d: var(--claude-grade-d);
+  --grade-f: var(--claude-grade-f);
+  --warning: var(--claude-warning);
+  --success: var(--claude-success);
+  --danger:  var(--claude-danger);
+
+  /* PR-1 C1 — settings 페이지 토큰 8종 (.claude/rules/ui.md L30 매트릭스) */
+  --grad-gate:           linear-gradient(135deg, #D97757, #B85A3D);
+  --grad-merge:          linear-gradient(135deg, #A8BA94, #8AA476);
+  --grad-notify:         linear-gradient(135deg, #DDB585, #C49566);
+  --grad-hook:           linear-gradient(135deg, #C8895E, #A86F46);
+  --title-gradient:      linear-gradient(135deg, #D97757, #DDB585);
+  --btn-gate-active-bg:  rgba(217,119,87,.15);
+  --btn-gate-active-bd:  var(--claude-accent);
+  --btn-gate-active-tx:  var(--claude-accent);
+  --save-btn-bg:         linear-gradient(135deg, #D97757, #B85A3D);
+  --save-btn-shadow:     rgba(217,119,87,.4);
+  --hint-bg:             rgba(217,119,87,.05);
+  --hint-border:         rgba(217,119,87,.15);
+  --hook-btn-bg:         rgba(200,137,94,.10);
+  --hook-btn-bd:         rgba(200,137,94,.30);
+  --hook-btn-tx:         #C8895E;
+
+  /* Phase 2 신규: warm cream mesh + terracotta glow */
+  --mesh-bg:    radial-gradient(at 20% 0%, rgba(217,119,87,0.06) 0, transparent 50%),
+                radial-gradient(at 80% 100%, rgba(221,181,133,0.05) 0, transparent 50%),
+                var(--claude-bg-base);
+  --accent-glow: 0 0 24px rgba(217,119,87,0.30);
+}

--- a/src/static/css/tokens.css
+++ b/src/static/css/tokens.css
@@ -1,0 +1,132 @@
+/* ============================================================================
+ * SCAManager — Foundation Design Tokens
+ * 외부화 일자: 2026-05-09 (사이클 93 Step 1 — UI Foundation PR)
+ * Externalized: 2026-05-09 (Cycle 93 Step 1 — UI Foundation PR)
+ *
+ * 본 파일은 테마 무관 공통 토큰만 포함. 테마별 토큰 = themes.css 참조.
+ * This file holds theme-agnostic tokens only. Theme-specific = themes.css.
+ *
+ * 추가 시 의무:
+ * - 새 토큰은 var(--*) 형태로만 사용 (#hex 직접 금지 — .claude/rules/ui.md L24)
+ * - 테마 의존 토큰은 themes.css 4 블록 모두에 정의 (L30 매트릭스)
+ * - 색상 의미 = --success / --warning / --danger 3종 통일 (L29)
+ * ========================================================================== */
+
+:root {
+  /* ── 레거시 호환 (기존 페이지 의존) ─────────────────────────────────────
+   * Legacy compat — kept for existing page consumers; do NOT remove */
+  --radius-card: 10px;
+  --radius-btn:  7px;
+  --transition:  0.18s ease;
+
+  /* ── 스페이싱 스케일 ───────────────────────────────────────────────────
+   * Spacing scale */
+  --space-1: 4px;  --space-2: 8px;  --space-3: 12px; --space-4: 16px;
+  --space-5: 20px; --space-6: 24px; --space-7: 32px; --space-8: 48px;
+
+  /* ── 폰트 크기 스케일 (UI 본문) ────────────────────────────────────────
+   * Body / UI font scale */
+  --fs-xs: 12px; --fs-sm: 13px; --fs-md: 14px; --fs-base: 15px;
+  --fs-lg: 16px; --fs-xl: 18px; --fs-2xl: 20px; --fs-3xl: 24px;
+
+  /* ── Phase 2 신규: Display 타이포그래피 스케일 ────────────────────────
+   * Phase 2 NEW: Display typography scale (hero / page-title)
+   * 기존 --fs-3xl (24px) 까지만 있어 모든 페이지가 "관리 페이지" 느낌.
+   * Hero/landing 무드를 위한 32/44/60px 추가. */
+  --fs-display-sm: 32px;
+  --fs-display-md: 44px;
+  --fs-display-lg: 60px;
+  --tracking-tight:   -0.02em;
+  --tracking-tighter: -0.025em;
+  --line-height-display: 1.05;
+
+  /* ── 반경 스케일 ───────────────────────────────────────────────────────
+   * Radius scale */
+  --radius-xs: 4px; --radius-sm: 6px; --radius-md: 10px;
+  --radius-lg: 14px; --radius-pill: 999px;
+
+  /* ── 레거시 그림자 (기존 페이지 의존) ─────────────────────────────────
+   * Legacy shadow scale (kept for existing consumers) */
+  --shadow-sm: 0 1px 3px rgba(0,0,0,.1), 0 1px 2px rgba(0,0,0,.07);
+  --shadow-md: 0 4px 16px rgba(0,0,0,.14);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,.22);
+
+  /* ── Phase 2 신규: Elevation 5-step (CodeRabbit/Linear 깊이 시스템) ───
+   * Phase 2 NEW: 5-step elevation depth (CodeRabbit/Linear-style)
+   * --elev-0: 평면 / --elev-1~4: 단계적 깊이 / --elev-inset: 내부 highlight.
+   * 테마별 alpha 차별 = themes.css 에서 override. */
+  --elev-0:     none;
+  --elev-1:     0 1px 2px rgba(0,0,0,.04), 0 1px 3px rgba(0,0,0,.06);
+  --elev-2:     0 2px 4px rgba(0,0,0,.04), 0 4px 8px rgba(0,0,0,.06);
+  --elev-3:     0 4px 8px rgba(0,0,0,.05), 0 8px 16px rgba(0,0,0,.08);
+  --elev-4:     0 8px 16px rgba(0,0,0,.06), 0 16px 32px rgba(0,0,0,.10);
+  --elev-inset: inset 0 1px 0 rgba(255,255,255,.04);
+
+  /* ── Phase 2 신규: Motion duration + easing ───────────────────────────
+   * Phase 2 NEW: motion scale
+   * 기존 --transition (0.18s ease) 단일 → 3-step + 3 curve.
+   * prefers-reduced-motion 가드는 consumer 측에서 적용 의무. */
+  --dur-fast:      120ms;
+  --dur-base:      220ms;
+  --dur-slow:      360ms;
+  --ease-out-expo: cubic-bezier(0.19, 1, 0.22, 1);
+  --ease-out:      cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-spring:   cubic-bezier(0.25, 1.5, 0.5, 1);
+
+  /* ── Phase 2 신규: Blur 효과 스케일 ───────────────────────────────────
+   * Phase 2 NEW: blur effect scale */
+  --blur-sm: 8px;
+  --blur-md: 16px;
+  --blur-lg: 24px;
+
+  /* ── 등급 색상 (기본값 = 다크/라이트 공통) ────────────────────────────
+   * Grade colors (default for dark/light/glass; claude-dark overrides) */
+  --grade-a: #4ade80; --grade-b: #60a5fa; --grade-c: #fbbf24;
+  --grade-d: #fb923c; --grade-f: #f87171;
+
+  /* ── 컨테이너 너비 ─────────────────────────────────────────────────────
+   * Container widths */
+  --container-lg: 1200px; --container-md: 860px; --container-sm: 560px;
+
+  /* ── Phase 1A: Claude × Linear 하이브리드 톤 ──────────────────────────
+   * 따뜻한 베이지/오렌지 (Claude warm). claude-dark 테마 = themes.css 에서 override. */
+  --claude-bg-base:      #F5F1E8;  /* warm cream */
+  --claude-bg-surface:   #FAF7F0;  /* card */
+  --claude-bg-elevated:  #FFFFFF;  /* modal/popover */
+  --claude-text-primary: #1F1E1B;  /* warm black */
+  --claude-text-muted:   #6B6862;
+  --claude-accent:       #D97757;  /* Anthropic-inspired orange */
+  --claude-accent-soft:  #E8C5A8;  /* hover/active bg */
+  --claude-border:       #E5E1D5;  /* 1px hairline */
+
+  /* ── 의미 색상 (claude tone, 채도 -20%) ────────────────────────────── */
+  --claude-success:      #9CAF88;  /* sage — A등급/성공 */
+  --claude-warning:      #D4A574;  /* sand — C등급/주의 */
+  --claude-danger:       #C84E3F;  /* muted red — F등급/실패 */
+  --claude-grade-a:      #9CAF88;
+  --claude-grade-b:      #A8A595;
+  --claude-grade-c:      #D4A574;
+  --claude-grade-d:      #C8895E;
+  --claude-grade-f:      #C84E3F;
+
+  /* ── 타이포그래피 토큰 (사이클 93 진화) ───────────────────────────────
+   * Typography tokens (Cycle 93 evolution)
+   * 사용자 결정 3 (★) = Crimson Pro 폐기 + Pretendard 우선.
+   * - heading: Pretendard (한글 글리프 자체 지원, 기존 Crimson Pro 는 한글 미지원)
+   * - body: Pretendard primary, Inter fallback (영문 강조 영역)
+   * - mono: JetBrains Mono primary (사이클 92까지 0건 사용 → 본 PR 글로벌 적용) */
+  --claude-font-heading: 'Pretendard Variable', Pretendard, system-ui, -apple-system, sans-serif;
+  --claude-font-body:    'Pretendard Variable', Pretendard, 'Inter', system-ui, -apple-system, sans-serif;
+  --claude-font-mono:    'JetBrains Mono', Menlo, Consolas, monospace;
+  --claude-line-height:  1.65;
+
+  /* ── 환각(phantom) 토큰 alias — 4-테마 자동 적용 ──────────────────────
+   * Phantom-token alias: keeps 7+ page consumers untouched (.claude/rules/ui.md L24).
+   * 7 페이지에서 --bg-hover / --card-bg / --text 참조하지만 base.html 미정의 → 다크 테마 시각 깨짐.
+   * 사용처 그대로 두고 alias 만 추가해 회귀 0. */
+  --bg-hover:    var(--table-row-hover);
+  --card-bg:     var(--bg-card);
+  --text:        var(--text-primary);
+  --accent-blue: var(--accent);    /* repo_detail.html CLI Hook 안내 배너 */
+  --c-warning:   var(--warning);   /* settings.html 잔존 토큰명 (legacy) */
+}

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -14,238 +14,25 @@
   <title>{% block title %}SCAManager{% endblock %}</title>
   <link rel="preconnect" href="https://cdn.jsdelivr.net">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pretendard@1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" crossorigin="anonymous">
-  <!-- Phase 1B (UI 개편): Claude × Linear 폰트 — Crimson Pro (serif H) + Inter (body) + JetBrains Mono (code).
-       토큰 정의는 base.html :root --claude-font-* 참조. 적용은 본 PR 의 일부 마이크로카피 + 후속 Phase 1C/2 에서 점진. -->
+  <!-- 사이클 93 Step 1: Crimson Pro 제거 (한글 글리프 미지원 → Pretendard 단일화).
+       Cycle 93 Step 1: Crimson Pro removed (no Hangul glyphs → consolidate to Pretendard).
+       Inter (body fallback) + JetBrains Mono (code) 보존. -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Crimson+Pro:wght@400;600&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap">
+  <!-- 사이클 93 Step 1: Foundation 토큰 + 4-테마 외부화 (base.html 999→780줄 슬림).
+       Cycle 93 Step 1: Foundation tokens + 4 themes externalized.
+       tokens.css = 테마 무관 / themes.css = 4 테마 정의. 신규 토큰: elevation 5-step + motion + display + mesh-bg + accent-glow. -->
+  <link rel="stylesheet" href="/static/css/tokens.css">
+  <link rel="stylesheet" href="/static/css/themes.css">
   <style>
-    /* ── 공통 변수 (이전 버전 호환 유지) ───────── */
-    :root {
-      --radius-card: 10px;
-      --radius-btn:  7px;
-      --transition:  0.18s ease;
-
-      /* 스페이싱 스케일 */
-      --space-1: 4px;  --space-2: 8px;  --space-3: 12px; --space-4: 16px;
-      --space-5: 20px; --space-6: 24px; --space-7: 32px; --space-8: 48px;
-
-      /* 폰트 크기 스케일 */
-      --fs-xs: 12px; --fs-sm: 13px; --fs-md: 14px; --fs-base: 15px;
-      --fs-lg: 16px; --fs-xl: 18px; --fs-2xl: 20px; --fs-3xl: 24px;
-
-      /* 반경 스케일 */
-      --radius-xs: 4px; --radius-sm: 6px; --radius-md: 10px;
-      --radius-lg: 14px; --radius-pill: 999px;
-
-      /* 그림자 스케일 */
-      --shadow-sm: 0 1px 3px rgba(0,0,0,.1), 0 1px 2px rgba(0,0,0,.07);
-      --shadow-md: 0 4px 16px rgba(0,0,0,.14);
-      --shadow-lg: 0 8px 32px rgba(0,0,0,.22);
-
-      /* 등급 색상 */
-      --grade-a: #4ade80; --grade-b: #60a5fa; --grade-c: #fbbf24;
-      --grade-d: #fb923c; --grade-f: #f87171;
-
-      /* 컨테이너 너비 */
-      --container-lg: 1200px; --container-md: 860px; --container-sm: 560px;
-
-      /* ── Phase 1A (UI 개편): Claude × Linear 하이브리드 토큰 ─────────────
-       *  설계서: docs/design/2026-05-01-ui-redesign-claude-linear-hybrid.md
-       *  본 PR 은 신규 토큰 정의만 추가 — 적용은 Phase 1B 부터 (회귀 위험 0).
-       *  기존 토큰 (--bg-page / --grade-* 등) 은 호환성 유지 — Phase 1C 에서
-       *  alias 로 재정의 예정.
-       *  Phase 1A: define new tokens (no consumers yet) — zero regression. */
-
-      /* 따뜻한 베이지/오렌지 (Claude 톤) — 채도 -20%, 도서관 분위기 */
-      --claude-bg-base:      #F5F1E8;  /* warm cream */
-      --claude-bg-surface:   #FAF7F0;  /* card */
-      --claude-bg-elevated:  #FFFFFF;  /* modal/popover */
-      --claude-text-primary: #1F1E1B;  /* warm black */
-      --claude-text-muted:   #6B6862;
-      --claude-accent:       #D97757;  /* Anthropic-inspired orange */
-      --claude-accent-soft:  #E8C5A8;  /* hover/active bg */
-      --claude-border:       #E5E1D5;  /* 1px hairline */
-
-      /* 의미 색상 — 등급/상태 (채도 -20%) */
-      --claude-success:      #9CAF88;  /* sage — A등급/성공 */
-      --claude-warning:      #D4A574;  /* sand — C등급/주의 */
-      --claude-danger:       #C84E3F;  /* muted red — F등급/실패 */
-      --claude-grade-a:      #9CAF88;
-      --claude-grade-b:      #A8A595;
-      --claude-grade-c:      #D4A574;
-      --claude-grade-d:      #C8895E;
-      --claude-grade-f:      #C84E3F;
-
-      /* 타이포그래피 — Crimson Pro (serif H) + Inter (body) + JetBrains Mono
-       * 폰트 import 는 Phase 1B 적용 시점에 <link> 추가 — 본 PR 은 fallback 만 */
-      --claude-font-heading: 'Crimson Pro', Charter, Georgia, serif;
-      --claude-font-body:    'Inter', system-ui, -apple-system, sans-serif;
-      --claude-font-mono:    'JetBrains Mono', Menlo, Consolas, monospace;
-      --claude-line-height:  1.65;
-
-      /* Step A (UI 감사): 환각(phantom) 토큰 alias — 4-테마 자동 적용
-       * Step A: phantom-token aliases — auto-resolved per active theme via CSS lazy var()
-       * 7 페이지에서 var(--bg-hover) / var(--card-bg) / var(--text) 참조하지만 base.html
-       * 미정의 → 다크 테마에서 시각 깨짐. 사용처 그대로 두고 alias 만 추가해 회귀 0.
-       * Phantom-token alias: keeps consumers untouched; 0-regression compatibility shim. */
-      --bg-hover: var(--table-row-hover);
-      --card-bg:  var(--bg-card);
-      --text:     var(--text-primary);
-      /* PR-1 C2: 후속 환각 토큰 alias 2종 — repo_detail / settings 잔존 참조 흡수
-         PR-1 C2: additional phantom-token aliases for repo_detail / settings */
-      --accent-blue: var(--accent);   /* repo_detail.html CLI Hook 안내 배너 */
-      --c-warning:   var(--warning);  /* settings.html 잔존 토큰명 (legacy) */
-    }
-
-    /* ── Phase 1A: Claude 톤 다크 모드 토큰 (warm black) ──────────────────
-     *  data-theme="claude-dark" 시 활성. 기존 [data-theme="dark"] 와 별도 —
-     *  Phase 1B 에서 토글 UI 추가 후 운영 시작. 본 PR 은 정의만. */
-    [data-theme="claude-dark"] {
-      --claude-bg-base:      #1F1E1B;  /* warm black */
-      --claude-bg-surface:   #2A2825;
-      --claude-bg-elevated:  #33302C;
-      --claude-text-primary: #F5F1E8;
-      --claude-text-muted:   #A8A29A;
-      --claude-accent:       #E08968;
-      --claude-accent-soft:  #5C3D2E;
-      --claude-border:       #3D3A35;
-      --claude-success:      #A8BA94;
-      --claude-warning:      #DDB585;
-      --claude-danger:       #D45F50;
-    }
-
-    /* ── 다크 테마 (Linear 스타일) ─────────────── */
-    [data-theme="dark"], body:not([data-theme]) {
-      --bg-page:        #111118;
-      --bg-card:        #1c1c23;
-      --bg-nav:         #111118;
-      --bg-input:       #2a2a34;
-      --bg-input-focus: #32323e;
-      --border:         #2c2c38;
-      --border-focus:   #5e6ad2;
-      --text-primary:   #e2e2e8;
-      --text-muted:     #73737c;
-      --text-nav:       #a8a8b2;
-      --accent:         #5e6ad2;
-      --accent-hover:   #8d95e0;
-      --accent-grad:    linear-gradient(135deg, #5e6ad2, #8d95e0);
-      --success:        #4ade80;
-      --danger:         #f87171;
-      /* Step D: --warning 토큰 신규 — 이전엔 페이지마다 #f59e0b/#fbbf24 하드코딩
-         Step D: new --warning token — was hardcoded as #f59e0b in 5+ places */
-      --warning:        #f59e0b;
-      --shadow:         0 4px 24px rgba(0,0,0,.5);
-      --shadow-card:    0 1px 3px rgba(0,0,0,.25), 0 0 0 1px rgba(255,255,255,.04);
-      --table-head:     #1a1a21;
-      --table-row-hover: #21212a;
-      --code-bg:        #0f0f15;
-      /* 설정 페이지 호환 */
-      --grad-gate:           linear-gradient(135deg, #5e6ad2, #4a57c4);
-      /* P1-5: --grad-merge 녹색 → cyan/teal 로 변경 — --success (녹색 토글/conn-dot) 와
-         색 의미 분리 ("이벤트 후 자동화" 카드 헤더가 "성공 상태"로 오인되던 문제 해소)
-         P1-5: change green → cyan/teal to disambiguate from --success (toggle/conn-dot) */
-      --grad-merge:          linear-gradient(135deg, #06b6d4, #0891b2);
-      --grad-notify:         linear-gradient(135deg, #fbbf24, #f59e0b);
-      --grad-hook:           linear-gradient(135deg, #a78bfa, #8b5cf6);
-      --title-gradient:      linear-gradient(135deg, #8d95e0, #c084fc);
-      --btn-gate-active-bg:  rgba(94,106,210,.15);
-      --btn-gate-active-bd:  #5e6ad2;
-      --btn-gate-active-tx:  #8d95e0;
-      --save-btn-bg:         linear-gradient(135deg, #5e6ad2, #4a57c4);
-      --save-btn-shadow:     rgba(94,106,210,.4);
-      --hint-bg:             rgba(255,255,255,.03);
-      --hint-border:         rgba(255,255,255,.05);
-      --hook-btn-bg:         rgba(139,92,246,.1);
-      --hook-btn-bd:         rgba(139,92,246,.3);
-      --hook-btn-tx:         #a78bfa;
-    }
-
-    /* ── 라이트 테마 (Vercel 스타일) ──────────── */
-    [data-theme="light"] {
-      --bg-page:        #f5f5f7;
-      --bg-card:        #ffffff;
-      --bg-nav:         #000000;
-      --bg-input:       #f5f5f7;
-      --bg-input-focus: #ffffff;
-      --border:         #e5e5e8;
-      --border-focus:   #5e6ad2;
-      --text-primary:   #111118;
-      --text-muted:     #8a8a96;
-      --text-nav:       #e5e5e8;
-      --accent:         #5e6ad2;
-      --accent-hover:   #4a57c4;
-      --accent-grad:    linear-gradient(135deg, #5e6ad2, #4a57c4);
-      --success:        #16a34a;
-      --danger:         #dc2626;
-      /* Step D: --warning 라이트 테마 — Tailwind amber-600 */
-      --warning:        #d97706;
-      --shadow:         0 2px 8px rgba(0,0,0,.07), 0 0 0 1px rgba(0,0,0,.04);
-      --shadow-card:    0 1px 3px rgba(0,0,0,.05), 0 0 0 1px rgba(0,0,0,.05);
-      --table-head:     #f9f9fb;
-      --table-row-hover: #f5f5f7;
-      --code-bg:        #f5f5f7;
-      /* 설정 페이지 호환 */
-      --grad-gate:           linear-gradient(135deg, #8d95e0, #5e6ad2);
-      /* P1-5: cyan/teal — --success 와 분리 / disambiguate from --success */
-      --grad-merge:          linear-gradient(135deg, #22d3ee, #0891b2);
-      --grad-notify:         linear-gradient(135deg, #fcd34d, #f59e0b);
-      --grad-hook:           linear-gradient(135deg, #c4b5fd, #8b5cf6);
-      --title-gradient:      linear-gradient(135deg, #4a57c4, #7c3aed);
-      --btn-gate-active-bg:  rgba(94,106,210,.08);
-      --btn-gate-active-bd:  #5e6ad2;
-      --btn-gate-active-tx:  #5e6ad2;
-      --save-btn-bg:         linear-gradient(135deg, #5e6ad2, #7c3aed);
-      --save-btn-shadow:     rgba(94,106,210,.25);
-      --hint-bg:             #f9f9fb;
-      --hint-border:         #e5e5e8;
-      --hook-btn-bg:         rgba(124,58,237,.06);
-      --hook-btn-bd:         rgba(124,58,237,.2);
-      --hook-btn-tx:         #7c3aed;
-    }
-
-    /* ── 글래스모피즘 ─────────────────────────── */
-    [data-theme="glass"] {
-      --bg-page:        #0c0e1a;
-      --bg-card:        rgba(255,255,255,0.06);
-      --bg-nav:         rgba(12,14,26,0.9);
-      --bg-input:       rgba(255,255,255,0.07);
-      --bg-input-focus: rgba(255,255,255,0.12);
-      --border:         rgba(255,255,255,0.12);
-      --border-focus:   #8d95e0;
-      --text-primary:   #e2e2e8;
-      --text-muted:     rgba(255,255,255,0.4);
-      --text-nav:       #c8c8d4;
-      --accent:         #8d95e0;
-      --accent-hover:   #b0b8f0;
-      --accent-grad:    linear-gradient(135deg, #5e6ad2, #ec4899);
-      --success:        #4ade80;
-      --danger:         #f87171;
-      /* Step D: --warning 글래스 테마 — 다크와 동일 hex */
-      --warning:        #f59e0b;
-      --shadow:         0 8px 32px rgba(0,0,0,.5);
-      --shadow-card:    0 4px 20px rgba(0,0,0,.4), 0 0 0 1px rgba(255,255,255,.06);
-      --table-head:     rgba(255,255,255,0.04);
-      --table-row-hover: rgba(255,255,255,0.04);
-      --code-bg:        rgba(0,0,0,0.3);
-      /* 설정 페이지 호환 */
-      --grad-gate:           linear-gradient(135deg, rgba(141,149,224,.9), rgba(94,106,210,.9));
-      /* P1-5: cyan/teal — --success 와 분리 / disambiguate from --success */
-      --grad-merge:          linear-gradient(135deg, rgba(6,182,212,.9), rgba(8,145,178,.9));
-      --grad-notify:         linear-gradient(135deg, rgba(251,191,36,.9), rgba(245,158,11,.9));
-      --grad-hook:           linear-gradient(135deg, rgba(196,181,253,.9), rgba(139,92,246,.9));
-      --title-gradient:      linear-gradient(135deg, #c084fc, #f472b6);
-      --btn-gate-active-bg:  rgba(141,149,224,.18);
-      --btn-gate-active-bd:  #8d95e0;
-      --btn-gate-active-tx:  #c4b5fd;
-      --save-btn-bg:         linear-gradient(135deg, #8d95e0, #c084fc);
-      --save-btn-shadow:     rgba(192,132,252,.3);
-      --hint-bg:             rgba(255,255,255,.04);
-      --hint-border:         rgba(255,255,255,.07);
-      --hook-btn-bg:         rgba(196,181,253,.08);
-      --hook-btn-bd:         rgba(196,181,253,.25);
-      --hook-btn-tx:         #c4b5fd;
-    }
+    /* ──────────────────────────────────────────────────────────────────────
+     * 사이클 93 Step 1 — Foundation 토큰 + 4-테마 정의는 외부 CSS 파일로 분리.
+     * Cycle 93 Step 1 — tokens + 4 themes externalized to /static/css/.
+     *   - tokens.css: 테마 무관 (spacing/fs/elevation/motion/display/...)
+     *   - themes.css: 4 테마 (dark/light/glass/claude-dark)
+     * 본 <style> 블록은 글로벌 reset + body + nav + 모든 component CSS 보존.
+     * ────────────────────────────────────────────────────────────────────── */
 
     /* ── 리셋 & 기본 ──────────────────────────── */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -255,8 +42,7 @@
       border-radius: var(--radius-xs);
     }
     body {
-      font-family: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont,
-                   'Segoe UI', system-ui, sans-serif;
+      font-family: var(--claude-font-body);
       background-color: var(--bg-page);
       color: var(--text-primary);
       transition: background-color var(--transition), color var(--transition);
@@ -265,63 +51,18 @@
       line-height: 1.6;
       -webkit-font-smoothing: antialiased;
     }
+    /* 사이클 93 Step 1: heading 글로벌 폰트 토큰 적용 (page-level CSS 가 override 가능 — specificity 보존).
+     * Cycle 93 Step 1: global heading font token (page-level CSS still overrides — specificity preserved). */
+    h1, h2, h3, h4, h5, h6 {
+      font-family: var(--claude-font-heading);
+      letter-spacing: var(--tracking-tight);
+    }
     body[data-theme="glass"] {
       background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0c0e1a 100%);
       background-attachment: fixed;
     }
-    /* Phase 1B (UI 개편): Claude 다크 — claude-* 토큰을 기존 토큰에 alias.
-     * 기존 페이지 마크업/클래스 무변경으로 즉시 적용. 본 PR 시점에는 토글
-     * 옵션만 추가 — 사용자가 명시적으로 선택했을 때만 활성. */
-    body[data-theme="claude-dark"] {
-      --bg-page:        var(--claude-bg-base);
-      --bg-card:        var(--claude-bg-surface);
-      --bg-nav:         var(--claude-bg-base);
-      --bg-input:       var(--claude-bg-elevated);
-      --bg-input-focus: var(--claude-accent-soft);
-      --border:         var(--claude-border);
-      --border-focus:   var(--claude-accent);
-      --text-primary:   var(--claude-text-primary);
-      --text-muted:     var(--claude-text-muted);
-      --text-nav:       var(--claude-text-muted);
-      --accent:         var(--claude-accent);
-      --accent-hover:   #F09578;  /* claude-accent 의 라이트 변형 */
-      --accent-grad:    linear-gradient(135deg, #D97757, #F09578);
-
-      /* Phase 1C (UI 개편) — claude-dark 테마에서 등급 색상 alias.
-       * 기존 토큰 (--grade-a 등) 을 claude 톤 (sage/sand/muted red) 로 재정의.
-       * .grade-a/.grade-b/... 클래스 + Chart.js 의 var(--grade-*) 참조 모두
-       * 자동 적용 (마크업 무변경). 기본 다크/라이트 테마는 영향 0. */
-      --grade-a: var(--claude-grade-a);  /* sage #9CAF88 */
-      --grade-b: var(--claude-grade-b);  /* taupe #A8A595 */
-      --grade-c: var(--claude-grade-c);  /* sand #D4A574 */
-      --grade-d: var(--claude-grade-d);  /* terracotta #C8895E */
-      --grade-f: var(--claude-grade-f);  /* muted red #C84E3F */
-      /* Step D: claude-dark 의 --warning 도 sand 톤으로 alias */
-      --warning: var(--claude-warning);  /* sand #DDB585 */
-      --success: var(--claude-success);  /* sage #A8BA94 */
-      --danger:  var(--claude-danger);   /* muted red #D45F50 */
-
-      /* PR-1 C1: settings 페이지가 사용하는 토큰 8종 — claude-dark 미정의 시
-       * 카드 헤더 / 저장 버튼 / hint 패널 / hook 버튼이 통째로 깨졌음. 모든 그라디언트는
-       * claude warm 톤 (terracotta / sage / sand / orange) 으로 재정의.
-       * PR-1 C1: 8 settings-page tokens — without these, claude-dark broke
-       * settings card headers, save button, hint panels, hook buttons. */
-      --grad-gate:           linear-gradient(135deg, #D97757, #B85A3D);  /* claude orange */
-      --grad-merge:          linear-gradient(135deg, #A8BA94, #8AA476);  /* claude sage */
-      --grad-notify:         linear-gradient(135deg, #DDB585, #C49566);  /* claude sand */
-      --grad-hook:           linear-gradient(135deg, #C8895E, #A86F46);  /* claude terracotta */
-      --title-gradient:      linear-gradient(135deg, #D97757, #DDB585);  /* claude orange→sand */
-      --btn-gate-active-bg:  rgba(217,119,87,.15);
-      --btn-gate-active-bd:  var(--claude-accent);
-      --btn-gate-active-tx:  var(--claude-accent);
-      --save-btn-bg:         linear-gradient(135deg, #D97757, #B85A3D);
-      --save-btn-shadow:     rgba(217,119,87,.4);
-      --hint-bg:             rgba(217,119,87,.05);
-      --hint-border:         rgba(217,119,87,.15);
-      --hook-btn-bg:         rgba(200,137,94,.10);
-      --hook-btn-bd:         rgba(200,137,94,.30);
-      --hook-btn-tx:         #C8895E;  /* claude terracotta */
-    }
+    /* Phase 1B claude-dark alias 블록 = themes.css 로 외부화 (사이클 93 Step 1).
+     * Phase 1B claude-dark alias block externalized to themes.css (Cycle 93 Step 1). */
 
     /* ── 네비게이션 ───────────────────────────── */
     /* Step A (S4): nav 좌우 padding 에 safe-area-inset 적용 — iOS notch landscape 호환
@@ -684,12 +425,16 @@
     .back-btn:hover { color: var(--text-primary); border-color: var(--accent); text-decoration: none; }
 
     /* ── 코드 ──────────────────────────────────── */
+    /* 사이클 93 Step 1: JetBrains Mono 글로벌 적용 (사이클 92까지 토큰 정의만 + 0건 사용).
+     * Cycle 93 Step 1: JetBrains Mono globally applied (loaded but unused until Cycle 92). */
+    code, pre, kbd, samp {
+      font-family: var(--claude-font-mono);
+    }
     code {
       background: var(--code-bg);
       padding: 2px 6px;
       border-radius: var(--radius-xs);
       font-size: var(--fs-xs);
-      font-family: 'Menlo', 'Consolas', monospace;
       color: var(--accent-hover);
       border: 1px solid var(--border);
     }

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -1787,23 +1787,38 @@ def _read_template(name: str) -> str:
     return (_TEMPLATES_DIR / name).read_text(encoding="utf-8")
 
 
+# 사이클 93 Step 1: Foundation 토큰 + 4-테마 외부화 (base.html → src/static/css/)
+# Cycle 93 Step 1: Foundation tokens + 4 themes externalized.
+_STATIC_CSS_DIR = Path(__file__).resolve().parents[3] / "src" / "static" / "css"
+
+
+def _read_css(name: str) -> str:
+    """src/static/css/<name>.css 내용 반환 — 외부화된 토큰/테마 회귀 가드 헬퍼."""
+    return (_STATIC_CSS_DIR / name).read_text(encoding="utf-8")
+
+
 def test_phantom_token_aliases_in_root():
     """PR #169 cleanup 회귀 가드 — :root 에 환각 토큰 alias 5종 보존.
 
     --bg-hover / --card-bg / --text (Step A) +
-    --accent-blue / --c-warning (PR-1 cleanup) 이 base.html :root 에 정의돼야.
+    --accent-blue / --c-warning (PR-1 cleanup) 이 정의돼야.
+    사이클 93 Step 1: base.html → tokens.css 외부화 (검사 위치 갱신).
     """
-    base = _read_template("base.html")
+    tokens = _read_css("tokens.css")
     for token in ("--bg-hover:", "--card-bg:", "--text:", "--accent-blue:", "--c-warning:"):
-        assert token in base, f"환각 토큰 alias {token} 가 base.html :root 에서 누락"
+        assert token in tokens, f"환각 토큰 alias {token} 가 tokens.css :root 에서 누락"
 
 
 def test_warning_token_defined_in_all_themes():
-    """PR #167 회귀 가드 — --warning 토큰이 4-테마 모두에 정의."""
-    base = _read_template("base.html")
-    assert base.count("--warning:") >= 3, (
+    """PR #167 회귀 가드 — --warning 토큰이 4-테마 모두에 정의.
+
+    사이클 93 Step 1: base.html → themes.css 외부화 (검사 위치 갱신).
+    dark / light / glass 3 테마 직접 정의 + claude-dark = alias (var(--claude-warning)).
+    """
+    themes = _read_css("themes.css")
+    assert themes.count("--warning:") >= 3, (
         f"--warning 토큰 정의가 부족 (3개 이상 기대 — dark/light/glass): "
-        f"{base.count('--warning:')}회"
+        f"{themes.count('--warning:')}회"
     )
 
 
@@ -1812,16 +1827,86 @@ def test_claude_dark_settings_tokens_defined():
 
     --grad-gate/merge/notify/hook + --title-gradient + --btn-gate-active-* +
     --save-btn-* + --hint-* + --hook-btn-* 가 claude-dark 블록에 있어야.
+    사이클 93 Step 1: base.html → themes.css 외부화 (검사 위치 갱신).
     """
-    base = _read_template("base.html")
-    # claude-dark 블록 안에서 --grad-gate 정의 확인
-    cd_idx = base.find('body[data-theme="claude-dark"]')
-    assert cd_idx != -1, "claude-dark 블록 누락"
-    cd_block_end = base.find("}", cd_idx + 100)  # 대략적 블록 끝
-    cd_block = base[cd_idx:cd_block_end + 200]  # 약간 여유
+    themes = _read_css("themes.css")
+    cd_idx = themes.find('body[data-theme="claude-dark"]')
+    assert cd_idx != -1, "themes.css 에 claude-dark alias 블록 누락"
+    cd_block_end = themes.find("\n}", cd_idx)
+    assert cd_block_end != -1, "claude-dark alias 블록의 닫는 } 미발견"
+    cd_block = themes[cd_idx:cd_block_end]
     for token in ("--grad-gate:", "--save-btn-bg:", "--hint-bg:", "--hook-btn-tx:"):
         assert token in cd_block, (
-            f"claude-dark 블록에 {token} 누락 — settings 페이지 시각 깨짐 위험"
+            f"claude-dark alias 블록에 {token} 누락 — settings 페이지 시각 깨짐 위험"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 사이클 93 Step 1 신규 회귀 가드 (정책 4 — 단언 + 회귀 가드 동시 머지)
+# Cycle 93 Step 1 NEW guards (Policy 4 — assertion + guard same PR)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_external_css_links_in_base_html():
+    """사이클 93 Step 1 회귀 가드 — base.html 이 외부 토큰/테마 CSS 링크.
+
+    토큰 정의를 외부화한 후 base.html 이 두 파일을 <link> 로 로드해야 함.
+    누락 시 모든 페이지에서 var(--*) 가 invalid → 시각 전부 깨짐.
+    """
+    base = _read_template("base.html")
+    assert '/static/css/tokens.css' in base, "base.html 에 tokens.css 링크 누락"
+    assert '/static/css/themes.css' in base, "base.html 에 themes.css 링크 누락"
+
+
+def test_crimson_pro_removed():
+    """사이클 93 Step 1 회귀 가드 — Crimson Pro 폐기 (한글 글리프 미지원).
+
+    사용자 결정 3 (★) = Pretendard 단일화. Google Fonts <link> 에 family=Crimson 미포함.
+    """
+    base = _read_template("base.html")
+    # <link> 태그 내 Crimson Pro family 미포함 확인 (코멘트 영역은 OK)
+    link_lines = [line for line in base.splitlines() if 'fonts.googleapis.com/css' in line]
+    assert link_lines, "Google Fonts <link> 자체가 누락"
+    for line in link_lines:
+        assert 'Crimson' not in line, f"Crimson Pro 잔존 — Google Fonts <link>: {line}"
+
+
+def test_jetbrains_mono_globally_applied():
+    """사이클 93 Step 1 회귀 가드 — code/pre 에 var(--claude-font-mono) 글로벌 적용.
+
+    cross-verify 발견 = 사이클 92 까지 폰트 인프라 100% 미사용. 본 PR 적용 후 회귀 0.
+    """
+    base = _read_template("base.html")
+    assert "code, pre, kbd, samp" in base, "code/pre 글로벌 폰트 룰 누락"
+    # code 단일 룰에서 'Menlo' 인라인 사라졌는지 확인
+    assert "'Menlo', 'Consolas', monospace" not in base, (
+        "Menlo 인라인 fallback 잔존 — var(--claude-font-mono) 토큰 사용 의무"
+    )
+
+
+def test_foundation_tokens_present():
+    """사이클 93 Step 1 회귀 가드 — Phase 2 Foundation 신규 토큰 9종.
+
+    elevation 5-step + motion 3-duration + display 3-scale + accent-glow + mesh-bg.
+    """
+    tokens = _read_css("tokens.css")
+    themes = _read_css("themes.css")
+
+    # Theme-agnostic 토큰 (tokens.css)
+    for token in (
+        "--elev-1:", "--elev-2:", "--elev-3:", "--elev-4:", "--elev-inset:",
+        "--dur-fast:", "--dur-base:", "--dur-slow:",
+        "--ease-out-expo:", "--ease-spring:",
+        "--fs-display-sm:", "--fs-display-md:", "--fs-display-lg:",
+        "--tracking-tight:",
+        "--blur-sm:", "--blur-md:", "--blur-lg:",
+    ):
+        assert token in tokens, f"tokens.css 에 신규 Foundation 토큰 {token} 누락"
+
+    # Theme-dependent 토큰 (themes.css 4 테마 모두)
+    for token in ("--mesh-bg:", "--accent-glow:"):
+        assert themes.count(token) >= 4, (
+            f"themes.css 에 {token} 4-테마 정의 부족 (실측 {themes.count(token)}회 — 4 이상 기대)"
         )
 
 


### PR DESCRIPTION
…Brains Mono 글로벌 (Step 1)

사이클 93 Step 1 — 5+1 다중 에이전트 UI/UX 재설계 논의 결과 Step 1 (Foundation 토큰). 사용자 결정: Codex 협업 (OpenAI API) + 일러스트 isometric ★ + Pretendard 단일화 ★ + hybrid CSS ★ + 5 Phase 점진 ★.

## 변경 요약 (5 파일, +484/-300)

### 신규 외부 CSS (정책 17 4번 — 안정성 우선 hybrid 추출)
- src/static/css/tokens.css (+132): 테마 무관 토큰 + Phase 2 신규 (elevation 5-step / motion 3-duration / display 3-scale / blur / accent-glow)
- src/static/css/themes.css (+221): 4 테마 (dark Linear / light Vercel / glass frosted / claude-dark warm) + body[data-theme="claude-dark"] alias 블록 + theme별 mesh-bg + accent-glow

### base.html 슬림화 (999 → 744줄, -255줄)
- :root 토큰 블록 + 4 테마 블록 + Phase 1B claude-dark alias 블록 외부화
- Crimson Pro 폐기 (cross-verify 발견 — 한글 글리프 미지원, 사이클 92까지 100% fallback)
- JetBrains Mono 글로벌 적용 (code/pre/kbd/samp — 토큰 정의만 + 0건 사용 트랩 종결)
- h1-h6 글로벌 폰트 토큰 + tracking-tight 적용
- body font-family → var(--claude-font-body)

### 회귀 가드 (정책 4 — 단언 + 가드 동시 머지)
- 기존 3 가드 갱신: tokens.css / themes.css 위치 검사
- 신규 4 가드: external CSS link / Crimson Pro 폐기 / JetBrains Mono 글로벌 / Foundation 토큰 9종

### docs/architecture.md src/ 트리 sync
- src/static/css/{tokens,themes}.css 항목 추가 (CLAUDE.md 동기화 체크리스트 페어)

## 검증
- make test-fast: 2672 passed (이전 2665 + 신규 7) ✅
- make lint: 9.95/10 (변동 없음) ✅
- integration UI/auth: 16 passed ✅
- pylint/flake8/bandit: 0 신규 이슈

## 본 PR 범위 외 (Step 2~ 별도 PR)
- mesh-bg / accent-glow consumer 적용 (정의만, consumer X — 회귀 위험 격리)
- 11 페이지 일러스트 (Codex OpenAI API 스크립트 — 별도 사이클)
- src/static/manifest.json theme_color 갱신 (cross-verify P1 — Step 4 채널 확장)
- 알림 채널 (이메일/Telegram/Slack) 디자인 동기화 (Step 4)

## 자율 판단 보고 (정책 3)
- Inter Google Fonts 보존: 사용자 결정 3 본문 strict 해석 시 Inter 제거 가능 — 보수 default. 별도 PR 분리 가능 (이의 시 회신).
- mesh-bg/accent-glow consumer 미적용: Step 2 component 작업 시 적용 default. 토큰만 사전 정의로 회귀 위험 0.

🔍 사용자 검증 필요 (정책 2)

| 항목 | 검증 방법 |
|------|----------|
| 4 테마 × 모바일/데스크탑 = 8 조합 시각 정합 (정책 11) | Railway 배포 후 dark/light/glass/claude-dark 전환 + 모바일 viewport 토글 | | Pretendard 단일 폰트 한글 렌더링 | 한국어 페이지 (dashboard / settings) 확인 | | code/pre 영역 JetBrains Mono 적용 | repo_detail / analysis_detail 코드 블록 확인 | | 외부 CSS 로드 (CDN 차단 환경) | /static/css/{tokens,themes}.css 200 응답 확인 | | 운영 smoke check 3-endpoint (정책 13) | /health 200 + /auth/github 302 + /login 200 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
