### PR TITLE
feat(ui): Tailwind v4 빌드 파이프라인 신설 — Hybrid: 레이아웃 유틸리티 + CSS var 4-theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@ __pycache__/
 *.pyd
 .Python
 *.egg-info/
-dist/
-build/
+/dist/
+/build/
 *.egg
 
 # Virtual environments
@@ -52,3 +52,8 @@ Thumbs.db
 
 # superpowers plan/spec working dir (완료된 plan은 docs/_archive/ 로 수동 이동)
 docs/superpowers/
+
+# Node.js / Tailwind v4 빌드 (개발 의존성 + 빌드 결과물)
+# Node.js / Tailwind v4 build (dev dependencies + build artifacts)
+node_modules/
+src/static/css/dist/tailwind.css

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,25 @@
-.PHONY: install test test-v test-fast test-slow test-cov test-file test-isolated lint gate run migrate revision review install-playwright test-e2e test-e2e-headed
+.PHONY: install test test-v test-fast test-slow test-cov test-file test-isolated lint lint-strict gate run migrate revision review install-playwright test-e2e test-e2e-headed css-install css-build css-dev
 
-# 의존성 설치 (개발 환경 — 테스트/E2E 포함)
-# Install dependencies (development environment — includes tests/E2E).
+# 의존성 설치 (개발 환경 — 테스트/E2E + CSS 빌드 포함)
+# Install dependencies (development environment — includes tests/E2E + CSS build).
 install:
 	pip install -r requirements-dev.txt
