### PR TITLE
fix(ci): TruffleHog BASE==HEAD 오류 수정 — 이벤트별 2-step 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,13 @@ jobs:
       - name: TruffleHog — 커밋 메시지 + 코드 diff 시크릿 스캔
         # 코드 변경(diff) 와 커밋 메시지 본문 모두 스캔 — 2026-05-03 사고 유형 방어
         # Scans both code diffs and commit message bodies — guards against 2026-05-03 incident type
+        # push-to-main 이벤트: github.event.before(머지 이전 SHA) → BASE==HEAD 오류 방지
+        # push-to-main event: github.event.before (pre-merge SHA) prevents BASE==HEAD error
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
+          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           extra_args: --only-verified
 
   test-and-analyze:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,16 +18,26 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: TruffleHog — 커밋 메시지 + 코드 diff 시크릿 스캔
-        # 코드 변경(diff) 와 커밋 메시지 본문 모두 스캔 — 2026-05-03 사고 유형 방어
-        # Scans both code diffs and commit message bodies — guards against 2026-05-03 incident type
-        # push-to-main 이벤트: github.event.before(머지 이전 SHA) → BASE==HEAD 오류 방지
-        # push-to-main event: github.event.before (pre-merge SHA) prevents BASE==HEAD error
+      - name: TruffleHog — PR 이벤트 시크릿 스캔
+        # PR diff 범위만 스캔 — 2026-05-03 사고 유형 방어
+        # Scans PR diff range only — guards against 2026-05-03 incident type
+        if: github.event_name == 'pull_request'
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
-          head: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+          base: ${{ github.event.pull_request.base.sha }}
+          head: ${{ github.event.pull_request.head.sha }}
+          extra_args: --only-verified
+
+      - name: TruffleHog — push 이벤트 시크릿 스캔
+        # before == zeros(첫 push / force-push) 시 invalid SHA 오류 방지를 위해 건너뜀
+        # Skip when before is zeros (first push / force-push) to avoid invalid SHA error
+        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.before }}
+          head: ${{ github.sha }}
           extra_args: --only-verified
 
   test-and-analyze:


### PR DESCRIPTION
## 변경 내용

push-to-main 이벤트에서 TruffleHog가 `BASE and HEAD commits are the same` 오류로 exit 1하여 CI 전체가 실패하는 문제를 수정합니다.

### 원인

`base: ${{ github.event.repository.default_branch }}` 설정 시 PR merge 후 push-to-main 이벤트에서 BASE(`main` 브랜치명)와 HEAD가 동일 커밋을 가리켜 TruffleHog가 스캔을 거부함.

### 수정 방법

인라인 삼항 조건식 1-step → 이벤트별 명시적 2-step 분리:

- **PR 이벤트**: `pull_request.base.sha` / `pull_request.head.sha` 사용
- **push 이벤트**: `github.event.before` / `github.sha` 사용
- **zero-SHA 가드**: `before == 000...000` (첫 push/force-push) 시 push step skip — SCAManager PR-only workflow(정책 7)에서 실질적으로 발생하지 않는 케이스

### Codex mutual 검증 (정책 18)

- 1차 검증: NG 2건 (zero-SHA 가드 누락 + 조건식 구조)
- 2차 검증: **OVERALL OK** — zero-SHA skip이 의도된 정책임 확인

## 🔍 사용자 검증 필요

- [ ] PR merge 후 CI `TruffleHog secret scan` job이 `success`로 통과하는지 확인
- [ ] 다음 PR 생성 시 PR 이벤트 TruffleHog step이 정상 실행되는지 확인