### PR TITLE
refactor(s3776): 4 CRITICAL Cognitive Complexity 헬퍼 추출 (사이클 93 PR-B)

### DIFF
--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -489,6 +489,21 @@ async def _enqueue_merge_retry(  # pylint: disable=too-many-arguments
         )
 
 
+def _resolve_legacy_merge_state(ok: bool, outcome) -> tuple[str, "datetime | None"]:
+    """legacy auto-merge state 분류 — 사이클 93 PR-B (S3776 분리).
+
+    Resolve legacy merge state (Cycle 93 PR-B — extracted to reduce S3776).
+    - native enable 성공 → ENABLED_PENDING_MERGE (enabled_at = now)
+    - REST 폴백 성공 → DIRECT_MERGED (enabled_at = None)
+    - 실패 → LEGACY (enabled_at = None — state 분류 의미 없음)
+    """
+    if ok and outcome.path == PATH_NATIVE_ENABLE:
+        return _states.ENABLED_PENDING_MERGE, datetime.now(timezone.utc)
+    if ok:
+        return _states.DIRECT_MERGED, None
+    return _states.LEGACY, None
+
+
 async def _run_auto_merge_legacy(  # pylint: disable=too-many-arguments,too-many-locals
     config: RepoConfigData,
     github_token: str,
@@ -515,17 +530,9 @@ async def _run_auto_merge_legacy(  # pylint: disable=too-many-arguments,too-many
         )
         ok, reason = outcome.ok, outcome.reason
 
-        # Phase 3 PR-B1: native enable success → enabled_pending_merge,
-        # REST 폴백 즉시 성공 → direct_merged. 실패는 state="legacy" 기본값 유지.
-        if ok and outcome.path == PATH_NATIVE_ENABLE:
-            new_state = _states.ENABLED_PENDING_MERGE
-            enabled_at = datetime.now(timezone.utc)
-        elif ok:
-            new_state = _states.DIRECT_MERGED
-            enabled_at = None
-        else:
-            new_state = _states.LEGACY  # 실패 — state 분류 의미 없음
-            enabled_at = None
+        # Phase 3 PR-B1: state 분류 분리 (사이클 93 PR-B — S3776 16→<15)
+        # state derivation extracted to helper (Cycle 93 PR-B — S3776 16→<15)
+        new_state, enabled_at = _resolve_legacy_merge_state(ok, outcome)
 
         # Phase F.1: 모든 시도 DB 기록 — 관측 실패가 파이프라인을 중단시키지 않도록
         # Phase F.1: Record every attempt in DB — observability failures must not interrupt the pipeline.

--- a/src/middleware/locale.py
+++ b/src/middleware/locale.py
@@ -122,11 +122,50 @@ class LocaleMiddleware:  # pylint: disable=too-few-public-methods
         return None
 
     @staticmethod
-    def _parse_accept_language(headers: list) -> Optional[str]:
+    def _parse_q_weight(seg: str) -> float:
+        """RFC 7231 q-weight 단일 segment 파싱 — 사이클 93 PR-B (S3776 분리).
+
+        Parse a single RFC 7231 q-weight segment (Cycle 93 PR-B — S3776 split).
+        """
+        seg = seg.strip()
+        if not seg.startswith("q="):
+            return 1.0  # default per RFC 7231
+        try:
+            return float(seg[2:])
+        except (ValueError, IndexError):
+            return 0.0
+
+    @classmethod
+    def _parse_lang_items(cls, header_str: str) -> list[tuple[str, float]]:
+        """Accept-Language 본문 → (base_lang, q_weight) tuple list.
+
+        Decompose header into (base_lang, q_weight) tuples (Cycle 93 PR-B — S3776 split).
+        """
+        items: list[tuple[str, float]] = []
+        for part in header_str.split(","):
+            segments = part.split(";")
+            lang = segments[0].strip().lower()
+            if not lang:
+                continue
+            # 첫 segment 외에서 q= 찾기 (default 1.0)
+            # Find q= in non-first segments (default 1.0)
+            q_weight = 1.0
+            for seg in segments[1:]:
+                if seg.strip().startswith("q="):
+                    q_weight = cls._parse_q_weight(seg)
+                    break
+            # 정규화: "ko-KR" → "ko" (base lang only)
+            # Normalize: "ko-KR" → "ko" (base lang only)
+            items.append((lang.split("-")[0], q_weight))
+        return items
+
+    @classmethod
+    def _parse_accept_language(cls, headers: list) -> Optional[str]:
         """Accept-Language 헤더 RFC 7231 q-weight 파싱 후 최우선 locale 반환.
 
         Parse Accept-Language header per RFC 7231 q-weights, return top locale.
         예 (Example): "ko-KR,ko;q=0.9,en;q=0.8" → "ko"
+        사이클 93 PR-B: S3776 (24→<15) — _parse_q_weight + _parse_lang_items 분리.
         """
         for name, value in headers:
             if name.lower() != b"accept-language":
@@ -135,34 +174,11 @@ class LocaleMiddleware:  # pylint: disable=too-few-public-methods
                 header_str = value.decode("utf-8", errors="ignore")
             except (AttributeError, UnicodeDecodeError):
                 continue
-
-            # RFC 7231 파싱 — 각 항목 (lang, q-weight)
-            # RFC 7231 parsing — each item (lang, q-weight)
-            items = []
-            for part in header_str.split(","):
-                segments = part.split(";")
-                lang = segments[0].strip().lower()
-                if not lang:
-                    continue
-                q_weight = 1.0  # default per RFC 7231
-                for seg in segments[1:]:
-                    seg = seg.strip()
-                    if seg.startswith("q="):
-                        try:
-                            q_weight = float(seg[2:])
-                        except (ValueError, IndexError):
-                            q_weight = 0.0
-                # 정규화: "ko-KR" → "ko" (base lang only)
-                # Normalize: "ko-KR" → "ko" (base lang only)
-                base_lang = lang.split("-")[0]
-                items.append((base_lang, q_weight))
-
+            items = cls._parse_lang_items(header_str)
             if not items:
                 continue
-
-            # q-weight 내림차순 정렬 (안정 정렬 — 동일 q-weight 시 입력 순서 보존)
-            # Sort by q-weight descending (stable — preserves input order on ties)
+            # q-weight 내림차순 안정 정렬 (동일 q-weight 시 입력 순서 보존)
+            # Stable sort by q-weight descending (preserves input order on ties)
             items.sort(key=lambda x: x[1], reverse=True)
             return items[0][0]
-
         return None

--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -38,7 +38,7 @@ from src.shared.merge_metrics import log_merge_attempt
 logger = logging.getLogger(__name__)
 
 
-async def process_pending_retries(  # pylint: disable=too-many-locals,too-many-statements
+async def process_pending_retries(
     db: Session,
     *,
     now: datetime | None = None,
@@ -49,6 +49,8 @@ async def process_pending_retries(  # pylint: disable=too-many-locals,too-many-s
     Process the pending merge retry queue.
 
     Returns counts dict: {"claimed", "succeeded", "terminal", "abandoned", "released", "skipped"}
+    사이클 93 PR-B: 단일 row 처리 = `_process_single_retry` 분리 (S3776 26→<15).
+    Cycle 93 PR-B: per-row processing extracted to `_process_single_retry` (S3776 26→<15).
     """
     # 현재 시각 설정 — 테스트에서 주입 가능 (freezegun 불필요)
     # Set current time — injectable from tests (no freezegun needed)
@@ -75,150 +77,7 @@ async def process_pending_retries(  # pylint: disable=too-many-locals,too-many-s
 
     for row in claimed:
         try:
-            # ── a. GitHub 토큰 조회 ────────────────────────────────────────
-            # ── a. Resolve GitHub token ───────────────────────────────────
-            token = _resolve_github_token(db, row.repo_full_name)
-            if token is None:
-                # 토큰 없음 — 30초 후 재시도 대기로 복귀
-                # No token — release back to retry queue after 30s
-                _now_naive = now.replace(tzinfo=None) + timedelta(seconds=30)
-                merge_retry_repo.release_claim(
-                    db,
-                    row.id,
-                    next_retry_at=_now_naive,
-                    last_failure_reason="no_token",
-                )
-                counts["released"] += 1
-                continue
-
-            # ── b-0. 최대 시도 횟수 초과 검사 ────────────────────────────────────────
-            # ── b-0. Max attempts exhaustion check ─────────────────────────────────
-            if row.attempts_count >= row.max_attempts:
-                merge_retry_repo.mark_abandoned(
-                    db, row.id, reason="max_attempts_exceeded"
-                )
-                counts["abandoned"] += 1
-                continue
-
-            # ── b. 설정 재확인 (D5) ────────────────────────────────────────
-            # ── b. Re-read live config (D5) ───────────────────────────────
-            cfg = get_repo_config(db, row.repo_full_name)
-            if not (cfg.auto_merge and row.score >= cfg.merge_threshold):
-                # 설정이 변경되어 자동 머지 조건 미충족 → 포기
-                # Config changed so auto-merge condition no longer met → abandon
-                merge_retry_repo.mark_abandoned(db, row.id, reason="config_changed")
-                await _notify_config_changed(row, cfg)
-                counts["abandoned"] += 1
-                continue
-
-            # ── c. PR 사전 검사 (D7) ──────────────────────────────────────
-            # ── c. Pre-merge guard (D7) ───────────────────────────────────
-            pr_data = await _get_pr_data(token, row.repo_full_name, row.pr_number)
-
-            if pr_data is None:
-                # PR 데이터 조회 실패 — 30초 후 재시도
-                # PR data fetch failed — retry after 30s
-                _now_naive = now.replace(tzinfo=None) + timedelta(seconds=30)
-                merge_retry_repo.release_claim(
-                    db,
-                    row.id,
-                    next_retry_at=_now_naive,
-                    last_failure_reason="pr_fetch_failed",
-                )
-                counts["released"] += 1
-                continue
-
-            # 이미 머지된 PR — 성공으로 처리
-            # PR already merged — treat as success
-            if pr_data.get("merged") is True:
-                merge_retry_repo.mark_succeeded(db, row.id, reason="already_merged")
-                counts["succeeded"] += 1
-                continue
-
-            # SHA drift 검사 — force-push 감지
-            # SHA drift check — detects force-push
-            head_sha = pr_data.get("head", {}).get("sha", "")
-            if head_sha and head_sha != row.commit_sha:
-                merge_retry_repo.mark_abandoned(db, row.id, reason="sha_drift")
-                counts["abandoned"] += 1
-                continue
-
-            # ── d. merge_pr 호출 ──────────────────────────────────────────
-            # ── d. Call merge_pr ──────────────────────────────────────────
-            ok, reason, _ = await merge_pr(
-                token,
-                row.repo_full_name,
-                row.pr_number,
-                expected_sha=row.commit_sha,
-            )
-
-            # ── e. 성공 처리 ──────────────────────────────────────────────
-            # ── e. Handle success ─────────────────────────────────────────
-            if ok:
-                log_merge_attempt(
-                    db,
-                    analysis_id=row.analysis_id,
-                    repo_name=row.repo_full_name,
-                    pr_number=row.pr_number,
-                    score=row.score,
-                    threshold=row.threshold_at_enqueue,
-                    success=True,
-                    reason=None,
-                )
-                merge_retry_repo.mark_succeeded(db, row.id)
-                await _notify_merge_succeeded(row, cfg)
-                counts["succeeded"] += 1
-                continue
-
-            # ── f. 실패 분류 ──────────────────────────────────────────────
-            # ── f. Classify failure ───────────────────────────────────────
-            reason_tag = parse_reason_tag(reason)
-            # F1: pr_data 에 이미 base.ref 가 있으므로 추가 호출 없이 활용
-            # F1: pr_data already contains base.ref — reuse without extra API call
-            base_ref = pr_data.get("base", {}).get("ref", "main")
-            ci_status = await _get_ci_status_safe(
-                token, row.repo_full_name, row.commit_sha, base_ref=base_ref,
-            )
-
-            expired = is_expired(row, now=now, max_age_hours=settings.merge_retry_max_age_hours)
-
-            if (not should_retry(reason_tag, ci_status)) or expired:
-                # 재시도 불가 또는 만료 → terminal 처리
-                # Non-retryable or expired → terminal
-                log_merge_attempt(
-                    db,
-                    analysis_id=row.analysis_id,
-                    repo_name=row.repo_full_name,
-                    pr_number=row.pr_number,
-                    score=row.score,
-                    threshold=row.threshold_at_enqueue,
-                    success=False,
-                    reason=reason,
-                )
-                merge_retry_repo.mark_terminal(db, row.id, reason=reason_tag)
-                await _notify_merge_terminal(row, cfg, reason, reason_tag)
-                if cfg.auto_merge_issue_on_failure:
-                    await _create_failure_issue_safe(token, row, cfg, reason, reason_tag)
-                counts["terminal"] += 1
-                continue
-
-            # ── g. 일시적 실패 — 백오프 후 재시도 대기로 복귀 ────────────
-            # ── g. Transient failure — bump and release with backoff ──────
-            next_retry_at = compute_next_retry_at(
-                row.attempts_count,
-                now=now,
-                initial_backoff=settings.merge_retry_initial_backoff_seconds,
-                max_backoff=settings.merge_retry_max_backoff_seconds,
-            )
-            merge_retry_repo.release_claim(
-                db,
-                row.id,
-                next_retry_at=next_retry_at.replace(tzinfo=None),  # naive UTC for DB
-                last_failure_reason=reason_tag,
-                last_detail_message=reason,
-            )
-            counts["released"] += 1
-
+            await _process_single_retry(db, row, now, counts)
         except (httpx.HTTPError, SQLAlchemyError) as exc:
             # 인프라 에러 — 클레임 해제, 짧은 백오프, attempts_count 미증가
             # Infra error — release claim, short backoff, do NOT bump attempts_count
@@ -236,6 +95,123 @@ async def process_pending_retries(  # pylint: disable=too-many-locals,too-many-s
             counts["released"] += 1
 
     return counts
+
+
+async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-return-statements
+    db: Session,
+    row,
+    now: datetime,
+    counts: dict[str, int],
+) -> None:
+    """단일 retry row 처리 — 사이클 93 PR-B (S3776 26→<15 분리).
+
+    Process a single retry row (Cycle 93 PR-B — extracted from process_pending_retries).
+    counts dict 직접 mutate. 호출자 (process_pending_retries) 가 try/except wrap.
+    """
+    # ── a. GitHub 토큰 조회 ────────────────────────────────────────
+    token = _resolve_github_token(db, row.repo_full_name)
+    if token is None:
+        # 토큰 없음 — 30초 후 재시도 대기로 복귀
+        # No token — release back to retry queue after 30s
+        _now_naive = now.replace(tzinfo=None) + timedelta(seconds=30)
+        merge_retry_repo.release_claim(
+            db, row.id, next_retry_at=_now_naive, last_failure_reason="no_token",
+        )
+        counts["released"] += 1
+        return
+
+    # ── b-0. 최대 시도 횟수 초과 ───────────────────────────────────
+    if row.attempts_count >= row.max_attempts:
+        merge_retry_repo.mark_abandoned(db, row.id, reason="max_attempts_exceeded")
+        counts["abandoned"] += 1
+        return
+
+    # ── b. 설정 재확인 (D5) ────────────────────────────────────────
+    cfg = get_repo_config(db, row.repo_full_name)
+    if not (cfg.auto_merge and row.score >= cfg.merge_threshold):
+        # 설정이 변경되어 자동 머지 조건 미충족 → 포기
+        # Config changed so auto-merge condition no longer met → abandon
+        merge_retry_repo.mark_abandoned(db, row.id, reason="config_changed")
+        await _notify_config_changed(row, cfg)
+        counts["abandoned"] += 1
+        return
+
+    # ── c. PR 사전 검사 (D7) ──────────────────────────────────────
+    pr_data = await _get_pr_data(token, row.repo_full_name, row.pr_number)
+    if pr_data is None:
+        _now_naive = now.replace(tzinfo=None) + timedelta(seconds=30)
+        merge_retry_repo.release_claim(
+            db, row.id, next_retry_at=_now_naive, last_failure_reason="pr_fetch_failed",
+        )
+        counts["released"] += 1
+        return
+
+    # 이미 머지된 PR — 성공
+    if pr_data.get("merged") is True:
+        merge_retry_repo.mark_succeeded(db, row.id, reason="already_merged")
+        counts["succeeded"] += 1
+        return
+
+    # SHA drift — force-push 감지
+    head_sha = pr_data.get("head", {}).get("sha", "")
+    if head_sha and head_sha != row.commit_sha:
+        merge_retry_repo.mark_abandoned(db, row.id, reason="sha_drift")
+        counts["abandoned"] += 1
+        return
+
+    # ── d. merge_pr 호출 ──────────────────────────────────────────
+    ok, reason, _ = await merge_pr(
+        token, row.repo_full_name, row.pr_number, expected_sha=row.commit_sha,
+    )
+
+    # ── e. 성공 처리 ──────────────────────────────────────────────
+    if ok:
+        log_merge_attempt(
+            db, analysis_id=row.analysis_id, repo_name=row.repo_full_name,
+            pr_number=row.pr_number, score=row.score,
+            threshold=row.threshold_at_enqueue, success=True, reason=None,
+        )
+        merge_retry_repo.mark_succeeded(db, row.id)
+        await _notify_merge_succeeded(row, cfg)
+        counts["succeeded"] += 1
+        return
+
+    # ── f. 실패 분류 ──────────────────────────────────────────────
+    reason_tag = parse_reason_tag(reason)
+    # F1: pr_data 에 이미 base.ref 가 있으므로 추가 호출 없이 활용
+    base_ref = pr_data.get("base", {}).get("ref", "main")
+    ci_status = await _get_ci_status_safe(
+        token, row.repo_full_name, row.commit_sha, base_ref=base_ref,
+    )
+    expired = is_expired(row, now=now, max_age_hours=settings.merge_retry_max_age_hours)
+
+    if (not should_retry(reason_tag, ci_status)) or expired:
+        # 재시도 불가 또는 만료 → terminal
+        log_merge_attempt(
+            db, analysis_id=row.analysis_id, repo_name=row.repo_full_name,
+            pr_number=row.pr_number, score=row.score,
+            threshold=row.threshold_at_enqueue, success=False, reason=reason,
+        )
+        merge_retry_repo.mark_terminal(db, row.id, reason=reason_tag)
+        await _notify_merge_terminal(row, cfg, reason, reason_tag)
+        if cfg.auto_merge_issue_on_failure:
+            await _create_failure_issue_safe(token, row, cfg, reason, reason_tag)
+        counts["terminal"] += 1
+        return
+
+    # ── g. 일시적 실패 — 백오프 후 재시도 대기로 복귀 ────────────
+    next_retry_at = compute_next_retry_at(
+        row.attempts_count,
+        now=now,
+        initial_backoff=settings.merge_retry_initial_backoff_seconds,
+        max_backoff=settings.merge_retry_max_backoff_seconds,
+    )
+    merge_retry_repo.release_claim(
+        db, row.id,
+        next_retry_at=next_retry_at.replace(tzinfo=None),  # naive UTC for DB
+        last_failure_reason=reason_tag, last_detail_message=reason,
+    )
+    counts["released"] += 1
 
 
 # ---------------------------------------------------------------------------

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -266,12 +266,64 @@ async def _regate_pr_if_needed(
         )
 
 
+async def _race_recover_existing(
+    db: Session,
+    params: _AnalysisSaveParams,
+    existing,
+):
+    """기존 Analysis 발견 시 race-recovery 분기 — 사이클 93 PR-B (S3776 분리).
+
+    Race-recovery branch when existing Analysis is found (Cycle 93 PR-B — S3776 split).
+    PR 이벤트가 push 이벤트와 동시 도착해 dedup 통과 시 pr_number 보정 + gate 재실행.
+    """
+    try:
+        repo_config = get_repo_config(db, params.repo_name)
+    except (SQLAlchemyError, KeyError):
+        repo_config = None
+
+    if params.pr_number is None or existing.pr_number is not None:
+        return repo_config
+
+    try:
+        existing.pr_number = params.pr_number
+        db.commit()
+        await run_gate_check(
+            repo_name=params.repo_name,
+            pr_number=params.pr_number,
+            analysis_id=existing.id,
+            result=existing.result,
+            github_token=params.owner_token,
+            db=db,
+            config=repo_config,
+        )
+        logger.info(
+            "Race-recovered: PR #%d re-gated on concurrent existing Analysis %d (sha=%s)",
+            params.pr_number, existing.id, params.commit_sha[:8],
+        )
+    except SQLAlchemyError:
+        # Phase H PR-6A: logger.exception 으로 stack trace 보존
+        logger.exception(
+            "Race-recovery pr_number commit failed (sha=%s, pr=#%d)",
+            params.commit_sha, params.pr_number,
+        )
+        db.rollback()
+    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        # logger.exception 으로 stack trace 보존 — Railway 로그에서 진짜 원인 추적
+        # logger.exception preserves the stack trace for Railway log triage
+        logger.exception(
+            "Race-recovery gate check failed (pr=#%d, sha=%s)",
+            params.pr_number, params.commit_sha[:8],
+        )
+    return repo_config
+
+
 async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
     """Analysis를 DB에 저장하고 Gate Engine을 실행한다.
 
     Returns:
         (repo_config, analysis_id, result_dict) 튜플.
         중복 커밋이면 (repo_config_or_None, None, None).
+    사이클 93 PR-B: race-recovery 분기 = `_race_recover_existing` 분리 (S3776 20→<15).
     """
     repo = repository_repo.find_by_full_name(db, params.repo_name)
     if repo is None:
@@ -285,51 +337,7 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
     existing = analysis_repo.find_by_sha(db, params.commit_sha, repo.id)
     if existing is not None:
         logger.info("Commit %s already saved (concurrent insert detected), skipping", params.commit_sha)
-        # Phase 2 race fix (PR #105 silent skip 사고 대응):
-        # push 이벤트가 먼저 통과해 pr_number=None 으로 저장되고, 그 사이 이 PR
-        # 이벤트가 도착하면 1차 dedup → _regate_pr_if_needed 경로로 진입한다.
-        # 그러나 두 이벤트가 거의 동시에 도착해 둘 다 1차 dedup 통과 → 분석을
-        # 실행 → 2차 dedup 에서 PR 이벤트만 여기로 진입할 수 있다. 이때 gate 가
-        # 실행되지 않으면 PR #105 처럼 코멘트/머지 모두 누락된다 (silent skip).
-        # 보정: pr_number 가 비어있는 기존 Analysis 에 현재 PR 번호 부여 후 gate
-        # 재실행. _regate_pr_if_needed 와 동일한 의미론.
-        # Race fix: when an existing Analysis lacks pr_number and this is a PR event,
-        # patch pr_number then re-run the gate (matches `_regate_pr_if_needed`).
-        try:
-            repo_config = get_repo_config(db, params.repo_name)
-        except (SQLAlchemyError, KeyError):
-            repo_config = None
-        if params.pr_number is not None and existing.pr_number is None:
-            try:
-                existing.pr_number = params.pr_number
-                db.commit()
-                await run_gate_check(
-                    repo_name=params.repo_name,
-                    pr_number=params.pr_number,
-                    analysis_id=existing.id,
-                    result=existing.result,
-                    github_token=params.owner_token,
-                    db=db,
-                    config=repo_config,
-                )
-                logger.info(
-                    "Race-recovered: PR #%d re-gated on concurrent existing Analysis %d (sha=%s)",
-                    params.pr_number, existing.id, params.commit_sha[:8],
-                )
-            except SQLAlchemyError:
-                # Phase H PR-6A: logger.exception 으로 stack trace 보존
-                logger.exception(
-                    "Race-recovery pr_number commit failed (sha=%s, pr=#%d)",
-                    params.commit_sha, params.pr_number,
-                )
-                db.rollback()
-            except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-                # logger.exception 으로 stack trace 보존 — Railway 로그에서 진짜 원인 추적 가능
-                # logger.exception preserves the stack trace for Railway log triage
-                logger.exception(
-                    "Race-recovery gate check failed (pr=#%d, sha=%s)",
-                    params.pr_number, params.commit_sha[:8],
-                )
+        repo_config = await _race_recover_existing(db, params, existing)
         return repo_config, None, None
     result_dict = build_analysis_result_dict(
         params.ai_review, params.score_result, params.analysis_results,


### PR DESCRIPTION
SonarCloud 89 open issues 중 4 CRITICAL (S3776 Cognitive Complexity) 우선 cleanup PR. 사용자 결정 = "이번 사이클 — 4 CRITICAL S3776 만 우선 cleanup PR 권장".

## 변경 요약 (4 파일, +235/-228 net 양수 = 헬퍼 함수 docstring 분량)

### 1. src/middleware/locale.py:125 (24→<15)
- _parse_q_weight(seg) — RFC 7231 q-weight 단일 segment 파싱 분리
- _parse_lang_items(header_str) — Accept-Language 본문 → tuple list 분리
- _parse_accept_language = header 검색 + 헬퍼 호출 + sort = 단순화

### 2. src/gate/engine.py:492 (16→<15)
- _resolve_legacy_merge_state(ok, outcome) — state/enabled_at 결정 로직 분리
- _run_auto_merge_legacy = 한 줄 호출로 단순화

### 3. src/services/merge_retry_service.py:41 (26→<15)
- _process_single_retry(db, row, now, counts) — 단일 row 처리 (a~g 7 단계) 분리
- process_pending_retries = claim + iterate + delegate (try/except wrap 보존)

### 4. src/worker/pipeline.py:269 (20→<15)
- _race_recover_existing(db, params, existing) — race-recovery 분기 (PR/push 동시 도착 시 pr_number 보정 + gate 재실행) 분리
- _save_and_gate = 멱등성 검사 + 헬퍼 위임으로 단순화

## 정합 검증 (path-scoped rules)
- .claude/rules/i18n.md (locale.py) — 5단계 locale 감지 / RFC 7231 q-weight 동작 보존 ✅
- .claude/rules/api.md (engine.py) — keyword-only 강제 / MergeAttempt 관측 보존 ✅
- .claude/rules/pipeline.md (pipeline.py + merge_retry.py) — 멱등성 / process_pending_retries 시그니처 / build_analysis_result_dict 보존 ✅
- 정책 16 가독성 우선 정합 — 함수 내부 복잡도 분리 (사용처 1이라도 가독성 분리 OK)

## 검증
- make test-fast: 2694 passed (변동 없음 — 회귀 0) ✅
- make lint: 9.95/10 (변동 없음) ✅
- integration (merge_retry / pipeline / locale / gate): 33 passed ✅

## 본 PR 범위 외 (다음 사이클 follow-up)
- 60 MAJOR issues (S8415 Undocumented HTTPException 14 + S1172 Unused param 12 + Web/CSS 22 + S125 commented 5 + S1192 dup 3) — 별도 사이클
- 21 MINOR issues (S7503 async/no-await 5 + S5713 redundant catch 4 + JS modernization) — 별도 사이클
- 추정 잔여 부채 ~9시간

## 자율 판단 보고 (정책 3 ⚠️)
- 헬퍼 함수 시그니처 자율 결정 (cross-verify 미디스패치):
  - _parse_q_weight: staticmethod (사용처 1 — _parse_lang_items 만)
  - _parse_lang_items: classmethod (cls._parse_q_weight 호출)
  - _resolve_legacy_merge_state: 모듈 함수 (state/datetime tuple 반환)
  - _process_single_retry: async 모듈 함수 (counts mutate 의도)
  - _race_recover_existing: async 모듈 함수 (repo_config 반환)
- 분리 위험 영역 (정책 17 4번 default 페어): 4 함수 모두 hot-path — 시그니처 변경 X (헬퍼 추가만, 외부 호출 영향 0). 회귀 위험 저.

🔍 **Codex 검증 의뢰 의무** (정책 18 mutual 첫 적용 PR 후 두 번째 적용) — Codex 환경에서 본 PR 검토 후 동의/이의 회신 부탁드립니다. 검토 영역:
- 4 헬퍼 함수의 cognitive complexity 실 < 15 검증
- 시그니처 보존 (외부 호출 영향 0)
- async/sync 일관성 (3 헬퍼 async / 2 sync)
- 의도된 동작 보존 (race-recovery early return / state classification / RFC 7231 정확성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 변경 요약
<!-- 무엇을, 왜 변경했는지 1~3줄로 -->


## 체크리스트

### 기본
- [ ] `make test` 통과 (0 failed)
- [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)

### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
- [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가

### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
- [ ] `alembic/versions/` 마이그레이션 파일 생성 (`make revision m="설명"`)
- [ ] `server_default` 포함 여부 확인 (`nullable=False` 컬럼은 필수)
- [ ] `make migrate` 왕복 검증 (`downgrade -1` → `upgrade head`)
- [ ] `test_migration_completeness` CI 통과 확인

### 수치 변경 시 (없으면 이 섹션 전체 삭제)
- [ ] `docs/STATE.md` 헤더 수치 갱신
- [ ] `README.md` + `README.ko.md` 배지 갱신
