### PR TITLE
fix(security): startup warning for missing TELEGRAM_WEBHOOK_SECRET in prod

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -92,6 +92,16 @@ async def lifespan(_app: FastAPI):
                 "TOKEN_ENCRYPTION_KEY required when STRICT_TOKEN_ENCRYPTION=true"
             )
         logger.warning("%s", warning_msg)
+    if is_prod_like and not (settings.telegram_webhook_secret or "").strip():
+        # Telegram webhook 시크릿 미설정 시 /webhooks/telegram 인증이 완전히 우회됨.
+        # When TELEGRAM_WEBHOOK_SECRET is not set, /webhooks/telegram auth is bypassed entirely.
+        logger.warning(
+            "SECURITY: TELEGRAM_WEBHOOK_SECRET is not set in production "
+            "(APP_BASE_URL=%s). The /webhooks/telegram endpoint will accept "
+            "requests without authentication. Set TELEGRAM_WEBHOOK_SECRET to "
+            "the value configured in your Telegram bot's webhook settings.",
+            settings.app_base_url,
+        )
     try:
         await asyncio.wait_for(asyncio.to_thread(_run_migrations), timeout=30)
         logger.info("DB migration completed")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -271,6 +271,73 @@ def test_lifespan_warmup_ping_handles_failure_silently(caplog):
 # UI 감사 Step C 회귀 가드 — Chart.js vendoring 이 정상 마운트됐는지 확인
 # UI audit Step C regression guard — verify Chart.js is correctly mounted
 
+# --- TELEGRAM_WEBHOOK_SECRET 부재 경고 (prod 환경) ---
+# --- TELEGRAM_WEBHOOK_SECRET absence warning (prod environment) ---
+
+def test_lifespan_warns_telegram_webhook_secret_missing_in_prod(caplog):
+    """prod 환경(https URL)에서 TELEGRAM_WEBHOOK_SECRET 미설정 시 SECURITY 경고 출력.
+    Warns when TELEGRAM_WEBHOOK_SECRET is unset in production — /webhooks/telegram auth bypassed.
+    """
+    import logging as _logging
+    with patch("src.main._run_migrations"), \
+         patch("src.main.settings") as mock_settings:
+        mock_settings.session_secret = "test-session-secret-32-chars-long!"
+        mock_settings.anthropic_api_key = "sk-ant-test-key"
+        mock_settings.app_base_url = "https://scamanager.example.com"
+        mock_settings.token_encryption_key = "valid-fernet-key"
+        mock_settings.strict_token_encryption = False
+        mock_settings.telegram_webhook_secret = ""
+        with caplog.at_level(_logging.WARNING, logger="src.main"):
+            with TestClient(app):
+                pass
+    assert any("TELEGRAM_WEBHOOK_SECRET" in rec.message for rec in caplog.records), \
+        "prod 환경에서 TELEGRAM_WEBHOOK_SECRET 부재 경고가 로그에 남지 않았습니다"
+
+
+def test_lifespan_no_warning_telegram_webhook_secret_set_in_prod(caplog):
+    """prod 환경이라도 TELEGRAM_WEBHOOK_SECRET 가 설정되어 있으면 경고 없음.
+    No warning when TELEGRAM_WEBHOOK_SECRET is set — authentication is active.
+    """
+    import logging as _logging
+    with patch("src.main._run_migrations"), \
+         patch("src.main.settings") as mock_settings:
+        mock_settings.session_secret = "test-session-secret-32-chars-long!"
+        mock_settings.anthropic_api_key = "sk-ant-test-key"
+        mock_settings.app_base_url = "https://scamanager.example.com"
+        mock_settings.token_encryption_key = "valid-fernet-key"
+        mock_settings.strict_token_encryption = False
+        mock_settings.telegram_webhook_secret = "some-secret-token"
+        with caplog.at_level(_logging.WARNING, logger="src.main"):
+            with TestClient(app) as c:
+                c.get("/health")
+    assert not any("TELEGRAM_WEBHOOK_SECRET" in rec.message for rec in caplog.records), \
+        "시크릿이 설정되어 있는데도 TELEGRAM_WEBHOOK_SECRET 경고가 남았습니다"
+
+
+def test_lifespan_no_warning_telegram_webhook_secret_dev_env(caplog):
+    """dev 환경(http URL)에서는 시크릿이 없어도 경고 없음 — prod 전용 체크.
+    No warning in dev (http) environments — the check is prod-only.
+    """
+    import logging as _logging
+    with patch("src.main._run_migrations"), \
+         patch("src.main.settings") as mock_settings:
+        mock_settings.session_secret = "test-session-secret-32-chars-long!"
+        mock_settings.anthropic_api_key = "sk-ant-test-key"
+        mock_settings.app_base_url = "http://localhost:8000"
+        mock_settings.token_encryption_key = ""
+        mock_settings.strict_token_encryption = False
+        mock_settings.telegram_webhook_secret = ""
+        with caplog.at_level(_logging.WARNING, logger="src.main"):
+            with TestClient(app) as c:
+                c.get("/health")
+    assert not any("TELEGRAM_WEBHOOK_SECRET" in rec.message for rec in caplog.records), \
+        "dev(http) 환경에서 TELEGRAM_WEBHOOK_SECRET 경고가 남았습니다"
+
+
+# --- PR-4 G1: StaticFiles `/static/vendor/chart.umd.min.js` 200 응답 가드 ---
+# UI 감사 Step C 회귀 가드 — Chart.js vendoring 이 정상 마운트됐는지 확인
+# UI audit Step C regression guard — verify Chart.js is correctly mounted
+
 def test_static_chartjs_returns_200(client):
     """StaticFiles `/static/vendor/chart.umd.min.js` 가 200 + JS Content-Type 반환.
     Verify vendored Chart.js is served successfully.


### PR DESCRIPTION
## Summary

- Adds a production-only startup warning when `TELEGRAM_WEBHOOK_SECRET` is not set
- Without the secret, `/webhooks/telegram` accepts all requests with no authentication (the `if settings.telegram_webhook_secret:` guard at `src/webhook/providers/telegram.py:189` is completely skipped)
- Mirrors the existing `TOKEN_ENCRYPTION_KEY` warning pattern: fires only when `APP_BASE_URL` starts with `https`

## Change

```python
# src/main.py — inside lifespan startup, after TOKEN_ENCRYPTION_KEY block
if is_prod_like and not (settings.telegram_webhook_secret or "").strip():
    logger.warning(
        "SECURITY: TELEGRAM_WEBHOOK_SECRET is not set in production ..."
    )
```

## Test plan

- `tests/unit/test_main.py` — 23 tests pass (existing lifespan startup tests cover warning paths)

## 🔍 사용자 검증 필요

- [ ] Railway Logs: deploy 후 `TELEGRAM_WEBHOOK_SECRET` 미설정 환경에서 WARNING 로그 확인
- [ ] `TELEGRAM_WEBHOOK_SECRET` 설정된 운영 환경에서는 WARNING 미출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)