### PR TITLE
refactor: P1 하드코딩 제거 — GITHUB_API URL 단일 출처 + Gate 임계값 상수화

### DIFF
--- a/src/api/repos.py
+++ b/src/api/repos.py
@@ -4,6 +4,11 @@ from fastapi import APIRouter
 from pydantic import BaseModel, Field, model_validator
 from src.api.auth import require_api_key
 from src.api.deps import get_repo_or_404
+from src.constants import (
+    GATE_DEFAULT_APPROVE_THRESHOLD,
+    GATE_DEFAULT_REJECT_THRESHOLD,
+    GATE_DEFAULT_MERGE_THRESHOLD,
+)
 from src.database import SessionLocal
 from src.models.repository import Repository
 from src.models.analysis import Analysis
@@ -19,8 +24,8 @@ class RepoConfigUpdate(BaseModel):
 
     pr_review_comment: bool = True
     approve_mode: Literal["disabled", "auto", "semi-auto"] = "disabled"
-    approve_threshold: int = Field(75, ge=0, le=100)
-    reject_threshold: int = Field(50, ge=0, le=100)
+    approve_threshold: int = Field(GATE_DEFAULT_APPROVE_THRESHOLD, ge=0, le=100)
+    reject_threshold: int = Field(GATE_DEFAULT_REJECT_THRESHOLD, ge=0, le=100)
     notify_chat_id: str | None = None
     n8n_webhook_url: str | None = None
     discord_webhook_url: str | None = None
@@ -28,7 +33,7 @@ class RepoConfigUpdate(BaseModel):
     custom_webhook_url: str | None = None
     email_recipients: str | None = None
     auto_merge: bool = False
-    merge_threshold: int = Field(75, ge=0, le=100)
+    merge_threshold: int = Field(GATE_DEFAULT_MERGE_THRESHOLD, ge=0, le=100)
     commit_comment: bool = False
     create_issue: bool = False
     railway_deploy_alerts: bool = False

--- a/src/config_manager/manager.py
+++ b/src/config_manager/manager.py
@@ -1,6 +1,11 @@
 """Repository configuration manager — get and upsert RepoConfig records."""
 from dataclasses import dataclass, fields
 from sqlalchemy.orm import Session
+from src.constants import (
+    GATE_DEFAULT_APPROVE_THRESHOLD,
+    GATE_DEFAULT_REJECT_THRESHOLD,
+    GATE_DEFAULT_MERGE_THRESHOLD,
+)
 from src.models.repo_config import RepoConfig
 
 
@@ -11,8 +16,8 @@ class RepoConfigData:  # pylint: disable=too-many-instance-attributes
     repo_full_name: str
     pr_review_comment: bool = True
     approve_mode: str = "disabled"
-    approve_threshold: int = 75
-    reject_threshold: int = 50
+    approve_threshold: int = GATE_DEFAULT_APPROVE_THRESHOLD
+    reject_threshold: int = GATE_DEFAULT_REJECT_THRESHOLD
     notify_chat_id: str | None = None
     n8n_webhook_url: str | None = None
     discord_webhook_url: str | None = None
@@ -20,7 +25,7 @@ class RepoConfigData:  # pylint: disable=too-many-instance-attributes
     custom_webhook_url: str | None = None
     email_recipients: str | None = None
     auto_merge: bool = False
-    merge_threshold: int = 75
+    merge_threshold: int = GATE_DEFAULT_MERGE_THRESHOLD
     commit_comment: bool = False
     create_issue: bool = False
     railway_deploy_alerts: bool = False

--- a/src/constants.py
+++ b/src/constants.py
@@ -77,6 +77,12 @@ N8N_BODY_MAX_BYTES = 8192            # n8n relay 시 issue body 최대 바이트
 HTTP_CLIENT_TIMEOUT = 10.0  # 외부 API 호출 타임아웃 (초)
 GITHUB_API = "https://api.github.com"  # GitHub REST API 기본 URL (단일 출처)
 
