### PR TITLE
fix(p2): async DNS in validate_external_url + strengthen concurrency test assertions

### DIFF
--- a/src/notifier/_http.py
+++ b/src/notifier/_http.py
@@ -1,4 +1,5 @@
 """SSRF-safe HTTP helpers for external webhook notifiers."""
+import asyncio
 import ipaddress
 import logging
 import socket
@@ -28,7 +29,7 @@ def _is_dangerous_ip(addr: str) -> bool:
         return False
 
 
-def validate_external_url(url: str) -> bool:
+async def validate_external_url(url: str) -> bool:
     """Return True only if *url* is safe to use as an external webhook target.
 
     Blocks:
@@ -36,6 +37,9 @@ def validate_external_url(url: str) -> bool:
     - IP literals in private/loopback/link-local/reserved/multicast ranges
     - Hostnames that DNS-resolve to any such address (DNS-rebinding defence)
     - Empty or malformed URLs
+
+    DNS 조회는 asyncio.to_thread 으로 실행 — 이벤트 루프 블로킹 방지.
+    DNS lookup runs in asyncio.to_thread to avoid blocking the event loop.
     """
     if not url:
         return False
@@ -60,9 +64,12 @@ def validate_external_url(url: str) -> bool:
     except ValueError:
         pass  # hostname is a domain name — proceed to DNS resolution
 
-    # DNS resolution: block if any returned address is private/internal
+    # DNS resolution: block if any returned address is private/internal.
+    # socket.getaddrinfo 는 sync blocking — asyncio.to_thread 로 오프로드.
+    # socket.getaddrinfo is sync blocking — offload via asyncio.to_thread.
     try:
-        addrs = [sockaddr[0] for _f, _t, _p, _c, sockaddr in socket.getaddrinfo(hostname, None)]
+        raw = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
+        addrs = [sockaddr[0] for _f, _t, _p, _c, sockaddr in raw]
     except socket.gaierror:
         logger.warning("SSRF guard: DNS resolution failed for hostname '%s'", hostname)
         return False

