### PR TITLE
fix(deploy): nixpacks pip not found 수정 — install phase 제거 + npm ci/build railway.toml 이전

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -6,13 +6,10 @@ cmds = [
   "curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && apt-get install -y nodejs"
 ]
 
-# Tailwind v4 CSS 빌드 파이프라인 (Hybrid: 레이아웃 유틸리티 + CSS var 4-theme)
-# Tailwind v4 CSS build pipeline (Hybrid: layout utilities + CSS var 4-theme)
-[phases.install]
-cmds = [
-  "pip install -r requirements.txt",
-  "npm ci"
-]
+# [phases.install] 제거 — nixpacks Python 기본 동작(python -m venv + pip install)에 위임
+# [phases.install] removed — delegate to nixpacks Python default (python -m venv + pip install)
+# pip 직접 호출 시 venv 미생성으로 "pip: command not found" (exit 127) 발생
+# Direct pip call without venv causes "pip: command not found" (exit 127)
 
-[phases.build]
-cmds = ["npm run build"]
+# [phases.build] 제거 — railway.toml buildCommand가 상위 오버라이드 (npm ci + npm run build 포함)
+# [phases.build] removed — railway.toml buildCommand overrides (includes npm ci + npm run build)

--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,6 @@
 [build]
 builder = "NIXPACKS"
-buildCommand = "npm install -g eslint@9 @typescript-eslint/parser @typescript-eslint/eslint-plugin && solc-select install 0.8.20 && solc-select use 0.8.20 && gem install rubocop-ast -v 1.36.2 --no-document --bindir /usr/bin && gem install rubocop -v 1.57.2 --no-document --bindir /usr/bin && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.55.2"
+buildCommand = "npm install -g eslint@9 @typescript-eslint/parser @typescript-eslint/eslint-plugin && solc-select install 0.8.20 && solc-select use 0.8.20 && gem install rubocop-ast -v 1.36.2 --no-document --bindir /usr/bin && gem install rubocop -v 1.57.2 --no-document --bindir /usr/bin && curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/bin v1.55.2 && npm ci && npm run build"
 
 [deploy]
 startCommand = "uvicorn src.main:app --host 0.0.0.0 --port $PORT --proxy-headers"


### PR DESCRIPTION
## 요약

Railway 빌드 연속 실패 (`e0aa9411`, `4fe65058`) 근본 원인 수정.

### 실패 로그 (Railway API 직접 확인)
\`\`\`
[stage-0  9/14] RUN pip install -r requirements.txt
/bin/bash: line 1: pip: command not found
Build Failed: exit code: 127
\`\`\`

### 원인
| 단계 | 문제 |
|------|------|
| `nixpacks.toml [phases.install]` 커스텀 cmds | nixpacks Python 기본 동작(`python -m venv` → pip) 오버라이드 |
| `pip install -r requirements.txt` 직접 호출 | venv 미생성 상태 → 시스템 pip 없음 → exit 127 |
| `[phases.build] npm run build` | `railway.toml buildCommand`가 상위 오버라이드 → 실행 안 됨 |

### 수정 내용
- **`nixpacks.toml`**: `[phases.install]` + `[phases.build]` 제거 → nixpacks Python 기본 처리에 위임
- **`railway.toml`**: `buildCommand` 끝에 `&& npm ci && npm run build` 추가

### 빌드 단계 (수정 후 예상)
```
nixpacks 기본: python -m venv --copies /opt/venv && . /opt/venv/bin/activate && pip install -r requirements.txt ✅
railway buildCommand: eslint + solc + rubocop + golangci-lint + npm ci + npm run build ✅
→ tailwind.css 생성 보장 ✅
```

## 🔍 사용자 검증 필요 (정책 2)
- [ ] Railway 배포 후 빌드 로그에서 `pip: command not found` 에러 없음 확인
- [ ] `npm ci` 및 `npm run build` 단계 정상 실행 확인
- [ ] 앱 정상 기동 및 `/health` 200 응답 확인

## ⚠️ 자율 판단 보고 (정책 3)
- Codex 로컬 리뷰 불가 (Windows `CreateProcessAsUserW` 샌드박스 제한) → Claude 직접 diff 검증으로 대체
- `railway up` 이 의도치 않게 실행되어 실패 배포 `4fe65058` 추가 발생 — 동일 원인으로 동일하게 실패 확인됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)