### PR TITLE
fix: auto-merge 재시도 안정성 개선 — cron fallback + 정책 완화 3건

### DIFF
--- a/src/gate/retry_policy.py
+++ b/src/gate/retry_policy.py
@@ -39,6 +39,9 @@ _STATE_TERMINALITY: dict[str, str] = {
     # CI 진행 중일 수도, 실패했을 수도 있음 — 추가 판단 필요
     # Could be CI running or a failing check — needs further disambiguation
     "unstable": "needs_disambiguation",
+    # has_hooks: GitHub Branch Protection hook 대기 — CI 완료 후 해소되므로 재시도 가능
+    # has_hooks: GitHub Branch Protection hook pending — resolves after CI completes, so retriable
+    "has_hooks": "retriable",
     # 이하 모두 즉시 종료 (재시도 불가)
     # All states below are immediately terminal (no retry)
     "clean": "terminal",
@@ -46,7 +49,6 @@ _STATE_TERMINALITY: dict[str, str] = {
     "behind": "terminal",
     "dirty": "terminal",
     "draft": "terminal",
-    "has_hooks": "terminal",
 }
 
 
@@ -84,7 +86,9 @@ def should_retry(reason_tag: str, ci_status: str) -> bool:
     if reason_tag == UNSTABLE_CI:
         # CI 진행 중이거나 방금 통과했으면 재시도 — merge API 갱신 지연 가능
         # Retry when CI is still running or just passed — merge API may lag
-        return ci_status in ("running", "passed")
+        # unknown: GitHub API 일시 오류 시 영구 종료 방지 — running으로 간주 재시도
+        # unknown: prevents permanent terminal on transient GitHub API errors — treat as running
+        return ci_status in ("running", "passed", "unknown")
 
     if reason_tag == UNKNOWN_STATE_TIMEOUT:
         # GitHub가 아직 상태 계산 중일 때만 재시도

--- a/src/webhook/providers/github.py
+++ b/src/webhook/providers/github.py
@@ -466,25 +466,32 @@ async def _handle_check_suite_completed(  # NOSONAR python:S7503 — caller awai
 
 
 async def _trigger_retry_for_sha(repo_full_name: str, commit_sha: str) -> None:
-    """check_suite.completed 트리거 — 해당 SHA의 pending 재시도 행 즉시 처리.
-    Triggered by check_suite.completed — immediately processes pending retry rows for the SHA.
+    """check_suite.completed 트리거 — SHA 특정 행 즉시 처리 + overdue 전체 sweep.
+    Triggered by check_suite.completed — processes SHA-specific rows immediately,
+    then sweeps all overdue pending items as a cron failure fallback.
 
     별도 DB 세션 내에서 실행 (background task) — 웹훅 요청 세션과 독립.
     Runs in a separate DB session (background task) — independent of the webhook request session.
     """
     try:
+        # SHA 특정 행 우선 처리 (해당 CI 완료와 직접 연관된 항목)
+        # Process SHA-specific rows first (directly tied to the completed CI run)
         with SessionLocal() as db:
             rows = merge_retry_repo.find_pending_by_sha(
                 db,
                 repo_full_name=repo_full_name,
                 commit_sha=commit_sha,
             )
-            if not rows:
-                return
             ids = [r.id for r in rows]
 
+        if ids:
+            with SessionLocal() as db:
+                await process_pending_retries(db, only_ids=ids)
+
+        # overdue 전체 sweep — cron 실패 fallback (next_retry_at 만료 항목 처리)
+        # Full overdue sweep — cron failure fallback (picks up items past next_retry_at)
         with SessionLocal() as db:
-            await process_pending_retries(db, only_ids=ids)
+            await process_pending_retries(db)
     except Exception as exc:  # pylint: disable=broad-except
         logger.warning(
             "_trigger_retry_for_sha 실패 (repo=%s, sha=%.7s): %s",

--- a/tests/unit/gate/test_auto_merge_enqueue.py
+++ b/tests/unit/gate/test_auto_merge_enqueue.py
@@ -364,9 +364,9 @@ async def test_run_auto_merge_uses_legacy_when_retry_disabled():
 # T8-9: CI status check fails → terminal (safe default)
 # ---------------------------------------------------------------------------
 
-async def test_run_auto_merge_terminal_when_ci_status_unknown():
-    """get_ci_status가 'unknown' 반환 → should_retry=False → 터미널 처리.
-    get_ci_status returns 'unknown' → should_retry=False → terminal failure.
+async def test_run_auto_merge_enqueue_when_ci_status_unknown():
+    """get_ci_status가 'unknown' 반환 → should_retry=True → 재시도 큐 등록 (transient 오류 보호).
+    get_ci_status returns 'unknown' → should_retry=True → enqueue for retry (protects against transient errors).
     """
     mock_db = MagicMock()
     config = _config()
@@ -388,8 +388,8 @@ async def test_run_auto_merge_terminal_when_ci_status_unknown():
         mock_state.return_value = ("unknown", "sha123")
         mock_merge.return_value = MergeOutcome(ok=False, reason="unstable_ci: state=unstable", head_sha="sha123", path=PATH_REST_FALLBACK)
         mock_required.return_value = {"ci/test"}
-        # CI 상태를 알 수 없음 → should_retry(unstable_ci, "unknown") = False
-        # CI status unknown → should_retry(unstable_ci, "unknown") = False
+        # CI 상태 알 수 없음 (GitHub API 일시 오류) → transient 보호 → 재시도 큐 등록
+        # CI status unknown (transient GitHub API error) → treat as running → enqueue for retry
         mock_ci.return_value = "unknown"
 
         await _run_auto_merge(
@@ -397,10 +397,11 @@ async def test_run_auto_merge_terminal_when_ci_status_unknown():
             analysis_id=1, db=mock_db,
         )
 
-        # unknown CI 상태 → 재시도 불가 → 터미널 / Unknown CI → no retry → terminal
-        mock_repo.enqueue_or_bump.assert_not_called()
-        mock_deferred_notify.assert_not_called()
-        mock_fail_notify.assert_called_once()
+        # unknown → retriable → 재시도 큐 등록, 터미널 알림 없음
+        # unknown → retriable → enqueued, no terminal notification
+        mock_repo.enqueue_or_bump.assert_called_once()
+        mock_deferred_notify.assert_called_once()
+        mock_fail_notify.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/gate/test_retry_policy.py
+++ b/tests/unit/gate/test_retry_policy.py
@@ -75,7 +75,7 @@ def test_parse_reason_tag_whitespace_stripped():
         ("behind", "terminal"),
         ("dirty", "terminal"),
         ("draft", "terminal"),
-        ("has_hooks", "terminal"),
+        ("has_hooks", "retriable"),
         ("totally_made_up_state", "terminal"),
     ],
 )