--- a/src/notifier/discord.py
+++ b/src/notifier/discord.py
@@ -89,7 +89,7 @@ async def send_discord_notification(
     """Discord Embed 메시지를 Webhook URL로 전송한다 (Phase 3 PR-10 — i18n)."""
     if not webhook_url:
         return
-    if not validate_external_url(webhook_url):
+    if not await validate_external_url(webhook_url):
         logger.warning("send_discord_notification: blocked unsafe URL '%s'", webhook_url)
         return
     embed = _build_embed(

--- a/src/notifier/n8n.py
+++ b/src/notifier/n8n.py
@@ -49,7 +49,7 @@ async def notify_n8n(
     """n8n Webhook으로 분석 점수 페이로드를 POST한다 (envelope 구조)."""
     if not webhook_url:
         return
-    if not validate_external_url(webhook_url):
+    if not await validate_external_url(webhook_url):
         logger.warning("notify_n8n: blocked unsafe URL '%s'", webhook_url)
         return
     payload = _build_envelope(
@@ -79,7 +79,7 @@ async def notify_n8n_issue(
     """GitHub Issue 이벤트를 n8n Webhook으로 릴레이한다 (envelope 구조)."""
     if not webhook_url:
         return
-    if not validate_external_url(webhook_url):
+    if not await validate_external_url(webhook_url):
         logger.warning("notify_n8n_issue: blocked unsafe URL '%s'", webhook_url)
         return
 

--- a/src/notifier/slack.py
+++ b/src/notifier/slack.py
@@ -102,7 +102,7 @@ async def send_slack_notification(
     """Slack Incoming Webhook으로 분석 결과 메시지를 전송한다 (Phase 3 PR-10 — i18n)."""
     if not webhook_url:
         return
-    if not validate_external_url(webhook_url):
+    if not await validate_external_url(webhook_url):
         logger.warning("send_slack_notification: blocked unsafe URL '%s'", webhook_url)
         return
     payload = _build_payload(

--- a/src/notifier/webhook.py
+++ b/src/notifier/webhook.py
@@ -50,7 +50,7 @@ async def send_webhook_notification(
     """범용 Webhook URL로 분석 결과 JSON을 POST한다."""
     if not webhook_url:
         return
-    if not validate_external_url(webhook_url):
+    if not await validate_external_url(webhook_url):
         logger.warning("send_webhook_notification: blocked unsafe URL '%s'", webhook_url)
         return
     payload = _build_payload(repo_name, commit_sha, score_result, analysis_results, pr_number, ai_review)

--- a/tests/integration/test_retry_concurrency_postgres.py
+++ b/tests/integration/test_retry_concurrency_postgres.py
@@ -168,10 +168,14 @@ def test_concurrent_claim_no_double_processing():
         # Must complete without errors.
         assert not errors, f"Unexpected errors from worker threads: {errors}"
 
-        # 각 스레드가 결과를 반환했는지 확인
-        # Confirm each thread produced a result.
-        assert results[0] is not None
-        assert results[1] is not None
+        # 각 스레드가 정확히 1개 행을 클레임했는지 확인 (limit=1, 2개 시드)
+        # Confirm each thread claimed exactly 1 row (limit=1, 2 seeded rows).
+        assert len(results[0]) == 1, (
+            f"Worker 0 expected exactly 1 claimed row, got {results[0]}"
+        )
+        assert len(results[1]) == 1, (
+            f"Worker 1 expected exactly 1 claimed row, got {results[1]}"
+        )
 
         # 두 스레드가 획득한 행 id 를 합산
         # Aggregate claimed row ids from both threads.
@@ -330,10 +334,14 @@ def test_skip_locked_prevents_concurrent_double_claim():
         # Must complete without errors.
         assert not errors, f"Unexpected errors from worker threads: {errors}"
 
-        # 각 스레드가 결과를 반환했는지 확인
-        # Confirm each thread produced a result.
-        assert results[0] is not None
-        assert results[1] is not None
+        # 각 워커가 리스트를 반환했는지 확인 (SKIP LOCKED 로 한 워커는 0개 가능)
+        # Confirm each worker returned a list (one may get 0 rows due to SKIP LOCKED).
+        assert isinstance(results[0], list), (
+            f"Worker 0 did not return a list: {results[0]}"
+        )
+        assert isinstance(results[1], list), (
+            f"Worker 1 did not return a list: {results[1]}"
+        )
 
         # 두 결과를 합산 — 정확히 1개 행만 클레임되어야 함
         # Aggregate results — exactly 1 row must be claimed in total.

--- a/tests/unit/notifier/test_http.py
+++ b/tests/unit/notifier/test_http.py
@@ -24,64 +24,64 @@ from src.notifier._http import validate_external_url, build_safe_client
 # ---------------------------------------------------------------------------
 
 
-def test_validate_blocks_loopback_ipv4():
+async def test_validate_blocks_loopback_ipv4():
     # 127.0.0.1 루프백 주소는 반드시 차단
     # 127.0.0.1 loopback address must be blocked.
-    assert validate_external_url("http://127.0.0.1/hook") is False
+    assert await validate_external_url("http://127.0.0.1/hook") is False
 
 
-def test_validate_blocks_loopback_ipv6():
+async def test_validate_blocks_loopback_ipv6():
     # IPv6 루프백 ::1 도 차단
     # IPv6 loopback ::1 must also be blocked.
-    assert validate_external_url("http://[::1]/hook") is False
+    assert await validate_external_url("http://[::1]/hook") is False
 
 
-def test_validate_blocks_private_10_range():
+async def test_validate_blocks_private_10_range():
     # RFC 1918 10.x.x.x 사설 대역 차단
     # RFC 1918 10.x.x.x private range must be blocked.
-    assert validate_external_url("https://10.0.0.1/hook") is False
+    assert await validate_external_url("https://10.0.0.1/hook") is False
 
 
-def test_validate_blocks_private_192_range():
+async def test_validate_blocks_private_192_range():
     # RFC 1918 192.168.x.x 사설 대역 차단
     # RFC 1918 192.168.x.x private range must be blocked.
-    assert validate_external_url("https://192.168.1.1/hook") is False
+    assert await validate_external_url("https://192.168.1.1/hook") is False
 
 
-def test_validate_blocks_link_local():
+async def test_validate_blocks_link_local():
     # AWS IMDSv1 인스턴스 메타데이터 주소 차단 (169.254.169.254)
-    assert validate_external_url("https://169.254.169.254/hook") is False
+    assert await validate_external_url("https://169.254.169.254/hook") is False
 
 
-def test_validate_blocks_http_scheme():
+async def test_validate_blocks_http_scheme():
     # https 전용 — http:// 스킴은 차단
-    assert validate_external_url("http://example.com/hook") is False
+    assert await validate_external_url("http://example.com/hook") is False
 
 
-def test_validate_allows_https_public_url():
+async def test_validate_allows_https_public_url():
     # 공인 IP로 해석되는 https URL은 허용
     # socket.getaddrinfo를 mock해 공인 IP(1.2.3.4) 반환
     fake_addrinfo = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("1.2.3.4", 0))]
     with patch("socket.getaddrinfo", return_value=fake_addrinfo):
-        assert validate_external_url("https://discord.com/api/webhooks/123") is True
+        assert await validate_external_url("https://discord.com/api/webhooks/123") is True
 
 
-def test_validate_hostname_resolves_to_private_ip_blocked():
+async def test_validate_hostname_resolves_to_private_ip_blocked():
     # DNS가 사설 IP를 반환하는 외부처럼 보이는 도메인 차단 (DNS 리바인딩 방어)
     # Block seemingly external domains whose DNS resolves to private IPs (DNS rebinding defence).
     fake_addrinfo = [(socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.1", 0))]
     with patch("socket.getaddrinfo", return_value=fake_addrinfo):
-        assert validate_external_url("https://evil.example.com/hook") is False
+        assert await validate_external_url("https://evil.example.com/hook") is False
 
 
-def test_validate_empty_string_returns_false():
+async def test_validate_empty_string_returns_false():
     # 빈 문자열은 False 반환
-    assert validate_external_url("") is False
+    assert await validate_external_url("") is False
 
 
-def test_validate_invalid_url_returns_false():
+async def test_validate_invalid_url_returns_false():
     # URL 형식이 아닌 문자열은 False 반환
-    assert validate_external_url("not-a-url") is False
+    assert await validate_external_url("not-a-url") is False
 
 
 # ---------------------------------------------------------------------------
@@ -116,10 +116,10 @@ def test_build_safe_client_no_follow_redirects():
 # ---------------------------------------------------------------------------
 
 
-def test_validate_logs_warning_on_private_ip(caplog):
+async def test_validate_logs_warning_on_private_ip(caplog):
     # 사설 IP 차단 시 logger.warning이 호출되어야 한다
     with caplog.at_level(logging.WARNING, logger="src.notifier._http"):
-        result = validate_external_url("https://192.168.1.1/hook")
+        result = await validate_external_url("https://192.168.1.1/hook")
     assert result is False
     assert len(caplog.records) >= 1
     assert any(r.levelno == logging.WARNING for r in caplog.records)


### PR DESCRIPTION
## Summary

- `validate_external_url` was calling `socket.getaddrinfo` synchronously inside an async context, which blocks the event loop while DNS resolves. Wrapped with `asyncio.to_thread` and made the function `async`; updated all 5 callers (`discord.py`, `slack.py`, `n8n.py` ×2, `webhook.py`) with `await`.
- Integration test had two `assert results[i] is not None` assertions that pass even when a worker returns an empty list `[]` (a concurrency bug scenario). Replaced with:
  - First test (2 seeds, 2 workers): `assert len(results[i]) == 1` — each worker must claim exactly 1 row
  - Second test (1 seed, 2 workers): `assert isinstance(results[i], list)` — one worker legitimately gets 0 rows via SKIP LOCKED; the total-is-1 assertion downstream already covers correctness

## Files changed

| File | Change |
|------|--------|
| `src/notifier/_http.py` | `async def validate_external_url` + `asyncio.to_thread` DNS |
| `src/notifier/{discord,slack,n8n,webhook}.py` | `await validate_external_url(...)` |
| `tests/unit/notifier/test_http.py` | `async def` tests (asyncio_mode=auto) |
| `tests/integration/test_retry_concurrency_postgres.py` | Stronger per-worker assertions |

## Test plan

- `tests/unit/notifier/` — 229 passed
- `tests/unit/` — 2809 passed, 1 skipped

## 🔍 사용자 검증 필요

- [ ] Discord/Slack/n8n/webhook 알림이 실제 URL로 정상 전송되는지 운영 환경 확인
- [ ] Railway 배포 후 notifier 관련 로그 WARNING 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)