### PR TITLE
feat: 메모리 슬러그 교차 점검 스크립트 + active.md 스테일 어노테이션 제거

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test test-v test-fast test-slow test-cov test-file test-isolated lint lint-strict gate run migrate revision review install-playwright test-e2e test-e2e-headed css-install css-build css-dev
+.PHONY: install test test-v test-fast test-slow test-cov test-file test-isolated lint lint-strict gate run migrate revision review check-memory-refs install-playwright test-e2e test-e2e-headed css-install css-build css-dev
 
 # 의존성 설치 (개발 환경 — 테스트/E2E + CSS 빌드 포함)
 # Install dependencies (development environment — includes tests/E2E + CSS build).
@@ -100,6 +100,11 @@ migrate:
 # Local code review via CLI.
 review:
 	python -m src.cli review
+
+# 메모리 슬러그 교차 점검 — 문서 참조 vs 실제 파일 비교, 스테일 어노테이션 탐지
+# Memory slug cross-check — compare doc references vs actual files, detect stale annotations.
+check-memory-refs:
+	python scripts/check_memory_refs.py
 
 # 개발 서버 실행
 # Start the development server (port 8000).

--- a/docs/policies/active.md
+++ b/docs/policies/active.md
@@ -217,7 +217,7 @@ git push -u origin <branch>
    - 검증 방법 부재 → 회귀 가드 추가 의무 또는 사용자 명시 검증 요청
 3. **위반 시 회복**: 사전 사고 누락 후 진행 시 사용자 발견 → 즉시 사과 + 영향 범위 분석 + revert 결정 회신.
 
-**위임 분류 3-tier 통합** (`feedback-architecture-decision-pre-confirm.md` (현재 미생성)):
+**위임 분류 3-tier 통합** (`feedback-architecture-decision-pre-confirm.md`):
 - **High (사전 확인 의무)** = 정책 15 적용 (DB 스키마 / API / 권한 / 데이터 모델) — 옵션 표 + 사용자 1줄 명시
 - **Medium (자율 + 보고)** = 정책 15 적용 (헬퍼 함수 / 정책 본문 진화) — Claude 사전 사고 후 자율 진입 + PR 본문 자율 판단 보고
 - **Low (즉시 진입)** = 정책 15 면제 OK (회귀 가드 / docstring / typo) — 단 (b)/(c) 자문은 의무
