### PR TITLE
docs: STATE.md 사이클 96 PR-D5 이력 갱신

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -59,5 +59,5 @@
 
 - **그룹 13~61** (2026-04 ~ 2026-05-02): [docs/_archive/STATE-groups-13-61-2026-05.md](_archive/STATE-groups-13-61-2026-05.md)
 - **사이클 62~92** (2026-05-03 ~ 2026-05-11): [docs/cycle-history.md](cycle-history.md)
-- **사이클 95** (2026-05-14): 문서 정비 P2 (#410~#413) — testing.md SessionLocal 경고 추가 / architecture.md mockup-polar.html 항목 / AGENTS.md 중복 표 → 링크 3건 / STATE.md 그룹 13-61 아카이브 / CLAUDE.md HTML 주석 7블록 + line 361 압축 (59줄 절감). PR-D5 예정: 블록 3·5 docs/policies 이전 후 제거.
-- **사이클 96** (2026-05-14): pylint 10.00/10 달성 (#415) — C0415 17건 inline disable + C0301/R0913/R0917/W0718/W0613/E0401 처리.
+- **사이클 95** (2026-05-14): 문서 정비 P2 (#410~#413) — testing.md SessionLocal 경고 추가 / architecture.md mockup-polar.html 항목 / AGENTS.md 중복 표 → 링크 3건 / STATE.md 그룹 13-61 아카이브 / CLAUDE.md HTML 주석 7블록 + line 361 압축 (59줄 절감).
+- **사이클 96** (2026-05-14): pylint 10.00/10 달성 (#415) — C0415 17건 inline disable + C0301/R0913/R0917/W0718/W0613/E0401 처리. PR-D5 (#417): CLAUDE.md HTML 블록 3·5 → docs/policies/active.md 이전 (#정책-17-why-how + #정책-5-phase-종료-cross-reference 신설).


### PR DESCRIPTION
## 변경 내용

사이클 96 작업 이력에 PR-D5 (#417) 완료 항목 추가.

- 사이클 95 "PR-D5 예정" 문구 제거 (완료됨)
- 사이클 96에 PR-D5 (#417) 완료 내용 추가

## 🔍 사용자 검증 필요

- [ ] docs/STATE.md 사이클 96 이력이 올바른지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)