### PR TITLE
feat: per-repository code insights page (/repos/{name}/insights)

### DIFF
--- a/alembic/versions/0031_repo_insights_cache.py
+++ b/alembic/versions/0031_repo_insights_cache.py
@@ -1,0 +1,79 @@
+"""insight_narrative_cache에 repo_id FK 추가 — 리포별 AI 내러티브 캐시 지원.
+
+Add repo_id FK to insight_narrative_cache — repo-specific AI narrative cache support.
+
+Revision ID: 0031repoinsights
+Revises: 0030i18ncolumns
+Create Date: 2026-05-12
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from src.shared.alembic_dialect import is_postgresql
+
+revision = "0031repoinsights"
+down_revision = "0030i18ncolumns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """repo_id 컬럼 추가 + PG 부분 유니크 인덱스 교체.
+
+    Add repo_id column + replace PG unique constraints with partial indexes.
+    """
+    # 1. repo_id 컬럼 추가 (nullable FK, CASCADE)
+    # 1. Add nullable repo_id column (FK with CASCADE delete)
+    op.add_column(
+        "insight_narrative_cache",
+        sa.Column(
+            "repo_id",
+            sa.Integer(),
+            sa.ForeignKey("repositories.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+    )
+
+    # 2. 기존 제약 교체 (PG only)
+    # 2. Replace old constraint + add partial indexes (PG only)
+    if is_postgresql(op.get_bind()):
+        # 기존 (user_id, days) 유니크 제약 삭제 — repo_id 추가로 전역+리포 다중 행 필요
+        # Drop old (user_id, days) unique constraint — needed for global+repo coexistence
+        op.drop_constraint("uq_insight_cache_user_days", "insight_narrative_cache")
+
+        # 전역 캐시 부분 유니크 인덱스 (repo_id IS NULL)
+        # Partial unique index for global cache rows (repo_id IS NULL)
+        op.execute(
+            "CREATE UNIQUE INDEX uq_insight_cache_global "
+            "ON insight_narrative_cache (user_id, days, language) "
+            "WHERE repo_id IS NULL"
+        )
+
+        # 리포별 캐시 부분 유니크 인덱스 (repo_id IS NOT NULL)
+        # Partial unique index for repo-specific cache rows
+        op.execute(
+            "CREATE UNIQUE INDEX uq_insight_cache_repo "
+            "ON insight_narrative_cache (user_id, days, language, repo_id) "
+            "WHERE repo_id IS NOT NULL"
+        )
+
+    # 3. repo_id 검색 인덱스 (전체 환경)
+    # 3. repo_id lookup index (all environments)
+    op.create_index("ix_insight_cache_repo_id", "insight_narrative_cache", ["repo_id"])
+
+
+def downgrade() -> None:
+    """역순 복구 — 인덱스 삭제 → 컬럼 삭제 → 구 제약 복구.
+
+    Reverse: drop indexes → drop column → restore old constraint.
+    """
+    op.drop_index("ix_insight_cache_repo_id", table_name="insight_narrative_cache")
+
+    if is_postgresql(op.get_bind()):
+        op.execute("DROP INDEX IF EXISTS uq_insight_cache_repo")
+        op.execute("DROP INDEX IF EXISTS uq_insight_cache_global")
+        op.create_unique_constraint(
+            "uq_insight_cache_user_days", "insight_narrative_cache", ["user_id", "days"]
+        )
+
+    op.drop_column("insight_narrative_cache", "repo_id")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,8 @@ src/
 │   ├── css/dist/tailwind.css    # Tailwind v4 빌드 출력 (npm run build → Railway buildCommand, #376)
 │   ├── css/illustrations.css    # 일러스트 배치 CSS — .illustration/--hero/--empty/--tutorial + 모바일 반응형 (#375)
 │   ├── css/admin.css            # 관리자 페이지 공통 스타일 — .admin-* 글래스모피즘 컴포넌트 (admin_rls_audit, admin_tenants 공유)
+│   ├── css/repo_insights.css    # 리포별 인사이트 페이지 전용 스타일 — .ri-* 클래스 (CPD 분리)
+│   │                            # Repo insights page scoped styles (.ri-* classes, CPD prevention)
 │   └── illustrations/           # DALL-E 3 생성 일러스트 5장 commit (#375 Step 2-B: login_hero/dashboard_empty/overview_onboarding/add_repo_hero/filter_empty)
 ├── scripts/                     # 로컬 도구 (production import X) — Cycle 93 Step 2
 │   ├── illustration_prompts.py  # 5장 isometric prompt 정의 (login_hero/dashboard_empty/overview_onboarding/add_repo_hero/filter_empty)
@@ -45,7 +47,9 @@ src/
 ├── services/
 │   ├── analytics_service.py     # 집계 단일 출처 — weekly_summary, moving_average, resolve_chat_id
 │   ├── cron_service.py          # 주기 실행 — run_weekly_reports, run_trend_check
-│   ├── dashboard_service.py     # /dashboard 9 공개 함수 (KPI 4 + trend + frequent_issues + auto_merge_kpi + feedback_status + insight_narrative + dashboard_security + dashboard_usage) + RLS 격리 헬퍼 2건
+│   ├── dashboard_service.py     # /dashboard 9 공개 함수 (KPI 4 + trend + frequent_issues + auto_merge_kpi + feedback_status + insight_narrative + dashboard_security + dashboard_usage + repo_insight_cards) + RLS 격리 헬퍼 2건
+│   ├── repo_insight_service.py  # 리포별 집계 6 함수 (repo_kpi/recurring_issues/problem_files/ai_suggestions/category_breakdown/insight_narrative)
+│   │                            # Per-repo aggregation 6 functions
 │   ├── merge_retry_service.py   # process_pending_retries 워커 (CI-aware)
 │   ├── security_scan_service.py # Code/Secret Scanning 폴링 + audit log + GHAS graceful degradation
 │   ├── saas_service.py          # tenant_inventory + rls_audit_matrix (Cycle 79 PR 3a)
@@ -53,7 +57,7 @@ src/
 ├── auth/
 │   ├── session.py               # get_current_user() + require_login + require_admin (3-layer SaaS 검증)
 │   └── github.py                # /login, /auth/github, /auth/callback, /auth/logout
-├── models/                      # 10 ORM 모델 — repository, analysis, analysis_feedback, repo_config, gate_decision, merge_attempt, merge_retry, security_alert_log, insight_narrative_cache, user
+├── models/                      # 10 ORM 모델 — repository, analysis, analysis_feedback, repo_config, gate_decision, merge_attempt, merge_retry, security_alert_log, insight_narrative_cache (0031: repo_id FK), user
 ├── webhook/
 │   ├── _helpers.py              # get_webhook_secret() + cache (TTL 300s)
 │   ├── validator.py             # HMAC-SHA256 서명 검증
@@ -98,8 +102,8 @@ src/
 ├── ui/
 │   ├── _helpers.py              # get_accessible_repo, webhook_base_url, delete_repo_cascade, templates
 │   ├── router.py                # aggregator
-│   └── routes/                  # overview / dashboard (mode 4종) / add_repo / settings / actions / detail / admin
-├── templates/                   # base, login, overview, repo_detail, analysis_detail, settings, dashboard, admin_*
+│   └── routes/                  # overview / dashboard (mode 4종) / add_repo / settings / actions / detail / admin / repo_insights
+├── templates/                   # base, login, overview, repo_detail, analysis_detail, settings, dashboard, admin_*, repo_insights
 ├── cli/                         # python -m src.cli review (git_diff + formatter)
 ├── repositories/                # DB 접근 계층 10종
 └── worker/pipeline.py           # run_analysis_pipeline, build_analysis_result_dict
@@ -153,6 +157,7 @@ Telegram 반자동 콜백:
   → GET /dashboard?days=&mode={overview|insight|security|usage}
   → GET /insights, /insights/me        (301 redirect → /dashboard)
   → GET /repos/{repo}                  (점수 차트 + 이력)
+  → GET /repos/{repo}/insights         (리포별 KPI + 반복 이슈 + 문제 파일 + AI 제안 + 카테고리 분석)
   → GET /repos/{repo}/analyses/{id}    (분석 상세)
   → GET /api/repos, /api/repos/{repo}/stats
 

--- a/src/models/insight_narrative_cache.py
+++ b/src/models/insight_narrative_cache.py
@@ -1,19 +1,13 @@
 """InsightNarrativeCache ORM — Insight 모드 Claude AI narrative 1h TTL 캐시.
 
-Cycle 74 PR-B Phase 2-B 🅑 — UX 영향 최소 + 60% Anthropic API 비용 절감.
-Cycle 74 PR-B Phase 2-B 🅑 — minimum UX impact + 60% Anthropic API cost reduction.
+InsightNarrativeCache ORM — Insight mode Claude AI narrative 1h TTL cache.
 
-Phase 1 PR-1c (사이클 84) — 다국어 지원 캐시 키 분리:
-- language 컬럼 추가 + composite index (user_id, days, language) 갱신
-- 동일 사용자 다른 언어 transition 시 잘못된 캐시 hit 차단 (cross-verify 6차 §3.1 발견)
-
-Phase 1 PR-1c (Cycle 84) — multilingual cache key separation:
-- Add language column + composite index (user_id, days, language)
-- Prevents stale cache hits when same user transitions languages
+0031 — `repo_id` nullable FK 추가 (repo_id=NULL: 전체 대시보드 캐시, repo_id=N: 리포별 캐시).
+0031 — Add nullable `repo_id` FK (NULL=global dashboard cache, N=repo-specific cache).
 """
 from datetime import datetime, timezone
 
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Integer, String, UniqueConstraint
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Integer, String
 
 from src.database import Base
 
@@ -27,13 +21,14 @@ class InsightNarrativeCache(Base):
 
     __tablename__ = "insight_narrative_cache"
     __table_args__ = (
-        UniqueConstraint("user_id", "days", name="uq_insight_cache_user_days"),
-        # Phase 1 PR-1c — composite index (user_id, days, language) 캐시 키 분리
-        # Phase 1 PR-1c — composite index for multilingual cache key separation
+        # 0031: old (user_id, days) UniqueConstraint removed — repo_id 추가로 다중 행 허용.
+        # 0031: old (user_id, days) UniqueConstraint removed — multiple rows allowed with repo_id.
+        # Partial uniqueness enforced by migration 0031 partial indexes (PG only).
         Index(
             "ix_insight_cache_user_days_language",
             "user_id", "days", "language",
         ),
+        Index("ix_insight_cache_repo_id", "repo_id"),
     )
 
     id = Column(Integer, primary_key=True, index=True)
@@ -41,12 +36,15 @@ class InsightNarrativeCache(Base):
         Integer, ForeignKey("users.id", ondelete="CASCADE"),
         nullable=False, index=True,
     )
-    days = Column(Integer, nullable=False)  # 윈도우 (1/7/30/90)
-    # Phase 1 PR-1c — 다국어 캐시 키 (default "en", server_default 의존)
-    # Phase 1 PR-1c — multilingual cache key (default "en", relies on server_default)
+    days = Column(Integer, nullable=False)
     language = Column(String(5), nullable=False, default="en", server_default="en")
+    # 0031 — repo-specific cache key (NULL = global dashboard narrative)
+    # 0031 — 리포별 캐시 키 (NULL = 전체 대시보드 내러티브)
+    repo_id = Column(
+        Integer, ForeignKey("repositories.id", ondelete="CASCADE"),
+        nullable=True, index=True,
+    )
     response_json = Column(JSON, nullable=False)
-    # 4 카드 narrative + status + generated_at 통합 dict
     created_at = Column(
         DateTime, default=lambda: datetime.now(timezone.utc), nullable=False,
     )

--- a/src/repositories/insight_narrative_cache_repo.py
+++ b/src/repositories/insight_narrative_cache_repo.py
@@ -1,6 +1,8 @@
 """InsightNarrativeCache Repository — get / upsert / delete (1h TTL pattern).
 
 Cycle 74 PR-B Phase 2-B 🅑 — Insight 모드 Claude AI 호출 빈도 제한 (60% 절감).
