### PR TITLE
fix(ci): Dependabot PR SonarCloud 실패 수정 — SONAR_TOKEN 없을 때 건너뜀

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: SonarCloud scan
+        # Dependabot PR 는 GitHub 보안 정책상 SONAR_TOKEN 시크릿에 접근 불가 — 건너뜀
+        # Dependabot PRs cannot access SONAR_TOKEN due to GitHub security policy — skip.
+        if: github.actor != 'dependabot[bot]'
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 문제

현재 5개의 Dependabot PR (#386~#390)이 모두 CI `pytest + Codecov + SonarCloud` 체크에서 실패 중.

**근본 원인**: Dependabot PR은 GitHub 보안 정책상 `secrets.*`에 접근 불가 → `SONAR_TOKEN`이 빈 값으로 전달 → SonarCloud 스캔 실패:

```
SONAR_TOKEN:   (빈 값)
ERROR Project not found. Please check the 'sonar.projectKey' and 'sonar.organization' properties,
the 'SONAR_TOKEN' environment variable...
Action failed: exit code 3
```

## 수정 내용

`SonarCloud scan` 스텝에 `if: github.actor != 'dependabot[bot]'` 조건 추가.

- **Dependabot PR**: SonarCloud 스텝 건너뜀 → CI는 pytest + Codecov 결과만으로 판정
- **일반 PR / main push**: SonarCloud 스캔 정상 실행 (기존 동작 완전 보존)

## 🔍 사용자 검증 필요

- [ ] 이 PR 머지 후 Dependabot PR 중 하나를 골라 CI 재실행 → `pytest + Codecov + SonarCloud` 통과 확인
- [ ] main branch push 시 SonarCloud 분석이 여전히 정상 실행되는지 확인 (SonarCloud 대시보드)

## 자율 판단 보고 (정책 3)

- 기존 SonarCloud 분석 빈도(일반 PR + main push)는 유지 — Dependabot PR만 제외
- 대안으로 Dependabot를 GitHub Settings에서 별도 시크릿 설정하는 방법도 있으나 UI 접근 불가라 코드 방식으로 해결
- IDE 경고(S6505/S8541/S8543/S8544) — 기존부터 있던 경고로 이 PR 범위 외