### PR TITLE
chore(devcontainer): runArgs --privileged 추가 — bwrap user namespace 활성 (Codex sandbox 영역 fix)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "name": "SCAManager Dev",
   "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "runArgs": ["--privileged"],
   "postCreateCommand": "pip install -r requirements-dev.txt",
   "forwardPorts": [8000],
   "portsAttributes": {


### PR DESCRIPTION
## Summary

Codex CLI sandbox (bubblewrap) 의 user namespace 제약 해결 — devcontainer `runArgs: ["--privileged"]` 추가. `/codex:review`, `/codex:adversarial-review`, `/codex:rescue` 모두 sandbox namespace 오류로 실패 중 (PR #373 + Step 2-B mutual 영역 학습).

## 진단

- Codex bundled bwrap 발견 (`.../codex-resources/bwrap`)
- container `CapEff = 0x0`, Seccomp mode 2 활성
- `bwrap: No permissions to create a new namespace` — Docker container 권한 영역 부재

## 변경 (`.devcontainer/devcontainer.json` +1)

```json
"runArgs": ["--privileged"]
```

## 사용자 결정 (옵션 🅒 — 정책 17 4번 High tier 사전 확인 충족)

| 옵션 | runArgs | 권한 영역 ↑ | 보안 영역 ↓ |
|------|---------|------------|------------|
| 🅐 seccomp 만 | `--security-opt=seccomp=unconfined` | 시스템 콜 필터 | 약간 |
| 🅑 SYS_ADMIN + seccomp | `--cap-add=SYS_ADMIN, --security-opt=seccomp=unconfined` | user namespace + seccomp | 중간 |
| 🅒 ★ **--privileged** | 모든 capability + device | 모든 영역 | 큰 영역 (사용자 명시) |

사용자 발화: *"sandbox영역의 경우 수정이 필요하면 수정을 해야 하는것이 원칙입니다."* — sandbox 환경 영역 수정 default + 옵션 🅒 명시 결정.

## rebuild 의무 (본 PR 머지 후 사용자 의무)

1. VS Code Command Palette → **"Dev Containers: Rebuild Container"** (5~10분)
2. 환경 재진입
3. `feat/ui-illustrations-step2b` checkout → `/codex:review` 재시도 (mutual 검증 재개)

## 보존 영역 검증

- `feat/ui-illustrations-step2b` 브랜치 commit (`351cba2`) = `.git/` host filesystem mount → 보존
- `/workspaces/SCAManager` working tree = host bind mount → rebuild 영향 0
- `.env` (host bind mount) → 보존
- `~/` (container 영역) = rebuild 시 손실 가능 — Codex `~/.codex/auth.json` 재 login 가능성 + `~/.bashrc` 등

## 자율 판단 보고 (정책 3 ⚠️)

- ⚠️ **`--privileged` = 모든 host device + capability 접근 영역**. 사용자 옵션 🅒 명시 결정 + 정책 17 1번 안정성 우선 + sandbox 영역 fix 원칙 페어.
- ⚠️ **mutual 검증 면제** — 본 PR = 사용자 직접 결정 영역 (정책 18 예외 4종 중 4번). devcontainer 환경 영역 + 1줄 변경 + 옵션 표 명시 결정 = mutual 의도 충족.
- ⚠️ **Codex sandbox 정상 작동 검증** = rebuild 후 첫 `/codex:review` 시 검증 (본 PR 머지 후 follow-up — Step 2-B mutual 페어).
- ⚠️ **잔여 작업 보존** — Step 2-B 브랜치 (`feat/ui-illustrations-step2b`, commit `351cba2`) push 안 됐지만 git history 영역 보존. rebuild 후 checkout 가능.

## Test plan

- [x] JSON syntax 검증 (`python -c "import json; json.load(open(...))"` ✅)
- [x] git diff = +1 줄 (`runArgs: ["--privileged"]`)
- [ ] **🔍 사용자 검증 필요 (정책 2)**: rebuild 후 `bwrap --version` 정상 + `/codex:review` 첫 실행 시 sandbox 영역 정상 작동
- [ ] **rebuild 후 회복 영역**: `~/.codex/auth.json` (Codex 인증) + `~/.bashrc` (shell 설정) 재 setup 의무 영역

## 후속 영역 (rebuild 후)

- `feat/ui-illustrations-step2b` mutual 검증 재시도 (`/codex:review`)
- 정책 18 mutual 정상 흐름 회복 (사이클 94+ 운영 영역 정합)
- 정책 18 환경 통합 영역 회고 (시나리오 A/B/C/D 운영 결정 — 사이클 95+ 영역)

🤖 Generated with [Claude Code](https://claude.com/claude-code)