### PR TITLE
fix: scripts 하드코딩 경로 제거 + dashboard async 블로킹 수정

### DIFF
--- a/scripts/i18n_comments/_apply_html_translations.py
+++ b/scripts/i18n_comments/_apply_html_translations.py
@@ -95,6 +95,6 @@ def apply_translations(base: Path, translations: dict[str, list[tuple[str, str]]
 
 
 if __name__ == "__main__":
-    base = Path("f:/DEVELOPMENT/SOURCE/CLAUDE/SCAManager")
+    base = Path(__file__).resolve().parents[2]
     n = apply_translations(base, TRANSLATIONS)
     print(f"\nTotal HTML translations applied: {n}")

--- a/scripts/i18n_comments/_apply_test_translations.py
+++ b/scripts/i18n_comments/_apply_test_translations.py
@@ -338,6 +338,6 @@ def apply_translations(base: Path, translations: dict[str, list[tuple[str, str]]
 
 
 if __name__ == "__main__":
-    base = Path("f:/DEVELOPMENT/SOURCE/CLAUDE/SCAManager")
+    base = Path(__file__).resolve().parents[2]
     n = apply_translations(base, TRANSLATIONS)
     print(f"\nTotal translations applied: {n}")

--- a/scripts/i18n_comments/check_bilingual.py
+++ b/scripts/i18n_comments/check_bilingual.py
@@ -207,7 +207,7 @@ def main() -> int:
                         help="Filter report to phase files only (informational)")
     args = parser.parse_args()
 
-    base = Path("f:/DEVELOPMENT/SOURCE/CLAUDE/SCAManager")
+    base = Path(__file__).resolve().parents[2]
     roots = [base / p for p in args.paths]
     files = _collect_py_files(roots)
 

--- a/scripts/i18n_comments/translate_comments.py
+++ b/scripts/i18n_comments/translate_comments.py
@@ -43,7 +43,7 @@ except ImportError:
     print("ERROR: anthropic package not installed. Run: pip install anthropic", file=sys.stderr)
     sys.exit(1)
 
-BASE_DIR = Path("f:/DEVELOPMENT/SOURCE/CLAUDE/SCAManager")
+BASE_DIR = Path(__file__).resolve().parents[2]
 MANIFEST_PATH = BASE_DIR / "scripts" / "i18n_comments" / "manifest.json"
 GLOSSARY_PATH = BASE_DIR / "scripts" / "i18n_comments" / "glossary.md"
 

--- a/src/ui/routes/dashboard.py
+++ b/src/ui/routes/dashboard.py
@@ -11,6 +11,7 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
+from starlette.concurrency import run_in_threadpool
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+_DASHBOARD_TEMPLATE = "dashboard.html"
 
 _VALID_MODES = ("overview", "insight", "security", "usage")
 
@@ -103,10 +105,14 @@ async def dashboard(  # pylint: disable=too-many-locals
 
         if effective_mode == "security":
             # Cycle 73 F2 — Code Scanning + Secret Scanning audit dashboard (read-only).
-            security = dashboard_service.dashboard_security(db, user_id=current_user.id)
+            # SQLAlchemy 2.x: session은 단일 스레드 순차 접근 시 다른 스레드에 전달 가능.
+            # SQLAlchemy 2.x: session may be passed to another thread for sequential-only access.
+            security = await run_in_threadpool(
+                dashboard_service.dashboard_security, db, user_id=current_user.id
+            )
             return templates.TemplateResponse(
                 request,
-                "dashboard.html",
+                _DASHBOARD_TEMPLATE,
                 {
                     "current_user": current_user,
                     "mode": "security",
@@ -120,10 +126,12 @@ async def dashboard(  # pylint: disable=too-many-locals
         if effective_mode == "usage":
             # Cycle 79 PR 3b — SaaS Phase 1 본인 사용량 dashboard (read-only — user_id 직접 격리).
             # Cycle 79 PR 3b — SaaS Phase 1 own usage dashboard (read-only — user_id direct isolation).
-            usage = dashboard_service.dashboard_usage(db, user_id=current_user.id, days=days)
+            usage = await run_in_threadpool(
+                dashboard_service.dashboard_usage, db, user_id=current_user.id, days=days
+            )
             return templates.TemplateResponse(
                 request,
-                "dashboard.html",
+                _DASHBOARD_TEMPLATE,
                 {
                     "current_user": current_user,
                     "mode": "usage",
@@ -143,7 +151,7 @@ async def dashboard(  # pylint: disable=too-many-locals
             )
             return templates.TemplateResponse(
                 request,
-                "dashboard.html",
+                _DASHBOARD_TEMPLATE,
                 {
                     "current_user": current_user,
                     "mode": "insight",
@@ -157,17 +165,25 @@ async def dashboard(  # pylint: disable=too-many-locals
         # effective_mode == "overview" — 기존 동작 보존 + PR 5 user_id 격리
         # effective_mode == "overview" — preserves prior behavior + PR 5 user_id isolation
         _uid = current_user.id
-        kpi = dashboard_service.dashboard_kpi(db, days=days, user_id=_uid)
-        trend = dashboard_service.dashboard_trend(db, days=days, user_id=_uid)
-        frequent_issues = dashboard_service.frequent_issues_v2(db, days=days, n=5, user_id=_uid)
+
+        def _load_overview() -> tuple:
+            # 7 sync DB 호출을 스레드 풀에서 일괄 실행 — 이벤트 루프 블로킹 방지.
+            # Batch 7 sync DB calls in threadpool — prevents event loop blocking.
+            kpi_ = dashboard_service.dashboard_kpi(db, days=days, user_id=_uid)
+            trend_ = dashboard_service.dashboard_trend(db, days=days, user_id=_uid)
+            freq_ = dashboard_service.frequent_issues_v2(db, days=days, n=5, user_id=_uid)
+            am_ = dashboard_service.auto_merge_kpi(db, days=days, user_id=_uid)
+            mf_ = dashboard_service.merge_failure_distribution(db, days=days, n=5, user_id=_uid)
+            rc_ = dashboard_service.repo_insight_cards(db, days=days, user_id=_uid)
+            fb_ = dashboard_service.feedback_status(db)
+            return kpi_, trend_, freq_, am_, mf_, rc_, fb_
+
         # Phase 2 PR 1: Auto-merge KPI + 실패 분포.
-        auto_merge = dashboard_service.auto_merge_kpi(db, days=days, user_id=_uid)
-        merge_failures = dashboard_service.merge_failure_distribution(db, days=days, n=5, user_id=_uid)
         # 0031 — 리포별 인사이트 카드 섹션 (overview 모드 전용)
-        # 0031 — Per-repo insight card section (overview mode only)
-        repo_cards = dashboard_service.repo_insight_cards(db, days=days, user_id=_uid)
         # Phase 2 PR 2 (2026-05-02): feedback CTA — 운영 row=0 → 사용자 행동 유도.
-        feedback = dashboard_service.feedback_status(db)
+        kpi, trend, frequent_issues, auto_merge, merge_failures, repo_cards, feedback = (
+            await run_in_threadpool(_load_overview)
+        )
 
     return templates.TemplateResponse(
         request,


### PR DESCRIPTION
## Summary

- `scripts/i18n_comments/` 4 파일의 `f:/DEVELOPMENT/…` 절대 경로 → `Path(__file__).resolve().parents[2]` 동적 경로로 교체 (CI/배포 환경 이식성 확보)
- `src/ui/routes/dashboard.py`: security / usage / overview 3 모드의 동기 SQLAlchemy DB 호출을 `run_in_threadpool` 래핑 — async 이벤트 루프 블로킹 방지
- `_DASHBOARD_TEMPLATE = "dashboard.html"` 상수 추출 → SonarCloud S1192 (literal duplication) 경고 해소

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `scripts/i18n_comments/check_bilingual.py` | `base` 경로 동적화 |
| `scripts/i18n_comments/translate_comments.py` | `BASE_DIR` 경로 동적화 |
| `scripts/i18n_comments/_apply_html_translations.py` | `base` 경로 동적화 |
| `scripts/i18n_comments/_apply_test_translations.py` | `base` 경로 동적화 |
| `src/ui/routes/dashboard.py` | `run_in_threadpool` 래핑 3 모드 + `_DASHBOARD_TEMPLATE` 상수 |

## 기술 노트

- SQLAlchemy 2.x: session 을 `run_in_threadpool` 에 전달해도 안전 — 메인 코루틴이 중단된 동안 워커 스레드만 단독 접근 (sequential access guarantee)
- `with SessionLocal() as db:` 단일 outer block 유지 → 기존 `@contextmanager` 기반 mock 패턴 호환 유지
- `insight` 모드는 이미 `await dashboard_service.insight_narrative(...)` 순수 async — 변경 없음

## Test Results

```
tests/unit/ui/test_dashboard_route.py: 16 passed ✅
pylint src/: 10.00/10 ✅
SonarCloud S1192: 해소 ✅
```

## 🔍 사용자 검증 필요

- [ ] dashboard 각 모드 (`?mode=overview`, `?mode=security`, `?mode=usage`, `?mode=insight`) 실제 페이지 로딩 정상 여부 확인
- [ ] scripts 실행 환경이 Windows 외 환경(Railway/Codespaces)에서 경로 정상 해석 여부 확인 (동적 경로는 `__file__` 기준으로 계산되므로 문제 없을 것으로 예상)

🔍 Codex 검증 의뢰 (push 전 완료 후 생성)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)