### PR TITLE
fix: P0 — dead assertion, README badge, pipeline branch-delete KeyError

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
-[![Tests](https://img.shields.io/badge/Tests-2917_total_(2766_unit_+_151_integration)-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-2964_total_(2810_unit_+_154_integration)-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
 [![E2E](https://img.shields.io/badge/E2E-96_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -187,14 +187,18 @@ def _resolve_review_language(repo_name: str) -> str:
 
 def _extract_event_metadata(event: str, data: dict) -> tuple[str, str, str, int | None]:
     """Webhook 페이로드에서 repo_name, commit_sha, commit_message, pr_number를 추출한다."""
-    repo_name: str = data["repository"]["full_name"]
+    # 브랜치 삭제 push 시 "repository" 키가 None일 수 있으므로 `or {}` 패턴 필수 (PR #124 규칙)
+    # "repository" key may be None on branch-delete push — `or {}` pattern required (PR #124 rule)
+    repo_name: str = (data.get("repository") or {}).get("full_name", "")
     commit_message = _extract_commit_message(event, data)
     if event == "pull_request":
         pr_number: int | None = data["number"]
-        commit_sha: str = data["pull_request"]["head"]["sha"]
+        commit_sha: str = (data.get("pull_request") or {}).get("head", {}).get("sha", "")
     else:
         pr_number = None
-        commit_sha = data["after"]
+        # 브랜치 삭제 시 "after"가 없거나 0000...000일 수 있음 — .get() 방어
+        # Branch-delete sends "after" as missing or all-zeros — use .get() defensively
+        commit_sha = data.get("after", "")
     return repo_name, commit_sha, commit_message, pr_number
 
 

--- a/tests/unit/scorer/test_calculator.py
+++ b/tests/unit/scorer/test_calculator.py
@@ -25,9 +25,12 @@ def test_bandit_high_severity_lowers_security_score():
     assert result.security_score < 20
 
 def test_grade_a_for_score_90_plus():
-    result = calculate_score([_make_result([])])
-    if result.total >= 90:
-        assert result.grade == "A"
+    # AI 점수 최대값으로 100점을 강제해 등급 A 검증 (기본값으로는 89점 — if 조건 미충족)
+    # Force total=100 with max AI scores to verify grade A (defaults yield 89 — condition never met)
+    ai = _make_ai_review(commit_score=20, ai_score=20, test_score=10)
+    result = calculate_score([_make_result([])], ai_review=ai)
+    assert result.total >= 90
+    assert result.grade == "A"
 
 def test_grade_f_for_low_score():
     many_issues = [


### PR DESCRIPTION
## Summary

- **test_calculator.py**: \`test_grade_a_for_score_90_plus\` — \`if result.total >= 90:\` 조건은 기본 AI 점수(total=89)로 항상 False, assert가 단 한 번도 실행되지 않았음. 최대 AI 점수(\`commit=20, ai=20, test=10\`)로 total=100을 강제해 실제로 등급 A를 검증하도록 수정.
- **README.md**: Tests 배지 \`2917 (2766+151)\` → \`2964 (2810+154)\` pytest --collect-only 실측값으로 갱신.
- **pipeline.py**: \`_extract_event_metadata\`의 \`data["repository"]["full_name"]\`과 \`data["after"]\` 직접 접근이 브랜치 삭제 push 이벤트 시 KeyError 유발. PR #124 규칙의 \`(data.get("x") or {}).get(...)\` 패턴으로 수정.

## 🔍 사용자 검증 필요

- [ ] \`make test\` 전체 통과 확인
- [ ] 브랜치 삭제 webhook 또는 Railway 운영 로그에서 pipeline KeyError 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)