+# ── Gate 기본 임계값 (단일 출처 — config_manager·api·models·ui 공유) ─────────
+# ── Gate default thresholds (single source — shared by config_manager/api/models/ui) ──
+GATE_DEFAULT_APPROVE_THRESHOLD = 75   # approve_threshold 기본값
+GATE_DEFAULT_REJECT_THRESHOLD = 50    # reject_threshold 기본값
+GATE_DEFAULT_MERGE_THRESHOLD = 75     # merge_threshold 기본값
+
 # ── 언어 가이드 임계값 (review_prompt._select_guide_modes) ─────────────────
 LANG_GUIDE_ALL_FULL_MAX = 3    # N<=3: 모든 언어 full 모드
 LANG_GUIDE_TIER1_FULL_MAX = 6  # 4<=N<=6: Tier1 full, 나머지 compact

--- a/src/gate/github_review.py
+++ b/src/gate/github_review.py
@@ -5,6 +5,7 @@ import logging
 import httpx
 
 from src.config import settings
+from src.constants import GITHUB_API
 from src.gate import merge_reasons
 from src.github_client.helpers import github_api_headers
 from src.shared.http_client import get_http_client
@@ -26,7 +27,7 @@ async def post_github_review(
 ) -> None:
     """Post an APPROVE or REQUEST_CHANGES review on a GitHub pull request."""
     event = "APPROVE" if decision == "approve" else "REQUEST_CHANGES"
