### PR TITLE
fix: 설정 저장 버튼 hx-boost 재방문 시 opacity:0 고착 수정

### DIFF
--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -1464,9 +1464,12 @@
 
   // 저장 바 슬라이드 업 입장 애니메이션 — DOM 준비 후 .visible 추가
   // Save bar slide-up entrance — add .visible after DOM ready
-  (function initSaveBarEntrance() {
+  function _initSaveBar() {
     var saveBar = document.querySelector('.save-bar');
     if (!saveBar) { return; }
+    // hx-boost 재진입 시 애니메이션 재생을 위해 먼저 제거
+    // Remove first to replay animation on hx-boost re-entry
+    saveBar.classList.remove('visible');
     // requestAnimationFrame 2회 — 브라우저가 초기 렌더 완료 후 transition 트리거
     // Two rAF frames — ensures browser completes initial render before triggering transition
     requestAnimationFrame(function() {
@@ -1474,7 +1477,18 @@
         saveBar.classList.add('visible');
       });
     });
-  }());
+  }
+  _initSaveBar();
+
+  // hx-boost 재방문 시 opacity:0 고착 방지 — remove-before-add 패턴 (PR #435 학습)
+  // Prevent opacity:0 freeze on hx-boost re-visit — remove-before-add pattern (PR #435)
+  if (document._xSaveBarHandler) {
+    document.removeEventListener('htmx:afterSettle', document._xSaveBarHandler);
+    document.removeEventListener('htmx:historyRestore', document._xSaveBarHandler);
+  }
+  document._xSaveBarHandler = _initSaveBar;
+  document.addEventListener('htmx:afterSettle', document._xSaveBarHandler);
+  document.addEventListener('htmx:historyRestore', document._xSaveBarHandler);
 
   // 토스트 클릭 시 즉시 닫기 + URL 쿼리 제거
   const toast = document.getElementById('saveToast');


### PR DESCRIPTION
## Summary

- `.save-bar`의 초기 CSS가 `opacity: 0; transform: translateY(8px)` — JS가 `.visible` 클래스를 추가해야만 버튼이 표시됨
- 기존 `initSaveBarEntrance` IIFE가 최초 로드에만 실행되고 `htmx:afterSettle` / `htmx:historyRestore` 이벤트에 미등록 → hx-boost 재방문 시 `.visible`이 추가되지 않아 저장 버튼 `opacity: 0` 고착

## 변경 내용

`src/templates/settings.html`
- `initSaveBarEntrance` IIFE → `_initSaveBar` named function으로 교체
- `_initSaveBar()` 즉시 호출 (초기 로드 동작 유지)
- remove-before-add 패턴으로 `htmx:afterSettle` + `htmx:historyRestore` 이벤트 등록 (PR #435 학습 패턴 동일 적용)
- hx-boost 재진입 시 애니메이션 재생을 위해 `classList.remove('visible')` 선행

## 다중 에이전트 조사 결과

| 에이전트 | 관점 | P0 원인 |
|---------|------|---------|
| CSS/레이아웃 | `.save-bar { opacity: 0 }` 초기값 + JS `.visible` 미추가 | settings.html:299-306 |
| HTML/JS 구조 | IIFE가 `htmx:afterSettle` 미등록, `base.html:916` 패턴과 불일치 | settings.html:1467-1477 |
| 테마 토큰/git 이력 | CSS 토큰 이상 없음, `--save-btn-shadow` 4테마 모두 정의됨 | 원인 아님 확인 |

## 🔍 사용자 검증 필요

- [ ] 설정 페이지 직접 접근 시 저장 버튼이 슬라이드 업 애니메이션과 함께 표시되는지 확인
- [ ] 다른 페이지(대시보드 등)에서 설정 페이지로 hx-boost 이동 후 저장 버튼 표시 여부 확인
- [ ] 브라우저 뒤로가기 → 설정 페이지 재방문 시 저장 버튼 표시 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)