### PR TITLE
docs: P2-4 testing.md SessionLocal 경고 + P2-5 architecture.md mockup-polar.html

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -22,6 +22,7 @@ paths:
 - **Mock side_effect 재귀**: `mock.add.side_effect = fn` 설정 후 fn 내에서 `original_add(obj)` 호출 시 재귀 발생. side_effect 함수에서는 원본 mock을 호출하지 말 것 — 캡처만 하고 return None.
 - **모듈 레벨 캐시 격리**: `src/webhook/_helpers.py`의 `_webhook_secret_cache`는 모듈 레벨 dict. `tests/conftest.py`의 `_clear_webhook_secret_cache` autouse fixture가 테스트마다 자동 클리어. 신규 모듈 레벨 캐시 추가 시 동일한 autouse fixture 패턴 적용 필수.
 - **`services/analytics_service.py` 테스트 패턴**: `db: Session` 인자 + `now: datetime | None = None` 의존성 주입(freezegun 미사용). 각 테스트 파일은 자체 in-memory SQLite engine fixture (`tests/unit/repositories/test_analysis_feedback_repo.py:20-58` 참조). `func.count/avg/min/max` 호출 시 `# pylint: disable=not-callable` 인라인 주석 필수.
+- **SessionLocal Mock 한계**: `SessionLocal` Mock 은 ORM 속성 오류 미감지 — 핵심 라우트에 실 DB 테스트 병행 필수.
 
 ## 회귀 차단 트랩 (사고 검증 영역)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,7 @@ src/
 │   ├── css/admin.css            # 관리자 페이지 공통 스타일 — .admin-* 글래스모피즘 컴포넌트 (admin_rls_audit, admin_tenants 공유)
 │   ├── css/repo_insights.css    # 리포별 인사이트 페이지 전용 스타일 — .ri-* 클래스 (CPD 분리)
 │   │                            # Repo insights page scoped styles (.ri-* classes, CPD prevention)
+│   ├── mockup-polar.html        # 대시보드 KPI 레이아웃 목업 — SonarCloud sonar.exclusions 등재 (#399)
 │   └── illustrations/           # DALL-E 3 생성 일러스트 5장 commit (#375 Step 2-B: login_hero/dashboard_empty/overview_onboarding/add_repo_hero/filter_empty)
 ├── scripts/                     # 로컬 도구 (production import X) — Cycle 93 Step 2
 │   ├── illustration_prompts.py  # 5장 isometric prompt 정의 (login_hero/dashboard_empty/overview_onboarding/add_repo_hero/filter_empty)


### PR DESCRIPTION
## 변경 내용

### P2-4: `.claude/rules/testing.md`
- `SessionLocal` Mock 은 ORM 속성 오류 미감지 경고 추가 (Mock + Fixture 패턴 섹션)
- 핵심 라우트에 실 DB 테스트 병행 필수 안내

### P2-5: `docs/architecture.md`
- `src/static/mockup-polar.html` 항목 추가 — 대시보드 KPI 목업, SonarCloud sonar.exclusions 등재 (#399)

## 사이클 95 P2 범위
PR-D1 (Low risk): P2-4 + P2-5

## 🔍 사용자 검증 필요
- [ ] architecture.md static/ 트리에 mockup-polar.html 항목 표시 확인
- [ ] testing.md SessionLocal Mock 경고 위치 적절성 확인

🤖 Generated with [Claude Code](https://claude.ai/code)