+	npm install
+
+# CSS 빌드 (Tailwind v4 — 프로덕션 minified)
+# Build Tailwind v4 CSS (production minified).
+css-build:
+	npm run build
+
+# CSS 감시 빌드 (Tailwind v4 — 개발 watch 모드)
+# Watch and rebuild Tailwind v4 CSS (development watch mode).
+css-dev:
+	npm run dev:css
+
+# Node.js 의존성만 설치
+# Install Node.js dependencies only.
+css-install:
+	npm install
 
 # 테스트 (빠른 실행, 전체)
 # Run all tests (quick output).

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -5,3 +5,11 @@ aptPkgs = ["shellcheck", "cppcheck", "ruby-full", "golang-go", "build-essential"
 cmds = [
   "curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs"
 ]
+
+# Tailwind v4 CSS 빌드 파이프라인 (Hybrid: 레이아웃 유틸리티 + CSS var 4-theme)
+# Tailwind v4 CSS build pipeline (Hybrid: layout utilities + CSS var 4-theme)
+[phases.install]
+cmds = ["npm install"]
+
+[phases.build]
+cmds = ["npm run build"]

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -9,7 +9,10 @@ cmds = [
 # Tailwind v4 CSS 빌드 파이프라인 (Hybrid: 레이아웃 유틸리티 + CSS var 4-theme)
 # Tailwind v4 CSS build pipeline (Hybrid: layout utilities + CSS var 4-theme)
 [phases.install]
-cmds = ["npm install"]
+cmds = [
+  "pip install -r requirements.txt",
+  "npm ci"
+]
 
 [phases.build]
 cmds = ["npm run build"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1096 @@
+{
+  "name": "scamanager-ui",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "scamanager-ui",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@tailwindcss/cli": "^4.1.0",
+        "tailwindcss": "^4.1.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@tailwindcss/cli": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.3.0.tgz",
+      "integrity": "sha512-X9kdlqyMopO9fewbgHsEeuy31YzMHbdZ9VsKt004tB+mxSg1CNbyhZYCzvhciN0AM4R4b5lvIprPjtNq7iQxpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@parcel/watcher": "^2.5.1",
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "enhanced-resolve": "^5.21.0",
+        "mri": "^1.2.0",
+        "picocolors": "^1.1.1",
+        "tailwindcss": "4.3.0"
+      },
+      "bin": {
+        "tailwindcss": "dist/index.mjs"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.2.tgz",
+      "integrity": "sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "scamanager-ui",
+  "version": "1.0.0",
+  "private": true,
+  "description": "SCAManager UI build — Tailwind v4 CSS pipeline",
+  "scripts": {
+    "build": "tailwindcss -i ./src/static/css/main.css -o ./src/static/css/dist/tailwind.css --minify",
+    "dev:css": "tailwindcss -i ./src/static/css/main.css -o ./src/static/css/dist/tailwind.css --watch"
+  },
+  "devDependencies": {
+    "@tailwindcss/cli": "^4.1.0",
+    "tailwindcss": "^4.1.0"
+  }
+}

--- a/src/static/css/main.css
+++ b/src/static/css/main.css
@@ -1,0 +1,14 @@
+/* SCAManager Tailwind v4 entry — Hybrid: layout utilities + CSS var theming */
+
+@import "tailwindcss";
+
+/* Explicit source scan: Jinja2 templates + static JS */
+@source "../../templates";
+@source "../js";
+
+/* 4-theme custom variants (preserves CSS custom property theming system)
+ * Usage: dark:bg-[var(--bg-card)] light:text-[var(--text-1)] etc. */
+@custom-variant dark (&:where([data-theme=dark], [data-theme=dark] *));
+@custom-variant light (&:where([data-theme=light], [data-theme=light] *));
+@custom-variant glass (&:where([data-theme=glass], [data-theme=glass] *));
+@custom-variant claude (&:where([data-theme=claude-dark], [data-theme=claude-dark] *));

--- a/src/static/mockup-polar.html
+++ b/src/static/mockup-polar.html
@@ -1,0 +1,829 @@
+<!DOCTYPE html>
+<html lang="ko" data-theme="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SCAManager — Polar/Linear 리디자인 목업 (Phase 0 시각 합의)</title>
+  <link rel="preconnect" href="https://cdn.jsdelivr.net">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/pretendard@1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css">
+  <style>
+    /* ── Design tokens — Polar/Linear 팔레트 ── */
+    :root {
+      --font: 'Pretendard Variable', Pretendard, system-ui, -apple-system, sans-serif;
+
+      /* 간격 */
+      --s1: 4px;  --s2: 8px;  --s3: 12px; --s4: 16px;
+      --s5: 20px; --s6: 24px; --s7: 32px; --s8: 48px; --s9: 64px;
+
+      /* 폰트 */
+      --xs: 11px; --sm: 13px; --md: 14px; --base: 15px;
+      --lg: 17px; --xl: 20px; --2xl: 24px; --3xl: 30px;
+
+      /* 반경 */
+      --r-sm: 6px; --r-md: 10px; --r-lg: 14px; --r-xl: 20px; --r-pill: 999px;
+
+      /* 모션 */
+      --dur: 180ms; --ease: cubic-bezier(0.16, 1, 0.3, 1);
+
+      /* 등급 색 */
+      --grade-a: #4ade80; --grade-b: #60a5fa; --grade-c: #fbbf24;
+      --grade-d: #fb923c; --grade-f: #f87171;
+    }
+
+    /* ── 다크 테마 (Polar/Linear 감성) ── */
+    [data-theme="dark"] {
+      --bg-base:    #0d0d12;      /* 깊은 네이비 블랙 */
+      --bg-card:    #13131a;      /* 카드 */
+      --bg-card-hov:#16161f;
+      --bg-nav:     rgba(10,10,15,0.85);
+      --bg-input:   #1a1a24;
+      --border:     rgba(255,255,255,0.07);
+      --border-hov: rgba(255,255,255,0.14);
+      --border-acc: rgba(99,102,241,0.6);
+      --text-1:     #f0f0f8;      /* primary */
+      --text-2:     #8b8b9e;      /* muted */
+      --text-3:     #6b6b7e;      /* subtle */
+      --accent:     #6366f1;      /* indigo */
+      --accent-2:   #818cf8;      /* indigo lighter */
+      --accent-3:   #a5b4fc;      /* indigo hover */
+      --purple:     #a855f7;
+      --success:    #4ade80;
+      --warning:    #fbbf24;
+      --danger:     #f87171;
+      --shadow-sm:  0 1px 2px rgba(0,0,0,0.4);
+      --shadow-md:  0 4px 16px rgba(0,0,0,0.5), 0 1px 4px rgba(0,0,0,0.3);
+      --shadow-lg:  0 8px 32px rgba(0,0,0,0.6), 0 2px 8px rgba(0,0,0,0.4);
+      --shadow-acc: 0 4px 20px rgba(99,102,241,0.35);
+
+      /* Mesh gradient background */
+      --mesh-bg:
+        radial-gradient(ellipse 80% 50% at 10% -10%, rgba(99,102,241,0.12) 0, transparent 60%),
+        radial-gradient(ellipse 60% 40% at 90% 110%, rgba(168,85,247,0.08) 0, transparent 55%),
+        #0d0d12;
+    }
+
+    /* ── 라이트 테마 (Vercel 감성) ── */
+    [data-theme="light"] {
+      --bg-base:    #fafafa;
+      --bg-card:    #ffffff;
+      --bg-card-hov:#f8f8fc;
+      --bg-nav:     rgba(0,0,0,0.95);
+      --bg-input:   #f5f5f8;
+      --border:     #e5e5ec;
+      --border-hov: #d0d0dc;
+      --border-acc: rgba(99,102,241,0.5);
+      --text-1:     #111118;
+      --text-2:     #6b6b7e;
+      --text-3:     #9b9bae;
+      --accent:     #4f46e5;
+      --accent-2:   #6366f1;
+      --accent-3:   #818cf8;
+      --purple:     #9333ea;
+      --success:    #16a34a;
+      --warning:    #d97706;
+      --danger:     #dc2626;
+      --shadow-sm:  0 1px 3px rgba(0,0,0,0.06), 0 1px 2px rgba(0,0,0,0.04);
+      --shadow-md:  0 4px 16px rgba(0,0,0,0.08), 0 1px 4px rgba(0,0,0,0.04);
+      --shadow-lg:  0 8px 32px rgba(0,0,0,0.1), 0 2px 8px rgba(0,0,0,0.06);
+      --shadow-acc: 0 4px 20px rgba(99,102,241,0.25);
+      --mesh-bg:
+        radial-gradient(ellipse 80% 50% at 10% -10%, rgba(99,102,241,0.06) 0, transparent 60%),
+        radial-gradient(ellipse 60% 40% at 90% 110%, rgba(168,85,247,0.04) 0, transparent 55%),
+        #fafafa;
+    }
+
+    /* ── 리셋 ── */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    *:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: var(--r-sm); }
+
+    body {
+      font-family: var(--font);
+      background: var(--mesh-bg);
+      background-attachment: fixed;
+      color: var(--text-1);
+      font-size: var(--md);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      min-height: 100vh;
+    }
+
+    /* ── NAV ── */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      background: var(--bg-nav);
+      backdrop-filter: blur(20px) saturate(180%);
+      -webkit-backdrop-filter: blur(20px) saturate(180%);
+      border-bottom: 1px solid rgba(255,255,255,0.06);
+      height: 56px;
+      display: flex;
+      align-items: center;
+      padding: 0 var(--s6);
+      gap: var(--s3);
+    }
+    [data-theme="light"] nav { border-bottom-color: rgba(0,0,0,0.08); }
+
+    .nav-logo {
+      display: flex;
+      align-items: center;
+      gap: var(--s2);
+      text-decoration: none;
+      margin-right: var(--s3);
+    }
+    .nav-logo-icon {
+      width: 28px; height: 28px;
+      background: linear-gradient(135deg, #6366f1, #a855f7);
+      border-radius: 8px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 14px;
+      box-shadow: 0 2px 8px rgba(99,102,241,0.4);
+    }
+    .nav-logo strong {
+      font-size: var(--sm);
+      font-weight: 600;
+      color: #fff;
+      letter-spacing: -0.3px;
+    }
+
+    .nav-link {
+      display: flex; align-items: center; gap: var(--s1);
+      color: rgba(255,255,255,0.5);
+      text-decoration: none;
+      font-size: var(--sm);
+      font-weight: 500;
+      padding: var(--s1) var(--s3);
+      border-radius: var(--r-sm);
+      transition: color var(--dur) var(--ease), background var(--dur) var(--ease);
+    }
+    .nav-link:hover { color: rgba(255,255,255,0.85); background: rgba(255,255,255,0.06); }
+    .nav-link.active { color: #fff; background: rgba(255,255,255,0.1); }
+    .nav-link .icon { font-size: 12px; opacity: 0.7; }
+
+    .nav-spacer { flex: 1; }
+
+    .nav-badge {
+      display: inline-flex; align-items: center;
+      background: rgba(99,102,241,0.15);
+      border: 1px solid rgba(99,102,241,0.3);
+      color: var(--accent-3);
+      font-size: 11px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--r-pill);
+      margin-right: var(--s2);
+    }
+
+    .nav-avatar {
+      width: 28px; height: 28px;
+      background: linear-gradient(135deg, #6366f1, #a855f7);
+      border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 12px; font-weight: 700; color: #fff;
+      cursor: pointer;
+      border: 2px solid rgba(255,255,255,0.1);
+      transition: border-color var(--dur);
+    }
+    .nav-avatar:hover { border-color: rgba(99,102,241,0.6); }
+
+    .btn-theme {
+      display: flex; align-items: center; gap: var(--s1);
+      background: rgba(255,255,255,0.06);
+      border: 1px solid rgba(255,255,255,0.1);
+      color: rgba(255,255,255,0.6);
+      padding: 5px 10px;
+      border-radius: var(--r-pill);
+      font-size: 11px; font-weight: 500;
+      cursor: pointer; font-family: inherit;
+      transition: all var(--dur) var(--ease);
+    }
+    .btn-theme:hover { background: rgba(255,255,255,0.1); color: rgba(255,255,255,0.9); }
+
+    /* ── CONTAINER ── */
+    .container {
+      max-width: 1160px;
+      margin: 0 auto;
+      padding: var(--s8) var(--s6);
+    }
+
+    /* ── PAGE HEADER ── */
+    .page-header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      margin-bottom: var(--s8);
+      gap: var(--s4);
+    }
+    .page-header-left {}
+    .page-eyebrow {
+      font-size: var(--xs);
+      font-weight: 600;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--accent-2);
+      margin-bottom: var(--s2);
+      display: flex; align-items: center; gap: var(--s2);
+    }
+    .page-eyebrow::before {
+      content: '';
+      width: 16px; height: 2px;
+      background: var(--accent);
+      border-radius: 2px;
+      display: inline-block;
+    }
+    .page-title {
+      font-size: var(--3xl);
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      color: var(--text-1);
+      line-height: 1.1;
+    }
+    .page-desc {
+      margin-top: var(--s2);
+      font-size: var(--sm);
+      color: var(--text-2);
+      line-height: 1.6;
+    }
+    .page-actions { display: flex; align-items: center; gap: var(--s2); flex-shrink: 0; }
+
+    /* ── BUTTONS ── */
+    .btn {
+      display: inline-flex; align-items: center; gap: var(--s2);
+      font-family: var(--font);
+      font-size: var(--sm);
+      font-weight: 500;
+      padding: 7px 14px;
+      border-radius: var(--r-md);
+      border: 1px solid transparent;
+      cursor: pointer;
+      text-decoration: none;
+      transition: all var(--dur) var(--ease);
+      line-height: 1.4;
+      white-space: nowrap;
+    }
+    .btn-primary {
+      background: linear-gradient(135deg, #6366f1, #8b5cf6);
+      color: #fff;
+      border-color: transparent;
+      box-shadow: 0 2px 8px rgba(99,102,241,0.35), var(--shadow-sm);
+    }
+    .btn-primary:hover {
+      background: linear-gradient(135deg, #5558e8, #7c3aed);
+      box-shadow: 0 4px 16px rgba(99,102,241,0.5), var(--shadow-sm);
+      transform: translateY(-1px);
+    }
+    .btn-primary:active { transform: translateY(0); }
+
+    .btn-ghost {
+      background: transparent;
+      color: var(--text-2);
+      border-color: var(--border);
+    }
+    .btn-ghost:hover {
+      background: var(--bg-input);
+      color: var(--text-1);
+      border-color: var(--border-hov);
+    }
+
+    .btn-sm { padding: 5px 10px; font-size: var(--xs); border-radius: var(--r-sm); }
+
+    /* ── KPI CARDS ── */
+    .kpi-grid {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: var(--s4);
+      margin-bottom: var(--s7);
+    }
+    @media (max-width: 900px) { .kpi-grid { grid-template-columns: repeat(2, 1fr); } }
+    @media (max-width: 480px) { .kpi-grid { grid-template-columns: 1fr; } }
+
+    .kpi-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-lg);
+      padding: var(--s5) var(--s5);
+      box-shadow: var(--shadow-sm);
+      transition: all var(--dur) var(--ease);
+      position: relative;
+      overflow: hidden;
+    }
+    .kpi-card::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(99,102,241,0.03), transparent 60%);
+      pointer-events: none;
+    }
+    .kpi-card:hover {
+      border-color: var(--border-acc);
+      box-shadow: var(--shadow-md);
+      transform: translateY(-2px);
+    }
+    .kpi-label {
+      font-size: var(--xs);
+      font-weight: 600;
+      color: var(--text-3);
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      margin-bottom: var(--s2);
+      display: flex; align-items: center; gap: var(--s2);
+    }
+    .kpi-icon { font-size: 14px; }
+    .kpi-value {
+      font-size: 28px;
+      font-weight: 700;
+      letter-spacing: -0.04em;
+      color: var(--text-1);
+      line-height: 1;
+    }
+    .kpi-delta {
+      margin-top: var(--s2);
+      font-size: var(--xs);
+      color: var(--text-3);
+      display: flex; align-items: center; gap: 4px;
+    }
+    .kpi-delta.up { color: var(--success); }
+    .kpi-delta.down { color: var(--danger); }
+    .kpi-delta .arr { font-size: 10px; }
+
+    /* ── MAIN CARD ── */
+    .main-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--r-xl);
+      overflow: hidden;
+      box-shadow: var(--shadow-md);
+    }
+
+    .card-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--s5) var(--s6);
+      border-bottom: 1px solid var(--border);
+    }
+    .card-title {
+      font-size: var(--base);
+      font-weight: 600;
+      color: var(--text-1);
+      display: flex; align-items: center; gap: var(--s2);
+    }
+    .card-subtitle { font-size: var(--xs); color: var(--text-3); margin-top: 2px; }
+    .card-actions { display: flex; gap: var(--s2); }
+
+    /* ── TABLE ── */
+    .table-wrap { overflow-x: auto; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    thead th {
+      padding: var(--s3) var(--s5);
+      font-size: var(--xs);
+      font-weight: 600;
+      color: var(--text-3);
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      text-align: left;
+      border-bottom: 1px solid var(--border);
+      background: transparent;
+      white-space: nowrap;
+    }
+    tbody tr {
+      transition: background var(--dur) var(--ease);
+      border-bottom: 1px solid var(--border);
+    }
+    tbody tr:last-child { border-bottom: none; }
+    tbody tr:hover { background: rgba(99,102,241,0.04); }
+    tbody td {
+      padding: var(--s4) var(--s5);
+      font-size: var(--sm);
+      color: var(--text-1);
+      vertical-align: middle;
+    }
+
+    .repo-name {
+      display: flex; align-items: center; gap: var(--s2);
+      font-weight: 600;
+      color: var(--text-1);
+      text-decoration: none;
+      font-size: var(--sm);
+    }
+    .repo-name:hover { color: var(--accent-3); }
+    .repo-dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--success);
+      flex-shrink: 0;
+      box-shadow: 0 0 6px rgba(74,222,128,0.6);
+    }
+    .repo-org { color: var(--text-3); font-weight: 400; }
+
+    .score-pill {
+      display: inline-flex; align-items: center;
+      font-size: var(--sm);
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+    .score-pill.high { color: var(--grade-a); }
+    .score-pill.mid  { color: var(--grade-c); }
+    .score-pill.low  { color: var(--grade-f); }
+
+    .grade-badge {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 24px; height: 24px;
+      border-radius: var(--r-sm);
+      font-size: var(--xs);
+      font-weight: 800;
+      letter-spacing: -0.02em;
+    }
+    .grade-badge.A { background: rgba(74,222,128,0.12); color: var(--grade-a); border: 1px solid rgba(74,222,128,0.2); }
+    .grade-badge.B { background: rgba(96,165,250,0.12); color: var(--grade-b); border: 1px solid rgba(96,165,250,0.2); }
+    .grade-badge.C { background: rgba(251,191,36,0.12); color: var(--grade-c); border: 1px solid rgba(251,191,36,0.2); }
+    .grade-badge.D { background: rgba(251,146,60,0.12); color: var(--grade-d); border: 1px solid rgba(251,146,60,0.2); }
+    .grade-badge.F { background: rgba(248,113,113,0.12); color: var(--grade-f); border: 1px solid rgba(248,113,113,0.2); }
+
+    .count-chip {
+      display: inline-flex; align-items: center;
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: var(--r-pill);
+      padding: 2px 8px;
+      font-size: var(--xs);
+      color: var(--text-2);
+      font-weight: 500;
+    }
+
+    .action-link {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: var(--xs);
+      color: var(--text-3);
+      text-decoration: none;
+      padding: 4px 8px;
+      border-radius: var(--r-sm);
+      border: 1px solid var(--border);
+      transition: all var(--dur) var(--ease);
+    }
+    .action-link:hover {
+      color: var(--accent-2);
+      border-color: var(--border-acc);
+      background: rgba(99,102,241,0.06);
+    }
+
+    /* ── CHIP FILTERS ── */
+    .filter-row {
+      display: flex;
+      align-items: center;
+      gap: var(--s2);
+      padding: var(--s3) var(--s5);
+      border-bottom: 1px solid var(--border);
+    }
+    .filter-chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: var(--xs); font-weight: 500;
+      padding: 4px 10px;
+      border-radius: var(--r-pill);
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--text-3);
+      cursor: pointer; font-family: inherit;
+      transition: all var(--dur) var(--ease);
+    }
+    .filter-chip:hover { border-color: var(--border-acc); color: var(--accent-2); }
+    .filter-chip.active {
+      background: rgba(99,102,241,0.12);
+      border-color: rgba(99,102,241,0.4);
+      color: var(--accent-3);
+    }
+
+    /* ── SEARCH ── */
+    .search-wrap {
+      position: relative;
+      flex: 1;
+      max-width: 240px;
+    }
+    .search-icon {
+      position: absolute;
+      left: 10px; top: 50%;
+      transform: translateY(-50%);
+      font-size: 12px;
+      color: var(--text-3);
+      pointer-events: none;
+    }
+    .search-input {
+      width: 100%;
+      background: var(--bg-input);
+      border: 1px solid var(--border);
+      border-radius: var(--r-md);
+      padding: 6px 10px 6px 30px;
+      font-size: var(--xs);
+      color: var(--text-1);
+      font-family: var(--font);
+      outline: none;
+      transition: border-color var(--dur);
+    }
+    .search-input::placeholder { color: var(--text-3); }
+    .search-input:focus { border-color: var(--border-acc); background: var(--bg-card); }
+
+    /* ── ANNOTATION BANNER (Phase 0 note) ── */
+    .phase-banner {
+      background: rgba(99,102,241,0.08);
+      border: 1px solid rgba(99,102,241,0.2);
+      border-radius: var(--r-lg);
+      padding: var(--s4) var(--s5);
+      margin-bottom: var(--s6);
+      display: flex;
+      align-items: flex-start;
+      gap: var(--s3);
+    }
+    .phase-banner-icon { font-size: 18px; flex-shrink: 0; margin-top: 1px; }
+    .phase-banner-title {
+      font-size: var(--sm); font-weight: 600;
+      color: var(--accent-3);
+      margin-bottom: 4px;
+    }
+    .phase-banner-body {
+      font-size: var(--xs);
+      color: var(--text-2);
+      line-height: 1.6;
+    }
+    .phase-banner-body code {
+      font-family: 'JetBrains Mono', monospace;
+      background: rgba(99,102,241,0.15);
+      padding: 1px 5px;
+      border-radius: 3px;
+      font-size: 11px;
+      color: var(--accent-3);
+    }
+
+    /* ── THEME TOGGLE ── */
+    .theme-row {
+      display: flex;
+      align-items: center;
+      gap: var(--s2);
+      margin-bottom: var(--s6);
+    }
+    .theme-row-label { font-size: var(--xs); color: var(--text-3); margin-right: var(--s2); }
+    .theme-pill {
+      display: inline-flex; align-items: center;
+      padding: 4px 10px;
+      border-radius: var(--r-pill);
+      border: 1px solid var(--border);
+      background: transparent;
+      font-size: var(--xs); font-weight: 500;
+      color: var(--text-3);
+      cursor: pointer; font-family: inherit;
+      transition: all var(--dur) var(--ease);
+    }
+    .theme-pill.active {
+      background: rgba(99,102,241,0.12);
+      border-color: rgba(99,102,241,0.4);
+      color: var(--accent-3);
+    }
+    .theme-pill:hover:not(.active) { border-color: var(--border-hov); color: var(--text-1); }
+
+    /* ── COMPARISON LABEL ── */
+    .cmp-label {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: var(--xs); font-weight: 600;
+      padding: 2px 8px;
+      border-radius: var(--r-pill);
+      margin-bottom: var(--s3);
+    }
+    .cmp-label.new { background: rgba(74,222,128,0.12); color: var(--grade-a); border: 1px solid rgba(74,222,128,0.2); }
+
+    /* ── EMPTY STATE ── */
+    .empty-state {
+      padding: var(--s9) var(--s6);
+      text-align: center;
+    }
+    .empty-icon { font-size: 40px; margin-bottom: var(--s4); opacity: 0.4; }
+    .empty-title { font-size: var(--xl); font-weight: 700; color: var(--text-1); margin-bottom: var(--s2); }
+    .empty-body { font-size: var(--sm); color: var(--text-2); max-width: 340px; margin: 0 auto var(--s5); line-height: 1.7; }
+
+    /* ── STATUS DOTS ── */
+    .status-dot {
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      display: inline-block;
+      flex-shrink: 0;
+    }
+    .status-dot.green { background: var(--success); box-shadow: 0 0 5px rgba(74,222,128,0.5); }
+    .status-dot.yellow { background: var(--warning); }
+    .status-dot.red { background: var(--danger); }
+
+  </style>
+</head>
+<body>
+
+<!-- NAV -->
+<nav>
+  <a href="#" class="nav-logo">
+    <div class="nav-logo-icon">⚡</div>
+    <strong>SCAManager</strong>
+  </a>
+
+  <a href="#" class="nav-link active"><span class="icon">◻</span> 개요</a>
+  <a href="#" class="nav-link"><span class="icon">📊</span> 대시보드</a>
+  <a href="#" class="nav-link"><span class="icon">⚙</span> 설정</a>
+
+  <div class="nav-spacer"></div>
+
+  <span class="nav-badge">Beta</span>
+
+  <button class="btn-theme" onclick="toggleTheme()">
+    <span id="theme-label">🌙 Dark</span> ▾
+  </button>
+
+  <div class="nav-avatar" title="xzawed">X</div>
+</nav>
+
+<!-- MAIN -->
+<div class="container">
+
+  <!-- Phase 0 annotation banner -->
+  <div class="phase-banner">
+    <div class="phase-banner-icon">🎨</div>
+    <div>
+      <div class="phase-banner-title">Phase 0 — 시각 합의 목업 (Visual Alignment Mockup)</div>
+      <div class="phase-banner-body">
+        이 페이지는 Polar/Linear 스타일 리디자인의 시각 방향을 보여주는 목업입니다.
+        실제 구현 전 사용자 승인 후 Phase 1 (Global Shell PR) 진행.
+        아래 테마 버튼으로 <code>dark</code> / <code>light</code> 전환 가능.
+        기존 코드 변경 없음 — 이 파일만 독립적으로 제공됩니다.
+      </div>
+    </div>
+  </div>
+
+  <!-- Theme toggle row -->
+  <div class="theme-row">
+    <span class="theme-row-label">테마 전환:</span>
+    <button class="theme-pill active" id="pill-dark" onclick="setTheme('dark')">🌙 Dark (Polar)</button>
+    <button class="theme-pill" id="pill-light" onclick="setTheme('light')">☀️ Light (Vercel)</button>
+  </div>
+
+  <!-- PAGE HEADER -->
+  <div class="page-header">
+    <div class="page-header-left">
+      <div class="page-eyebrow">리포지토리 현황</div>
+      <h1 class="page-title">분석 개요</h1>
+      <p class="page-desc">연결된 8개 리포지토리의 코드 품질 현황을 확인하세요.</p>
+    </div>
+    <div class="page-actions">
+      <button class="btn btn-ghost">필터 ▾</button>
+      <a href="#" class="btn btn-primary">+ 리포 추가</a>
+    </div>
+  </div>
+
+  <span class="cmp-label new">✨ 신규 디자인</span>
+
+  <!-- KPI GRID -->
+  <div class="kpi-grid">
+    <div class="kpi-card">
+      <div class="kpi-label"><span class="kpi-icon">📈</span> 평균 점수</div>
+      <div class="kpi-value">78.4</div>
+      <div class="kpi-delta up"><span class="arr">↑</span> +3.2 (30일)</div>
+    </div>
+    <div class="kpi-card">
+      <div class="kpi-label"><span class="kpi-icon">🔍</span> 분석 건수</div>
+      <div class="kpi-value">247</div>
+      <div class="kpi-delta up"><span class="arr">↑</span> 이번 달 +18</div>
+    </div>
+    <div class="kpi-card">
+      <div class="kpi-label"><span class="kpi-icon">🔴</span> 보안 HIGH</div>
+      <div class="kpi-value">3</div>
+      <div class="kpi-delta down"><span class="arr">↑</span> +1 신규</div>
+    </div>
+    <div class="kpi-card">
+      <div class="kpi-label"><span class="kpi-icon">⚡</span> Auto-merge율</div>
+      <div class="kpi-value">91<span style="font-size:16px;font-weight:500">%</span></div>
+      <div class="kpi-delta up"><span class="arr">↑</span> +4% (30일)</div>
+    </div>
+  </div>
+
+  <!-- MAIN TABLE CARD -->
+  <div class="main-card">
+    <div class="card-header">
+      <div>
+        <div class="card-title">
+          <span>리포지토리</span>
+          <span class="count-chip">8개</span>
+        </div>
+        <div class="card-subtitle">마지막 동기화: 방금 전</div>
+      </div>
+      <div class="card-actions">
+        <button class="btn btn-ghost btn-sm">내보내기</button>
+      </div>
+    </div>
+
+    <!-- Filter row -->
+    <div class="filter-row">
+      <div class="search-wrap">
+        <span class="search-icon">🔍</span>
+        <input class="search-input" type="text" placeholder="리포 검색...">
+      </div>
+      <button class="filter-chip active">전체</button>
+      <button class="filter-chip">A / B 등급</button>
+      <button class="filter-chip">주의 필요</button>
+    </div>
+
+    <!-- Table -->
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>리포지토리</th>
+            <th>분석</th>
+            <th>평균 점수</th>
+            <th>등급</th>
+            <th>상태</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <a href="#" class="repo-name">
+                <span class="repo-dot"></span>
+                <span><span class="repo-org">xzawed/</span>SCAManager</span>
+              </a>
+            </td>
+            <td><span class="count-chip">247회</span></td>
+            <td><span class="score-pill high">92.1</span></td>
+            <td><span class="grade-badge A">A</span></td>
+            <td><span class="status-dot green"></span></td>
+            <td><a href="#" class="action-link">⚙ 설정</a></td>
+          </tr>
+          <tr>
+            <td>
+              <a href="#" class="repo-name">
+                <span class="repo-dot"></span>
+                <span><span class="repo-org">xzawed/</span>api-gateway</span>
+              </a>
+            </td>
+            <td><span class="count-chip">183회</span></td>
+            <td><span class="score-pill high">84.7</span></td>
+            <td><span class="grade-badge B">B</span></td>
+            <td><span class="status-dot green"></span></td>
+            <td><a href="#" class="action-link">⚙ 설정</a></td>
+          </tr>
+          <tr>
+            <td>
+              <a href="#" class="repo-name">
+                <span class="repo-dot" style="background:var(--warning);box-shadow:0 0 5px rgba(251,191,36,0.5)"></span>
+                <span><span class="repo-org">xzawed/</span>data-pipeline</span>
+              </a>
+            </td>
+            <td><span class="count-chip">96회</span></td>
+            <td><span class="score-pill mid">61.3</span></td>
+            <td><span class="grade-badge C">C</span></td>
+            <td><span class="status-dot yellow"></span></td>
+            <td><a href="#" class="action-link">⚙ 설정</a></td>
+          </tr>
+          <tr>
+            <td>
+              <a href="#" class="repo-name">
+                <span class="repo-dot" style="background:var(--danger);box-shadow:0 0 5px rgba(248,113,113,0.5)"></span>
+                <span><span class="repo-org">xzawed/</span>legacy-monolith</span>
+              </a>
+            </td>
+            <td><span class="count-chip">41회</span></td>
+            <td><span class="score-pill low">38.9</span></td>
+            <td><span class="grade-badge F">F</span></td>
+            <td><span class="status-dot red"></span></td>
+            <td><a href="#" class="action-link">⚙ 설정</a></td>
+          </tr>
+          <tr>
+            <td>
+              <a href="#" class="repo-name">
+                <span class="repo-dot"></span>
+                <span><span class="repo-org">xzawed/</span>auth-service</span>
+              </a>
+            </td>
+            <td><span class="count-chip">128회</span></td>
+            <td><span class="score-pill high">77.2</span></td>
+            <td><span class="grade-badge B">B</span></td>
+            <td><span class="status-dot green"></span></td>
+            <td><a href="#" class="action-link">⚙ 설정</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+</div>
+
+<script>
+  function setTheme(t) {
+    document.documentElement.setAttribute('data-theme', t);
+    document.getElementById('theme-label').textContent = t === 'dark' ? '🌙 Dark' : '☀️ Light';
+    document.getElementById('pill-dark').className = 'theme-pill' + (t === 'dark' ? ' active' : '');
+    document.getElementById('pill-light').className = 'theme-pill' + (t === 'light' ? ' active' : '');
+  }
+  function toggleTheme() {
+    const cur = document.documentElement.getAttribute('data-theme');
+    setTheme(cur === 'dark' ? 'light' : 'dark');
+  }
+</script>
+</body>
+</html>

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -26,6 +26,9 @@
   <link rel="stylesheet" href="/static/css/tokens.css">
   <link rel="stylesheet" href="/static/css/themes.css">
   <link rel="stylesheet" href="/static/css/illustrations.css">