@@ -249,7 +249,7 @@ git push -u origin <branch>
 - ❌ `build_review_prompt` 토큰 예산 8000 → 축소 (사이클 72 사용자 명시 보류 — 품질 저하 원치 않음)
 - ❌ `review_guides/` 50개 언어 Tier1 full ~500 토큰 압축 (사이클 72 사용자 명시 보류 — 체크리스트 ↓ → 리뷰 깊이 ↓ 위험)
 - ✅ 진행 OK 영역 (사이클 72 검증): `review_code` prompt caching = **이미 100% 적용** (사이클 63 #218 — `src/analyzer/io/ai_review.py:79,89`) — multi-block 확장 (system + lang_guides 분리) 만 Phase 3 후보 (단 `build_review_prompt` 시그니처 변경 = High tier 사전 확인 의무) / 모델 분기 (Haiku/Sonnet/Opus) — Phase 2 (1주 운영 데이터 후 결정, AI 리뷰 품질 영향 = High tier) / 동일 SHA 결과 재사용 = **이미 100% 적용** (3-tier dedup — `src/worker/pipeline.py:178-181`) / Insight narrative 호출 빈도 제한 — Phase 2 (DB 캐싱 1h TTL 후보) / **cache hit rate 모니터링 인프라 = 사이클 72 PR 2 (#242) 도입** (`src/shared/claude_metrics.py::get_cache_stats` + cache 비용 모델 정확화 + silent fallback streak WARNING)
-- 신규 토큰 절약 영역 도입 시 사용자 사전 확인 의무 (정책 15 + High tier — `feedback-architecture-decision-pre-confirm.md` (현재 미생성) 페어)
+- 신규 토큰 절약 영역 도입 시 사용자 사전 확인 의무 (정책 15 + High tier — `feedback-architecture-decision-pre-confirm.md` 페어)
 
 **default 적용 패턴**:
 - **변수명** = 의도 명시 (예: `data` X → `repository_user_id` ○)
@@ -260,7 +260,7 @@ git push -u origin <branch>
 - **early return** = 중첩 깊이 ≤ 3 (R0911 임계 default)
 
 **금지 패턴** (단순화 위반):
-- ❌ 추상 베이스 클래스 / Protocol — 사용처 ≥ 3 일 때만 도입 (`feedback-architecture-decision-pre-confirm.md` (현재 미생성) Medium tier 기준 페어)
+- ❌ 추상 베이스 클래스 / Protocol — 사용처 ≥ 3 일 때만 도입 (`feedback-architecture-decision-pre-confirm.md` Medium tier 기준 페어)
 - ❌ Generic 타입 매개변수 — 사용처 ≥ 3 시점 도입
 - ❌ 메타클래스 / 데코레이터 체인 — 표준 라이브러리 (functools/contextlib) 외 자체 작성 금지 (사용자 명시 시만 OK)
 - ❌ "다음 확장 대비" 분기 — 현재 요건만 구현 (정책 7 강화 응집 단위 부합)
@@ -328,8 +328,8 @@ git push -u origin <branch>
 - 트리거 미충족 시 = default 정책 8 매 회고 cross-verify 적용 (정책 17 5번째 default 미적용)
 
 **Cross-ref**:
-- 메모리 `feedback-pr-push-direct-validation.md` (현재 미생성) 사이클 89 진화 (시간차 결함 누적 행 추가) 페어
-- 메모리 `feedback-fixture-model-sync-discipline.md` (사이클 89 신설, 현재 미생성) 페어
+- 메모리 `feedback-pr-push-direct-validation.md` 사이클 89 진화 (시간차 결함 누적 행 추가) 페어
+- 메모리 `feedback-fixture-model-sync-discipline.md` (사이클 89 신설) 페어
 - 정책 8 진화 (3) cross-verify Round 2 단위 분포 실측 의무 페어
 
 ---
@@ -393,7 +393,7 @@ git push -u origin <branch>
 
 작업 완료 보고 시 검증 의뢰 명시 누락 시 = **다음 응답에서 회복 의무** (자성 1줄 + 의뢰 1줄 추가). 회복 누락 시 = 다음 사이클 회고 §자성 명시 의무.
 
-**양방향 비대칭 위험**: Claude 측 회복 가드 = 메모리 `feedback-codex-post-validation-mandatory.md` (현재 미생성) 적용. Codex 측 회복 가드 = AGENTS.md hooks 또는 Codex system prompt 영역 (SCAManager 통제 외 — Codex 측 적용 검증 불가). default 보고: AGENTS.md 본문에 "Codex 환경 진입 시 본 섹션 read 의무" 명시 (PR #368 머지) — Codex 측 강제력 = 0 (자율 적용 영역).
+**양방향 비대칭 위험**: Claude 측 회복 가드 = 메모리 `feedback-codex-post-validation-mandatory.md` 적용. Codex 측 회복 가드 = AGENTS.md hooks 또는 Codex system prompt 영역 (SCAManager 통제 외 — Codex 측 적용 검증 불가). default 보고: AGENTS.md 본문에 "Codex 환경 진입 시 본 섹션 read 의무" 명시 (PR #368 머지) — Codex 측 강제력 = 0 (자율 적용 영역).
 
 ### 검증 사례 (사이클 93 첫 운영)
 
@@ -419,7 +419,7 @@ git push -u origin <branch>
 | CLAUDE.md 정책 18 default rule | CLAUDE.md §"사용자 협업 정책" 정책 17 직후 | default rule 변경 시 sync |
 | detail · 검증 사례 · Why · How | docs/policies/active.md §"정책 18" (본 섹션) | detail 영역 변경 시 sync |
 | 진화 default 추적 | docs/policies/history.md §"보존 영역" — 정책 18 entry | 사이클 94+ 진화 시 추가 |
-| Claude 측 숙지 | 메모리 `feedback-codex-post-validation-mandatory.md` (현재 미생성) | 매 사이클 30초 grep 의무 |
+| Claude 측 숙지 | 메모리 `feedback-codex-post-validation-mandatory.md` | 매 사이클 30초 grep 의무 |
 
 **5-way sync 가드** — 본문 충돌 시 **CLAUDE.md 정책 18 우선** (정책 일관성 — Claude 가 SCAManager 운영 주체).
 
@@ -429,8 +429,8 @@ git push -u origin <branch>
 - 정책 8 페어 (5+1 cross-verify ↔ mutual 2-layer 격리 의무)
 - 정책 9 페어 (회고 자유 발언 = Claude 단독 / 회고 결과물 = Codex 검증 의뢰 의무)
 - 정책 17 5번 default 페어 (정기 검증 ≥ 5 사이클 ↔ mutual 매 PR 시점 차별)
-- 메모리 `feedback-codex-post-validation-mandatory.md` (현재 미생성, Claude 측 숙지)
-- 메모리 `feedback-pr-scoped-ci-endpoint-pattern.md` (현재 미생성, 사이클 93 사고 학습 페어)
+- 메모리 `feedback-codex-post-validation-mandatory.md` (Claude 측 숙지)
+- 메모리 `feedback-pr-scoped-ci-endpoint-pattern.md` (사이클 93 사고 학습 페어)
 
 ---
 

--- a/scripts/check_memory_refs.py
+++ b/scripts/check_memory_refs.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+메모리 슬러그 교차 점검 스크립트.
+Memory slug cross-checker script.
+
+CLAUDE.md / docs/policies/active.md / history.md 에서 참조된 메모리 슬러그와
+실제 메모리 디렉토리 파일 목록을 비교해 누락·스테일 어노테이션·미참조 파일을 보고한다.
+
+Compares memory slugs referenced in project docs against actual files in the memory
+directory, reporting: missing files, stale "(현재 미생성)" annotations, unreferenced files.
+"""
+import io
+import re
+import sys
+from pathlib import Path
+
+# Windows cp949 환경에서 한글/이모지 출력 오류 방지
+# Prevent encoding errors on Windows cp949 for Korean/emoji output.
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8")
+
+MEMORY_DIR = (
+    Path.home() / ".claude" / "projects" / "d--Source-SCAManager" / "memory"
+)
+DOC_FILES = [
+    "CLAUDE.md",
+    "docs/policies/active.md",
+    "docs/policies/history.md",
+]
+SLUG_PATTERN = re.compile(r"`((?:feedback|project|user)-[\w-]+\.md)`")
+STALE_PATTERN = re.compile(
+    r"`((?:feedback|project|user)-[\w-]+\.md)`\s*\(현재 미생성[^)]*\)"
+)
+
+
+def collect_referenced(project_root: Path) -> dict[str, list[str]]:
+    """각 문서에서 메모리 슬러그 참조를 수집한다. / Collect memory slug references from each doc."""
+    referenced: dict[str, list[str]] = {}
+    for rel_path in DOC_FILES:
+        full_path = project_root / rel_path
+        if not full_path.exists():
+            continue
+        content = full_path.read_text(encoding="utf-8")
+        for match in SLUG_PATTERN.finditer(content):
+            referenced.setdefault(match.group(1), []).append(rel_path)
+    return referenced
+
+
+def collect_stale(project_root: Path, actual: set[str]) -> list[tuple[str, str]]:
+    """파일은 생성됐으나 '(현재 미생성)' 어노테이션이 잔존하는 항목 탐지.
+    Detect slugs where the file exists but a '(현재 미생성)' annotation still remains."""
+    stale: list[tuple[str, str]] = []
+    for rel_path in DOC_FILES:
+        full_path = project_root / rel_path
+        if not full_path.exists():
+            continue
+        content = full_path.read_text(encoding="utf-8")
+        for match in STALE_PATTERN.finditer(content):
+            slug = match.group(1)
+            if slug in actual:
+                stale.append((rel_path, slug))
+    return stale
+
+
+def print_report(
+    referenced: dict[str, list[str]],
+    actual: set[str],
+    stale: list[tuple[str, str]],
+) -> bool:
+    """결과를 출력하고 문제가 없으면 True를 반환한다. / Print report; return True when clean."""
+    missing = {slug for slug in referenced if slug not in actual}
+    extra = actual - set(referenced.keys())
+
+    print("=== SCAManager 메모리 슬러그 점검 / Memory Slug Check ===\n")
+    print(f"참조된 슬러그: {len(referenced)}개")
+    print(f"실제 파일:     {len(actual)}개")
+
+    ok = True
+
+    if missing:
+        ok = False
+        print(f"\n❌ 누락 파일 ({len(missing)}개 — 문서 참조 O, 파일 X):")
+        for slug in sorted(missing):
+            refs = ", ".join(referenced[slug])
+            print(f"  {slug}  ← {refs}")
+    else:
+        print("\n✅ 모든 참조 슬러그에 실제 파일 존재")
+
+    if stale:
+        ok = False
+        print(f"\n⚠️  스테일 어노테이션 ({len(stale)}건 — 파일 생성 후 '(현재 미생성)' 잔존):")
+        for doc, slug in stale:
+            print(f"  {doc}: `{slug}` (현재 미생성) → 어노테이션 제거 필요")
+    else:
+        print("✅ 스테일 '(현재 미생성)' 어노테이션 없음")
+
+    if extra:
+        print(f"\nℹ️  미참조 파일 ({len(extra)}개 — 문서 참조 X, 파일 O):")
+        for slug in sorted(extra):
+            print(f"  {slug}")
+
+    return ok
+
+
+def main() -> int:
+    project_root = Path(__file__).resolve().parents[1]
+
+    if not MEMORY_DIR.exists():
+        print(f"❌ 메모리 디렉토리 없음: {MEMORY_DIR}")
+        return 1
+
+    referenced = collect_referenced(project_root)
+    actual = {f.name for f in MEMORY_DIR.glob("*.md") if f.name != "MEMORY.md"}
+    stale = collect_stale(project_root, actual)
+
+    return 0 if print_report(referenced, actual, stale) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- `scripts/check_memory_refs.py` 신설 — CLAUDE.md/active.md/history.md 에서 참조된 메모리 슬러그와 실제 파일 비교, 스테일 `(현재 미생성)` 어노테이션 탐지
- `Makefile` `check-memory-refs` 타깃 추가 (`make check-memory-refs`)
- `docs/policies/active.md` 8건 스테일 `(현재 미생성)` 어노테이션 제거 (해당 파일 모두 생성 완료)

## 변경 파일

| 파일 | 변경 내용 |
|------|---------|
| `scripts/check_memory_refs.py` | 신규 — 슬러그 교차 점검 스크립트 (UTF-8 강제, S3776 CC ≤ 15) |
| `Makefile` | `check-memory-refs` 타깃 추가 |
| `docs/policies/active.md` | 8건 `(현재 미생성)` 어노테이션 제거 |

## 스크립트 출력 예시 (clean 상태)

```
=== SCAManager 메모리 슬러그 점검 / Memory Slug Check ===
참조된 슬러그: 6개
실제 파일:     18개
✅ 모든 참조 슬러그에 실제 파일 존재
✅ 스테일 '(현재 미생성)' 어노테이션 없음
ℹ️  미참조 파일 (12개 — 문서 참조 X, 파일 O): ...
```

Exit code 0 = clean / 1 = missing 파일 또는 스테일 어노테이션 존재

## 🔍 사용자 검증 필요

- [ ] `make check-memory-refs` 로컬 실행 — exit 0 + ✅ 2줄 확인
- [ ] `docs/policies/active.md` 내 `(현재 미생성)` 문자열 잔존 여부 확인 (`grep "현재 미생성" docs/policies/active.md` → 0 결과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)