### PR TITLE
fix(sonar): Jinja2 HTML 템플릿 JS 파싱 오류 억제

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -24,6 +24,12 @@ sonar.tests=tests
 sonar.exclusions=**/__pycache__/**,**/*.pyc,**/migrations/**,alembic/versions/**,docs/**,e2e/**,src/scripts/**
 sonar.test.inclusions=tests/**/*.py
 
+# JavaScript 제외 — Jinja2 {{ }} 구문이 있는 HTML 템플릿은 JS 파서가 파싱 불가
+# Exclude HTML templates from JS analysis — Jinja2 {{ }} syntax causes JS parser errors.
+# (src/templates/**/*.html 은 Web 룰셋 분석 대상에서는 제외하지 않음 — CDN SRI 체크 등 유지)
+# (src/templates/**/*.html is NOT excluded from Web analysis — CDN SRI checks etc. still apply.)
+sonar.javascript.exclusions=src/templates/**/*.html,src/static/mockup-polar.html
+
 # Python 버전 (SonarCloud 가 파일 파싱 시 사용)
 # Python version used by SonarCloud when parsing files.
 sonar.python.version=3.12


### PR DESCRIPTION
## 문제

SonarCloud 스캔 시 HTML 템플릿 파일에서 다음 ERROR가 발생:

```
ERROR Error: Unexpected token (341:26)  → src/templates/repo_detail.html
ERROR Error: Unexpected token (560:23)  → src/templates/analysis_detail.html
ERROR Error: Unexpected token (748:29)  → src/templates/dashboard.html
```

**원인**: HTML `<script>` 블록 안의 Jinja2 `{{ variable }}` 구문(예: `analysis_detail.html:562` — `var TREND = {{ trend_data | tojson }};`)을 SonarCloud JS 파서가 유효하지 않은 JavaScript로 인식.

## 수정

`sonar.javascript.exclusions` 설정 추가:

```properties
sonar.javascript.exclusions=src/templates/**/*.html,src/static/mockup-polar.html
```

- **JS 분석**: HTML 템플릿 제외 → Jinja2 구문 파싱 오류 0
- **Web 룰셋 분석 (CDN SRI 체크 등)**: 영향 없음 — `sonar.javascript.exclusions`는 JS 분석만 제어

## CodeQL `py/unused-import` Open Alert 현황 (별도 처리 필요)

| Alert # | 파일 | 이유 | 판단 |
|---------|------|------|------|
| #375 | `tests/integration/test_insight_caching.py:32` | `InsightNarrativeCache` — SQLAlchemy `Base.metadata` 등록 목적 intentional import | False positive |
| #374 | `src/gate/native_automerge.py:40` | `ENABLE_DISABLED_IN_REPO`, `ENABLE_PERMISSION_DENIED` — 테스트 소비자용 re-export | False positive |

두 alert 모두 `# noqa: F401` + 주석 명시된 의도적 패턴. PR 머지 후 GitHub Security 탭에서 dismiss 예정.

## 🔍 사용자 검증 필요

- [ ] PR 머지 후 main에서 SonarCloud CI 재실행 → JS 파싱 ERROR 0건 확인
- [ ] SonarCloud 대시보드 Quality Gate 상태 확인 (pass 전환 여부)

## 정책 11 — Claude 시각 검증 불가

이번 PR은 `sonar-project.properties`만 수정 (HTML/CSS 변경 없음) → 8 조합 시각 체크리스트 해당 없음.