### PR TITLE
fix(ui): 메인 페이지 테이블 헤더/데이터 컬럼 오정렬 수정

### DIFF
--- a/src/templates/overview.html
+++ b/src/templates/overview.html
@@ -106,9 +106,12 @@
   }
 
   /* 리포 행 — 호버 액센트 바 효과
-     Repo row — hover accent bar effect */
+     Repo row — hover accent bar effect
+     🔴 tr::before 방식은 Chromium이 phantom table-column으로 취급 → thead/tbody 컬럼 오정렬.
+     🔴 tr::before causes Chromium to insert phantom first column → thead/tbody column desync.
+     → first-child td의 inset box-shadow 방식으로 교체 (position:relative 불필요).
+     → Replaced with inset box-shadow on first td (no position:relative needed). */
   .repo-row {
-    position: relative;
     transition: background 0.15s;
   }
   .repo-row td {
@@ -119,22 +122,15 @@
   }
   .repo-row:last-child td { border-bottom: none; }
 
-  /* 왼쪽 액센트 바 (호버 시 노출)
-     Left accent bar (shown on hover) */
-  .repo-row::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 3px;
-    background: var(--accent);
-    transform: scaleY(0);
-    transform-origin: center;
-    transition: transform 0.15s;
-    border-radius: 0 2px 2px 0;
+  /* 왼쪽 액센트 바 — inset box-shadow (호버 시 노출)
+     Left accent bar — inset box-shadow (shown on hover) */
+  .repo-row td:first-child {
+    box-shadow: inset 3px 0 0 transparent;
+    transition: box-shadow 0.15s;
   }
-  .repo-row:hover::before { transform: scaleY(1); }
+  .repo-row:hover td:first-child {
+    box-shadow: inset 3px 0 0 var(--accent);
+  }
   .repo-row:hover { background: var(--table-row-hover, transparent); }
 
   /* 리포 링크


### PR DESCRIPTION
## 문제

메인 페이지(`/`) 리포지토리 테이블에서 헤더와 데이터 셀이 한 컬럼씩 어긋나 있었습니다.
- `리포지토리` 헤더 아래 → 빈 공간
- `분析` 헤더 아래 → 실제 리포 링크
- `평균 점수` 헤더 아래 → 분석 횟수
- (이하 전부 한 칸 오른쪽 밀림)

## 근본 원인

Chromium 브라우저가 `<tr>`에 `content: ''` 인 `::before` 슈도엘리먼트가 있으면
이를 **phantom 첫 번째 table-column**으로 취급합니다.

- `thead`의 `<th>` 셀들은 columns 0–4에 정상 배치
- `tbody`의 `.repo-row::before`(invisible, `position: absolute`) 가 column 0을 차지
- 실제 `<td>` 셀들이 columns 1–5로 밀려 헤더와 불일치

Playwright DOM 측정으로 확인:
- `th0.left = 51px` (리포지토리), `td0.left = 246px` (분析 헤더 위치)
- `content: none !important` 주입 즉시 모든 컬럼 `aligned: true` 복구

## 해결책

`.repo-row::before` (position:absolute 액센트 바) 와 `position: relative` 제거 →
`td:first-child`에 **inset box-shadow**로 왼쪽 액센트 바 대체.

```css
/* 이전: tr::before → Chromium phantom-column 버그 유발 */
.repo-row { position: relative; }
.repo-row::before { content: ''; position: absolute; width: 3px; ... }

/* 이후: td:first-child inset box-shadow */
.repo-row td:first-child {
  box-shadow: inset 3px 0 0 transparent;
  transition: box-shadow 0.15s;
}
.repo-row:hover td:first-child {
  box-shadow: inset 3px 0 0 var(--accent);
}
```

시각 효과는 동일합니다(3px 왼쪽 색상 바, 호버 시 노출).

## 테스트

- ✅ `pytest tests/unit/` 2756 passed
- ✅ Playwright DOM 검증: `content: none` 주입 후 모든 컬럼 정렬 확인
- ✅ CSS 변경 적용 후 동일 결과 예상

## 🔍 사용자 검증 필요

- [ ] 메인 페이지(`/`) 테이블 헤더/데이터 컬럼 정렬 확인 (리포지토리 헤더 아래 리포 링크)
- [ ] 행 호버 시 왼쪽 액센트 바(3px 색상) 표시 확인
- [ ] 4 테마(dark/light/glass/claude-dark) × 데스크탑/모바일 8 조합 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)