### PR TITLE
fix(cycle-93-residual): E2E UI 2건 skip + _reset_repo_config 헬퍼 (사이클 94 mutual 첫 NG→OK)

### DIFF
--- a/e2e/test_settings.py
+++ b/e2e/test_settings.py
@@ -1,7 +1,28 @@
 """E2E — 설정 페이지 테스트."""
+import os
+
 import pytest
 
 SETTINGS_URL = "/repos/owner%2Ftestrepo/settings"
+SETTINGS_REPO = "owner/testrepo"
+
+
+def _reset_repo_config(repo_full_name=SETTINGS_REPO):
+    """공유 E2E DB의 리포 설정을 기본 상태로 되돌린다."""
+    from sqlalchemy import create_engine, text
+
+    database_url = os.environ.get("DATABASE_URL", "")
+    assert database_url.startswith("sqlite:///"), "E2E DATABASE_URL must be sqlite"
+
+    engine = create_engine(database_url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                text("DELETE FROM repo_configs WHERE repo_full_name=:repo_full_name"),
+                {"repo_full_name": repo_full_name},
+            )
+    finally:
+        engine.dispose()
 
 
 def _expand_advanced(page):
@@ -501,20 +522,12 @@ def test_save_error_forces_advanced_mode(seeded_page, base_url):
     assert mode == "advanced", f"save_error=1 시 data-settings-mode='advanced' 기대, 실제 {mode!r}"
 
 
-@pytest.mark.skip(
-    reason=(
-        "Test ordering 트랩 — 단독 실행 PASS / 전체 실행 fail. 원인: 직전 test "
-        "(test_gate_mode_persists_after_save L313 등) 가 RepoConfig.approve_mode 를 'auto'로 저장 후 "
-        "본 test 진입 시 `_detect_initial_mode` = 비-default 1건 → 'advanced' 반환 (default 위반). "
-        "해결 영역 = E2E DB 격리 fixture 신설 (사이클 94+ 사용자 사전 확인 의무 — High tier). "
-        "사이클 93 학습 — seeded_page fixture 가 새 browser context 만 격리하고 server DB 공유 한계."
-    )
-)
 def test_save_success_keeps_simple_mode(seeded_page, base_url):
     """?saved=1 (성공) 쿼리로 접근 시 모드는 유지 (강제 전환 없음).
 
     Phase 2A: localStorage 또는 서버 신호 또는 simple default — saved 는 강제 전환 사유 아님.
     """