@@ -96,7 +96,7 @@ def test_mergeable_state_terminality_matrix(state, expected):
         ("unstable_ci", "running", True),
         ("unstable_ci", "passed", True),
         ("unstable_ci", "failed", False),
-        ("unstable_ci", "unknown", False),
+        ("unstable_ci", "unknown", True),
         ("unknown_state_timeout", "running", True),
         ("unknown_state_timeout", "passed", False),
         ("unknown_state_timeout", "failed", False),

--- a/tests/unit/webhook/providers/test_check_suite_handler.py
+++ b/tests/unit/webhook/providers/test_check_suite_handler.py
@@ -167,15 +167,18 @@ async def test_pr_synchronize_calls_abandon_stale():
 
 
 async def test_trigger_retry_for_sha_calls_process_pending():
-    """_trigger_retry_for_sha → process_pending_retries with correct ids.
-    _trigger_retry_for_sha calls process_pending_retries with the IDs of pending rows.
+    """SHA 특정 행이 있을 때 SHA 한정 + overdue 전체 sweep 순서로 호출.
+    When SHA-specific rows exist, calls process_pending_retries twice:
+    first with only_ids, then without (full overdue sweep).
     """
-    from unittest.mock import AsyncMock, MagicMock, patch  # pylint: disable=import-outside-toplevel
+    from unittest.mock import AsyncMock, MagicMock, call, patch  # pylint: disable=import-outside-toplevel
 
     from src.webhook.providers.github import _trigger_retry_for_sha  # pylint: disable=import-outside-toplevel
 
     mock_row = MagicMock()
     mock_row.id = 99
+
+    _ok = {"claimed": 1, "succeeded": 1, "terminal": 0, "abandoned": 0, "released": 0, "skipped": 0}
 
     with patch("src.webhook.providers.github.SessionLocal") as mock_session_cls, \
          patch("src.webhook.providers.github.merge_retry_repo") as mock_repo, \
@@ -188,14 +191,7 @@ async def test_trigger_retry_for_sha_calls_process_pending():
         mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_db)
         mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
         mock_repo.find_pending_by_sha.return_value = [mock_row]
-        mock_process.return_value = {
-            "claimed": 1,
-            "succeeded": 1,
-            "terminal": 0,
-            "abandoned": 0,
-            "released": 0,
-            "skipped": 0,
-        }
+        mock_process.return_value = _ok
 
         await _trigger_retry_for_sha("owner/repo", "abc123")
 
@@ -204,4 +200,41 @@ async def test_trigger_retry_for_sha_calls_process_pending():
             repo_full_name="owner/repo",
             commit_sha="abc123",
         )
-        mock_process.assert_called_once_with(mock_db, only_ids=[99])
+        # SHA 한정 호출 + overdue 전체 sweep 호출 (cron fallback) 두 번 호출 검증
+        # Verifies two calls: SHA-specific first, then full overdue sweep (cron fallback)
+        assert mock_process.call_count == 2
+        assert mock_process.call_args_list[0] == call(mock_db, only_ids=[99])
+        assert mock_process.call_args_list[1] == call(mock_db)
+
+
+async def test_trigger_retry_for_sha_sweeps_overdue_when_no_sha_rows():
+    """SHA 특정 행이 없어도 overdue 전체 sweep은 실행된다 (cron fallback).
+    Full overdue sweep runs even when no SHA-specific rows are found (cron fallback).
+    """
+    from unittest.mock import AsyncMock, MagicMock, call, patch  # pylint: disable=import-outside-toplevel
+
+    from src.webhook.providers.github import _trigger_retry_for_sha  # pylint: disable=import-outside-toplevel
+
+    _ok = {"claimed": 0, "succeeded": 0, "terminal": 0, "abandoned": 0, "released": 0, "skipped": 0}
+
+    with patch("src.webhook.providers.github.SessionLocal") as mock_session_cls, \
+         patch("src.webhook.providers.github.merge_retry_repo") as mock_repo, \
+         patch(
+             "src.webhook.providers.github.process_pending_retries",
+             new_callable=AsyncMock,
+         ) as mock_process:
+
+        mock_db = MagicMock()
+        mock_session_cls.return_value.__enter__ = MagicMock(return_value=mock_db)
+        mock_session_cls.return_value.__exit__ = MagicMock(return_value=False)
+        # SHA 매칭 항목 없음
+        # No SHA-specific rows found
+        mock_repo.find_pending_by_sha.return_value = []
+        mock_process.return_value = _ok
+
+        await _trigger_retry_for_sha("owner/repo", "no_match_sha")
+
+        # SHA 특정 only_ids 호출은 없고, overdue 전체 sweep만 1회 호출
+        # No SHA-specific call (ids empty → skipped), only full sweep call
+        assert mock_process.call_count == 1
+        assert mock_process.call_args_list[0] == call(mock_db)


### PR DESCRIPTION
## 🔍 사용자 검증 필요

| 항목 | 검증 방법 |
|------|----------|
| 다음 PR 머지 후 자동 머지 성공률 | Railway 배포 후 테스트 PR 생성 → `merge_retry_queue` 확인 |
| `check_suite.completed` sweep 동작 | Railway 로그에서 `retry_pending_merges: counts` 확인 |
| `has_hooks` 재시도 동작 | Branch Protection hook 있는 리포에서 PR 테스트 |

> 정책 11: UI 변경 없음 — 시각 검증 불필요

---

## Summary

- MCP DB 조회로 `merge_retry_queue` 15개 항목이 `next_retry_at` 만료 후 1~9시간 대기 중임을 확인
- 5+1 에이전트 분석으로 3개 P0 원인 특정

### 핵심 버그: `_trigger_retry_for_sha` 조기 반환

```python
# 수정 전 — SHA 매칭 없으면 즉시 return → overdue sweep 영원히 실행 안 됨
if not rows:
    return

# 수정 후 — SHA 특정 처리 + 항상 overdue 전체 sweep (cron 실패 fallback)
if ids:
    await process_pending_retries(db, only_ids=ids)
await process_pending_retries(db)  # overdue sweep
```

`check_suite.completed` 웹훅이 Railway cron 실패 시 fallback 역할을 하도록 설계 변경.

### retry_policy.py 완화

| 변경 | 이전 | 이후 | 이유 |
|------|------|------|------|
| `has_hooks` terminality | `terminal` | `retriable` | CI hook 대기 → CI 완료 시 자동 해소 |
| `ci_status="unknown"` (UNSTABLE_CI) | terminal | retry | GitHub API 일시 오류 → transient 보호 |

## Test plan

- [x] `tests/unit/gate/test_retry_policy.py` — has_hooks + unknown 매트릭스 갱신
- [x] `tests/unit/webhook/providers/test_check_suite_handler.py` — 2개 신규 테스트 추가 (SHA 있을 때 2회 호출, SHA 없을 때 sweep 1회)
- [x] `tests/unit/gate/test_auto_merge_enqueue.py` — unknown→enqueue 동작으로 갱신
- [x] 전체 2964 테스트 통과

## 🔍 Codex 검증 의뢰 (push 전 → push 후 의뢰로 변경)
정책 18에 따라 Codex mutual 검증 의뢰합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)