### PR TITLE
fix(ui): 대시보드 기간/모드 토글 활성 표시 개선

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -65,7 +65,7 @@
   /* ── 범위 / 모드 토글 ────────────────────────────────────────── */
   .dash-range-toggle {
     display: inline-flex; gap: 1px; padding: 3px;
-    background: var(--bg-elevated, var(--card-bg, rgba(255,255,255,.04)));
+    background: var(--bg-card, rgba(255,255,255,.04));
     border-radius: 9px;
     border: 1px solid var(--border-subtle, rgba(255,255,255,.08));
   }
@@ -78,10 +78,10 @@
     transition: all .15s ease;
   }
   .dash-range-toggle a.active {
-    background: var(--bg-elevated);
+    background: var(--bg-elevated, rgba(255,255,255,.12));
     color: var(--text-1, var(--text-primary));
-    font-weight: 600;
-    box-shadow: 0 1px 2px rgba(0,0,0,.06);
+    font-weight: 700;
+    box-shadow: var(--shadow-sm, 0 1px 4px rgba(0,0,0,.15));
   }
 
   /* ── KPI 5 카드 — 프리미엄 스타일 + count-up ───────────────────
@@ -308,7 +308,7 @@
      Same design pattern as dash-range-toggle */
   .dash-mode-toggle {
     display: inline-flex; gap: 1px; padding: 3px;
-    background: var(--bg-elevated, var(--card-bg, rgba(255,255,255,.04)));
+    background: var(--bg-card, rgba(255,255,255,.04));
     border-radius: 9px;
     border: 1px solid var(--border-subtle, rgba(255,255,255,.08));
     margin-right: 8px;
@@ -322,10 +322,10 @@
     transition: all .15s ease;
   }
   .dash-mode-toggle a.active {
-    background: var(--bg-elevated);
+    background: var(--bg-elevated, rgba(255,255,255,.12));
     color: var(--text-1, var(--text-primary));
-    font-weight: 600;
-    box-shadow: 0 1px 2px rgba(0,0,0,.06);
+    font-weight: 700;
+    box-shadow: var(--shadow-sm, 0 1px 4px rgba(0,0,0,.15));
   }
 
   /* ── Insight 4 카드 grid (Phase 3 PR 3) ─────────────────────────
@@ -789,7 +789,7 @@
   </div>
 
   {# 자주 발생 이슈 / Phase 2 PR-6 — i18n #}
-  <div class="dash-issues-card reveal">
+  <div class="dash-issues-card">
     <h2 class="dash-section-title">{{ 'dashboard.frequent_issues' | i18n_args(locale | default('ko'), days=days) }}</h2>
     {% if frequent_issues %}
       <div class="dash-table-header">
@@ -824,7 +824,7 @@
 
   {# Phase 2 PR 1 — 자동 머지 실패 사유 분포 (운영 신호: unstable_ci 우세) / Phase 2 PR-6 — i18n #}
   {% if merge_failures %}
-  <div class="dash-issues-card reveal" style="margin-top: 16px;">
+  <div class="dash-issues-card" style="margin-top: 16px;">
     <h2 class="dash-section-title">{{ 'dashboard.merge_failures_title' | i18n_args(locale | default('ko'), days=days) }}</h2>
     {% for fail in merge_failures %}
     <div class="dash-issue-row">


### PR DESCRIPTION
## 원인 분석 (5+1 다중 에이전트 교차 검증)

E2E 테스트 14개 전체 통과 확인 → 클릭 자체는 정상 작동. 문제는 **시각적 구분 불가**:

- `.dash-range-toggle` 컨테이너와 `.dash-range-toggle a.active` 모두 `var(--bg-elevated)` 사용
- 같은 배경색 → 활성 pill 이 container 와 동일하게 보임 → 어떤 기간이 선택됐는지 구분 어려움
- 특히 light/pastel 테마에서 `--bg-elevated = #ffffff` 가 동일 → 시각 차이 0

## 변경 내용

| 요소 | 변경 전 | 변경 후 | 이유 |
|------|---------|---------|------|
| 컨테이너 background | `var(--bg-elevated, ...)` | `var(--bg-card, rgba(255,255,255,.04))` | dark: `rgba(255,255,255,.04)` vs elevated `#13131f` → 대비 생성 |
| 활성 pill box-shadow | `0 1px 2px rgba(0,0,0,.06)` | `var(--shadow-sm, 0 1px 4px rgba(0,0,0,.15))` | 테마별 ring/depth 자동 적용 |
| 활성 pill font-weight | `600` | `700` | 볼드 강화로 텍스트 차별화 |
| `dash-issues-card` reveal | `class="dash-issues-card reveal"` | `class="dash-issues-card"` | 커밋 64e0e6e KPI/차트 카드 reveal 제거와 일관성 |

`.dash-mode-toggle` (모드 토글)도 동일 패턴 적용.

## 테스트

```
pytest e2e/test_dashboard.py -v
→ 14 passed ✅
```

## 🔍 사용자 검증 필요

> ⚠️ Claude는 UI 시각 검증 불가 — 아래 4-테마 × 2-환경 조합을 직접 확인해주세요.

| 테마 | 데스크탑 | 모바일 |
|------|----------|--------|
| dark (catppuccin default) | ☐ 기간 토글 활성 pill 보임 | ☐ |
| light | ☐ 기간 토글 활성 pill 보임 | ☐ |
| pastel | ☐ 기간 토글 활성 pill 보임 | ☐ |
| catppuccin | ☐ 기간 토글 활성 pill 보임 | ☐ |

확인 포인트: 1d / 7d / 30d / 90d 클릭 시 선택된 버튼이 다른 버튼과 시각적으로 구분되는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)