+  <!-- Tailwind v4 utilities (Hybrid: layout/spacing/typography utilities, no Preflight override)
+       Inline <style> below retains higher specificity for existing components -->
+  <link rel="stylesheet" href="/static/css/dist/tailwind.css">
   <style>
     /* ──────────────────────────────────────────────────────────────────────
      * 사이클 93 Step 1 — Foundation 토큰 + 4-테마 정의는 외부 CSS 파일로 분리.


### PR DESCRIPTION
## 🎨 UI 대개편 Phase 0+1 기반 — Tailwind v4 빌드 파이프라인

### 변경 요약
- **`package.json`**: `tailwindcss@^4.1.0` + `@tailwindcss/cli` devDependency 추가
- **`src/static/css/main.css`**: Tailwind v4 진입점 — `@import "tailwindcss"` + 4-theme `@custom-variant` 정의
  - `dark:` / `light:` / `glass:` / `claude:` 4종 variant → 기존 CSS custom property 테마 시스템과 병행
- **`src/static/css/dist/.gitkeep`**: 빌드 출력 디렉토리 플레이스홀더 (tailwind.css 는 .gitignore)
- **`src/templates/base.html`**: `tailwind.css` 링크 추가 (inline `<style>` 앞 — 기존 컴포넌트 CSS 특이성 보존)
- **`Makefile`**: `css-build` / `css-dev` / `css-install` 타겟 추가; `install`에 `npm install` 포함
- **`nixpacks.toml`**: `[phases.install] npm install` + `[phases.build] npm run build` 추가
- **`.gitignore`**: `/dist/` `/build/` root 고정 (전역 매칭 방지); `node_modules/` + `dist/tailwind.css` 제외
- **`src/static/mockup-polar.html`**: Phase 0 시각 합의 목업 (Polar/Linear dark/light 전환 미리보기)

### 전략: Hybrid 방식
```
Tailwind v4 = 레이아웃/간격/타이포 유틸리티 (flex, grid, p-*, text-*, rounded-* 등)
CSS custom properties = 4-theme 색상/테마 (tokens.css + themes.css 보존)
```

### 검증
- `npm run build` → **11KB minified**, Done in 240ms ✅
- 기존 로그인/개요 페이지 **시각 회귀 0** (Playwright 스크린샷 확인) ✅
- 테스트 **2807 passed** — 8 failed/18 errors 는 사전존재 cp949 인코딩 문제 (이번 PR 무관) ✅

### 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 시 `npm run build` 정상 실행 여부 (nixpacks.toml `[phases.build]` 추가됨)
- [ ] 4-테마 전환 시 시각 이상 없는지 확인 (dark/light/glass/claude-dark)
- [ ] `http://localhost:8001/static/mockup-polar.html` 에서 Phase 0 목업 확인 후 방향 최종 승인

### 🎨 정책 11 — UI 변경 8조합 시각 체크리스트
| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | ⬜ | ⬜ |
| light | ⬜ | ⬜ |
| glass | ⬜ | ⬜ |
| claude-dark | ⬜ | ⬜ |

> Claude는 정적 코드만 검증 가능 — 8조합 시각 정합성은 사용자 확인 의무 (정책 11)

### ⚠️ 자율 판단 보고 (정책 3)
- Codex 로컬 리뷰 불가 (Windows CreateProcessAsUserW 샌드박스 제한) → push 후 GitHub diff 기반 Codex 리뷰로 대체 진행
- 재부팅 후 secpol.msc 특권 부여 시 이후 PR부터 push 전 로컬 Codex 리뷰 정상화 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)