### PR TITLE
fix: CI 타임아웃 해소 + CodeQL py/url-redirection 3건 수정

### DIFF
--- a/src/ui/routes/settings.py
+++ b/src/ui/routes/settings.py
@@ -273,11 +273,11 @@ async def reinstall_hook(
 ):
     """기존 등록 리포에 .scamanager/ 파일을 재커밋한다."""
     with SessionLocal() as db:
-        get_accessible_repo(db, repo_name, current_user)
-        config = repo_config_repo.find_by_full_name(db, repo_name)
+        repo = get_accessible_repo(db, repo_name, current_user)
+        config = repo_config_repo.find_by_full_name(db, repo.full_name)
         if config is None:
             config = RepoConfig(
-                repo_full_name=repo_name,
+                repo_full_name=repo.full_name,
                 hook_token=secrets.token_hex(32),
             )
             db.add(config)
@@ -289,13 +289,15 @@ async def reinstall_hook(
     server_url = webhook_base_url(request)
     ok = await commit_scamanager_files(
         current_user.plaintext_token or "",
-        repo_name,
+        repo.full_name,
         server_url,
         hook_token,
     )
 
     status = "hook_ok" if ok else "hook_fail"
-    safe_repo_name = quote(repo_name, safe="")
+    # repo.full_name 사용 — DB 검증값으로 CodeQL py/url-redirection 차단
+    # Use repo.full_name (DB-validated) to prevent CodeQL py/url-redirection
+    safe_repo_name = quote(repo.full_name, safe="")
     return RedirectResponse(
         url=f"/repos/{safe_repo_name}/settings?{status}=1",
         status_code=303,
@@ -332,7 +334,9 @@ async def reinstall_webhook(
             new_id = await create_webhook(token, repo_name, webhook_url, new_secret)
         except (httpx.HTTPError, KeyError, ValueError, OSError) as exc:
             logger.warning("Webhook reinstall failed: %s", exc)
-            safe_repo_name = quote(repo_name, safe="")
+            # repo.full_name 사용 — DB 검증값으로 CodeQL py/url-redirection 차단
+            # Use repo.full_name (DB-validated) to prevent CodeQL py/url-redirection
+            safe_repo_name = quote(repo.full_name, safe="")
             return RedirectResponse(
                 url=f"/repos/{safe_repo_name}/settings?hook_fail=1",
                 status_code=303,
@@ -342,7 +346,9 @@ async def reinstall_webhook(
         repo.webhook_secret = new_secret
         db.commit()
 
-    safe_repo_name = quote(repo_name, safe="")
+    # repo.full_name 사용 — DB 검증값으로 CodeQL py/url-redirection 차단
+    # Use repo.full_name (DB-validated) to prevent CodeQL py/url-redirection
+    safe_repo_name = quote(repo.full_name, safe="")
     return RedirectResponse(
         url=f"/repos/{safe_repo_name}/settings?hook_ok=1",
         status_code=303,

--- a/tests/unit/github_client/test_github_repos.py
+++ b/tests/unit/github_client/test_github_repos.py
@@ -26,6 +26,9 @@ async def test_list_user_repos_returns_repo_list():
     mock_resp = MagicMock()
     mock_resp.json.return_value = mock_response_data
     mock_resp.raise_for_status = MagicMock()
+    # pagination 루프 종료 — 미설정 시 MagicMock이 truthy라 while url: 무한 루프 → 30s 타임아웃
+    # Terminate pagination loop — without this, MagicMock is truthy causing infinite while url: loop
+    mock_resp.links = {}
 
     with patch("src.github_client.repos.get_http_client") as mock_get:
         mock_client = AsyncMock()


### PR DESCRIPTION
## Summary

- **CI 타임아웃 수정** (`test_list_user_repos_returns_repo_list`): `mock_resp.links = {}` 누락으로 `while url:` 루프가 무한 반복 → 30s 타임아웃 발생. `links = {}` 설정으로 첫 페이지 후 루프 종료.
- **CodeQL py/url-redirection #400/#401/#402 수정** (`src/ui/routes/settings.py`): `reinstall_hook` / `reinstall_webhook` 3곳에서 URL 파라미터 `repo_name` 대신 DB에서 조회한 `repo.full_name` 사용으로 신뢰할 수 없는 소스 차단.
- **CodeQL alert #399 false-positive dismiss**: `test_static_analyzer.py` line 15 — `_PylintAnalyzer`/`_Flake8Analyzer` import는 `patch()` 대상 의도를 명시하는 의도적 import. GitHub API로 dismiss 처리.
- **Issue #451 close**: PR #450 사용자 수동 머지 완료 확인 후 auto-merge failure 알림 이슈 close.

## Changes

| 파일 | 변경 내용 |
|------|----------|
| `tests/unit/github_client/test_github_repos.py` | `mock_resp.links = {}` 추가 (pagination 루프 종료) |
| `src/ui/routes/settings.py` | `reinstall_hook`: `get_accessible_repo` 반환값 캡처 + `repo.full_name` 사용 (3곳) |
| `src/ui/routes/settings.py` | `reinstall_webhook`: `quote(repo_name)` → `quote(repo.full_name)` 2곳 |

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인 (이번 PR push 후 Actions 탭)
- [ ] GitHub Security 탭 → Code Scanning alert #400/#401/#402 resolved 확인 (CodeQL 주 1회 실행 — 즉시 반영 안 될 수 있음)
- [ ] `/repos/{repo}/settings` → "Reinstall Hook" / "Reinstall Webhook" 버튼 정상 동작 확인 (운영 환경)

Closes #452 (P1 항목 중 CI 수정 완료)