### PR TITLE
fix: 리포 추가 페이지 일러스트 정렬 불일치 수정

### DIFF
--- a/src/templates/add_repo.html
+++ b/src/templates/add_repo.html
@@ -148,6 +148,13 @@
   @media (max-width: 480px) {
     .add-repo-card { padding: 20px 16px; }
   }
+
+  /* 이미지와 카드를 동일한 560px 열로 묶어 정렬 통일
+     Constrain illustration and card to the same 560px column */
+  .add-repo-col {
+    max-width: 560px;
+    margin: 0 auto;
+  }
 </style>
 
 <div class="toast" id="errorToast"></div>
@@ -160,6 +167,10 @@
   </div>
 </div>
 
+{# 이미지와 카드를 동일한 560px 열로 묶어 정렬 통일 (illustration--tutorial max-width:100% 와 카드 padding 차이로 인한 시각 불일치 해소)
+   Wrap illustration and card in the same 560px column to fix visual misalignment caused by illustration--tutorial max-width:100% vs card padding #}
+<div class="add-repo-col">
+
 {# Cycle 94 Step 2-B — repository 분석 파이프라인 일러스트 (1792x1024 가로형)
    Cycle 94 Step 2-B — repository analysis pipeline illustration (1792x1024 landscape) #}
 <img src="/static/illustrations/add_repo_hero.png"
@@ -167,8 +178,7 @@
      alt=""
      role="presentation"
      loading="eager"
-     decoding="sync"
-     style="max-width: 560px;">
+     decoding="sync">
 
 {# Phase 2 PR-5 — 다국어 적용. JS 동적 텍스트는 data-i18n-* 속성으로 서버측 주입
    (LocaleMiddleware ↔ Jinja {{ locale }} 페어 — XSS 차단 + race condition 0). #}
@@ -193,6 +203,8 @@
     </button>
   </form>
 </div>
+
+</div>{# /add-repo-col #}
 
 {% block scripts %}
 <script>


### PR DESCRIPTION
## Summary

- `illustration--tutorial` 클래스의 `max-width: 100%`가 컨테이너(1200px) 기준으로 적용되어, 카드의 32px padding으로 좁아 보이는 카드보다 이미지가 시각적으로 더 넓게 보이는 정렬 불일치 수정
- `.add-repo-col` 래퍼 클래스(max-width: 560px, margin: 0 auto) 추가하여 이미지와 카드를 동일한 560px 열로 묶음
- 이미지 태그의 인라인 `style="max-width: 560px;"` 제거 — 부모 컨테이너가 폭을 제어하므로 불필요

## 변경 내용

- `src/templates/add_repo.html`: `.add-repo-col` CSS 추가, `<img>` + `.add-repo-card`를 래퍼 div로 묶음, 인라인 스타일 제거

## 🔍 사용자 검증 필요

- [ ] `/repos/add` 페이지에서 일러스트 이미지와 폼 카드의 폭이 동일하게 정렬되는지 시각 확인
- [ ] 모바일(768px 이하)에서 레이아웃이 깨지지 않는지 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)