+    _reset_repo_config()
     seeded_page.goto(f"{base_url}{SETTINGS_URL}?saved=1")
     seeded_page.wait_for_timeout(300)
     mode = seeded_page.evaluate(

--- a/e2e/test_settings.py
+++ b/e2e/test_settings.py
@@ -1,4 +1,5 @@
 """E2E — 설정 페이지 테스트."""
+import pytest
 
 SETTINGS_URL = "/repos/owner%2Ftestrepo/settings"
 
@@ -349,8 +350,17 @@ def test_single_column_layout_on_mobile(seeded_page, base_url):
     assert columns.count(" ") == 0 or columns.strip().split() == [columns.strip().split()[0]]
 
 
+@pytest.mark.skip(
+    reason=(
+        "사이클 81/82/84 settings.html 진화 후 모든 .settings-grid 인스턴스 = single-child → "
+        "P0-1 default `:has(> .s-card:only-child) { grid-template-columns: 1fr; }` 의도된 1열 영역. "
+        "본 test의 '1024px 데스크탑 = 2열' 가정 무효화 — 사이클 93 학습. "
+        "`querySelector('.settings-grid')` 첫번째 인스턴스 (L664 PR 동작 규칙) = single-child → 1열 의도. "
+        "다수 자식 grid 영역 부재 = 본 검증 영역 미존재. 재활성화 시점 = 다수 자식 grid 인스턴스 도입 시 (UX 결정)."
+    )
+)
 def test_two_column_layout_on_desktop(seeded_page, base_url):
-    """1024px 뷰포트에서 설정 그리드가 2컬럼이어야 한다."""
+    """1024px 뷰포트에서 설정 그리드가 2컬럼이어야 한다 (사이클 81/82/84 진화로 미적용)."""
     seeded_page.set_viewport_size({"width": 1024, "height": 768})
     seeded_page.goto(f"{base_url}{SETTINGS_URL}")
     columns = seeded_page.evaluate(
@@ -491,6 +501,15 @@ def test_save_error_forces_advanced_mode(seeded_page, base_url):
     assert mode == "advanced", f"save_error=1 시 data-settings-mode='advanced' 기대, 실제 {mode!r}"
 
 
+@pytest.mark.skip(
+    reason=(
+        "Test ordering 트랩 — 단독 실행 PASS / 전체 실행 fail. 원인: 직전 test "
+        "(test_gate_mode_persists_after_save L313 등) 가 RepoConfig.approve_mode 를 'auto'로 저장 후 "
+        "본 test 진입 시 `_detect_initial_mode` = 비-default 1건 → 'advanced' 반환 (default 위반). "
+        "해결 영역 = E2E DB 격리 fixture 신설 (사이클 94+ 사용자 사전 확인 의무 — High tier). "
+        "사이클 93 학습 — seeded_page fixture 가 새 browser context 만 격리하고 server DB 공유 한계."
+    )
+)
 def test_save_success_keeps_simple_mode(seeded_page, base_url):
     """?saved=1 (성공) 쿼리로 접근 시 모드는 유지 (강제 전환 없음).
 


### PR DESCRIPTION
## Summary

사이클 93 잔여 작업 (E2E UI 2건) 진행 + **사이클 94 mutual (정책 18) 첫 NG → Codex 코드 수정 → OK 운영 사례**.
`chore/cycle-93-residual-tasks` (529c0a5) cherry-pick → main 위 fork → Codex IDE Extension review → fix-up.

## 변경 (e2e/test_settings.py 만)

- **commit 9500c03**: `test_two_column_layout_on_desktop` skip (사이클 81/82/84 single-child grid — UX 결정 영역) + `test_save_success_keeps_simple_mode` skip (test ordering 트랩 — RepoConfig.approve_mode leak)
- **commit 65b4870 (Codex fix-up)**: `_reset_repo_config()` 헬퍼 신설 (sqlite assert 가드 + sqlalchemy 직접 SQL — ORM lazy import 트랩 회피) → `test_save_success` skip 제거 + `_reset_repo_config()` 호출로 ordering 트랩 차단

## mutual 흐름 (정책 18 사이클 94)

1. Claude cherry-pick → Codex 검증 의뢰 (사용자 IDE Extension)
2. **Codex review NG** → `_reset_repo_config()` 헬퍼로 직접 차단 권장 → IDE Extension 통해 코드 수정
3. 사용자 OK 회신 → Claude 자가 검증 (table/컬럼/sqlite 패턴 실측 정합) → push (양방향 OK)

## Test plan

- [x] flake8/pylint 10.00/10
- [x] table/컬럼 실측 정합 (`src/models/repo_config.py:11, 13`)
- [x] sqlite 패턴 정합 (`e2e/conftest.py:103, 160`)
- [ ] **🔍 사용자 검증 필요 (정책 2)**: `make test-e2e` — `test_save_success_keeps_simple_mode` PASS (헬퍼가 ordering 트랩 차단) + `test_two_column_layout_on_desktop` SKIP (사유 표시) + 다른 E2E 회귀 0
- [ ] **시각 검증 미해당** — UI/시각 변경 0 (정책 11 8 조합 체크리스트 미적용)

## 자율 판단 보고 (정책 3 ⚠️)

- ⚠️ **E2E DB 격리 fixture 영역 도입** — 정책 17 4번 "분리 위험 영역 사용자 사전 확인 의무" High tier. **Codex 코드 수정 + 사용자 OK 회신** 으로 사전 확인 충족 (Claude 단독 진행 X)
- ⚠️ **단순 헬퍼 (사용처 1)** — 정책 16 단순화 정합 (5줄 sqlalchemy 직접 SQL < ORM session/import overhead). 사용처 ≥ 3 도달 시 conftest.py 추출 결정
- ⚠️ **test_two_column skip 유지** — UX 결정 영역 (Codex 도 단정 안 함, 다수 자식 grid 도입 시 재활성화)
- ⚠️ **사이클 94 mutual 첫 NG → 코드 수정 → OK 첫 사례** — 정책 18 ROI 첫 검증 (5+1 cross-verify ↔ mutual 2-layer 격리 효과)

## 잔여 영역 (본 PR 머지 후)

- 원본 brunch `chore/cycle-93-residual-tasks` (529c0a5) = stale → 정리 대상
- 누적 stale 9 브랜치 일괄 삭제 옵션 (정책 12 사용자 사전 승인 영역 — 별도 진행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)