### PR TITLE
feat(mcp): Repo 분석 레포트 MCP tool 선언

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,6 +107,9 @@ src/
 │   ├── router.py                # aggregator
 │   └── routes/                  # overview / dashboard (mode 5종) / add_repo / settings / actions / detail / admin / repo_insights
 ├── templates/                   # base, landing, login, overview, repo_detail, analysis_detail, settings, dashboard, admin_*, repo_insights, add_repo
+├── mcp/
+│   ├── __init__.py              # MCP tool 선언 패키지
+│   └── repo_report_tools.py     # list_repo_reports / get_repo_report tool 스키마
 ├── cli/                         # python -m src.cli review (git_diff + formatter)
 ├── repositories/                # DB 접근 계층 10종
 └── worker/pipeline.py           # run_analysis_pipeline, build_analysis_result_dict

--- a/src/mcp/__init__.py
+++ b/src/mcp/__init__.py
@@ -1,0 +1,3 @@
+"""MCP tool 선언 패키지.
+MCP tool declaration package.
+"""

--- a/src/mcp/repo_report_tools.py
+++ b/src/mcp/repo_report_tools.py
@@ -1,0 +1,59 @@
+"""Repo 분석 레포트 MCP tool 선언.
+MCP tool declarations for repo analysis reports.
+
+이 모듈은 /api/repos/report 및 /api/repos/{name}/report 엔드포인트를
+MCP tool로 노출한다. 비즈니스 로직 없음 — API 레이어 래퍼.
+
+This module exposes the repo report API endpoints as MCP tools.
+No business logic — pure API wrappers.
+"""
+
+# MCP tool 선언 목록 (Anthropic tool use 스키마 준수)
+# MCP tool declaration list (follows Anthropic tool use schema)
+tools: list[dict] = [
+    {
+        "name": "list_repo_reports",
+        "description": (
+            "연결된 모든 Repo의 분석 요약을 반환합니다. "
+            "각 Repo의 평균 점수·등급·점수 변화·경고 여부와 "
+            "전체 포트폴리오 요약(등급 분포·경고 수)을 포함합니다.\n\n"
+            "Returns analysis summary for all connected repositories. "
+            "Includes avg_score, grade, score_delta, warning flag per repo "
+            "and portfolio-level summary (grade_distribution, warning_count)."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "days": {
+                    "type": "integer",
+                    "default": 30,
+                    "description": "집계 기간 (일). 1~365. 기본값 30. / Aggregation window in days. 1–365. Default 30.",
+                }
+            },
+        },
+    },
+    {
+        "name": "get_repo_report",
+        "description": (
+            "특정 Repo의 상세 분석 레포트를 반환합니다. "
+            "점수 트렌드·이슈 카테고리 분포·AI 코드리뷰 제안·반복 발생 이슈를 포함합니다.\n\n"
+            "Returns detailed analysis report for a specific repository. "
+            "Includes score trend, category breakdown, AI suggestions, and recurring issues."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "repo_name": {
+                    "type": "string",
+                    "description": "owner/repo 형식. 예: myorg/backend-api / Format: owner/repo. Example: myorg/backend-api",
+                },
+                "days": {
+                    "type": "integer",
+                    "default": 30,
+                    "description": "집계 기간 (일). 1~365. 기본값 30. / Aggregation window in days. 1–365. Default 30.",
+                },
+            },
+            "required": ["repo_name"],
+        },
+    },
+]

--- a/tests/unit/mcp/test_repo_report_tools.py
+++ b/tests/unit/mcp/test_repo_report_tools.py
@@ -1,0 +1,43 @@
+"""MCP repo_report_tools 스키마 검증 테스트.
+Schema validation tests for MCP repo_report_tools.
+"""
+from src.mcp.repo_report_tools import tools
+
+
+def test_tool_list_length():
+    """tool 선언이 정확히 2개여야 한다."""
+    assert len(tools) == 2
+
+
+def test_tool_names():
+    """tool 이름이 규격과 일치해야 한다."""
+    names = {t["name"] for t in tools}
+    assert "list_repo_reports" in names
+    assert "get_repo_report" in names
+
+
+def test_list_repo_reports_schema():
+    """list_repo_reports — days 파라미터 선택 필드."""
+    tool = next(t for t in tools if t["name"] == "list_repo_reports")
+    assert "description" in tool
+    schema = tool["input_schema"]
+    assert schema["type"] == "object"
+    assert "days" in schema["properties"]
+    # days는 required 아님
+    assert "required" not in schema or "days" not in schema.get("required", [])
+
+
+def test_get_repo_report_schema():
+    """get_repo_report — repo_name 필수 필드."""
+    tool = next(t for t in tools if t["name"] == "get_repo_report")
+    assert "description" in tool
+    schema = tool["input_schema"]
+    assert "repo_name" in schema["properties"]
+    assert "repo_name" in schema["required"]
+
+
+def test_tool_descriptions_non_empty():
+    """모든 tool에 description이 있어야 한다."""
+    for tool in tools:
+        assert tool.get("description", "").strip(), \
+            f"{tool['name']} description 없음"


### PR DESCRIPTION
## Summary
- `src/mcp/` 패키지 신설
- `list_repo_reports` tool — 연결된 전체 Repo KPI 요약 (avg_score·grade·warning)
- `get_repo_report` tool — 개별 Repo 상세 레포트 (score_trend·category·AI 요약·권장사항)
- `/api/repos/report` API 래퍼 (비즈니스 로직 없음)

## Depends on
PR #442 (`feat/repo-report-dashboard-ui`) → PR #441 (`feat/repo-report-api`) 순차 의존

## 🔍 사용자 검증 필요
- [ ] Claude Desktop 또는 MCP 클라이언트에서 tool 스키마 로드 확인
- [ ] `get_repo_report("owner/repo")` 호출 → 정상 JSON 응답 확인

## Test
단위 5개 추가 (tool 스키마 검증) — 전체 2912 통과

🤖 Generated with [Claude Code](https://claude.ai/code)