### PR TITLE
fix(tests): CodeQL unused import 해소 — InsightNarrativeCache from-import 제거

### DIFF
--- a/tests/unit/migrations/test_0031_repo_insights_cache.py
+++ b/tests/unit/migrations/test_0031_repo_insights_cache.py
@@ -25,7 +25,6 @@ from src.database import Base
 import src.models.user  # noqa: F401  pylint: disable=unused-import,wrong-import-position
 import src.models.repository  # noqa: F401  pylint: disable=unused-import,wrong-import-position
 import src.models.insight_narrative_cache  # noqa: F401  pylint: disable=unused-import,wrong-import-position
-from src.models.insight_narrative_cache import InsightNarrativeCache  # noqa: F401
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

- `tests/unit/migrations/test_0031_repo_insights_cache.py:28` 에서 미사용 `from src.models.insight_narrative_cache import InsightNarrativeCache` 제거 (CodeQL alerts #387 + #389 해소)
  - 해당 테스트는 `src.models.insight_narrative_cache.InsightNarrativeCache(...)` 전체 경로로 사용하므로 bare-name import 불필요
  - line 27 의 `import src.models.insight_narrative_cache` 는 `Base.metadata` 등록 side-effect로 유지

## Code Scanning Alert 처리 요약

| Alert | 조치 |
|-------|------|
| #390 `py/exit-from-finally` (warning) | PR #428 commit 2ac2459 에서 수정 완료 — CI 재실행 후 자동 닫힘 |
| #389 `py/unused-import` test_0031 | ✅ 이 PR에서 코드 수정으로 해소 |
| #387 `py/import-and-import-from` test_0031 | ✅ 이 PR에서 코드 수정으로 해소 |
| #386 `py/unused-import` test_repo_insights_route.py | ✅ false-positive dismiss (Base.metadata 등록 side-effect) |
| #384 `py/unused-import` test_repo_insight_service.py | ✅ false-positive dismiss (Base.metadata 등록 side-effect) |

## 🔍 사용자 검증 필요

- [ ] `make test` 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/code)