+0031 — repo-scoped cache helpers 추가 (get_fresh_repo / upsert_repo / invalidate_repo).
+0031 — Add repo-scoped cache helpers (get_fresh_repo / upsert_repo / invalidate_repo).
 """
 from __future__ import annotations
 
@@ -19,9 +21,9 @@ DEFAULT_TTL_SECONDS = 3600
 def get_fresh(
     db: Session, *, user_id: int, days: int, now: datetime | None = None,
 ) -> dict[str, Any] | None:
-    """캐시 조회 — 만료 미경과 시 response_json 반환, 없거나 만료면 None.
+    """전체 대시보드 캐시 조회 — 만료 미경과 시 response_json 반환, 없거나 만료면 None.
 
-    Get cache — return response_json if not expired, else None.
+    Get global dashboard cache — return response_json if not expired, else None.
     """
     now = now or datetime.now(timezone.utc)
     row = (
@@ -29,6 +31,7 @@ def get_fresh(
         .filter(
             InsightNarrativeCache.user_id == user_id,
             InsightNarrativeCache.days == days,
+            InsightNarrativeCache.repo_id.is_(None),
         )
         .first()
     )
@@ -48,9 +51,9 @@ def upsert(
     db: Session, *, user_id: int, days: int, response: dict[str, Any],
     ttl_seconds: int = DEFAULT_TTL_SECONDS, now: datetime | None = None,
 ) -> InsightNarrativeCache:
-    """캐시 upsert — (user_id, days) 키 기준 INSERT 또는 UPDATE.
+    """전체 대시보드 캐시 upsert — (user_id, days, repo_id=NULL) 키 기준.
 
-    Upsert cache by (user_id, days). INSERT if absent, UPDATE if present.
+    Upsert global dashboard cache by (user_id, days, repo_id=NULL).
     """
     now = now or datetime.now(timezone.utc)
     expires_at = now + timedelta(seconds=ttl_seconds)
@@ -59,6 +62,7 @@ def upsert(
         .filter(
             InsightNarrativeCache.user_id == user_id,
             InsightNarrativeCache.days == days,
+            InsightNarrativeCache.repo_id.is_(None),
         )
         .first()
     )
@@ -71,7 +75,7 @@ def upsert(
         return existing
 
     row = InsightNarrativeCache(
-        user_id=user_id, days=days, response_json=response,
+        user_id=user_id, days=days, repo_id=None, response_json=response,
         created_at=now, expires_at=expires_at,
     )
     db.add(row)
@@ -81,15 +85,120 @@ def upsert(
 
 
 def invalidate(db: Session, *, user_id: int, days: int) -> bool:
-    """사용자 명시 Refresh 시 강제 무효화 (DELETE).
+    """전체 대시보드 캐시 강제 무효화 (DELETE, repo_id=NULL).
 
-    Force invalidate (DELETE) on user-explicit Refresh.
+    Force invalidate global dashboard cache (DELETE, repo_id=NULL).
     Returns True if deleted, False if not found.
     """
     row = (
         db.query(InsightNarrativeCache)
         .filter(
             InsightNarrativeCache.user_id == user_id,
+            InsightNarrativeCache.days == days,
+            InsightNarrativeCache.repo_id.is_(None),
+        )
+        .first()
+    )
+    if row is None:
+        return False
+    db.delete(row)
+    db.commit()
+    return True
+
+
+# ─── 0031: repo-scoped cache helpers ─────────────────────────────────────────
+# ─── 0031: 리포별 캐시 헬퍼 ─────────────────────────────────────────────────
+
+
+def get_fresh_repo(
+    db: Session,
+    *,
+    user_id: int,
+    repo_id: int,
+    days: int,
+    language: str = "en",
+    now: datetime | None = None,
+) -> dict[str, Any] | None:
+    """리포별 캐시 조회 — 만료 미경과 시 response_json 반환, 없거나 만료면 None.
+
+    Get repo-specific cache — return response_json if not expired, else None.
+    """
+    now = now or datetime.now(timezone.utc)
+    row = (
+        db.query(InsightNarrativeCache)
+        .filter(
+            InsightNarrativeCache.user_id == user_id,
+            InsightNarrativeCache.repo_id == repo_id,
+            InsightNarrativeCache.days == days,
+            InsightNarrativeCache.language == language,
+        )
+        .first()
+    )
+    if row is None:
+        return None
+    expires = row.expires_at
+    if expires.tzinfo is None:
+        expires = expires.replace(tzinfo=timezone.utc)
+    if expires <= now:
+        return None
+    return dict(row.response_json or {})
+
+
+def upsert_repo(
+    db: Session,
+    *,
+    user_id: int,
+    repo_id: int,
+    days: int,
+    language: str = "en",
+    response: dict[str, Any],
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    now: datetime | None = None,
+) -> InsightNarrativeCache:
+    """리포별 캐시 upsert — (user_id, repo_id, days, language) 키 기준.
+
+    Upsert repo-specific cache by (user_id, repo_id, days, language).
+    """
+    now = now or datetime.now(timezone.utc)
+    expires_at = now + timedelta(seconds=ttl_seconds)
+    existing = (
+        db.query(InsightNarrativeCache)
+        .filter(
+            InsightNarrativeCache.user_id == user_id,
+            InsightNarrativeCache.repo_id == repo_id,
+            InsightNarrativeCache.days == days,
+            InsightNarrativeCache.language == language,
+        )
+        .first()
+    )
+    if existing is not None:
+        existing.response_json = response
+        existing.created_at = now
+        existing.expires_at = expires_at
+        db.commit()
+        db.refresh(existing)
+        return existing
+    row = InsightNarrativeCache(
+        user_id=user_id, repo_id=repo_id, days=days, language=language,
+        response_json=response, created_at=now, expires_at=expires_at,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row
+
+
+def invalidate_repo(db: Session, *, user_id: int, repo_id: int, days: int) -> bool:
+    """리포별 캐시 강제 무효화 (DELETE).
+
+    Force invalidate repo-specific cache (DELETE).
+    Returns True if deleted, False if not found.
+    """
+    row = (
+        db.query(InsightNarrativeCache)
+        .filter(
+            InsightNarrativeCache.user_id == user_id,
+            InsightNarrativeCache.repo_id == repo_id,
             InsightNarrativeCache.days == days,
         )
         .first()

--- a/src/repositories/insight_narrative_cache_repo.py
+++ b/src/repositories/insight_narrative_cache_repo.py
@@ -19,7 +19,12 @@ DEFAULT_TTL_SECONDS = 3600
 
 
 def get_fresh(
-    db: Session, *, user_id: int, days: int, now: datetime | None = None,
+    db: Session,
+    *,
+    user_id: int,
+    days: int,
+    language: str = "en",
+    now: datetime | None = None,
 ) -> dict[str, Any] | None:
     """전체 대시보드 캐시 조회 — 만료 미경과 시 response_json 반환, 없거나 만료면 None.
 
@@ -32,6 +37,7 @@ def get_fresh(
             InsightNarrativeCache.user_id == user_id,
             InsightNarrativeCache.days == days,
             InsightNarrativeCache.repo_id.is_(None),
+            InsightNarrativeCache.language == language,
         )
         .first()
     )
@@ -48,12 +54,18 @@ def get_fresh(
 
 
 def upsert(
-    db: Session, *, user_id: int, days: int, response: dict[str, Any],
-    ttl_seconds: int = DEFAULT_TTL_SECONDS, now: datetime | None = None,
+    db: Session,
+    *,
+    user_id: int,
+    days: int,
+    language: str = "en",
+    response: dict[str, Any],
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    now: datetime | None = None,
 ) -> InsightNarrativeCache:
-    """전체 대시보드 캐시 upsert — (user_id, days, repo_id=NULL) 키 기준.
+    """전체 대시보드 캐시 upsert — (user_id, days, language, repo_id=NULL) 키 기준.
 
-    Upsert global dashboard cache by (user_id, days, repo_id=NULL).
+    Upsert global dashboard cache by (user_id, days, language, repo_id=NULL).
     """
     now = now or datetime.now(timezone.utc)
     expires_at = now + timedelta(seconds=ttl_seconds)
@@ -63,6 +75,7 @@ def upsert(
             InsightNarrativeCache.user_id == user_id,
             InsightNarrativeCache.days == days,
             InsightNarrativeCache.repo_id.is_(None),
+            InsightNarrativeCache.language == language,
         )
         .first()
     )
@@ -75,8 +88,8 @@ def upsert(
         return existing
 
     row = InsightNarrativeCache(
-        user_id=user_id, days=days, repo_id=None, response_json=response,
-        created_at=now, expires_at=expires_at,
+        user_id=user_id, days=days, language=language, repo_id=None,
+        response_json=response, created_at=now, expires_at=expires_at,
     )
     db.add(row)
     db.commit()
@@ -188,23 +201,31 @@ def upsert_repo(
     return row
 
 
-def invalidate_repo(db: Session, *, user_id: int, repo_id: int, days: int) -> bool:
+def invalidate_repo(
+    db: Session,
+    *,
+    user_id: int,
+    repo_id: int,
+    days: int,
+    language: str | None = None,
+) -> int:
     """리포별 캐시 강제 무효화 (DELETE).
 
     Force invalidate repo-specific cache (DELETE).
-    Returns True if deleted, False if not found.
+
+    language=None 시 해당 (user_id, repo_id, days) 모든 언어 행 삭제.
+    language=None: delete all language variants for (user_id, repo_id, days).
+    Returns count of deleted rows.
     """
-    row = (
-        db.query(InsightNarrativeCache)
-        .filter(
-            InsightNarrativeCache.user_id == user_id,
-            InsightNarrativeCache.repo_id == repo_id,
-            InsightNarrativeCache.days == days,
-        )
-        .first()
+    q = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == user_id,
+        InsightNarrativeCache.repo_id == repo_id,
+        InsightNarrativeCache.days == days,
     )
-    if row is None:
-        return False
-    db.delete(row)
+    if language is not None:
+        q = q.filter(InsightNarrativeCache.language == language)
+    rows = q.all()
+    for row in rows:
+        db.delete(row)
     db.commit()
-    return True
+    return len(rows)

--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -434,6 +434,85 @@ def feedback_status(db: Session, *, threshold: int = 10) -> dict[str, Any]:
     }
 
 
+# ─── 0031: 리포별 인사이트 카드 (대시보드 섹션용) ───────────────────────────
+# ─── 0031: Per-repo insight cards (dashboard section) ────────────────────────
+
+
+def repo_insight_cards(
+    db: Session,
+    days: int = 30,
+    *,
+    user_id: int | None = None,
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """사용자 소유 리포별 인사이트 카드 요약 — 대시보드 카드 섹션용 (최대 10개).
+
+    Per-repo insight card summary for the dashboard section (max 10 repos).
+
+    Returns list of dicts with: repo_id, full_name, avg_score, grade,
+    recurring_issue_count, score_trend, insights_url.
+    """
+    from src.services.repo_insight_service import (  # noqa: PLC0415
+        repo_kpi,
+        repo_recurring_issues,
+    )
+
+    _now = now or datetime.now(timezone.utc)
+
+    # 사용자 소유 리포 조회 (legacy NULL 포함)
+    # Fetch user-owned repos (legacy NULL user_id included)
+    repo_q = select(Repository)
+    if user_id is not None:
+        repo_q = repo_q.where(
+            (Repository.user_id == user_id) | (Repository.user_id.is_(None))
+        )
+    repos = list(db.scalars(repo_q.limit(50)).all())
+    if not repos:
+        return []
+
+    # 각 리포별 요약 집계
+    # Aggregate summary per repo
+    cards = []
+    for repo in repos:
+        kpi = repo_kpi(db, repo.id, days, now=_now)
+        if kpi["analysis_count"] == 0:
+            continue  # 해당 기간 내 분석 없는 리포 제외 / Skip repos with no analyses in window
+
+        recurring = repo_recurring_issues(db, repo.id, days, n=20, now=_now)
+        recurring_count = len(recurring)
+
+        trend = _score_trend(kpi["score_delta"])
+
+        cards.append({
+            "repo_id": repo.id,
+            "full_name": repo.full_name,
+            "avg_score": kpi["avg_score"],
+            "grade": kpi["grade"],
+            "recurring_issue_count": recurring_count,
+            "score_trend": trend,
+            "insights_url": f"/repos/{repo.full_name}/insights",
+        })
+
+    # avg_score 내림차순 정렬 후 최대 10개 반환
+    # Sort by avg_score descending, return max 10
+    cards.sort(key=lambda c: c["avg_score"] or 0, reverse=True)
+    return cards[:10]
+
+
+def _score_trend(score_delta: float | None) -> str:
+    """점수 delta → 추세 문자열 변환.
+
+    Convert score delta to trend string.
+    """
+    if score_delta is None:
+        return "flat"
+    if score_delta > 1.0:
+        return "up"
+    if score_delta < -1.0:
+        return "down"
+    return "flat"
+
+
 # ─── Phase 3 PR 2: Insight 모드 narrative ──────────────────────────────────
 
 

--- a/src/services/repo_insight_service.py
+++ b/src/services/repo_insight_service.py
@@ -1,0 +1,366 @@
+"""리포별 코드 인사이트 서비스 — 5 집계 함수 + AI narrative.
+
+Repository-level code insight service — 5 aggregation functions + AI narrative.
+
+모든 집계 함수는 Analysis.result JSON을 Python-side 루프로 처리 (최근 30건 상한).
+All aggregation functions process Analysis.result JSON Python-side (max 30 rows).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import anthropic
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.config import settings
+from src.models.analysis import Analysis
+from src.scorer.calculator import calculate_grade
+from src.shared.claude_metrics import extract_anthropic_usage, log_claude_api_call
+
+logger = logging.getLogger(__name__)
+
+# 집계 최대 분석 건수 — Python 루프 O(N×이슈수) 상한
+# Max analyses per aggregation — caps Python loop O(N×issues)
+_MAX_ANALYSES = 30
+
+
+def _fetch_analyses(
+    db: Session, repo_id: int, days: int, now: datetime
+) -> list[Analysis]:
+    """최근 days 내 분석 최대 _MAX_ANALYSES 건 조회 (created_at 내림차순).
+
+    Fetch up to _MAX_ANALYSES analyses within `days` window, newest first.
+    """
+    since = now - timedelta(days=days)
+    return list(
+        db.scalars(
+            select(Analysis)
+            .where(Analysis.repo_id == repo_id)
+            .where(Analysis.created_at >= since)
+            .where(Analysis.created_at <= now)
+            .where(Analysis.result.isnot(None))
+            .order_by(Analysis.created_at.desc())
+            .limit(_MAX_ANALYSES)
+        ).all()
+    )
+
+
+def repo_kpi(
+    db: Session, repo_id: int, days: int = 30, now: datetime | None = None
+) -> dict[str, Any]:
+    """KPI 4종 — 평균 점수/등급/분석수/최다 반복 이슈/보안 HIGH/점수 delta.
+
+    Returns KPI dict with avg_score, grade, analysis_count, top_recurring_issue,
+    top_recurring_count, high_security_count, score_delta.
+    """
+    _now = now or datetime.now(timezone.utc)
+    cur = _fetch_analyses(db, repo_id, days, _now)
+
+    # 직전 동일 기간 (delta 비교용)
+    # Previous identical window for delta comparison
+    prev_since = _now - timedelta(days=days * 2)
+    prev_until = _now - timedelta(days=days)
+    prev = list(
+        db.scalars(
+            select(Analysis)
+            .where(Analysis.repo_id == repo_id)
+            .where(Analysis.created_at >= prev_since)
+            .where(Analysis.created_at < prev_until)
+            .where(Analysis.result.isnot(None))
+            .limit(_MAX_ANALYSES)
+        ).all()
+    )
+
+    cur_scores = [a.score for a in cur if a.score is not None]
+    prev_scores = [a.score for a in prev if a.score is not None]
+    avg_score = round(sum(cur_scores) / len(cur_scores), 1) if cur_scores else None
+    prev_avg = round(sum(prev_scores) / len(prev_scores), 1) if prev_scores else None
+    score_delta = (
+        round(avg_score - prev_avg, 1)
+        if (avg_score is not None and prev_avg is not None)
+        else None
+    )
+    grade = calculate_grade(int(avg_score)) if avg_score is not None else "?"
+
+    # 이슈 빈도 카운트
+    # Issue frequency count
+    issue_counter: dict[str, int] = {}
+    high_security = 0
+    for a in cur:
+        for issue in (a.result or {}).get("issues", []):
+            if not isinstance(issue, dict):
+                continue
+            key = issue.get("message") or issue.get("code")
+            if key:
+                issue_counter[key] = issue_counter.get(key, 0) + 1
+            if (
+                issue.get("category") == "security"
+                and issue.get("severity", "").upper() in ("HIGH", "ERROR")
+            ):
+                high_security += 1
+
+    top_issue, top_count = None, 0
+    if issue_counter:
+        top_issue, top_count = max(issue_counter.items(), key=lambda x: x[1])
+
+    return {
+        "avg_score": avg_score,
+        "grade": grade,
+        "analysis_count": len(cur),
+        "top_recurring_issue": top_issue,
+        "top_recurring_count": top_count,
+        "high_security_count": high_security,
+        "score_delta": score_delta,
+    }
+
+
+def repo_recurring_issues(
+    db: Session, repo_id: int, days: int = 30, n: int = 10, now: datetime | None = None
+) -> list[dict[str, Any]]:
+    """이슈 빈도 Top N — category/severity/tool/language 포함, 빈도 내림차순.
+
+    Top N issues by frequency, sorted descending.
+    """
+    _now = now or datetime.now(timezone.utc)
+    analyses = _fetch_analyses(db, repo_id, days, _now)
+
+    counter: dict[str, int] = {}
+    meta: dict[str, dict[str, str]] = {}
+    for a in analyses:
+        for issue in (a.result or {}).get("issues", []):
+            if not isinstance(issue, dict):
+                continue
+            key = issue.get("message") or issue.get("code")
+            if not key:
+                continue
+            counter[key] = counter.get(key, 0) + 1
+            if key not in meta:
+                meta[key] = {
+                    "category": issue.get("category", ""),
+                    "severity": issue.get("severity", ""),
+                    "tool": issue.get("tool", ""),
+                    "language": issue.get("language", ""),
+                }
+
+    return [
+        {
+            "message": msg,
+            "count": cnt,
+            "category": meta[msg]["category"],
+            "severity": meta[msg]["severity"],
+            "tool": meta[msg]["tool"],
+            "language": meta[msg]["language"],
+        }
+        for msg, cnt in sorted(counter.items(), key=lambda x: x[1], reverse=True)[:n]
+    ]
+
+
+def repo_problem_files(
+    db: Session, repo_id: int, days: int = 30, n: int = 5, now: datetime | None = None
+) -> list[dict[str, Any]]:
+    """문제 파일 Top N — file_feedbacks[].file 빈도 집계 + 프로그레스 바용 pct.
+
+    Top N problem files by frequency, with pct relative to max count.
+    """
+    _now = now or datetime.now(timezone.utc)
+    analyses = _fetch_analyses(db, repo_id, days, _now)
+
+    counter: dict[str, int] = {}
+    for a in analyses:
+        for fb in (a.result or {}).get("file_feedbacks", []):
+            if not isinstance(fb, dict):
+                continue
+            fname = fb.get("file")
+            if fname:
+                counter[fname] = counter.get(fname, 0) + 1
+
+    if not counter:
+        return []
+
+    sorted_items = sorted(counter.items(), key=lambda x: x[1], reverse=True)[:n]
+    max_count = sorted_items[0][1]
+    return [
+        {"file": fname, "count": cnt, "pct": round(cnt / max_count * 100)}
+        for fname, cnt in sorted_items
+    ]
+
+
+def repo_ai_suggestions(
+    db: Session, repo_id: int, days: int = 30, n: int = 10, now: datetime | None = None
+) -> list[dict[str, Any]]:
+    """AI 제안 Top N — 60자 prefix 그룹화, ai_review_status=success 분석만 포함.
+
+    Top N AI suggestions grouped by 60-char prefix, success analyses only.
+    """
+    _now = now or datetime.now(timezone.utc)
+    analyses = _fetch_analyses(db, repo_id, days, _now)
+
+    counter: dict[str, int] = {}
+    for a in analyses:
+        if (a.result or {}).get("ai_review_status") != "success":
+            continue
+        for suggestion in (a.result or {}).get("ai_suggestions", []):
+            if not isinstance(suggestion, str) or not suggestion.strip():
+                continue
+            prefix = suggestion[:60]
+            counter[prefix] = counter.get(prefix, 0) + 1
+
+    return [
+        {"suggestion": prefix, "count": cnt}
+        for prefix, cnt in sorted(counter.items(), key=lambda x: x[1], reverse=True)[:n]
+    ]
+
+
+def repo_category_breakdown(
+    db: Session, repo_id: int, days: int = 30, now: datetime | None = None
+) -> dict[str, int]:
+    """이슈 카테고리×심각도 4-way 분포 — Chart.js 도넛용.
+
+    4-way issue distribution for Chart.js donut chart.
+    """
+    _now = now or datetime.now(timezone.utc)
+    analyses = _fetch_analyses(db, repo_id, days, _now)
+
+    counts: dict[str, int] = {
+        "security_error": 0,
+        "security_warning": 0,
+        "code_quality_error": 0,
+        "code_quality_warning": 0,
+    }
+    for a in analyses:
+        for issue in (a.result or {}).get("issues", []):
+            if not isinstance(issue, dict):
+                continue
+            category = issue.get("category", "")
+            severity = issue.get("severity", "").lower()
+            is_error = severity in ("error", "high")
+            if category == "security":
+                counts["security_error" if is_error else "security_warning"] += 1
+            elif category == "code_quality":
+                counts["code_quality_error" if is_error else "code_quality_warning"] += 1
+
+    counts["total"] = sum(counts.values())
+    return counts
+
+
+# ─── AI 내러티브 ──────────────────────────────────────────────────────────
+
+
+def _extract_narrative_json(text: str) -> str:
+    """Claude 응답에서 JSON 추출 — 코드 블록 우선, {~} fallback.
+
+    Extract JSON from Claude response — prefer fenced block, fallback to braces.
+    """
+    cleaned = text.strip()
+    block = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", cleaned, re.DOTALL | re.IGNORECASE)
+    if block:
+        return block.group(1)
+    first, last = cleaned.find("{"), cleaned.rfind("}")
+    if first != -1 and last > first:
+        return cleaned[first : last + 1]
+    return cleaned
+
+
+async def repo_insight_narrative(
+    db: Session,
+    repo_id: int,
+    days: int = 30,
+    *,
+    repo_full_name: str = "",
+    kpi: dict[str, Any],
+    recurring: list[dict[str, Any]],
+    now: datetime | None = None,
+    refresh: bool = False,
+    user_id: int | None = None,
+    language: str = "en",
+) -> dict[str, Any]:
+    """리포별 Claude AI 진단 내러티브 — 1h TTL 캐시 + refresh 지원.
+
+    Repo-level Claude AI narrative — 1h TTL cache + refresh support.
+    Returns: {"text": str, "status": "success"|"no_api_key"|"no_data"|"api_error"}
+    """
+    api_key = settings.anthropic_api_key
+    if not api_key:
+        return {"text": "", "status": "no_api_key"}
+
+    _now = now or datetime.now(timezone.utc)
+
+    if user_id is not None:
+        from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415
+
+        if refresh:
+            insight_narrative_cache_repo.invalidate_repo(
+                db, user_id=user_id, repo_id=repo_id, days=days
+            )
+        else:
+            cached = insight_narrative_cache_repo.get_fresh_repo(
+                db, user_id=user_id, repo_id=repo_id, days=days, language=language, now=_now,
+            )
+            if cached:
+                return cached
+
+    if not kpi.get("analysis_count"):
+        return {"text": "", "status": "no_data"}
+
+    user_prompt = (
+        f"Repository: {repo_full_name}\n"
+        f"Period: last {days} days\n"
+        f"Avg score: {kpi.get('avg_score')} ({kpi.get('grade')}), "
+        f"delta: {kpi.get('score_delta')}\n"
+        f"Analyses: {kpi.get('analysis_count')}\n"
+        f"Security HIGH: {kpi.get('high_security_count')}\n"
+        f"Top recurring issue: {kpi.get('top_recurring_issue')} "
+        f"({kpi.get('top_recurring_count')} times)\n"
+        f"Top 5 issues: {json.dumps(recurring[:5], ensure_ascii=False)}\n\n"
+        "Please provide a 2-3 paragraph diagnostic narrative in Korean summarizing "
+        "this repository's code quality status, key recurring problems, and concrete "
+        "next steps. Respond with strict JSON only: {\"text\": \"...narrative...\"}"
+    )
+
+    start = time.perf_counter()
+    client = anthropic.AsyncAnthropic(api_key=api_key, timeout=60.0, max_retries=2)
+    try:
+        response = await client.messages.create(
+            model=settings.claude_insight_model,
+            max_tokens=600,
+            messages=[{"role": "user", "content": user_prompt}],
+        )
+        duration_ms = (time.perf_counter() - start) * 1000
+        input_tokens, output_tokens = extract_anthropic_usage(response)
+        log_claude_api_call(
+            model=settings.claude_insight_model,
+            duration_ms=duration_ms,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            status="success",
+        )
+        raw = response.content[0].text
+        data = json.loads(_extract_narrative_json(raw))
+        result: dict[str, Any] = {"text": str(data.get("text", raw)), "status": "success"}
+    except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        duration_ms = (time.perf_counter() - start) * 1000
+        log_claude_api_call(
+            model=settings.claude_insight_model,
+            duration_ms=duration_ms,
+            input_tokens=0,
+            output_tokens=0,
+            status="error",
+        )
+        logger.exception("repo_insight_narrative API call failed")
+        return {"text": "", "status": "api_error"}
+
+    if user_id is not None:
+        from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415
+
+        insight_narrative_cache_repo.upsert_repo(
+            db, user_id=user_id, repo_id=repo_id, days=days,
+            language=language, response=result, now=_now,
+        )
+
+    return result

--- a/src/services/repo_insight_service.py
+++ b/src/services/repo_insight_service.py
@@ -51,7 +51,7 @@ def _fetch_analyses(
     )
 
 
-def repo_kpi(
+def repo_kpi(  # pylint: disable=too-many-locals
     db: Session, repo_id: int, days: int = 30, now: datetime | None = None
 ) -> dict[str, Any]:
     """KPI 4종 — 평균 점수/등급/분석수/최다 반복 이슈/보안 HIGH/점수 delta.
@@ -263,11 +263,11 @@ def _extract_narrative_json(text: str) -> str:
         return block.group(1)
     first, last = cleaned.find("{"), cleaned.rfind("}")
     if first != -1 and last > first:
-        return cleaned[first : last + 1]
+        return cleaned[first : last + 1]  # noqa: E203
     return cleaned
 
 
-async def repo_insight_narrative(
+async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many-locals
     db: Session,
     repo_id: int,
     days: int = 30,
@@ -292,6 +292,7 @@ async def repo_insight_narrative(
     _now = now or datetime.now(timezone.utc)
 
     if user_id is not None:
+        # pylint: disable=import-outside-toplevel
         from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415
 
         if refresh:
@@ -356,6 +357,7 @@ async def repo_insight_narrative(
         return {"text": "", "status": "api_error"}
 
     if user_id is not None:
+        # pylint: disable=import-outside-toplevel
         from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415
 
         insight_narrative_cache_repo.upsert_repo(

--- a/src/static/css/repo_insights.css
+++ b/src/static/css/repo_insights.css
@@ -1,0 +1,451 @@
+/* ──────────────────────────────────────────────────────────
+   Repo Insights page — scoped .ri-* classes
+   CPD 방지: admin.css 분리와 동일 패턴. 독립 파일 분리.
+   CPD prevention: same pattern as admin.css separation.
+   CSS variables only, no hardcoded hex.
+   ────────────────────────────────────────────────────────── */
+
+/* ── 페이지 레이아웃 / Page layout ─────────────────────── */
+.ri-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 24px 16px 64px;
+}
+
+/* ── 헤더 / Header ──────────────────────────────────────── */
+.ri-header {
+  margin-bottom: 28px;
+}
+
+.ri-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--text-2);
+  text-decoration: none;
+  margin-bottom: 12px;
+  transition: color 0.15s;
+}
+
+.ri-back-link:hover {
+  color: var(--accent);
+}
+
+.ri-repo-title {
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 4px;
+  background: linear-gradient(135deg, var(--text-1), var(--accent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.ri-header-meta {
+  font-size: 13px;
+  color: var(--text-2);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.ri-grade-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 20px;
+  font-size: 13px;
+  font-weight: 700;
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  color: var(--accent);
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+/* ── 기간 선택 버튼 / Period selector ───────────────────── */
+.ri-day-selector {
+  display: flex;
+  gap: 6px;
+}
+
+.ri-day-btn {
+  padding: 4px 12px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--text-2);
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  transition: background 0.15s, color 0.15s;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+}
+
+.ri-day-btn:hover,
+.ri-day-btn.active {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  color: var(--accent);
+  border-color: color-mix(in srgb, var(--accent) 30%, transparent);
+}
+
+/* ── KPI 카드 그리드 / KPI card grid ───────────────────── */
+.ri-kpi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.ri-kpi-card {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px) saturate(150%);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  padding: 18px 20px 16px;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.2s, box-shadow 0.2s;
+  min-height: 100px;
+}
+
+.ri-kpi-card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.ri-kpi-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-2);
+  margin-bottom: 8px;
+}
+
+.ri-kpi-value {
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text-1);
+  line-height: 1;
+  margin-bottom: 4px;
+}
+
+.ri-kpi-sub {
+  font-size: 12px;
+  color: var(--text-2);
+}
+
+.ri-delta-up   { color: var(--success); }
+.ri-delta-down { color: var(--danger); }
+
+/* ── 2열 그리드 (반복 이슈 + 도넛) / 2-col grid ─────────── */
+.ri-two-col {
+  display: grid;
+  grid-template-columns: 3fr 2fr;
+  gap: 20px;
+  margin-bottom: 24px;
+}
+
+/* ── 공통 카드 / Common card ────────────────────────────── */
+.ri-card {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px) saturate(150%);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  overflow: hidden;
+  margin-bottom: 24px;
+}
+
+.ri-card-header {
+  padding: 14px 18px 0;
+}
+
+.ri-card-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-1);
+  margin: 0 0 14px;
+}
+
+/* ── 반복 이슈 테이블 / Recurring issues table ───────────── */
+.ri-issues-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.ri-issues-table th {
+  text-align: left;
+  padding: 8px 18px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-2);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+}
+
+.ri-issues-table tbody tr {
+  position: relative;
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background 0.15s;
+}
+
+.ri-issues-table tbody tr:last-child {
+  border-bottom: none;
+}
+
+.ri-issues-table tbody tr::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  width: 3px;
+  background: var(--accent);
+  border-radius: 0 2px 2px 0;
+  transform: scaleY(0);
+  transform-origin: center;
+  transition: transform 0.15s;
+}
+
+.ri-issues-table tbody tr:hover::before {
+  transform: scaleY(1);
+}
+
+.ri-issues-table tbody tr:hover {
+  background: color-mix(in srgb, var(--accent) 5%, transparent);
+}
+
+.ri-issues-table td {
+  padding: 10px 18px;
+  font-size: 13px;
+  color: var(--text-1);
+  vertical-align: middle;
+}
+
+.ri-issues-table td.ri-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--text-2);
+}
+
+/* ── 심각도 배지 / Severity badge ───────────────────────── */
+.ri-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.ri-badge-error {
+  background: color-mix(in srgb, var(--danger) 15%, transparent);
+  color: var(--danger);
+  border: 1px solid color-mix(in srgb, var(--danger) 25%, transparent);
+}
+
+.ri-badge-warning {
+  background: color-mix(in srgb, var(--warning) 15%, transparent);
+  color: var(--warning);
+  border: 1px solid color-mix(in srgb, var(--warning) 25%, transparent);
+}
+
+.ri-badge-tool {
+  background: color-mix(in srgb, var(--text-2) 12%, transparent);
+  color: var(--text-2);
+  border: 1px solid color-mix(in srgb, var(--text-2) 20%, transparent);
+}
+
+/* ── 도넛 차트 컨테이너 / Donut chart container ──────────── */
+.ri-donut-wrap {
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+}
+
+.ri-donut-wrap canvas {
+  max-width: 200px;
+  max-height: 200px;
+}
+
+/* ── 문제 파일 / Problem files ──────────────────────────── */
+.ri-file-list {
+  padding: 0 18px 16px;
+  list-style: none;
+  margin: 0;
+}
+
+.ri-file-row {
+  margin-bottom: 12px;
+}
+
+.ri-file-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.ri-file-name {
+  font-size: 12px;
+  font-family: monospace;
+  color: var(--text-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 70%;
+}
+
+.ri-file-count {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-2);
+  font-variant-numeric: tabular-nums;
+}
+
+.ri-file-bar-bg {
+  height: 6px;
+  background: var(--border-subtle);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.ri-file-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2, var(--accent)));
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+
+/* ── AI 제안 / AI suggestions ───────────────────────────── */
+.ri-suggestions {
+  padding: 0 18px 16px;
+  counter-reset: suggestion;
+  list-style: none;
+  margin: 0;
+}
+
+.ri-suggestion-item {
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  counter-increment: suggestion;
+}
+
+.ri-suggestion-item:last-child {
+  border-bottom: none;
+}
+
+.ri-suggestion-num {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--text-2);
+  min-width: 20px;
+}
+
+.ri-suggestion-text {
+  font-size: 13px;
+  color: var(--text-1);
+  flex: 1;
+  line-height: 1.5;
+}
+
+.ri-suggestion-count {
+  font-size: 11px;
+  color: var(--text-2);
+  white-space: nowrap;
+}
+
+/* ── AI 내러티브 카드 / AI narrative card ───────────────── */
+.ri-narrative-card {
+  background: var(--bg-card);
+  backdrop-filter: blur(12px) saturate(150%);
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  padding: 20px 22px 22px;
+  margin-bottom: 24px;
+  position: relative;
+  overflow: hidden;
+}
+
+.ri-narrative-card::after {
+  content: "";
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--accent), var(--accent-2, var(--accent)));
+  border-radius: 0 0 12px 12px;
+}
+
+.ri-narrative-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-1);
+  margin: 0 0 12px;
+}
+
+.ri-narrative-text {
+  font-size: 14px;
+  color: var(--text-2);
+  line-height: 1.75;
+  white-space: pre-wrap;
+}
+
+/* ── 빈 상태 / Empty state ──────────────────────────────── */
+.ri-empty {
+  text-align: center;
+  padding: 40px 24px;
+  color: var(--text-2);
+  font-size: 14px;
+}
+
+/* ── 반응형 / Responsive ────────────────────────────────── */
+@media (max-width: 1024px) {
+  .ri-kpi-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .ri-page {
+    padding: 16px 12px 48px;
+  }
+
+  .ri-kpi-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 12px;
+  }
+
+  .ri-two-col {
+    grid-template-columns: 1fr;
+  }
+
+  .ri-repo-title {
+    font-size: 20px;
+  }
+
+  /* WCAG 2.5.5 — 모바일 인터랙티브 요소 최소 44px */
+  /* WCAG 2.5.5 — min 44px for mobile interactive elements */
+  .ri-day-btn {
+    min-height: 44px;
+    padding: 0 14px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ri-kpi-card,
+  .ri-issues-table tbody tr::before,
+  .ri-file-bar {
+    transition: none;
+  }
+}

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -840,6 +840,57 @@
   </div>
   {% endif %}
 
