### PR TITLE
fix(landing): phantom CSS token + architecture.md sync

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,7 @@ src/
 │   ├── _helpers.py              # get_accessible_repo, webhook_base_url, delete_repo_cascade, templates
 │   ├── router.py                # aggregator
 │   └── routes/                  # overview / dashboard (mode 4종) / add_repo / settings / actions / detail / admin / repo_insights
-├── templates/                   # base, login, overview, repo_detail, analysis_detail, settings, dashboard, admin_*, repo_insights
+├── templates/                   # base, landing, login, overview, repo_detail, analysis_detail, settings, dashboard, admin_*, repo_insights
 ├── cli/                         # python -m src.cli review (git_diff + formatter)
 ├── repositories/                # DB 접근 계층 10종
 └── worker/pipeline.py           # run_analysis_pipeline, build_analysis_result_dict

--- a/src/templates/landing.html
+++ b/src/templates/landing.html
@@ -123,7 +123,7 @@
       justify-content: space-between;
       padding: 0 clamp(16px, 5vw, 48px);
       height: 60px;
-      background: rgba(var(--bg-base-rgb, 7,7,15), 0.7);
+      background: var(--bg-nav);
       backdrop-filter: blur(20px);
       -webkit-backdrop-filter: blur(20px);
       border-bottom: 1px solid var(--border-subtle, rgba(255,255,255,0.06));


### PR DESCRIPTION
## Summary

- `src/templates/landing.html`: Replace undefined CSS variable `--bg-base-rgb` with `var(--bg-nav)` — `--bg-base-rgb` was not defined in any theme block in `themes.css`, causing the nav background to fall back to a hardcoded dark value across all 4 themes instead of using the proper theme token
- `docs/architecture.md`: Add `landing.html` to the templates section listing

## Related

Closes issues identified in code review on #428.

## 🔍 사용자 검증 필요

- [ ] Nav bar background renders correctly in all 4 themes (dark / light / glass / claude-dark)
- [ ] `docs/architecture.md` templates list now shows `landing` entry

🤖 Generated with [Claude Code](https://claude.ai/code)