### PR TITLE
fix: P1 품질·문서 — 테마명 deprecated 정정 + semgrep 테스트 강화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,7 +242,7 @@ make run               # 개발 서버 (port 8000, DB 마이그레이션 자동)
 
 #### 정책 11: **UI/시각 변경 PR 본문에 "Claude 시각 검증 불가" 의무 명시**
 
-사용자 발화 (2026-05-02 Phase 1 회고): *"PR본문 검증의 경우 디테일한 검증은 없었습니다."* — Claude 가 만든 UI/시각 변경 (template, css, html 파일) 은 정적 코드만 검증 가능. 4-테마 (dark/light/glass/claude-dark) × 모바일/데스크탑 8 조합 시각 정합성은 사용자 의무.
+사용자 발화 (2026-05-02 Phase 1 회고): *"PR본문 검증의 경우 디테일한 검증은 없었습니다."* — Claude 가 만든 UI/시각 변경 (template, css, html 파일) 은 정적 코드만 검증 가능. 4-테마 (dark/light/pastel/catppuccin) × 모바일/데스크탑 8 조합 시각 정합성은 사용자 의무.
 
 **default 의무**: `src/templates/*.html` / `src/static/**/*.css` / `base.html` `<style>` 블록 / 신규 시각 컴포넌트 변경 PR 작성 시 — PR 본문 최상단에 8 조합 체크리스트 삽입. 템플릿: [docs/policies/active.md#정책-11](docs/policies/active.md#정책-11)
 

--- a/docs/policies/active.md
+++ b/docs/policies/active.md
@@ -78,12 +78,12 @@ git push -u origin <branch>
 
 - [ ] dark 테마 데스크탑 (1440px+)
 - [ ] light 테마 데스크탑
-- [ ] glass 테마 데스크탑
-- [ ] claude-dark 테마 데스크탑
+- [ ] pastel 테마 데스크탑
+- [ ] catppuccin 테마 데스크탑
 - [ ] dark 테마 모바일 (375px ~ 767px)
 - [ ] light 테마 모바일
-- [ ] glass 테마 모바일
-- [ ] claude-dark 테마 모바일
+- [ ] pastel 테마 모바일
+- [ ] catppuccin 테마 모바일
 
 특히 검증 필요 (변경 영역 한정):
 - {변경 영역 설명}

--- a/tests/unit/analyzer/tools/test_semgrep.py
+++ b/tests/unit/analyzer/tools/test_semgrep.py
@@ -522,6 +522,10 @@ class TestSemgrepAnalyzeFileIntegration:
         # StaticAnalysisResult가 정상 반환되어야 한다
         from src.analyzer.io.static import StaticAnalysisResult
         assert isinstance(result, StaticAnalysisResult)
+        # 빈 출력 mock이므로 이슈 없어야 한다 (subprocess.run이 전체 패치됨)
+        # Empty mock output → no issues (subprocess.run is fully patched)
+        assert result.issues == []
+        assert result.filename == "app.py"
 
     def test_semgrep_skipped_for_python_file_when_not_installed(self):
         # semgrep 미설치 환경에서는 _SemgrepAnalyzer가 is_enabled()=False → run() 호출 안 됨
@@ -543,6 +547,9 @@ class TestSemgrepAnalyzeFileIntegration:
         # shutil.which=None이므로 semgrep의 run()은 호출되지 않아야 한다
         from src.analyzer.io.static import StaticAnalysisResult
         assert isinstance(result, StaticAnalysisResult)
+        # semgrep 미설치 + 빈 코드 → 이슈 없음, filename 정합 확인
+        # semgrep absent + trivial code → no issues; verify filename
+        assert result.filename == "module.py"
 
     def test_semgrep_runs_for_javascript_file_when_installed(self):
         # javascript 파일도 semgrep이 설치된 경우 분석 대상이 된다


### PR DESCRIPTION
## Summary

- **테마명 정정** (CLAUDE.md + docs/policies/active.md): \`glass\`/\`claude-dark\` → \`pastel\`/\`catppuccin\` — 실제 운영 테마명과 불일치했던 문서 내 8 조합 체크리스트 수정.
- **semgrep 테스트 강화** (test_semgrep.py): \`isinstance(result, StaticAnalysisResult)\` 단일 단언으로는 result 내용 미검증 → \`result.issues == []\` + \`result.filename\` 검증 추가. 감사 P1 식별 항목.

## 🔍 사용자 검증 필요

- [ ] \`make test\` 전체 통과 확인
- [ ] Settings 페이지에서 테마 토글(pastel/catppuccin/dark/light) 시 8 조합 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)