+  {# 0031 — 리포별 인사이트 카드 섹션 / Per-repo insight card section #}
+  {% if repo_cards %}
+  <div style="margin-top: 24px;">
+    <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:16px; flex-wrap:wrap; gap:8px;">
+      <h2 class="dash-section-title">🗂 리포별 인사이트</h2>
+      <span style="font-size:12px; color:var(--text-2);">최근 {{ days }}일</span>
+    </div>
+    <div style="display:grid; grid-template-columns:repeat(auto-fill, minmax(240px, 1fr)); gap:16px;">
+      {% for card in repo_cards %}
+      <a href="{{ card.insights_url }}" style="text-decoration:none;">
+        <div style="background:var(--bg-card); border:1px solid var(--border-subtle);
+                    border-radius:12px; padding:16px 18px; transition:transform 0.2s, box-shadow 0.2s;"
+             onmouseenter="this.style.transform='translateY(-2px)'; this.style.boxShadow='var(--shadow-md)'"
+             onmouseleave="this.style.transform=''; this.style.boxShadow=''">
+          <div style="font-size:13px; font-weight:600; color:var(--text-1); margin-bottom:8px;
+                      white-space:nowrap; overflow:hidden; text-overflow:ellipsis;"
+               title="{{ card.full_name }}">{{ card.full_name }}</div>
+          <div style="display:flex; align-items:center; gap:8px; margin-bottom:6px;">
+            <span style="display:inline-flex; align-items:center; padding:2px 10px;
+                         border-radius:20px; font-size:13px; font-weight:700;
+                         background:color-mix(in srgb, var(--accent) 15%, transparent);
+                         color:var(--accent); border:1px solid color-mix(in srgb, var(--accent) 30%, transparent);">
+              {{ card.grade }}
+            </span>
+            {% if card.avg_score is not none %}
+            <span style="font-size:20px; font-weight:700; color:var(--text-1);">{{ card.avg_score }}</span>
+            {% endif %}
+          </div>
+          <div style="font-size:12px; color:var(--text-2); margin-bottom:4px;">
+            반복이슈 {{ card.recurring_issue_count }}종
+          </div>
+          <div style="font-size:12px; color:var(--text-2);">
+            추세
+            {% if card.score_trend == 'up' %}
+              <span style="color:var(--success);">↑ 개선</span>
+            {% elif card.score_trend == 'down' %}
+              <span style="color:var(--danger);">↓ 하락</span>
+            {% else %}
+              <span>→ 유지</span>
+            {% endif %}
+          </div>
+          <div style="margin-top:10px; font-size:12px; color:var(--accent); font-weight:600;">
+            인사이트 보기 →
+          </div>
+        </div>
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
+
   {% endif %}{# end of mode == 'overview' branch (Phase 3 PR 3) #}
 </div>
 {% endblock %}

--- a/src/templates/repo_insights.html
+++ b/src/templates/repo_insights.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}{{ repo.full_name }} — Insights{% endblock %}
+{% block content %}
+<div>{{ repo.full_name }}</div>
+{% endblock %}

--- a/src/templates/repo_insights.html
+++ b/src/templates/repo_insights.html
@@ -1,5 +1,249 @@
 {% extends "base.html" %}
-{% block title %}{{ repo.full_name }} — Insights{% endblock %}
+{% block title %}{{ repo.full_name }} — Insights · SCAManager{% endblock %}
+
 {% block content %}
-<div>{{ repo.full_name }}</div>
+<link rel="stylesheet" href="/static/css/repo_insights.css">
+
+<div class="ri-page">
+
+  {# ── 헤더 ──────────────────────────────────────────────── #}
+  <div class="ri-header">
+    <a href="/dashboard" class="ri-back-link">← 대시보드</a>
+    <div style="display:flex; align-items:flex-end; justify-content:space-between; flex-wrap:wrap; gap:12px;">
+      <div>
+        <h1 class="ri-repo-title">📦 {{ repo.full_name }}</h1>
+        <div class="ri-header-meta">
+          <span class="ri-grade-badge">{{ kpi.grade }}</span>
+          <span>최근 {{ days }}일 · 분석 {{ kpi.analysis_count }}건 기준</span>
+          {% if kpi.score_delta is not none %}
+            {% if kpi.score_delta > 0 %}
+              <span class="ri-delta-up">↑ +{{ kpi.score_delta }}</span>
+            {% elif kpi.score_delta < 0 %}
+              <span class="ri-delta-down">↓ {{ kpi.score_delta }}</span>
+            {% endif %}
+          {% endif %}
+        </div>
+      </div>
+      <div class="ri-day-selector">
+        {% for d in [7, 30, 90] %}
+        <a href="/repos/{{ repo.full_name }}/insights?days={{ d }}"
+           class="ri-day-btn {% if days == d %}active{% endif %}">{{ d }}일</a>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
+  {# ── KPI 4 카드 ─────────────────────────────────────────── #}
+  <div class="ri-kpi-grid">
+    <div class="ri-kpi-card">
+      <div class="ri-kpi-label">평균 점수</div>
+      <div class="ri-kpi-value">
+        {% if kpi.avg_score is not none %}{{ kpi.avg_score }}{% else %}—{% endif %}
+      </div>
+      <div class="ri-kpi-sub">{{ kpi.grade }}등급</div>
+    </div>
+    <div class="ri-kpi-card">
+      <div class="ri-kpi-label">총 분석수</div>
+      <div class="ri-kpi-value">{{ kpi.analysis_count }}</div>
+      <div class="ri-kpi-sub">최근 {{ days }}일</div>
+    </div>
+    <div class="ri-kpi-card">
+      <div class="ri-kpi-label">최다 반복 이슈</div>
+      <div class="ri-kpi-value" style="font-size:16px; word-break:break-word;">
+        {% if kpi.top_recurring_issue %}{{ kpi.top_recurring_issue[:40] }}{% else %}—{% endif %}
+      </div>
+      {% if kpi.top_recurring_count %}
+      <div class="ri-kpi-sub">{{ kpi.top_recurring_count }}회 반복</div>
+      {% endif %}
+    </div>
+    <div class="ri-kpi-card">
+      <div class="ri-kpi-label">보안 HIGH</div>
+      <div class="ri-kpi-value {% if kpi.high_security_count > 0 %}ri-delta-down{% endif %}">
+        {{ kpi.high_security_count }}건
+      </div>
+      <div class="ri-kpi-sub">severity: error / HIGH</div>
+    </div>
+  </div>
+
+  {# ── AI 내러티브 (API 키 있을 때만) ────────────────────── #}
+  {% if narrative and narrative.text %}
+  <div class="ri-narrative-card">
+    <div class="ri-narrative-title">🤖 AI 종합 진단</div>
+    <p class="ri-narrative-text">{{ narrative.text }}</p>
+    <div style="text-align:right; margin-top:8px;">
+      <a href="/repos/{{ repo.full_name }}/insights?days={{ days }}&refresh=1"
+         style="font-size:11px; color:var(--text-2); text-decoration:none;">↺ 갱신</a>
+    </div>
+  </div>
+  {% endif %}
+
+  {# ── 2열: 반복 이슈 테이블 + 카테고리 도넛 ──────────────── #}
+  {% if recurring_issues or breakdown.total > 0 %}
+  <div class="ri-two-col">
+    <div class="ri-card">
+      <div class="ri-card-header">
+        <h2 class="ri-card-title">🔄 반복 이슈 랭킹</h2>
+      </div>
+      {% if recurring_issues %}
+      <table class="ri-issues-table" aria-label="반복 이슈 목록">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>이슈 메시지</th>
+            <th>도구</th>
+            <th class="ri-num">횟수</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for issue in recurring_issues %}
+          <tr>
+            <td style="color:var(--text-2); font-size:12px;">{{ loop.index }}</td>
+            <td>
+              <div style="font-size:13px; word-break:break-word;">{{ issue.message }}</div>
+              <div style="margin-top:3px; display:flex; gap:4px; flex-wrap:wrap;">
+                {% if issue.severity %}
+                <span class="ri-badge {% if issue.severity|lower in ('error','high') %}ri-badge-error{% else %}ri-badge-warning{% endif %}">
+                  {{ issue.severity }}
+                </span>
+                {% endif %}
+                {% if issue.tool %}
+                <span class="ri-badge ri-badge-tool">{{ issue.tool }}</span>
+                {% endif %}
+              </div>
+            </td>
+            <td style="font-size:12px; color:var(--text-2);">{{ issue.tool or '—' }}</td>
+            <td class="ri-num">{{ issue.count }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <div class="ri-empty">반복 이슈 없음</div>
+      {% endif %}
+    </div>
+
+    <div class="ri-card">
+      <div class="ri-card-header">
+        <h2 class="ri-card-title">📊 카테고리 비율</h2>
+      </div>
+      <div class="ri-donut-wrap">
+        {% if breakdown.total > 0 %}
+        <canvas id="riDonutChart" width="200" height="200"
+                aria-label="이슈 카테고리 비율 차트"></canvas>
+        <div style="margin-top:12px; font-size:12px; color:var(--text-2); text-align:center;">
+          전체 {{ breakdown.total }}건
+        </div>
+        {% else %}
+        <div class="ri-empty">집계 데이터 없음</div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  {# ── 문제 파일 TOP 5 ─────────────────────────────────────── #}
+  {% if problem_files %}
+  <div class="ri-card">
+    <div class="ri-card-header">
+      <h2 class="ri-card-title">📁 문제 파일 TOP {{ problem_files|length }}</h2>
+    </div>
+    <ul class="ri-file-list">
+      {% for f in problem_files %}
+      <li class="ri-file-row">
+        <div class="ri-file-info">
+          <span class="ri-file-name" title="{{ f.file }}">{{ f.file }}</span>
+          <span class="ri-file-count">{{ f.count }}회</span>
+        </div>
+        <div class="ri-file-bar-bg">
+          <div class="ri-file-bar" style="width: {{ f.pct }}%;"></div>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+  {% endif %}
+
+  {# ── AI 제안 모음 TOP 10 ─────────────────────────────────── #}
+  {% if ai_suggestions %}
+  <div class="ri-card">
+    <div class="ri-card-header">
+      <h2 class="ri-card-title">💡 AI 제안 모음</h2>
+    </div>
+    <ol class="ri-suggestions">
+      {% for s in ai_suggestions %}
+      <li class="ri-suggestion-item">
+        <span class="ri-suggestion-num">{{ loop.index }}</span>
+        <span class="ri-suggestion-text">{{ s.suggestion }}</span>
+        {% if s.count > 1 %}
+        <span class="ri-suggestion-count">{{ s.count }}회 언급</span>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ol>
+  </div>
+  {% endif %}
+
+  {# 분석 데이터 없을 때 empty state #}
+  {% if kpi.analysis_count == 0 %}
+  <div class="ri-card">
+    <div class="ri-empty">
+      <p>최근 {{ days }}일 내 분석 데이터가 없습니다.</p>
+      <small>GitHub Push 또는 PR 이벤트 발생 후 다시 확인하세요.</small>
+    </div>
+  </div>
+  {% endif %}
+
+</div>
+{% endblock %}
+
+{% block scripts %}
+{% if breakdown.total > 0 %}
+<script src="/static/vendor/chart.umd.min.js"></script>
+<script>
+(function() {
+  const breakdown = {{ breakdown | tojson }};
+
+  function readVar(name, fallback) {
+    const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    return v || fallback;
+  }
+
+  let riChart = null;
+  function buildRiChart() {
+    const ctx = document.getElementById('riDonutChart');
+    if (!ctx) return;
+    if (riChart) riChart.destroy();
+    riChart = new Chart(ctx, {
+      type: 'doughnut',
+      data: {
+        labels: ['보안 오류', '보안 경고', '코드품질 오류', '코드품질 경고'],
+        datasets: [{
+          data: [
+            breakdown.security_error,
+            breakdown.security_warning,
+            breakdown.code_quality_error,
+            breakdown.code_quality_warning,
+          ],
+          backgroundColor: [
+            readVar('--danger',  'oklch(0.637 0.237 25.331)'),
+            readVar('--warning', 'oklch(0.769 0.188 70.08)'),
+            readVar('--accent',  'oklch(0.585 0.233 277.117)'),
+            readVar('--text-2',  'oklch(0.554 0 0)'),
+          ],
+          borderWidth: 0,
+        }],
+      },
+      options: {
+        cutout: '62%',
+        plugins: { legend: { display: false } },
+        animation: { duration: 500 },
+      },
+    });
+  }
+
+  buildRiChart();
+  document.addEventListener('themechange', buildRiChart);
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/src/ui/router.py
+++ b/src/ui/router.py
@@ -15,6 +15,7 @@ from src.ui.routes import (
     dashboard,
     detail,
     overview,
+    repo_insights,
     settings,
 )
 
@@ -27,4 +28,5 @@ router.include_router(dashboard.router)      # GET /dashboard (Phase 1 PR 4 — 
 router.include_router(add_repo.router)       # GET/POST /repos/add, /api/github/repos
 router.include_router(settings.router)       # /repos/{name}/settings, reinstall-*
 router.include_router(actions.router)        # /repos/{name}/delete
+router.include_router(repo_insights.router)  # /repos/{name}/insights (catch-all 이전 등록 필수)
 router.include_router(detail.router)         # /repos/{name}/analyses/{id}, /repos/{name}  (catch-all 마지막)

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -163,6 +163,9 @@ async def dashboard(  # pylint: disable=too-many-locals
         # Phase 2 PR 1: Auto-merge KPI + 실패 분포.
         auto_merge = dashboard_service.auto_merge_kpi(db, days=days, user_id=_uid)
         merge_failures = dashboard_service.merge_failure_distribution(db, days=days, n=5, user_id=_uid)
+        # 0031 — 리포별 인사이트 카드 섹션 (overview 모드 전용)
+        # 0031 — Per-repo insight card section (overview mode only)
+        repo_cards = dashboard_service.repo_insight_cards(db, days=days, user_id=_uid)
         # Phase 2 PR 2 (2026-05-02): feedback CTA — 운영 row=0 → 사용자 행동 유도.
         feedback = dashboard_service.feedback_status(db)
 
@@ -179,6 +182,7 @@ async def dashboard(  # pylint: disable=too-many-locals
             "auto_merge": auto_merge,
             "merge_failures": merge_failures,
             "feedback": feedback,
+            "repo_cards": repo_cards,
             "days": days,
             "locale": locale_value,
         },

--- a/src/ui/routes/repo_insights.py
+++ b/src/ui/routes/repo_insights.py
@@ -57,7 +57,7 @@ def _find_repo(db: Session, repo_name: str, user_id: int):
 
 
 @router.get("/repos/{repo_name:path}/insights", response_class=HTMLResponse)
-async def repo_insights(
+async def repo_insights(  # pylint: disable=too-many-positional-arguments
     request: Request,
     repo_name: str,
     current_user: Annotated[CurrentUser, Depends(require_login)],

--- a/src/ui/routes/repo_insights.py
+++ b/src/ui/routes/repo_insights.py
@@ -1,0 +1,122 @@
+"""리포별 코드 인사이트 라우트 — GET /repos/{name}/insights.
+
+Repository code insights route — GET /repos/{name}/insights.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Generator
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.auth.session import CurrentUser, require_login
+from src.config import settings
+from src.database import SessionLocal
+from src.models.repository import Repository
+from src.services.repo_insight_service import (
+    repo_ai_suggestions,
+    repo_category_breakdown,
+    repo_insight_narrative,
+    repo_kpi,
+    repo_problem_files,
+    repo_recurring_issues,
+)
+from src.shared.log_safety import sanitize_for_log
+from src.ui._helpers import get_locale, templates
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _get_db() -> Generator[Session, None, None]:
+    """DB 세션 의존성 — 테스트에서 override 가능.
+
+    DB session dependency — overrideable in tests.
+    """
+    with SessionLocal() as db:
+        yield db
+
+
+def _find_repo(db: Session, repo_name: str, user_id: int):
+    """사용자 접근 가능한 리포 조회 — 없거나 권한 없으면 None.
+
+    Find user-accessible repo — returns None if not found or unauthorized.
+    """
+    repo = db.scalar(
+        select(Repository).where(Repository.full_name == repo_name)
+    )
+    if repo is None:
+        return None
+    if repo.user_id is not None and repo.user_id != user_id:
+        return None
+    return repo
+
+
+@router.get("/repos/{repo_name:path}/insights", response_class=HTMLResponse)
+async def repo_insights(
+    request: Request,
+    repo_name: str,
+    current_user: Annotated[CurrentUser, Depends(require_login)],
+    db: Annotated[Session, Depends(_get_db)],
+    days: int = 30,
+    refresh: int = 0,
+) -> HTMLResponse:
+    """리포별 코드 인사이트 페이지.
+
+    Per-repository code insights page.
+    """
+    logger.info(
+        "repo_insights user_id=%d repo=%s days=%s",
+        current_user.id,
+        sanitize_for_log(repo_name),
+        sanitize_for_log(str(days), max_len=5),
+    )
+
+    repo = _find_repo(db, repo_name, current_user.id)
+    if repo is None:
+        raise HTTPException(status_code=404, detail="Repository not found")
+
+    kpi = repo_kpi(db, repo.id, days)
+    recurring = repo_recurring_issues(db, repo.id, days)
+    problem_files = repo_problem_files(db, repo.id, days)
+    ai_suggestions = repo_ai_suggestions(db, repo.id, days)
+    breakdown = repo_category_breakdown(db, repo.id, days)
+
+    # AI 내러티브 — API 키 있을 때만
+    # AI narrative — only when API key is configured
+    narrative: dict | None = None
+    if settings.anthropic_api_key:
+        narrative = await repo_insight_narrative(
+            db,
+            repo.id,
+            days,
+            repo_full_name=repo.full_name,
+            kpi=kpi,
+            recurring=recurring,
+            refresh=bool(refresh),
+            user_id=current_user.id,
+            language=get_locale(request),
+        )
+        if narrative and narrative.get("status") != "success":
+            narrative = None
+
+    return templates.TemplateResponse(
+        request,
+        "repo_insights.html",
+        {
+            "current_user": current_user,
+            "repo": repo,
+            "days": days,
+            "kpi": kpi,
+            "recurring_issues": recurring,
+            "problem_files": problem_files,
+            "ai_suggestions": ai_suggestions,
+            "breakdown": breakdown,
+            "narrative": narrative,
+            "locale": get_locale(request),
+        },
+    )

--- a/tests/integration/test_repo_insights_css.py
+++ b/tests/integration/test_repo_insights_css.py
@@ -1,0 +1,65 @@
+"""repo_insights.css 통합 테스트 — 필수 클래스 + WCAG 2.5.5 44px 검증.
+
+repo_insights.css integration test — required classes + WCAG 2.5.5 44px check.
+"""
+from pathlib import Path
+
+import pytest
+
+CSS_PATH = Path("src/static/css/repo_insights.css")
+
+
+@pytest.fixture(scope="module")
+def css_content():
+    assert CSS_PATH.exists(), f"{CSS_PATH} not found"
+    return CSS_PATH.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("cls", [
+    ".ri-page",
+    ".ri-header",
+    ".ri-repo-title",
+    ".ri-grade-badge",
+    ".ri-kpi-grid",
+    ".ri-kpi-card",
+    ".ri-kpi-label",
+    ".ri-kpi-value",
+    ".ri-two-col",
+    ".ri-card",
+    ".ri-issues-table",
+    ".ri-badge-error",
+    ".ri-badge-warning",
+    ".ri-donut-wrap",
+    ".ri-file-bar",
+    ".ri-suggestions",
+    ".ri-narrative-card",
+    ".ri-empty",
+    ".ri-day-btn",
+])
+def test_ri_class_exists(css_content, cls):
+    """각 .ri-* 클래스가 CSS 파일에 정의되어 있다."""
+    assert cls in css_content, f"Missing CSS class: {cls}"
+
+
+def test_mobile_44px_applied_to_day_btn(css_content):
+    """모바일 @media 분기에 .ri-day-btn min-height: 44px가 있다."""
+    assert "min-height: 44px" in css_content
+    media_idx = css_content.rfind("@media (max-width: 768px)")
+    assert media_idx != -1
+    mobile_section = css_content[media_idx:]
+    assert "44px" in mobile_section
+
+
+def test_prefers_reduced_motion_present(css_content):
+    """prefers-reduced-motion 미디어 쿼리가 포함되어 있다."""
+    assert "prefers-reduced-motion" in css_content
+
+
+def test_no_hardcoded_hex_colors(css_content):
+    """CSS 파일에 직접 hex 색상 코드가 없다 (CSS variable 사용 의무)."""
+    import re
+    hex_colors = re.findall(
+        r"(?<![a-zA-Z0-9_-])#([0-9a-fA-F]{6}|[0-9a-fA-F]{3})(?![0-9a-fA-F])",
+        css_content,
+    )
+    assert hex_colors == [], f"Found hardcoded hex colors: {hex_colors}"

--- a/tests/unit/api/test_repo_insights_route.py
+++ b/tests/unit/api/test_repo_insights_route.py
@@ -10,7 +10,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
 
-import src.models  # noqa: F401
 import src.models.insight_narrative_cache  # noqa: F401  (register table on Base.metadata for create_all)
 from src.auth.session import CurrentUser, require_login
 from src.database import Base

--- a/tests/unit/api/test_repo_insights_route.py
+++ b/tests/unit/api/test_repo_insights_route.py
@@ -10,7 +10,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
 
-import src.models.insight_narrative_cache  # noqa: F401  (register table on Base.metadata for create_all)
+from src.models.insight_narrative_cache import InsightNarrativeCache  # noqa: F401  (register table on Base.metadata for create_all)
 from src.auth.session import CurrentUser, require_login
 from src.database import Base
 from src.main import app

--- a/tests/unit/api/test_repo_insights_route.py
+++ b/tests/unit/api/test_repo_insights_route.py
@@ -1,0 +1,125 @@
+"""repo_insights 라우트 단위 테스트 — 200/404/권한 격리.
+
+repo_insights route unit tests — 200/404/permission isolation.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+import src.models  # noqa: F401
+import src.models.insight_narrative_cache  # noqa: F401  (register table on Base.metadata for create_all)
+from src.auth.session import CurrentUser, require_login
+from src.database import Base
+from src.main import app
+from src.models.repository import Repository
+from src.models.user import User
+
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    sess = Session(engine)
+    yield sess
+    sess.close()
+    engine.dispose()
+
+
+@pytest.fixture()
+def test_user(db_session):
+    u = User(github_id=1, github_login="owner", email="owner@x.com", display_name="O")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def other_user(db_session):
+    u = User(github_id=2, github_login="other", email="other@x.com", display_name="X")
+    db_session.add(u)
+    db_session.commit()
+    db_session.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def repo(db_session, test_user):
+    r = Repository(full_name="owner/myrepo", user_id=test_user.id)
+    db_session.add(r)
+    db_session.commit()
+    db_session.refresh(r)
+    return r
+
+
+def _make_client(db_session, user):
+    current = CurrentUser(
+        id=user.id,
+        github_login=user.github_login,
+        email=user.email or "",
+        display_name=user.display_name or "",
+        plaintext_token="ghp_test",
+    )
+    from src.ui.routes.repo_insights import _get_db
+
+    # 기존 override 저장 후 복원 — 모듈 레벨 override 오염 방지
+    # Save existing overrides and restore after test — prevents module-level override pollution.
+    prev_require_login = app.dependency_overrides.get(require_login)
+    app.dependency_overrides[require_login] = lambda: current
+    app.dependency_overrides[_get_db] = lambda: db_session
+    client = TestClient(app)
+    yield client
+    if prev_require_login is None:
+        app.dependency_overrides.pop(require_login, None)
+    else:
+        app.dependency_overrides[require_login] = prev_require_login
+    app.dependency_overrides.pop(_get_db, None)
+
+
+@pytest.fixture()
+def client(db_session, test_user):
+    yield from _make_client(db_session, test_user)
+
+
+@pytest.fixture()
+def other_client(db_session, other_user):
+    yield from _make_client(db_session, other_user)
+
+
+def test_insights_page_returns_200(client, repo):
+    """GET /repos/owner/myrepo/insights → 200."""
+    response = client.get("/repos/owner/myrepo/insights")
+    assert response.status_code == 200
+
+
+def test_insights_page_contains_repo_name(client, repo):
+    """인사이트 페이지 HTML에 리포명이 포함된다."""
+    response = client.get("/repos/owner/myrepo/insights")
+    assert "owner/myrepo" in response.text
+
+
+def test_unknown_repo_returns_404(client):
+    """존재하지 않는 리포 → 404."""
+    response = client.get("/repos/nobody/unknown/insights")
+    assert response.status_code == 404
+
+
+def test_other_user_cannot_access_repo(other_client, repo):
+    """다른 사용자의 리포 → 404 (권한 격리)."""
+    response = other_client.get("/repos/owner/myrepo/insights")
+    assert response.status_code == 404
+
+
+def test_days_parameter_accepted(client, repo):
+    """?days=7, ?days=90 모두 200 반환."""
+    for days in (7, 90):
+        response = client.get(f"/repos/owner/myrepo/insights?days={days}")
+        assert response.status_code == 200

--- a/tests/unit/api/test_repo_insights_route.py
+++ b/tests/unit/api/test_repo_insights_route.py
@@ -10,7 +10,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy.pool import StaticPool
 
-from src.models.insight_narrative_cache import InsightNarrativeCache  # noqa: F401  (register table on Base.metadata for create_all)
+import src.models.insight_narrative_cache  # noqa: F401  (register table on Base.metadata for create_all)
 from src.auth.session import CurrentUser, require_login
 from src.database import Base
 from src.main import app

--- a/tests/unit/migrations/test_0031_repo_insights_cache.py
+++ b/tests/unit/migrations/test_0031_repo_insights_cache.py
@@ -49,25 +49,24 @@ def test_repo_id_is_nullable(engine):
 
 def test_global_and_repo_rows_coexist(engine):
     """같은 (user_id, days) 에 repo_id=NULL 과 repo_id=N 행이 공존 가능하다."""
-    from src.models.insight_narrative_cache import InsightNarrativeCache
     from datetime import datetime, timedelta, timezone
     from sqlalchemy.orm import Session
 
     _now = datetime.now(timezone.utc)
     with Session(engine) as db:
-        db.add(InsightNarrativeCache(
+        db.add(src.models.insight_narrative_cache.InsightNarrativeCache(
             user_id=1, days=30, language="en", repo_id=None,
             response_json={"status": "global"}, created_at=_now,
             expires_at=_now + timedelta(hours=1),
         ))
-        db.add(InsightNarrativeCache(
+        db.add(src.models.insight_narrative_cache.InsightNarrativeCache(
             user_id=1, days=30, language="en", repo_id=5,
             response_json={"status": "repo"}, created_at=_now,
             expires_at=_now + timedelta(hours=1),
         ))
         db.commit()
-        count = db.query(InsightNarrativeCache).filter(
-            InsightNarrativeCache.user_id == 1,
-            InsightNarrativeCache.days == 30,
+        count = db.query(src.models.insight_narrative_cache.InsightNarrativeCache).filter(
+            src.models.insight_narrative_cache.InsightNarrativeCache.user_id == 1,
+            src.models.insight_narrative_cache.InsightNarrativeCache.days == 30,
         ).count()
         assert count == 2

--- a/tests/unit/migrations/test_0031_repo_insights_cache.py
+++ b/tests/unit/migrations/test_0031_repo_insights_cache.py
@@ -1,0 +1,72 @@
+"""0031 마이그레이션 회귀 가드 — insight_narrative_cache.repo_id 컬럼 + 인덱스.
+
+0031 migration regression guard — insight_narrative_cache.repo_id column + index.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+# pylint: disable=wrong-import-position
+import pytest
+from sqlalchemy import create_engine, inspect
+
+from src.database import Base
+
+# Base.metadata.create_all 전 명시 import 의무 — FK 참조 테이블 포함
+# Explicit imports required before create_all — including FK-referenced tables
+import src.models.user  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+import src.models.repository  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+import src.models.insight_narrative_cache  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+
+
+@pytest.fixture()
+def engine():
+    """In-memory SQLite engine (Base.metadata.create_all 사용)."""
+    eng = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(eng)
+    yield eng
+    eng.dispose()
+
+
+def test_repo_id_column_exists(engine):
+    """insight_narrative_cache 테이블에 repo_id 컬럼이 존재한다."""
+    insp = inspect(engine)
+    cols = {c["name"] for c in insp.get_columns("insight_narrative_cache")}
+    assert "repo_id" in cols
+
+
+def test_repo_id_is_nullable(engine):
+    """repo_id 컬럼은 nullable 이다 (기존 전체 대시보드 캐시 하위 호환)."""
+    insp = inspect(engine)
+    col = next(c for c in insp.get_columns("insight_narrative_cache") if c["name"] == "repo_id")
+    assert col["nullable"] is True
+
+
+def test_global_and_repo_rows_coexist(engine):
+    """같은 (user_id, days) 에 repo_id=NULL 과 repo_id=N 행이 공존 가능하다."""
+    from src.models.insight_narrative_cache import InsightNarrativeCache
+    from datetime import datetime, timedelta, timezone
+    from sqlalchemy.orm import Session
+
+    _now = datetime.now(timezone.utc)
+    with Session(engine) as db:
+        db.add(InsightNarrativeCache(
+            user_id=1, days=30, language="en", repo_id=None,
+            response_json={"status": "global"}, created_at=_now,
+            expires_at=_now + timedelta(hours=1),
+        ))
+        db.add(InsightNarrativeCache(
+            user_id=1, days=30, language="en", repo_id=5,
+            response_json={"status": "repo"}, created_at=_now,
+            expires_at=_now + timedelta(hours=1),
+        ))
+        db.commit()
+        count = db.query(InsightNarrativeCache).filter(
+            InsightNarrativeCache.user_id == 1,
+            InsightNarrativeCache.days == 30,
+        ).count()
+        assert count == 2

--- a/tests/unit/migrations/test_0031_repo_insights_cache.py
+++ b/tests/unit/migrations/test_0031_repo_insights_cache.py
@@ -3,6 +3,7 @@
 0031 migration regression guard — insight_narrative_cache.repo_id column + index.
 """
 import os
+import importlib
 
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
@@ -18,9 +19,9 @@ from src.database import Base
 
 # Base.metadata.create_all 전 명시 import 의무 — FK 참조 테이블 포함
 # Explicit imports required before create_all — including FK-referenced tables
-import src.models.user  # noqa: F401  pylint: disable=unused-import,wrong-import-position
-import src.models.repository  # noqa: F401  pylint: disable=unused-import,wrong-import-position
-import src.models.insight_narrative_cache  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+importlib.import_module("src.models.user")
+importlib.import_module("src.models.repository")
+importlib.import_module("src.models.insight_narrative_cache")
 
 
 @pytest.fixture()

--- a/tests/unit/migrations/test_0031_repo_insights_cache.py
+++ b/tests/unit/migrations/test_0031_repo_insights_cache.py
@@ -3,7 +3,6 @@
 0031 migration regression guard — insight_narrative_cache.repo_id column + index.
 """
 import os
-import importlib
 
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
 os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
@@ -19,9 +18,14 @@ from src.database import Base
 
 # Base.metadata.create_all 전 명시 import 의무 — FK 참조 테이블 포함
 # Explicit imports required before create_all — including FK-referenced tables
-importlib.import_module("src.models.user")
-importlib.import_module("src.models.repository")
-importlib.import_module("src.models.insight_narrative_cache")
+# 🔴 regular `import X.Y` 문법 필수 — `importlib.import_module` 은 `src` 를 호출자 globals 에 바인딩하지 않음.
+# 🔴 Must use `import X.Y` syntax — importlib.import_module does NOT bind `src` in caller globals,
+#    and coverage.py in Python 3.12 rewrites lazy `from X import Y` inside functions to `X.Y` form,
+#    which then fails with NameError if `X` is not in scope.
+import src.models.user  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+import src.models.repository  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+import src.models.insight_narrative_cache  # noqa: F401  pylint: disable=unused-import,wrong-import-position
+from src.models.insight_narrative_cache import InsightNarrativeCache  # noqa: F401
 
 
 @pytest.fixture()

--- a/tests/unit/repositories/test_insight_narrative_cache_repo.py
+++ b/tests/unit/repositories/test_insight_narrative_cache_repo.py
@@ -93,3 +93,95 @@ def test_per_user_isolation(db):
     insight_narrative_cache_repo.upsert(db, user_id=2, days=7, response={"u": 2})
     assert insight_narrative_cache_repo.get_fresh(db, user_id=1, days=7) == {"u": 1}
     assert insight_narrative_cache_repo.get_fresh(db, user_id=2, days=7) == {"u": 2}
+
+
+def test_language_filter_isolates_cache(db):
+    """language 파라미터 — ko / en 독립 캐시."""
+    insight_narrative_cache_repo.upsert(db, user_id=1, days=7, language="en", response={"lang": "en"})
+    insight_narrative_cache_repo.upsert(db, user_id=1, days=7, language="ko", response={"lang": "ko"})
+    assert insight_narrative_cache_repo.get_fresh(db, user_id=1, days=7, language="en") == {"lang": "en"}
+    assert insight_narrative_cache_repo.get_fresh(db, user_id=1, days=7, language="ko") == {"lang": "ko"}
+
+
+# ─── repo-scoped helpers (0031) ────────────────────────────────────────────
+
+
+def test_get_fresh_repo_returns_none_when_absent(db):
+    """리포 캐시 없음 → None."""
+    result = insight_narrative_cache_repo.get_fresh_repo(db, user_id=1, repo_id=10, days=30)
+    assert result is None
+
+
+def test_get_fresh_repo_returns_cached(db):
+    """upsert_repo 후 즉시 get_fresh_repo = response_json."""
+    insight_narrative_cache_repo.upsert_repo(
+        db, user_id=1, repo_id=10, days=30, response={"text": "ok", "status": "success"}
+    )
+    result = insight_narrative_cache_repo.get_fresh_repo(db, user_id=1, repo_id=10, days=30)
+    assert result == {"text": "ok", "status": "success"}
+
+
+def test_get_fresh_repo_returns_none_after_ttl_expiry(db):
+    """TTL 만료 후 get_fresh_repo = None."""
+    from datetime import datetime, timedelta, timezone
+    now = datetime.now(timezone.utc)
+    insight_narrative_cache_repo.upsert_repo(
+        db, user_id=1, repo_id=10, days=30, response={"status": "success"}, ttl_seconds=60, now=now,
+    )
+    future = now + timedelta(seconds=61)
+    assert insight_narrative_cache_repo.get_fresh_repo(db, user_id=1, repo_id=10, days=30, now=future) is None
+
+
+def test_upsert_repo_replaces_existing(db):
+    """동일 (user_id, repo_id, days) 재 upsert = UPDATE (INSERT X)."""
+    insight_narrative_cache_repo.upsert_repo(db, user_id=1, repo_id=10, days=30, response={"v": 1})
+    insight_narrative_cache_repo.upsert_repo(db, user_id=1, repo_id=10, days=30, response={"v": 2})
+    result = insight_narrative_cache_repo.get_fresh_repo(db, user_id=1, repo_id=10, days=30)
+    assert result == {"v": 2}
+    rows = db.query(InsightNarrativeCache).filter_by(user_id=1, repo_id=10, days=30).all()
+    assert len(rows) == 1
+
+
+def test_upsert_repo_language_isolation(db):
+    """(repo_id, language) 분리 — en/ko 독립."""
+    insight_narrative_cache_repo.upsert_repo(db, user_id=1, repo_id=10, days=30, language="en", response={"lang": "en"})
+    insight_narrative_cache_repo.upsert_repo(db, user_id=1, repo_id=10, days=30, language="ko", response={"lang": "ko"})
+    assert insight_narrative_cache_repo.get_fresh_repo(db, user_id=1, repo_id=10, days=30, language="en") == {"lang": "en"}
+    assert insight_narrative_cache_repo.get_fresh_repo(db, user_id=1, repo_id=10, days=30, language="ko") == {"lang": "ko"}
+
+
+def test_invalidate_repo_with_language(db):
+    """invalidate_repo(language=) — 특정 언어 행만 삭제 후 count 반환."""
+    insight_narrative_cache_repo.upsert_repo(db, user_id=1, repo_id=10, days=30, language="en", response={"v": 1})
+    insight_narrative_cache_repo.upsert_repo(db, user_id=1, repo_id=10, days=30, language="ko", response={"v": 2})
+    deleted = insight_narrative_cache_repo.invalidate_repo(db, user_id=1, repo_id=10, days=30, language="en")
+    assert deleted == 1
+    assert insight_narrative_cache_repo.get_fresh_repo(db, user_id=1, repo_id=10, days=30, language="en") is None
+    assert insight_narrative_cache_repo.get_fresh_repo(db, user_id=1, repo_id=10, days=30, language="ko") is not None
+
+
+def test_invalidate_repo_all_languages(db):
+    """invalidate_repo(language=None) — 모든 언어 변형 일괄 삭제."""
+    insight_narrative_cache_repo.upsert_repo(db, user_id=1, repo_id=10, days=30, language="en", response={"v": 1})
+    insight_narrative_cache_repo.upsert_repo(db, user_id=1, repo_id=10, days=30, language="ko", response={"v": 2})
+    deleted = insight_narrative_cache_repo.invalidate_repo(db, user_id=1, repo_id=10, days=30, language=None)
+    assert deleted == 2
+    rows = db.query(InsightNarrativeCache).filter_by(user_id=1, repo_id=10, days=30).all()
+    assert rows == []
+
+
+def test_invalidate_repo_absent_returns_zero(db):
+    """없는 리포 캐시 삭제 → 0 반환."""
+    result = insight_narrative_cache_repo.invalidate_repo(db, user_id=1, repo_id=999, days=30)
+    assert result == 0
+
+
+def test_repo_cache_isolated_from_global(db):
+    """리포 캐시 ↔ 전체 캐시 완전 분리 (repo_id=NULL vs repo_id=N)."""
+    insight_narrative_cache_repo.upsert(db, user_id=1, days=30, response={"scope": "global"})
+    insight_narrative_cache_repo.upsert_repo(db, user_id=1, repo_id=5, days=30, response={"scope": "repo"})
+    assert insight_narrative_cache_repo.get_fresh(db, user_id=1, days=30) == {"scope": "global"}
+    assert insight_narrative_cache_repo.get_fresh_repo(db, user_id=1, repo_id=5, days=30) == {"scope": "repo"}
+    # 전체 캐시 무효화가 리포 캐시에 영향 없음
+    insight_narrative_cache_repo.invalidate(db, user_id=1, days=30)
+    assert insight_narrative_cache_repo.get_fresh_repo(db, user_id=1, repo_id=5, days=30) == {"scope": "repo"}

--- a/tests/unit/services/test_repo_insight_cards.py
+++ b/tests/unit/services/test_repo_insight_cards.py
@@ -12,7 +12,6 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-import src.models  # noqa: F401
 from src.database import Base
 from src.models.analysis import Analysis
 from src.models.repository import Repository

--- a/tests/unit/services/test_repo_insight_cards.py
+++ b/tests/unit/services/test_repo_insight_cards.py
@@ -1,0 +1,120 @@
+"""repo_insight_cards 단위 테스트 — 대시보드 리포별 인사이트 카드 섹션.
+
+repo_insight_cards unit tests — dashboard per-repo insight card section.
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+import src.models  # noqa: F401
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.repository import Repository
+from src.models.user import User
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def user(db):
+    u = User(github_id=77, github_login="owner", email="o@x.com", display_name="O")
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+def _make_repo(db, name, user_id):
+    r = Repository(full_name=name, user_id=user_id)
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _make_analysis(db, repo_id, score, offset_hours=0, result=None):
+    a = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{uuid.uuid4().hex}",
+        score=score,
+        grade="B",
+        result=result or {},
+        created_at=datetime.now(timezone.utc) - timedelta(hours=offset_hours),
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+class TestRepoInsightCards:
+    def test_returns_list_of_cards(self, db, user):
+        from src.services.dashboard_service import repo_insight_cards
+
+        r = _make_repo(db, "owner/api", user.id)
+        _make_analysis(db, r.id, 80)
+
+        result = repo_insight_cards(db, days=30, user_id=user.id)
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+    def test_card_has_required_keys(self, db, user):
+        from src.services.dashboard_service import repo_insight_cards
+
+        r = _make_repo(db, "owner/web", user.id)
+        _make_analysis(db, r.id, 75)
+
+        card = repo_insight_cards(db, days=30, user_id=user.id)[0]
+        assert set(card.keys()) >= {
+            "repo_id", "full_name", "avg_score", "grade",
+            "recurring_issue_count", "score_trend", "insights_url",
+        }
+
+    def test_insights_url_format(self, db, user):
+        from src.services.dashboard_service import repo_insight_cards
+
+        r = _make_repo(db, "owner/my-repo", user.id)
+        _make_analysis(db, r.id, 80)
+
+        card = repo_insight_cards(db, days=30, user_id=user.id)[0]
+        assert card["insights_url"] == "/repos/owner/my-repo/insights"
+
+    def test_empty_repos_returns_empty_list(self, db, user):
+        from src.services.dashboard_service import repo_insight_cards
+
+        result = repo_insight_cards(db, days=30, user_id=user.id)
+        assert result == []
+
+    def test_score_trend_up_when_improved(self, db, user):
+        from src.services.dashboard_service import repo_insight_cards
+
+        r = _make_repo(db, "owner/cli", user.id)
+        # Previous window: score 50 (35 days ago), current window: score 80 (5 hours ago)
+        _make_analysis(db, r.id, 50, offset_hours=24 * 35)
+        _make_analysis(db, r.id, 80, offset_hours=5)
+
+        card = repo_insight_cards(db, days=30, user_id=user.id)[0]
+        assert card["score_trend"] == "up"
+
+    def test_max_10_repos(self, db, user):
+        from src.services.dashboard_service import repo_insight_cards
+
+        for i in range(12):
+            r = _make_repo(db, f"owner/repo-{i}", user.id)
+            _make_analysis(db, r.id, 70)
+
+        result = repo_insight_cards(db, days=30, user_id=user.id)
+        assert len(result) <= 10

--- a/tests/unit/services/test_repo_insight_service.py
+++ b/tests/unit/services/test_repo_insight_service.py
@@ -1,4 +1,4 @@
-"""repo_insight_service 단위 테스트 — 5 집계 함수 + AI narrative stub.
+"""repo_insight_service 단위 테스트 — 5 집계 함수 + AI narrative.
 
 In-memory SQLite + Base.metadata.create_all 자체 fixture 사용.
 """
@@ -8,6 +8,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy import create_engine
@@ -256,3 +257,167 @@ class TestRepoCategoryBreakdown:
         from src.services.repo_insight_service import repo_category_breakdown
         bd = repo_category_breakdown(db, repo.id)
         assert bd["total"] == 0
+
+
+# ─── repo_insight_narrative ────────────────────────────────────────────────
+
+
+class TestRepoInsightNarrative:
+    """repo_insight_narrative async 함수 — 캐시/API/fallback 경로 검증."""
+
+    @pytest.mark.asyncio
+    async def test_no_api_key_returns_no_api_key_status(self, db, repo):
+        """ANTHROPIC_API_KEY 미설정 → no_api_key."""
+        from src.services.repo_insight_service import repo_insight_narrative
+        with patch("src.services.repo_insight_service.settings") as s:
+            s.anthropic_api_key = None
+            result = await repo_insight_narrative(
+                db, repo.id, kpi={"analysis_count": 5, "avg_score": 80, "grade": "B",
+                                   "score_delta": 1, "high_security_count": 0,
+                                   "top_recurring_issue": "x", "top_recurring_count": 1},
+                recurring=[],
+            )
+        assert result == {"text": "", "status": "no_api_key"}
+
+    @pytest.mark.asyncio
+    async def test_no_data_returns_no_data_status(self, db, repo):
+        """analysis_count=0 → no_data (API 호출 X)."""
+        from src.services.repo_insight_service import repo_insight_narrative
+        with patch("src.services.repo_insight_service.settings") as s:
+            s.anthropic_api_key = "sk-ant-test"
+            s.claude_insight_model = "claude-haiku-4-5-20251001"
+            result = await repo_insight_narrative(
+                db, repo.id, kpi={"analysis_count": 0}, recurring=[],
+            )
+        assert result == {"text": "", "status": "no_data"}
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_skips_api_call(self, db, repo, user):
+        """user_id 제공 + 유효 캐시 → API 호출 없이 캐시 반환."""
+        from src.repositories import insight_narrative_cache_repo
+        from src.services.repo_insight_service import repo_insight_narrative
+
+        cached = {"text": "cached narrative", "status": "success"}
+        insight_narrative_cache_repo.upsert_repo(
+            db, user_id=user.id, repo_id=repo.id, days=30, response=cached,
+        )
+        with patch("src.services.repo_insight_service.settings") as s:
+            s.anthropic_api_key = "sk-ant-test"
+            s.claude_insight_model = "claude-haiku-4-5-20251001"
+            result = await repo_insight_narrative(
+                db, repo.id, user_id=user.id,
+                kpi={"analysis_count": 5, "avg_score": 80, "grade": "B",
+                     "score_delta": 1, "high_security_count": 0,
+                     "top_recurring_issue": "x", "top_recurring_count": 1},
+                recurring=[],
+            )
+        assert result == cached
+
+    @pytest.mark.asyncio
+    async def test_api_success_stores_in_cache(self, db, repo, user):
+        """API 성공 + user_id 제공 → 결과 캐시 저장."""
+        from src.repositories import insight_narrative_cache_repo
+        from src.services.repo_insight_service import repo_insight_narrative
+
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text='{"text": "great repo"}')]
+        mock_msg.usage = MagicMock(input_tokens=10, output_tokens=20)
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_msg)
+
+        with patch("src.services.repo_insight_service.settings") as s, \
+             patch("src.services.repo_insight_service.anthropic.AsyncAnthropic", return_value=mock_client):
+            s.anthropic_api_key = "sk-ant-test"
+            s.claude_insight_model = "claude-haiku-4-5-20251001"
+            result = await repo_insight_narrative(
+                db, repo.id, user_id=user.id,
+                kpi={"analysis_count": 3, "avg_score": 75, "grade": "C",
+                     "score_delta": -2, "high_security_count": 1,
+                     "top_recurring_issue": "sql injection", "top_recurring_count": 2},
+                recurring=[{"message": "sql injection", "count": 2, "category": "security",
+                            "severity": "error", "tool": "bandit", "language": "python"}],
+            )
+        assert result["status"] == "success"
+        assert result["text"] == "great repo"
+        cached = insight_narrative_cache_repo.get_fresh_repo(db, user_id=user.id, repo_id=repo.id, days=30)
+        assert cached == result
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_api_error_status(self, db, repo):
+        """API 예외 → api_error."""
+        from src.services.repo_insight_service import repo_insight_narrative
+
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(side_effect=RuntimeError("network down"))
+
+        with patch("src.services.repo_insight_service.settings") as s, \
+             patch("src.services.repo_insight_service.anthropic.AsyncAnthropic", return_value=mock_client):
+            s.anthropic_api_key = "sk-ant-test"
+            s.claude_insight_model = "claude-haiku-4-5-20251001"
+            result = await repo_insight_narrative(
+                db, repo.id,
+                kpi={"analysis_count": 2, "avg_score": 60, "grade": "D",
+                     "score_delta": None, "high_security_count": 0,
+                     "top_recurring_issue": None, "top_recurring_count": 0},
+                recurring=[],
+            )
+        assert result == {"text": "", "status": "api_error"}
+
+    @pytest.mark.asyncio
+    async def test_refresh_invalidates_cache_and_calls_api(self, db, repo, user):
+        """refresh=True → 기존 캐시 삭제 + API 재호출."""
+        from src.repositories import insight_narrative_cache_repo
+        from src.services.repo_insight_service import repo_insight_narrative
+
+        # Seed stale cache
+        insight_narrative_cache_repo.upsert_repo(
+            db, user_id=user.id, repo_id=repo.id, days=30, response={"text": "old", "status": "success"}
+        )
+
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text='{"text": "refreshed narrative"}')]
+        mock_msg.usage = MagicMock(input_tokens=10, output_tokens=20)
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_msg)
+
+        with patch("src.services.repo_insight_service.settings") as s, \
+             patch("src.services.repo_insight_service.anthropic.AsyncAnthropic", return_value=mock_client):
+            s.anthropic_api_key = "sk-ant-test"
+            s.claude_insight_model = "claude-haiku-4-5-20251001"
+            result = await repo_insight_narrative(
+                db, repo.id, user_id=user.id, refresh=True,
+                kpi={"analysis_count": 2, "avg_score": 70, "grade": "C",
+                     "score_delta": 5, "high_security_count": 0,
+                     "top_recurring_issue": None, "top_recurring_count": 0},
+                recurring=[],
+            )
+        assert result["text"] == "refreshed narrative"
+        mock_client.messages.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_user_id_does_not_cache(self, db, repo):
+        """user_id=None → 캐시 저장 X."""
+        from src.models.insight_narrative_cache import InsightNarrativeCache
+        from src.services.repo_insight_service import repo_insight_narrative
+
+        mock_msg = MagicMock()
+        mock_msg.content = [MagicMock(text='{"text": "narrative"}')]
+        mock_msg.usage = MagicMock(input_tokens=5, output_tokens=10)
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_msg)
+
+        with patch("src.services.repo_insight_service.settings") as s, \
+             patch("src.services.repo_insight_service.anthropic.AsyncAnthropic", return_value=mock_client):
+            s.anthropic_api_key = "sk-ant-test"
+            s.claude_insight_model = "claude-haiku-4-5-20251001"
+            result = await repo_insight_narrative(
+                db, repo.id, user_id=None,
+                kpi={"analysis_count": 1, "avg_score": 80, "grade": "B",
+                     "score_delta": None, "high_security_count": 0,
+                     "top_recurring_issue": None, "top_recurring_count": 0},
+                recurring=[],
+            )
+        assert result["status"] == "success"
+        rows = db.query(InsightNarrativeCache).filter_by(repo_id=repo.id).all()
+        assert rows == []

--- a/tests/unit/services/test_repo_insight_service.py
+++ b/tests/unit/services/test_repo_insight_service.py
@@ -1,0 +1,258 @@
+"""repo_insight_service 단위 테스트 — 5 집계 함수 + AI narrative stub.
+
+In-memory SQLite + Base.metadata.create_all 자체 fixture 사용.
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+import src.models  # noqa: F401  side-effect: populate Base.metadata
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.repository import Repository
+from src.models.user import User
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def user(db):
+    u = User(github_id=99, github_login="tester", email="t@x.com", display_name="T")
+    db.add(u)
+    db.commit()
+    db.refresh(u)
+    return u
+
+
+@pytest.fixture()
+def repo(db, user):
+    r = Repository(full_name="owner/myrepo", user_id=user.id)
+    db.add(r)
+    db.commit()
+    db.refresh(r)
+    return r
+
+
+def _add_analysis(
+    db: Session,
+    repo_id: int,
+    *,
+    offset_hours: int = 0,
+    result: dict[str, Any] | None = None,
+    score: int = 70,
+) -> Analysis:
+    a = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{uuid.uuid4().hex}",
+        score=score,
+        grade="C",
+        result=result or {},
+        created_at=datetime.now(timezone.utc) - timedelta(hours=offset_hours),
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+# ─── repo_kpi ────────────────────────────────────────────────────────────
+
+
+class TestRepoKpi:
+    def test_returns_required_keys(self, db, repo):
+        from src.services.repo_insight_service import repo_kpi
+
+        _add_analysis(db, repo.id, score=80)
+        result = repo_kpi(db, repo.id)
+
+        assert set(result.keys()) >= {
+            "avg_score", "grade", "analysis_count",
+            "top_recurring_issue", "top_recurring_count",
+            "high_security_count", "score_delta",
+        }
+
+    def test_empty_repo_returns_none_avg(self, db, repo):
+        from src.services.repo_insight_service import repo_kpi
+
+        result = repo_kpi(db, repo.id)
+        assert result["avg_score"] is None
+        assert result["analysis_count"] == 0
+
+    def test_days_filter_excludes_old_analysis(self, db, repo):
+        from src.services.repo_insight_service import repo_kpi
+
+        _add_analysis(db, repo.id, offset_hours=24 * 40, score=50)  # 40 days ago
+        result = repo_kpi(db, repo.id, days=30)
+        assert result["analysis_count"] == 0
+
+    def test_counts_high_security_issues(self, db, repo):
+        from src.services.repo_insight_service import repo_kpi
+
+        _add_analysis(db, repo.id, result={
+            "issues": [
+                {"category": "security", "severity": "HIGH", "message": "sql inj"},
+                {"category": "code_quality", "severity": "error", "message": "line too long"},
+            ]
+        })
+        result = repo_kpi(db, repo.id)
+        assert result["high_security_count"] == 1
+
+    def test_identifies_top_recurring_issue(self, db, repo):
+        from src.services.repo_insight_service import repo_kpi
+
+        issue = {"category": "code_quality", "severity": "warning", "message": "line too long"}
+        for _ in range(3):
+            _add_analysis(db, repo.id, result={"issues": [issue]})
+        result = repo_kpi(db, repo.id)
+        assert result["top_recurring_issue"] == "line too long"
+        assert result["top_recurring_count"] == 3
+
+
+# ─── repo_recurring_issues ───────────────────────────────────────────────
+
+
+class TestRepoRecurringIssues:
+    def test_returns_sorted_by_count(self, db, repo):
+        from src.services.repo_insight_service import repo_recurring_issues
+
+        for _ in range(3):
+            _add_analysis(db, repo.id, result={"issues": [
+                {"message": "A", "category": "code_quality", "severity": "warning", "tool": "pylint", "language": "python"},
+            ]})
+        _add_analysis(db, repo.id, result={"issues": [
+            {"message": "B", "category": "security", "severity": "error", "tool": "bandit", "language": "python"},
+        ]})
+
+        result = repo_recurring_issues(db, repo.id)
+        assert result[0]["message"] == "A"
+        assert result[0]["count"] == 3
+        assert result[1]["message"] == "B"
+
+    def test_empty_returns_empty_list(self, db, repo):
+        from src.services.repo_insight_service import repo_recurring_issues
+        assert repo_recurring_issues(db, repo.id) == []
+
+    def test_result_dict_has_required_keys(self, db, repo):
+        from src.services.repo_insight_service import repo_recurring_issues
+
+        _add_analysis(db, repo.id, result={"issues": [
+            {"message": "x", "category": "security", "severity": "error", "tool": "bandit", "language": "python"},
+        ]})
+        item = repo_recurring_issues(db, repo.id)[0]
+        assert set(item.keys()) >= {"message", "count", "category", "severity", "tool", "language"}
+
+
+# ─── repo_problem_files ──────────────────────────────────────────────────
+
+
+class TestRepoProblemFiles:
+    def test_returns_sorted_by_count(self, db, repo):
+        from src.services.repo_insight_service import repo_problem_files
+
+        for _ in range(4):
+            _add_analysis(db, repo.id, result={"file_feedbacks": [{"file": "src/main.py", "text": "x"}]})
+        _add_analysis(db, repo.id, result={"file_feedbacks": [{"file": "src/other.py", "text": "y"}]})
+
+        result = repo_problem_files(db, repo.id)
+        assert result[0]["file"] == "src/main.py"
+        assert result[0]["count"] == 4
+        assert result[0]["pct"] == 100
+
+    def test_pct_calculated_relative_to_max(self, db, repo):
+        from src.services.repo_insight_service import repo_problem_files
+
+        for _ in range(4):
+            _add_analysis(db, repo.id, result={"file_feedbacks": [{"file": "a.py", "text": "x"}]})
+        for _ in range(2):
+            _add_analysis(db, repo.id, result={"file_feedbacks": [{"file": "b.py", "text": "y"}]})
+
+        result = repo_problem_files(db, repo.id)
+        assert result[0]["pct"] == 100
+        assert result[1]["pct"] == 50
+
+    def test_empty_returns_empty_list(self, db, repo):
+        from src.services.repo_insight_service import repo_problem_files
+        assert repo_problem_files(db, repo.id) == []
+
+
+# ─── repo_ai_suggestions ─────────────────────────────────────────────────
+
+
+class TestRepoAiSuggestions:
+    def test_groups_by_60char_prefix(self, db, repo):
+        from src.services.repo_insight_service import repo_ai_suggestions
+
+        suggestion = "A" * 70  # longer than 60 chars — two identical prefixes
+        for _ in range(2):
+            _add_analysis(db, repo.id, result={
+                "ai_review_status": "success",
+                "ai_suggestions": [suggestion],
+            })
+        result = repo_ai_suggestions(db, repo.id)
+        assert len(result) == 1
+        assert result[0]["count"] == 2
+
+    def test_excludes_non_success_analyses(self, db, repo):
+        from src.services.repo_insight_service import repo_ai_suggestions
+
+        _add_analysis(db, repo.id, result={
+            "ai_review_status": "error",
+            "ai_suggestions": ["fix this"],
+        })
+        assert repo_ai_suggestions(db, repo.id) == []
+
+    def test_empty_returns_empty_list(self, db, repo):
+        from src.services.repo_insight_service import repo_ai_suggestions
+        assert repo_ai_suggestions(db, repo.id) == []
+
+
+# ─── repo_category_breakdown ─────────────────────────────────────────────
+
+
+class TestRepoCategoryBreakdown:
+    def test_returns_5_keys(self, db, repo):
+        from src.services.repo_insight_service import repo_category_breakdown
+
+        result = repo_category_breakdown(db, repo.id)
+        assert set(result.keys()) == {
+            "security_error", "security_warning",
+            "code_quality_error", "code_quality_warning", "total",
+        }
+
+    def test_counts_by_category_and_severity(self, db, repo):
+        from src.services.repo_insight_service import repo_category_breakdown
+
+        _add_analysis(db, repo.id, result={"issues": [
+            {"category": "security", "severity": "error"},
+            {"category": "security", "severity": "warning"},
+            {"category": "code_quality", "severity": "error"},
+            {"category": "code_quality", "severity": "warning"},
+        ]})
+        bd = repo_category_breakdown(db, repo.id)
+        assert bd["security_error"] == 1
+        assert bd["security_warning"] == 1
+        assert bd["code_quality_error"] == 1
+        assert bd["code_quality_warning"] == 1
+        assert bd["total"] == 4
+
+    def test_empty_all_zeros(self, db, repo):
+        from src.services.repo_insight_service import repo_category_breakdown
+        bd = repo_category_breakdown(db, repo.id)
+        assert bd["total"] == 0


### PR DESCRIPTION
## Summary

- Add `GET /repos/{name}/insights` page showing per-repo KPI, recurring issues, problem files, AI suggestions, category breakdown, and optional AI narrative
- Extend `insight_narrative_cache` with nullable `repo_id` FK (migration 0031) for repo-scoped AI narrative caching
- Add `repo_insight_cards()` summary section to the dashboard overview mode
- New CSS file `repo_insights.css` with `.ri-*` scoped classes (CPD prevention pattern)
- 28+ new tests (unit + integration)

## Files added
- `src/services/repo_insight_service.py` — 5 aggregation functions + AI narrative
- `src/ui/routes/repo_insights.py` — route handler
- `src/templates/repo_insights.html` — Jinja2 template
- `src/static/css/repo_insights.css` — scoped `.ri-*` CSS
- `alembic/versions/0031_repo_insights_cache.py` — migration
- `tests/unit/migrations/test_0031_repo_insights_cache.py`
- `tests/unit/services/test_repo_insight_service.py`
- `tests/unit/services/test_repo_insight_cards.py`
- `tests/unit/api/test_repo_insights_route.py`
- `tests/integration/test_repo_insights_css.py`

## Files modified
- `src/models/insight_narrative_cache.py` — add `repo_id` column
- `src/repositories/insight_narrative_cache_repo.py` — add repo-scoped helpers
- `src/services/dashboard_service.py` — add `repo_insight_cards()`
- `src/ui/routes/dashboard.py` — call `repo_insight_cards()` in overview
- `src/templates/dashboard.html` — add repo card section
- `src/ui/router.py` — wire `repo_insights` router
- `docs/architecture.md` — sync new files

## 🔍 사용자 검증 필요

**Claude 시각 검증 불가 — 4-테마 × 모바일/데스크탑 8 조합 사용자 검증 의무**

| 조합 | URL | 확인 항목 | 완료 |
|------|-----|----------|------|
| Dark + Desktop | `/repos/{name}/insights` | KPI 카드 4종 렌더링, 테이블 컬럼 정렬 | [ ] |
| Dark + Mobile | `/repos/{name}/insights` | 2열→1열 전환, `.ri-day-btn` 44px 터치 영역 | [ ] |
| Light + Desktop | `/repos/{name}/insights` | CSS variable 색상 정합성 | [ ] |
| Light + Mobile | `/repos/{name}/insights` | 반응형 KPI 2×2 그리드 | [ ] |
| Glass + Desktop | `/repos/{name}/insights` | backdrop-filter 렌더링 | [ ] |
| Glass + Mobile | `/repos/{name}/insights` | 모바일 레이아웃 | [ ] |
| Claude-dark + Desktop | `/repos/{name}/insights` | 전체 색상 정합성 | [ ] |
| Claude-dark + Mobile | `/repos/{name}/insights` | 모바일 레이아웃 | [ ] |
| Dashboard (any theme) | `/dashboard` | 리포별 인사이트 카드 섹션 표시 | [ ] |

## Code Scanning
- [ ] GitHub Security 탭 Code Scanning open alert 수: (확인 후 기입)