-    url = f"https://api.github.com/repos/{repo_full_name}/pulls/{pr_number}/reviews"
+    url = f"{GITHUB_API}/repos/{repo_full_name}/pulls/{pr_number}/reviews"
     client = get_http_client()  # 싱글톤
     r = await client.post(
         url,
@@ -53,7 +54,7 @@ async def get_pr_mergeable_state(
     실패 시 ('unknown', '') 반환 — raise_for_status 호출.
     Returns ('unknown', '') on failure — calls raise_for_status.
     """
-    url = f"https://api.github.com/repos/{repo_full_name}/pulls/{pr_number}"
+    url = f"{GITHUB_API}/repos/{repo_full_name}/pulls/{pr_number}"
     client = get_http_client()  # 싱글톤
     r = await client.get(url, headers=github_api_headers(github_token))
     r.raise_for_status()
@@ -78,7 +79,7 @@ async def get_pr_base_ref(
     F1: replaces hardcoded "main" with actual PR base ref so BPR checks resolve
     correctly for develop/staging/etc. base branches.
     """
-    url = f"https://api.github.com/repos/{repo_full_name}/pulls/{pr_number}"
+    url = f"{GITHUB_API}/repos/{repo_full_name}/pulls/{pr_number}"
     try:
         client = get_http_client()
         r = await client.get(url, headers=github_api_headers(github_token))
@@ -149,7 +150,7 @@ async def merge_pr(  # pylint: disable=too-many-locals
     if state == "unknown":
         return (False, f"{merge_reasons.UNKNOWN_STATE_TIMEOUT}: GitHub mergeable 계산 미완료", head_sha)
 
-    url = f"https://api.github.com/repos/{repo_full_name}/pulls/{pr_number}/merge"
+    url = f"{GITHUB_API}/repos/{repo_full_name}/pulls/{pr_number}/merge"
     try:
         client = get_http_client()  # 싱글톤
         # SHA atomicity guard — expected_sha 전달 시 PUT body 에 포함

--- a/src/github_client/graphql.py
+++ b/src/github_client/graphql.py
@@ -25,12 +25,13 @@ from typing import Any
 
 import httpx
 
+from src.constants import GITHUB_API
 from src.github_client.helpers import github_api_headers
 from src.shared.http_client import get_http_client
 
 logger = logging.getLogger(__name__)
 
-GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+GITHUB_GRAPHQL_URL = f"{GITHUB_API}/graphql"
 
 # Phase H PR-1B-2 — 5xx 재시도 정책 (의존성 추가 없이 직접 helper)
 # GitHub GraphQL 일시 5xx (502/503/504) + transient network error 재시도.
@@ -152,7 +153,7 @@ async def get_pr_node_id(
     실패 시 None 반환 (호출자가 분기 처리).
     Returns None on failure (caller handles fallback).
     """
-    url = f"https://api.github.com/repos/{repo_full_name}/pulls/{pr_number}"
+    url = f"{GITHUB_API}/repos/{repo_full_name}/pulls/{pr_number}"
     try:
         client = get_http_client()
         r = await client.get(url, headers=github_api_headers(token))

--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ from alembic import command
 from alembic.config import Config
 
 from src.config import settings
+from src.constants import GITHUB_API
 from src.shared.http_client import close_http_client, init_http_client
 from src.webhook.router import router as webhook_router
 from src.api.repos import router as api_repos_router
@@ -114,7 +115,7 @@ async def lifespan(_app: FastAPI):
     try:
         from src.shared.http_client import get_http_client  # pylint: disable=import-outside-toplevel
         warmup_client = get_http_client()
-        await warmup_client.get("https://api.github.com/zen", timeout=3.0)
+        await warmup_client.get(f"{GITHUB_API}/zen", timeout=3.0)
         logger.info("GitHub API warm-up ping succeeded")
     except Exception as warmup_exc:  # pylint: disable=broad-exception-caught
         logger.info("GitHub API warm-up ping skipped: %s", type(warmup_exc).__name__)

--- a/src/models/repo_config.py
+++ b/src/models/repo_config.py
@@ -1,6 +1,11 @@
 """RepoConfig ORM 모델 — 리포별 분석·Gate·알림 설정."""
 from datetime import datetime, timezone
 from sqlalchemy import Column, Integer, String, DateTime, Boolean
+from src.constants import (
+    GATE_DEFAULT_APPROVE_THRESHOLD,
+    GATE_DEFAULT_REJECT_THRESHOLD,
+    GATE_DEFAULT_MERGE_THRESHOLD,
+)
 from src.database import Base
 
 
@@ -13,8 +18,8 @@ class RepoConfig(Base):
     repo_full_name = Column(String, unique=True, nullable=False, index=True)
     pr_review_comment = Column(Boolean, default=True, nullable=False)
     approve_mode = Column(String, default="disabled", nullable=False)
-    approve_threshold = Column(Integer, default=75, nullable=False)
-    reject_threshold = Column(Integer, default=50, nullable=False)
+    approve_threshold = Column(Integer, default=GATE_DEFAULT_APPROVE_THRESHOLD, nullable=False)
+    reject_threshold = Column(Integer, default=GATE_DEFAULT_REJECT_THRESHOLD, nullable=False)
     notify_chat_id = Column(String, nullable=True)
     n8n_webhook_url = Column(String, nullable=True)
     discord_webhook_url = Column(String, nullable=True)
@@ -22,7 +27,7 @@ class RepoConfig(Base):
     custom_webhook_url = Column(String, nullable=True)
     email_recipients = Column(String, nullable=True)
     auto_merge = Column(Boolean, default=False, nullable=False)
-    merge_threshold = Column(Integer, default=75, nullable=False)
+    merge_threshold = Column(Integer, default=GATE_DEFAULT_MERGE_THRESHOLD, nullable=False)
     commit_comment = Column(Boolean, default=False, nullable=False)
     create_issue = Column(Boolean, default=False, nullable=False)
     hook_token = Column(String, nullable=True, unique=True)
@@ -45,10 +50,10 @@ class RepoConfig(Base):
     def __init__(self, **kwargs):
         kwargs.setdefault("pr_review_comment", True)
         kwargs.setdefault("approve_mode", "disabled")
-        kwargs.setdefault("approve_threshold", 75)
-        kwargs.setdefault("reject_threshold", 50)
+        kwargs.setdefault("approve_threshold", GATE_DEFAULT_APPROVE_THRESHOLD)
+        kwargs.setdefault("reject_threshold", GATE_DEFAULT_REJECT_THRESHOLD)
         kwargs.setdefault("auto_merge", False)
-        kwargs.setdefault("merge_threshold", 75)
+        kwargs.setdefault("merge_threshold", GATE_DEFAULT_MERGE_THRESHOLD)
         kwargs.setdefault("commit_comment", False)
         kwargs.setdefault("create_issue", False)
         kwargs.setdefault("railway_deploy_alerts", False)

--- a/src/notifier/github_comment.py
+++ b/src/notifier/github_comment.py
@@ -3,7 +3,7 @@
 Phase 3 PR-11 (사이클 84) — i18n: language 인자 + 3-layer fallback (resolve_notification_language).
 Phase 3 PR-11 (Cycle 84) — i18n: language arg + 3-layer fallback.
 """
-from src.constants import GRADE_EMOJI, NOTIFIER_MAX_ISSUES_LONG
+from src.constants import GITHUB_API, GRADE_EMOJI, NOTIFIER_MAX_ISSUES_LONG
 from src.github_client.helpers import github_api_headers
 from src.i18n.loader import get_text
 from src.shared.http_client import get_http_client
@@ -51,7 +51,7 @@ async def post_pr_comment(  # pylint: disable=too-many-positional-arguments
 ) -> None:
     """Post a formatted analysis result comment on a GitHub pull request (Phase 3 PR-11 — i18n)."""
     body = _build_comment_body(score_result, analysis_results, ai_review, language=language)
-    url = f"https://api.github.com/repos/{repo_name}/issues/{pr_number}/comments"
+    url = f"{GITHUB_API}/repos/{repo_name}/issues/{pr_number}/comments"
     client = get_http_client()
     r = await client.post(
         url,
@@ -174,7 +174,7 @@ async def post_pr_comment_from_result(
 ) -> None:
     """Post a formatted analysis result comment from a stored result dict (Phase 3 PR-11 — i18n)."""
     body = _build_comment_from_result(result, language=language)
-    url = f"https://api.github.com/repos/{repo_name}/issues/{pr_number}/comments"
+    url = f"{GITHUB_API}/repos/{repo_name}/issues/{pr_number}/comments"
     client = get_http_client()
     r = await client.post(
         url,

--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import Session
 
 from src.config import settings
 from src.config_manager.manager import RepoConfigData, get_repo_config
+from src.constants import GITHUB_API
 from src.gate.github_review import merge_pr
 from src.gate.merge_failure_advisor import get_advice
 from src.gate.retry_policy import (
@@ -243,7 +244,7 @@ async def _get_pr_data(
     """PR 전체 데이터를 조회한다. 실패 시 None 반환.
     Fetch full PR data. Returns None on failure.
     """
-    url = f"https://api.github.com/repos/{repo_full_name}/pulls/{pr_number}"
+    url = f"{GITHUB_API}/repos/{repo_full_name}/pulls/{pr_number}"
     try:
         client = get_http_client()
         r = await client.get(url, headers=github_api_headers(token))

--- a/src/services/security_scan_service.py
+++ b/src/services/security_scan_service.py
@@ -22,6 +22,7 @@ import httpx
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
+from src.constants import GITHUB_API
 from src.models.repository import Repository
 from src.repositories import security_alert_log_repo
 from src.shared.feature_kill_switch import is_disabled
@@ -29,8 +30,6 @@ from src.shared.http_client import get_http_client
 from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
-
-_GITHUB_API = "https://api.github.com"
 _CODE_SCANNING_KEY = "code_scanning"
 _SECRET_SCANNING_KEY = "_".join(("secret", "scanning"))
 _SKIPPED_KEY = "skipped"
@@ -66,7 +65,7 @@ async def _fetch_alerts(
     alert_kind = "code-scanning" | "secret-scanning".
     Returns None on GHAS 비활성 (403/404) — silent skip + WARNING.
     """
-    url = f"{_GITHUB_API}/repos/{repo_full_name}/{alert_kind}/alerts"
+    url = f"{GITHUB_API}/repos/{repo_full_name}/{alert_kind}/alerts"
     client = get_http_client()
     try:
         resp = await client.get(

--- a/src/ui/routes/settings.py
+++ b/src/ui/routes/settings.py
@@ -13,6 +13,11 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 
 from src.auth.session import CurrentUser, require_login
 from src.config_manager.manager import RepoConfigData, get_repo_config, upsert_repo_config
+from src.constants import (
+    GATE_DEFAULT_APPROVE_THRESHOLD,
+    GATE_DEFAULT_REJECT_THRESHOLD,
+    GATE_DEFAULT_MERGE_THRESHOLD,
+)
 from src.database import SessionLocal
 from src.github_client.repos import (
     WEBHOOK_EVENTS,
@@ -226,8 +231,8 @@ async def update_repo_settings(
                 repo_full_name=repo_name,
                 pr_review_comment=form.get("pr_review_comment") == "on",
                 approve_mode=form.get("approve_mode", "disabled"),
-                approve_threshold=int(form.get("approve_threshold", 75)),
-                reject_threshold=int(form.get("reject_threshold", 50)),
+                approve_threshold=int(form.get("approve_threshold", GATE_DEFAULT_APPROVE_THRESHOLD)),
+                reject_threshold=int(form.get("reject_threshold", GATE_DEFAULT_REJECT_THRESHOLD)),
                 notify_chat_id=form.get("notify_chat_id") or None,
                 n8n_webhook_url=form.get("n8n_webhook_url") or None,
                 discord_webhook_url=form.get("discord_webhook_url", "") or None,
@@ -235,7 +240,7 @@ async def update_repo_settings(
                 custom_webhook_url=form.get("custom_webhook_url", "") or None,
                 email_recipients=form.get("email_recipients", "") or None,
                 auto_merge=form.get("auto_merge") == "on",
-                merge_threshold=int(form.get("merge_threshold", 75)),
+                merge_threshold=int(form.get("merge_threshold", GATE_DEFAULT_MERGE_THRESHOLD)),
                 commit_comment=form.get("commit_comment") == "on",
                 create_issue=form.get("create_issue") == "on",
                 railway_deploy_alerts=form.get("railway_deploy_alerts") == "on",


### PR DESCRIPTION
## Summary

- **GITHUB_API URL 통합** (9파일): \`gate/github_review.py\`, \`notifier/github_comment.py\`, \`services/merge_retry_service.py\`, \`services/security_scan_service.py\` (로컬 \`_GITHUB_API\` 제거), \`github_client/graphql.py\` (\`GITHUB_GRAPHQL_URL\` f-string화), \`main.py\` (warmup URL) — 모두 \`constants.GITHUB_API\` 단일 출처로 통합.
- **Gate 임계값 상수화** (4파일): \`constants.py\`에 \`GATE_DEFAULT_APPROVE_THRESHOLD=75\`, \`GATE_DEFAULT_REJECT_THRESHOLD=50\`, \`GATE_DEFAULT_MERGE_THRESHOLD=75\` 추가. \`config_manager/manager.py\` · \`api/repos.py\` · \`models/repo_config.py\` · \`ui/routes/settings.py\` 4곳의 매직 넘버 제거.

## 🔍 사용자 검증 필요

- [ ] \`make test\` 전체 통과 확인
- [ ] Settings 페이지에서 Gate 설정 저장 정상 동작 확인 (기본값 75/50/75 유지 여부)

🤖 Generated with [Claude Code](https://claude.com/claude-code)