### PR TITLE
fix(ui): Repo 연결 페이지 일러스트 중앙 정렬 수정

### DIFF
--- a/src/static/css/illustrations.css
+++ b/src/static/css/illustrations.css
@@ -33,7 +33,7 @@
  * tutorial — horizontal 3-step layout (1792x1024 ratio) */
 .illustration--tutorial {
   max-width: 100%;
-  margin: 0 0 var(--space-5);
+  margin: 0 auto var(--space-5);
 }
 
 /* 모바일 — hero 축소 / Mobile — shrink hero */


### PR DESCRIPTION
## 문제

`/repos/add` 페이지에서 상단 일러스트와 하단 폼 카드의 가로 정렬이 불일치했습니다.

- **일러스트**: 왼쪽 정렬 (`margin: 0 0 ...` — auto 없음)
- **폼 카드**: 중앙 정렬 (`max-width: 560px; margin: 2rem auto`)

## 원인

`src/static/css/illustrations.css`의 `.illustration--tutorial` 클래스가
기본 `.illustration`의 `margin: 0 auto`를 `margin: 0 0 var(--space-5)`로 덮어썼습니다.

## 수정

```css
/* 이전 */
.illustration--tutorial {
  margin: 0 0 var(--space-5);        /* auto 없음 → 왼쪽 정렬 */
}

/* 이후 */
.illustration--tutorial {
  margin: 0 auto var(--space-5);     /* auto → 중앙 정렬 */
}
```

`overview.html`에서는 `max-width: 100%`(전폭)로 사용되므로 auto 마진 추가해도 시각 변화 없음.

## 🔍 사용자 검증 필요

- [ ] `/repos/add` 페이지: 일러스트와 폼 카드 가로 중앙 정렬 일치 확인
- [ ] `/` (overview) 페이지: 온보딩 일러스트 레이아웃 이상 없음 확인
- [ ] 4 테마(dark/light/glass/claude-dark) × 모바일/데스크탑 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)