### PR TITLE
docs: CLAUDE.md 정책 8·18 Phase 1 압축 (~10줄 절감)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,12 +181,7 @@ make run               # 개발 서버 (port 8000, DB 마이그레이션 자동)
 
 **default 회고 패턴** (Claude 단독 회고 금지):
 - **최소 4~5 에이전트 병렬 디스패치** (단일 메시지에 동시 tool_use)
-- **관점 분리** — 각 에이전트는 다른 관점에서 회고 (예시):
-  1. 작업 패턴 (PR 분할 / Step 모델 / cleanup 4 갈래 ROI)
-  2. 다중 에이전트 운영 (사이클별 ROI / false-positive / 신뢰성)
-  3. 사용자 ↔ Claude 협업 (결정 패턴 / 정보 비대칭 / 신뢰 모델)
-  4. 기술 학습 (신규 패턴 / 패밀리 분류 / 재사용성)
-  5. 문서 정합성 (stale 누적 / 메타 sync 효율)
+- **관점 분리** — 에이전트별 비중복 도메인 배정 (5종 예시: [docs/policies/active.md#정책-8-doc-audit-agent-domain](docs/policies/active.md#정책-8-doc-audit-agent-domain))
 - **각 에이전트 프롬프트 강제 조건**:
   - `self-contained` (다른 에이전트 결과 의존 0 — 병렬성 보호)
   - `line:span 인용 의무` (정책 6 — 환각 보고 80% 차단)
@@ -201,11 +196,10 @@ make run               # 개발 서버 (port 8000, DB 마이그레이션 자동)
 - 1차 5 에이전트 결과 받은 후 별도 cross-verify 에이전트 1건 디스패치 (= 5+1 = 6 패턴)
 - ❌ **cross-verify = `doc-consistency-reviewer` 사용 금지** — 회고 분석이 본 에이전트 scope 외라며 거절 사례 (사이클 64 #225 회고 보고서 §2)
 - ✅ **cross-verify default = `general-purpose` 또는 task-specific specialist** — 검증된 패턴 (사이클 65 #226 정합성 cleanup PR 검증)
-- ⚠️ **cross-verify 생략 가능 조건 (사이클 67 #232 사례)**: 사용자 신호 = "회고 이후 다음 작업" 같은 빠른 진행 명시 + 1차 5 결과 양과 깊이 충분 + Claude 자율 판단 보고 (정책 3) PR 본문 명시 시 cross-verify 생략 OK. 단, 다음 사이클 회고에서 보존 의무 (회귀 가드).
 - 🔴 **cross-verify 생략 정량 기준 (사이클 69 cross-verify 식별)**: "양과 깊이 충분" 의 정량 기준 = (1) 1차 5 에이전트 P0 합계 ≥ 8건 + (2) 관점 5종 모두 P0 1건 이상 식별 + (3) 사용자 빠른 진행 신호 명시 ("회고 이후 다음 작업" / "바로 진행" 등). **3 조건 모두 충족 시만 생략 OK**. Claude 자가 판단 X — 사용자 명시 신호 의무. 미충족 시 cross-verify (general-purpose) 강제.
 - 🔴 **cross-verify 생략 PR 본문 대조 표 default (사이클 87)**: 6차 생략 시 PR 본문 §"cross-verify 생략 사유" 에 사이클 69 정량 3 조건 대조 표 default. 3 조건 모두 ✅ 시만 생략 OK. 1 조건이라도 ❌ 시 cross-verify 강제. 표 형식 상세: [docs/policies/history.md#정책-8-진화](docs/policies/history.md#정책-8-진화).
 
-🔴 **단일 관점 회고 + cross-verify ROI 정량 (사이클 75 진화)**: 관점 1~5 중 1개 단독 회고 = 5+1 패턴 미적용 (정량 기준 적용 X, Claude 직접 작성 default). cross-verify ROI = 사이클당 평균 false-positive 차단 2~5건 + 신규 발견 1~6건 (사이클 64~74 누적 평균). default = 5+1 진행 + 정량 기준 충족 시 생략. 상세: [docs/policies/history.md#정책-8-진화](docs/policies/history.md#정책-8-진화).
+🔴 **단일 관점 회고 (사이클 75 진화)**: 관점 1~5 중 1개 단독 회고 = 5+1 패턴 미적용 (Claude 직접 작성 default). default = 5+1 진행 + 정량 기준 충족 시 생략. 상세: [docs/policies/history.md#정책-8-진화](docs/policies/history.md#정책-8-진화).
 
 🔴 **정책 8 진화 default 요약** (사이클 83~84, 92):
 - **(1) 단일 작업일 5+1 dispatch ≥ 5회 = 사용자 사전 확인 의무** (사이클 83). 사용자 명시 신호 시 면제 OK. 정책 16 5번 원칙 (토큰 비용 효율) 페어.
@@ -328,11 +322,7 @@ Why + How to apply (자가 검토 4 자문) 상세: [docs/policies/active.md#정
 - 메모리 grep / 단순 정보 제공
 - **사용자 직접 결정 영역** (사용자 명시 결정 = 최종, 두 LLM 검증 면제)
 
-**환경 통합 (현 SCAManager 기준)**: Codespaces 환경 default = 시나리오 A (사용자 별도 환경 Codex CLI 실행 + 채팅 회신). 사용자 회신 형식 3종 + 자동화 권장 + `.codex/hooks.json` Windows path 경고 상세: [docs/policies/active.md#정책-18](docs/policies/active.md#정책-18).
-
-**≥ 5 사이클 누적 시 ROI 재검증 의무** (정책 17 5번 default 정기 검증 페어) — 사용자 라운드트립 부담 정량 (사이클당 PR수 × N분) vs 단일 LLM blind spot 차단 가치 재평가.
-
-상세 + 검증 사례 + 양방향 흐름 표: [docs/policies/active.md#정책-18](docs/policies/active.md#정책-18) + AGENTS.md §"Claude ↔ Codex 양방향 mutual 검증 의무 (사이클 93 신설)" + 메모리 `feedback-codex-post-validation-mandatory.md`.
+상세: [docs/policies/active.md#정책-18](docs/policies/active.md#정책-18).
 
 ---
 


### PR DESCRIPTION
## 변경 내용

정책 8 (회고 5+1 패턴)과 정책 18 (mutual 검증 의무)의 반복 서술 압축. **행동 가이드 손실 0** — 디테일을 `docs/policies/active.md` / `history.md` 외부 링크로 위임.

### 압축 항목 4건

| 위치 | 변경 전 | 변경 후 | 절감 |
|------|--------|--------|------|
| 정책 8 관점 분리 (lines 184-189) | 5종 예시 번호 목록 6줄 | active.md 링크 1줄 | -5줄 |
| 정책 8 사이클 67 생략 조건 (line 204) | ⚠️ 사이클 67 생략 조건 1줄 | 삭제 (사이클 69 정량 기준에 상위 호환됨) | -1줄 |
| 정책 8 단일 관점 회고 (line 208) | ROI 수치 범위 포함 서술 | ROI 수치 제거 + history.md 링크 | -2줄 |
| 정책 18 하단 (lines 331-335) | 환경 통합 + ROI 재검증 + 3-way 참조 | active.md 링크 1줄 | -4줄 |

**순 절감: ~10줄** (`1 file changed, 3 insertions(+), 13 deletions(-)`)

## MUST KEEP 검증 (Codex 확인)

Codex mutual 검증 결과 **OK** — P8-1~P8-8 + P18-1~P18-4 전 항목 CLAUDE.md에 완전 보존 확인.

| MUST KEEP 항목 | 상태 |
|----------------|------|
| cross-verify 정량 3조건 (사이클 69) | ✅ 보존 |
| dispatch vs invocation 구분 (사이클 84) | ✅ 보존 |
| pytest 실측 의무 (사이클 92) | ✅ 보존 |
| cross-reference 표 7행 (17 정책) | ✅ 보존 |
| 예외 4종 (mutual 검증 면제) | ✅ 보존 |
| 5+1 ↔ mutual 2-layer 격리 | ✅ 보존 |
| push 전 검증 default | ✅ 보존 |
| NG 회기 ≤ 3회 default | ✅ 보존 |

## 🔍 사용자 검증 필요

- [ ] CLAUDE.md 탐색 시 정책 8 / 정책 18 행동 가이드가 자연스럽게 읽히는지 확인
- [ ] `docs/policies/active.md#정책-8-doc-audit-agent-domain` 앵커 링크 접근 가능 여부 확인

## Phase 2 예고

history.md 이전 + 추가 6~7줄 압축 (사이클 번호 주석 등) — 별도 PR 예정.

## 정책 11 — 시각 변경 없음

본 PR은 CLAUDE.md 텍스트 압축만 포함. UI/템플릿 변경 없음 → 8 조합 체크리스트 불필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)