### PR TITLE
fix(ui): HTMX hx-boost 코드리뷰 #434 후속 수정

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,7 @@ src/
 ├── main.py                     # FastAPI 앱, lifespan(DB 마이그레이션 + http_client), 전체 라우터 등록 + CachedStaticFiles `/static` mount (Cache-Control immutable 1년) + 미들웨어 LIFO 등록 (SecurityHeaders → RLSSessionMiddleware → SessionMiddleware → LocaleMiddleware)
 ├── static/
 │   ├── vendor/chart.umd.min.js  # Chart.js 4.4.0 UMD min vendoring
+│   ├── vendor/htmx.min.js       # HTMX 1.9.12 hx-boost 네비게이션 (전체 페이지 리로드 제거)
 │   ├── manifest.json            # PWA manifest (Cycle 81 PR-A)
 │   ├── icons/icon-{192,512}.svg # PWA maskable icons
 │   ├── css/{tokens,themes}.css  # Foundation 디자인 토큰 + 4-테마 정의 (Cycle 93 Step 1, base.html 외부화)

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -957,7 +957,12 @@
 
   buildDashChart();
   // base.html dispatchEvent('themechange') ↔ dashboard 차트 재빌드 (UI 감사 Step C 패턴 통일)
-  document.addEventListener('themechange', buildDashChart);
+  // hx-boost 재방문 시 리스너 누적 방지 — 최초 1회만 등록
+  // Guard against listener accumulation on hx-boost re-navigation — register only once
+  if (!document._dashThemeListener) {
+    document._dashThemeListener = true;
+    document.addEventListener('themechange', buildDashChart);
+  }
 </script>
 {% endif %}
 

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -484,8 +484,12 @@
     });
   }
 
-  // 테마 변경 시 마지막 필터 상태 데이터로 재빌드
-  document.addEventListener('themechange', function() { buildChart(); });
+  // hx-boost 재방문 시 리스너 누적 방지 — 최초 1회만 등록
+  // Guard against listener accumulation on hx-boost re-navigation — register only once
+  if (!document._repoThemeListener) {
+    document._repoThemeListener = true;
+    document.addEventListener('themechange', function() { buildChart(); });
+  }
 </script>
 <script>
 // ── 데이터 주입 ──────────────────────────────────────


### PR DESCRIPTION
## Summary

PR #434 코드리뷰 (#434#issuecomment-4452260803) 에서 발견된 2건 수정.

- `docs/architecture.md`: `vendor/htmx.min.js` 항목 추가 (CLAUDE.md 동기화 체크리스트 의무)
- `src/templates/repo_detail.html`: `themechange` 리스너에 `_repoThemeListener` 가드 추가 — hx-boost 재방문마다 `buildChart()` 누적 호출 방지
- `src/templates/dashboard.html`: `themechange` 리스너에 `_dashThemeListener` 가드 추가 — hx-boost 재방문마다 `buildDashChart()` 누적 호출 방지

## 🔍 사용자 검증 필요

정책 11 (UI 시각 변경):

| 확인 항목 | 방법 |
|-----------|------|
| `/` → `/dashboard` 3회 반복 방문 후 테마 토글 시 차트가 한 번만 재빌드 되는지 | 개발자 도구 콘솔에서 `buildDashChart` 호출 횟수 확인 |
| `repo_detail` 반복 방문 후 테마 토글 시 차트 정상 동작 | 동일 방법 |

🤖 Generated with [Claude Code](https://claude.ai/code)