### PR TITLE
feat(perf): 페이지 성능 측정 — E2E 테스트 + 독립 스크립트 + 첫 리포트

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test test-v test-fast test-slow test-cov test-file test-isolated lint lint-strict gate run migrate revision review check-memory-refs install-playwright test-e2e test-e2e-headed css-install css-build css-dev
+.PHONY: install test test-v test-fast test-slow test-cov test-file test-isolated lint lint-strict gate run migrate revision review check-memory-refs install-playwright test-e2e test-e2e-headed test-perf perf-report css-install css-build css-dev
 
 # 의존성 설치 (개발 환경 — 테스트/E2E + CSS 빌드 포함)
 # Install dependencies (development environment — includes tests/E2E + CSS build).
@@ -131,3 +131,13 @@ test-e2e:
 # Run E2E tests with browser visible.
 test-e2e-headed:
 	python -m pytest e2e/ -v -p no:asyncio --headed
+
+# 성능 테스트 (pytest 기반, 로컬 E2E 서버)
+# Run performance tests (pytest-based, local E2E server).
+test-perf:
+	python -m pytest e2e/ -m perf -v --timeout=120 -p no:asyncio
+
+# 성능 리포트 생성 (로컬 + 운영)
+# Generate performance report (local + production).
+perf-report:
+	python scripts/perf_measure.py

--- a/docs/design/2026-05-18-page-performance-measurement-design.md
+++ b/docs/design/2026-05-18-page-performance-measurement-design.md
@@ -1,0 +1,178 @@
+# SCAManager 페이지 성능 측정 설계
+
+작성일: 2026-05-18  
+목적: 전체 서비스 페이지 로딩 속도를 로컬·운영 양쪽에서 정밀 측정해 병목을 진단하고 사용자 만족도를 개선한다.
+
+---
+
+## 1. 측정 대상 페이지
+
+| 카테고리 | 경로 | 로컬 인증 | 운영 인증 |
+|----------|------|----------|----------|
+| 공개 | `/login` | ❌ | ❌ |
+| 공개 | `/` (landing) | ❌ | ❌ |
+| 주요 UI | `/overview` | ✅ bypass | TTFB only |
+| 주요 UI | `/dashboard` | ✅ bypass | TTFB only |
+| 주요 UI | `/settings` | ✅ bypass | TTFB only |
+| 리포 | `/repos/add` | ✅ bypass | TTFB only |
+| 리포 상세 | `/repos/{name}` | ✅ bypass + seed | TTFB only |
+| 분석 결과 | `/repos/{name}/analysis/{id}` | ✅ bypass + seed | TTFB only |
+| 인사이트 | `/repos/{name}/insights` | ✅ bypass + seed | TTFB only |
+| API | `/health` | ❌ | ❌ |
+| API | `/api/repos` | ✅ | TTFB only |
+| API | `/api/repos/{name}/report` | ✅ | TTFB only |
+
+**인증 전략**
+- **로컬**: `require_login` 의존성 오버라이드 (conftest.py 패턴) → 전체 렌더링 측정
+- **운영**: 공개 페이지는 전체 측정 / 인증 필요 페이지는 TTFB + HTTP 상태코드만 기록 (실 미로그인 사용자 체감 반영)
+
+---
+
+## 2. 측정 지표
+
+| 지표 | 수집 방법 | 목표 임계값 |
+|------|----------|------------|
+| TTFB | Navigation Timing `responseStart - requestStart` | < 300ms |
+| FCP | PerformanceObserver `paint` 타입 | < 1,500ms |
+| LCP | PerformanceObserver `largest-contentful-paint` | < 2,500ms |
+| DCL | Navigation Timing `domContentLoadedEventEnd` | < 1,500ms |
+| Load | Navigation Timing `loadEventEnd` | < 3,000ms |
+| 반복 | 페이지당 3회 측정 → avg / min / max | — |
+| 느린 API | response 시간 > 500ms 요청 캡처 | — |
+
+---
+
+## 3. 파일 구조
+
+```
+scripts/
+  perf_measure.py            # 독립 실행 성능 측정 스크립트
+e2e/
+  test_performance.py        # pytest 기반 — make test-e2e 통합
+docs/reports/
+  perf-YYYY-MM-DD.md         # 자동 생성 Markdown 리포트
+```
+
+---
+
+## 4. `scripts/perf_measure.py` 설계
+
+### 실행 인터페이스
+```bash
+python scripts/perf_measure.py                # 로컬 + 운영 양쪽 (기본)
+python scripts/perf_measure.py --local-only   # 로컬만
+python scripts/perf_measure.py --prod-only    # 운영만
+```
+
+### 처리 흐름
+```
+1. argparse → 실행 대상 결정
+2. [로컬] e2e/conftest.py 의 _setup_e2e_db + _start_uvicorn 재사용
+          서버 ready 폴링 (최대 30초)
+          seeded_page용 더미 레포 삽입 (_seed_repo)
+3. [운영] BASE_URL = https://scamanager-production.up.railway.app
+4. Playwright sync_api → Chromium headless 기동
+5. 페이지별 measure_page(page, url, runs=3) 호출
+6. 결과 수집 → Markdown 리포트 생성 → docs/reports/perf-{date}.md 저장
+7. 터미널에 요약 표 출력
+8. [로컬] 서버 종료
+```
+
+### 핵심 함수
+
+**`_single_measure(page, url) → dict`**
+- navigate 전 PerformanceObserver 등록 (FCP, LCP)
+- response 이벤트 리스너 등록 (느린 API 캡처)
+- `page.goto(url, wait_until="networkidle")` 실행
+- Navigation Timing API로 TTFB / DCL / Load 수집
+- FCP / LCP window 변수 읽기
+- 반환: `{ttfb, fcp, lcp, dcl, load, slow_requests}`
+
+**`measure_page(page, url, runs=3) → dict`**
+- `_single_measure` 3회 호출
+- avg / min / max 계산
+- 반환: 지표별 통계 + 느린 요청 합산
+
+**`render_markdown(local_results, prod_results) → str`**
+- 로컬 / 운영 / 비교 표 / 임계값 초과 항목 / 느린 API 섹션 구성
+
+---
+
+## 5. `e2e/test_performance.py` 설계
+
+기존 `e2e/conftest.py` fixtures (`live_server`, `page`, `seeded_page`) 재사용.
+
+```python
+THRESHOLDS = {
+    "ttfb": 500,   # ms — 로컬 SQLite 기준 완화값
+    "fcp":  1500,
+    "lcp":  2500,
+    "dcl":  1500,
+    "load": 3000,
+}
+```
+
+### 테스트 목록
+- `test_login_ttfb` / `test_login_load`
+- `test_overview_ttfb` / `test_overview_load`
+- `test_dashboard_ttfb` / `test_dashboard_lcp`
+- `test_settings_ttfb` / `test_settings_load`
+- `test_add_repo_ttfb`
+- `test_repo_detail_ttfb` / `test_repo_detail_load` (seeded_page)
+- `test_analysis_detail_load` (seeded_page + seeded_analysis)
+- `test_repo_insights_load` (seeded_page)
+
+각 테스트는 `@pytest.mark.perf` 마커를 달아 `make test-perf` 로 선택 실행 가능하게 한다.
+
+### 분석 레코드 시딩 전략
+`/repos/{name}/analysis/{id}` 페이지는 Analysis ORM 레코드가 필요하다.
+- `conftest.py`에 `seeded_analysis` session-scope fixture 추가: SQLite에 최소 Analysis 레코드 직접 INSERT
+- `perf_measure.py`에서도 동일하게 `_seed_analysis(db_path)` 헬퍼로 처리
+- 분석 ID는 시딩 후 SELECT로 조회해 URL에 삽입
+
+---
+
+## 6. Markdown 리포트 형식
+
+```markdown
+# SCAManager 페이지 성능 리포트
+측정일시: 2026-05-18 20:30 | 반복: 3회 | 브라우저: Chromium headless
+
+## 🏠 로컬 E2E 서버 (SQLite)
+| 페이지 | TTFB avg | FCP avg | LCP avg | DCL avg | Load avg | 판정 |
+| /login | 45ms | 210ms | 310ms | 180ms | 420ms | ✅ |
+| /dashboard | 890ms | 1.2s | 2.1s | 950ms | 2.8s | ⚠️ |
+
+## 🌐 운영 서버 (Railway)
+| 페이지 | TTFB avg | FCP avg | LCP avg | DCL avg | Load avg | 판정 |
+| /login | 180ms | 520ms | 780ms | 490ms | 1.1s | ✅ |
+
+## 📊 로컬 vs 운영 비교
+| 페이지 | 로컬 Load | 운영 Load | 배율 |
+
+## 🔴 임계값 초과 항목
+
+## 🔍 느린 API 엔드포인트 (> 500ms)
+| 엔드포인트 | 평균 응답 | 크기 |
+```
+
+---
+
+## 7. Makefile 명령 추가
+
+```makefile
+test-perf:          ## 성능 테스트 (pytest 기반, 로컬)
+    python -m pytest e2e/ -m perf -v
+
+perf-report:        ## 성능 리포트 생성 (로컬 + 운영)
+    python scripts/perf_measure.py
+```
+
+---
+
+## 8. 비기능 요구사항
+
+- `perf_measure.py` 완료 후 항상 로컬 서버 정리 (signal handler)
+- pylint / flake8 통과 (기존 lint 기준 준수)
+- 운영 URL은 환경변수 `PERF_PROD_URL` 또는 스크립트 내 기본값으로 관리
+- 리포트 파일명: `docs/reports/perf-YYYY-MM-DD-HHMM.md` (중복 방지)

--- a/docs/reports/perf-2026-05-18-2314.md
+++ b/docs/reports/perf-2026-05-18-2314.md
@@ -1,0 +1,27 @@
+# SCAManager 페이지 성능 리포트
+측정일시: 2026-05-18 23:14 | 반복: 3회 | 브라우저: Chromium headless
+
+## 🏠 로컬 E2E 서버 (SQLite)
+
+| 페이지 | TTFB avg | FCP avg | LCP avg | DCL avg | Load avg | 판정 |
+|--------|----------|---------|---------|---------|----------|------|
+| /login | 18ms | 429ms | 528ms | 257ms | 363ms | ✅ |
+| / | 5ms | 181ms | 259ms | 16ms | 154ms | ✅ |
+| /health | 10ms | 27ms | 27ms | 16ms | 17ms | ✅ |
+| /dashboard | 51ms | 303ms | 500ms | 123ms | 148ms | ✅ |
+| /repos/add | 6ms | 223ms | 565ms | 20ms | 75ms | ✅ |
+| /repos/owner%2Ftestrepo | 13ms | 231ms | 231ms | 65ms | 103ms | ✅ |
+| /repos/owner%2Ftestrepo/insights | 16ms | 169ms | 169ms | 28ms | 32ms | ✅ |
+| /repos/.../analyses/1 | 26ms | 195ms | 195ms | 37ms | 41ms | ✅ |
+| /repos/owner%2Ftestrepo/settings | 30ms | 212ms | 292ms | 46ms | 52ms | ✅ |
+| /api/repos | 6ms | — | — | — | — | *(auth-only)* |
+| /api/repos/owner%2Ftestrepo/report | 10ms | — | — | — | — | *(auth-only)* |
+
+## ✅ 모든 페이지 임계값 이내
+
+## 🔍 느린 API 엔드포인트 (> 500ms)
+
+| 엔드포인트 | 평균 응답 |
+|-----------|---------|
+| http://127.0.0.1:8002/api/github/repos | 524ms |
+| http://127.0.0.1:8002/api/github/repos | 508ms |

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -315,7 +315,6 @@ def _seed_analysis(db_path: str) -> int:
     """owner/testrepo Analysis 레코드를 DB에 삽입하고 ID를 반환한다.
     Insert an Analysis record for owner/testrepo and return its ID.
     """
-    import json as _json
     from sqlalchemy import create_engine, text
     engine = create_engine(f"sqlite:///{db_path}")
     with engine.connect() as conn:
@@ -331,18 +330,20 @@ def _seed_analysis(db_path: str) -> int:
             VALUES
                 (:rid, 'perf-test-sha-001', 'perf: seed analysis for E2E',
                  85, 'B', :res, 'e2e-tester', datetime('now'))
-        """), {"rid": repo_id, "res": _json.dumps({"summary": "e2e perf test"})})
+        """), {"rid": repo_id, "res": json.dumps({"summary": "e2e perf test"})})
+        conn.commit()
         analysis_row = conn.execute(text(
             "SELECT id FROM analyses WHERE repo_id=:rid AND commit_sha='perf-test-sha-001'"
         ), {"rid": repo_id}).fetchone()
-        conn.commit()
+        if analysis_row is None:
+            raise RuntimeError("_seed_analysis: INSERT succeeded but row not found")
     engine.dispose()
     return analysis_row[0]
 
 
 @pytest.fixture(scope="session")
 def seeded_analysis(live_server):
-    """owner/testrepo + Analysis レコードを挿入し analysis_id を返す session fixture。
+    """owner/testrepo + Analysis 레코드를 삽입하고 analysis_id를 반환하는 session fixture.
     Seeds owner/testrepo repo and Analysis record; returns analysis_id (session-scoped).
     """
     db_path = os.environ.get("DATABASE_URL", "").replace("sqlite:///", "")

--- a/e2e/conftest.py
+++ b/e2e/conftest.py
@@ -309,3 +309,42 @@ def seeded_page(browser_instance, live_server, tmp_path_factory):
     pg = context.new_page()
     yield pg
     context.close()
+
+
+def _seed_analysis(db_path: str) -> int:
+    """owner/testrepo Analysis 레코드를 DB에 삽입하고 ID를 반환한다.
+    Insert an Analysis record for owner/testrepo and return its ID.
+    """
+    import json as _json
+    from sqlalchemy import create_engine, text
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        row = conn.execute(text(
+            "SELECT id FROM repositories WHERE full_name='owner/testrepo'"
+        )).fetchone()
+        if row is None:
+            raise RuntimeError("_seed_repo must be called before _seed_analysis")
+        repo_id = row[0]
+        conn.execute(text("""
+            INSERT OR IGNORE INTO analyses
+                (repo_id, commit_sha, commit_message, score, grade, result, author_login, created_at)
+            VALUES
+                (:rid, 'perf-test-sha-001', 'perf: seed analysis for E2E',
+                 85, 'B', :res, 'e2e-tester', datetime('now'))
+        """), {"rid": repo_id, "res": _json.dumps({"summary": "e2e perf test"})})
+        analysis_row = conn.execute(text(
+            "SELECT id FROM analyses WHERE repo_id=:rid AND commit_sha='perf-test-sha-001'"
+        ), {"rid": repo_id}).fetchone()
+        conn.commit()
+    engine.dispose()
+    return analysis_row[0]
+
+
+@pytest.fixture(scope="session")
+def seeded_analysis(live_server):
+    """owner/testrepo + Analysis レコードを挿入し analysis_id を返す session fixture。
+    Seeds owner/testrepo repo and Analysis record; returns analysis_id (session-scoped).
+    """
+    db_path = os.environ.get("DATABASE_URL", "").replace("sqlite:///", "")
+    _seed_repo(live_server, db_path)
+    return _seed_analysis(db_path)

--- a/e2e/pytest.ini
+++ b/e2e/pytest.ini
@@ -2,3 +2,5 @@
 pythonpath = ..
 # asyncio_mode 는 의도적으로 생략 — E2E 서버는 asyncio.new_event_loop()로 별도 관리
 # asyncio_mode=auto 를 추가하면 단위 테스트와 이벤트 루프 충돌 발생 (CLAUDE.md 참조)
+markers =
+    perf: performance measurement tests — run via `make test-perf`

--- a/e2e/test_performance.py
+++ b/e2e/test_performance.py
@@ -1,0 +1,240 @@
+"""E2E 성능 측정 테스트 — @pytest.mark.perf 마커로 선택 실행.
+E2E performance tests — selectively run via @pytest.mark.perf.
+"""
+import pytest
+
+THRESHOLDS = {
+    "ttfb": 500,   # ms — 로컬 SQLite 기준 완화값 / relaxed for local SQLite
+    "fcp":  1500,
+    "lcp":  2500,
+    "dcl":  1500,
+    "load": 3000,
+}
+
+_LCP_INIT_JS = """
+    window._perf_lcp = null;
+    try {
+        new PerformanceObserver((list) => {
+            const entries = list.getEntries();
+            if (entries.length > 0) {
+                window._perf_lcp = entries[entries.length - 1].startTime;
+            }
+        }).observe({ type: 'largest-contentful-paint', buffered: true });
+    } catch(e) {}
+"""
+
+
+def _measure_one(pg, url: str) -> dict:
+    """단일 측정 — TTFB/FCP/LCP/DCL/Load(ms) + 느린 요청 목록 반환.
+    Single measurement — TTFB/FCP/LCP/DCL/Load(ms) + slow request list.
+    """
+    slow: list[dict] = []
+
+    def _on_finished(req):
+        t = req.timing()
+        dur = t.get("responseEnd", 0) - t.get("requestStart", 0)
+        if dur > 500:
+            slow.append({"url": req.url, "ms": round(dur)})
+
+    pg.on("requestfinished", _on_finished)
+    try:
+        pg.goto(url, wait_until="networkidle", timeout=30_000)
+        metrics = pg.evaluate("""() => {
+            const nav = performance.getEntriesByType('navigation')[0] || {};
+            const fcp = performance.getEntriesByType('paint')
+                .find(e => e.name === 'first-contentful-paint');
+            return {
+                ttfb: Math.round((nav.responseStart || 0) - (nav.requestStart || 0)),
+                dcl:  Math.round((nav.domContentLoadedEventEnd || 0) - (nav.startTime || 0)),
+                load: Math.round((nav.loadEventEnd || 0) - (nav.startTime || 0)),
+                fcp:  fcp ? Math.round(fcp.startTime) : null,
+                lcp:  (typeof window._perf_lcp === 'number')
+                          ? Math.round(window._perf_lcp) : null,
+            };
+        }""")
+        metrics["slow_requests"] = slow[:]
+        return metrics
+    finally:
+        pg.remove_listener("requestfinished", _on_finished)
+
+
+def _measure_page(pg, url: str, runs: int = 3) -> dict:
+    """N회 측정 후 avg/min/max 통계 반환.
+    Returns avg/min/max stats over N runs.
+    """
+    results = [_measure_one(pg, url) for _ in range(runs)]
+    stats: dict = {}
+    for key in ("ttfb", "fcp", "lcp", "dcl", "load"):
+        vals = [r[key] for r in results if r.get(key) is not None]
+        stats[key] = {
+            "avg": round(sum(vals) / len(vals)) if vals else None,
+            "min": min(vals) if vals else None,
+            "max": max(vals) if vals else None,
+        }
+    stats["slow_requests"] = [req for r in results for req in r.get("slow_requests", [])]
+    return stats
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def perf_page(page):
+    """LCP observer가 주입된 일반 page fixture.
+    Standard page fixture with LCP PerformanceObserver injected.
+    """
+    page.add_init_script(_LCP_INIT_JS)
+    return page
+
+
+@pytest.fixture
+def perf_seeded_page(seeded_page):
+    """LCP observer가 주입된 seeded page fixture.
+    Seeded page fixture with LCP PerformanceObserver injected.
+    """
+    seeded_page.add_init_script(_LCP_INIT_JS)
+    return seeded_page
+
+
+@pytest.fixture
+def analysis_page(browser_instance, live_server, seeded_analysis):
+    """분석 상세 페이지용 page fixture — (page, analysis_id) 반환.
+    Page fixture for analysis detail — yields (page, analysis_id).
+    """
+    context = browser_instance.new_context(base_url=live_server)
+    pg = context.new_page()
+    pg.add_init_script(_LCP_INIT_JS)
+    yield pg, seeded_analysis
+    context.close()
+
+
+# ── Public pages ──────────────────────────────────────────────────────────
+
+@pytest.mark.perf
+def test_login_ttfb(perf_page, base_url):
+    """/login 초기 서버 응답 시간 < 500ms."""
+    stats = _measure_page(perf_page, f"{base_url}/login")
+    assert stats["ttfb"]["avg"] is not None
+    assert stats["ttfb"]["avg"] < THRESHOLDS["ttfb"], (
+        f"TTFB {stats['ttfb']['avg']}ms >= {THRESHOLDS['ttfb']}ms"
+    )
+
+
+@pytest.mark.perf
+def test_login_load(perf_page, base_url):
+    """/login 전체 로드 시간 < 3000ms."""
+    stats = _measure_page(perf_page, f"{base_url}/login")
+    assert stats["load"]["avg"] is not None
+    assert stats["load"]["avg"] < THRESHOLDS["load"], (
+        f"Load {stats['load']['avg']}ms >= {THRESHOLDS['load']}ms"
+    )
+
+
+@pytest.mark.perf
+def test_root_fcp(perf_page, base_url):
+    """/ (landing) FCP < 1500ms."""
+    stats = _measure_page(perf_page, f"{base_url}/")
+    if stats["fcp"]["avg"] is not None:
+        assert stats["fcp"]["avg"] < THRESHOLDS["fcp"], (
+            f"FCP {stats['fcp']['avg']}ms >= {THRESHOLDS['fcp']}ms"
+        )
+
+
+@pytest.mark.perf
+def test_root_load(perf_page, base_url):
+    """/ (landing) Load < 3000ms."""
+    stats = _measure_page(perf_page, f"{base_url}/")
+    assert stats["load"]["avg"] is not None
+    assert stats["load"]["avg"] < THRESHOLDS["load"], (
+        f"Load {stats['load']['avg']}ms >= {THRESHOLDS['load']}ms"
+    )
+
+
+@pytest.mark.perf
+def test_health_ttfb(perf_page, base_url):
+    """/health API 응답 시간 < 300ms."""
+    stats = _measure_page(perf_page, f"{base_url}/health")
+    assert stats["ttfb"]["avg"] is not None
+    assert stats["ttfb"]["avg"] < 300, (
+        f"/health TTFB {stats['ttfb']['avg']}ms >= 300ms"
+    )
+
+
+# ── Auth-bypass pages ─────────────────────────────────────────────────────
+
+@pytest.mark.perf
+def test_dashboard_ttfb(perf_page, base_url):
+    """/dashboard TTFB < 500ms."""
+    stats = _measure_page(perf_page, f"{base_url}/dashboard")
+    assert stats["ttfb"]["avg"] is not None
+    assert stats["ttfb"]["avg"] < THRESHOLDS["ttfb"], (
+        f"TTFB {stats['ttfb']['avg']}ms >= {THRESHOLDS['ttfb']}ms"
+    )
+
+
+@pytest.mark.perf
+def test_dashboard_lcp(perf_page, base_url):
+    """/dashboard LCP < 2500ms."""
+    stats = _measure_page(perf_page, f"{base_url}/dashboard")
+    if stats["lcp"]["avg"] is not None:
+        assert stats["lcp"]["avg"] < THRESHOLDS["lcp"], (
+            f"LCP {stats['lcp']['avg']}ms >= {THRESHOLDS['lcp']}ms"
+        )
+
+
+@pytest.mark.perf
+def test_add_repo_ttfb(perf_page, base_url):
+    """/repos/add TTFB < 500ms."""
+    stats = _measure_page(perf_page, f"{base_url}/repos/add")
+    assert stats["ttfb"]["avg"] is not None
+    assert stats["ttfb"]["avg"] < THRESHOLDS["ttfb"], (
+        f"TTFB {stats['ttfb']['avg']}ms >= {THRESHOLDS['ttfb']}ms"
+    )
+
+
+# ── Seeded repo pages ─────────────────────────────────────────────────────
+
+@pytest.mark.perf
+def test_repo_detail_ttfb(perf_seeded_page, base_url):
+    """/repos/owner%2Ftestrepo TTFB < 500ms."""
+    stats = _measure_page(perf_seeded_page, f"{base_url}/repos/owner%2Ftestrepo")
+    assert stats["ttfb"]["avg"] is not None
+    assert stats["ttfb"]["avg"] < THRESHOLDS["ttfb"], (
+        f"TTFB {stats['ttfb']['avg']}ms >= {THRESHOLDS['ttfb']}ms"
+    )
+
+
+@pytest.mark.perf
+def test_repo_detail_load(perf_seeded_page, base_url):
+    """/repos/owner%2Ftestrepo Load < 3000ms."""
+    stats = _measure_page(perf_seeded_page, f"{base_url}/repos/owner%2Ftestrepo")
+    assert stats["load"]["avg"] is not None
+    assert stats["load"]["avg"] < THRESHOLDS["load"], (
+        f"Load {stats['load']['avg']}ms >= {THRESHOLDS['load']}ms"
+    )
+
+
+@pytest.mark.perf
+def test_repo_insights_load(perf_seeded_page, base_url):
+    """/repos/owner%2Ftestrepo/insights Load < 3000ms."""
+    stats = _measure_page(
+        perf_seeded_page,
+        f"{base_url}/repos/owner%2Ftestrepo/insights",
+    )
+    assert stats["load"]["avg"] is not None
+    assert stats["load"]["avg"] < THRESHOLDS["load"], (
+        f"Load {stats['load']['avg']}ms >= {THRESHOLDS['load']}ms"
+    )
+
+
+# ── Seeded analysis pages ─────────────────────────────────────────────────
+
+@pytest.mark.perf
+def test_analysis_detail_load(analysis_page, base_url):
+    """/repos/owner%2Ftestrepo/analyses/{id} Load < 3000ms."""
+    pg, analysis_id = analysis_page
+    url = f"{base_url}/repos/owner%2Ftestrepo/analyses/{analysis_id}"
+    stats = _measure_page(pg, url)
+    assert stats["load"]["avg"] is not None
+    assert stats["load"]["avg"] < THRESHOLDS["load"], (
+        f"Load {stats['load']['avg']}ms >= {THRESHOLDS['load']}ms"
+    )

--- a/e2e/test_performance.py
+++ b/e2e/test_performance.py
@@ -9,6 +9,7 @@ THRESHOLDS = {
     "lcp":  2500,
     "dcl":  1500,
     "load": 3000,
+    "health_ttfb": 300,   # /health endpoint — tighter TTFB budget / tighter for health check
 }
 
 _LCP_INIT_JS = """
@@ -44,7 +45,7 @@ def _measure_one(pg, url: str) -> dict:
             const fcp = performance.getEntriesByType('paint')
                 .find(e => e.name === 'first-contentful-paint');
             return {
-                ttfb: Math.round((nav.responseStart || 0) - (nav.requestStart || 0)),
+                ttfb: Math.round((nav.responseStart || 0) - (nav.fetchStart || 0)),
                 dcl:  Math.round((nav.domContentLoadedEventEnd || 0) - (nav.startTime || 0)),
                 load: Math.round((nav.loadEventEnd || 0) - (nav.startTime || 0)),
                 fcp:  fcp ? Math.round(fcp.startTime) : null,
@@ -154,8 +155,8 @@ def test_health_ttfb(perf_page, base_url):
     """/health API 응답 시간 < 300ms."""
     stats = _measure_page(perf_page, f"{base_url}/health")
     assert stats["ttfb"]["avg"] is not None
-    assert stats["ttfb"]["avg"] < 300, (
-        f"/health TTFB {stats['ttfb']['avg']}ms >= 300ms"
+    assert stats["ttfb"]["avg"] < THRESHOLDS["health_ttfb"], (
+        f"/health TTFB {stats['ttfb']['avg']}ms >= {THRESHOLDS['health_ttfb']}ms"
     )
 
 

--- a/e2e/test_performance.py
+++ b/e2e/test_performance.py
@@ -32,7 +32,7 @@ def _measure_one(pg, url: str) -> dict:
     slow: list[dict] = []
 
     def _on_finished(req):
-        t = req.timing()
+        t = req.timing
         dur = t.get("responseEnd", 0) - t.get("requestStart", 0)
         if dur > 500:
             slow.append({"url": req.url, "ms": round(dur)})

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,4 @@ filterwarnings =
 markers =
     slow: tests that run real subprocesses (linters, compilers) — automatically
         applied to files under tests/integration/ via integration/conftest.py
+    perf: performance measurement tests — run via `make test-perf`

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -485,8 +485,8 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
         if db_file and os.path.exists(db_file):
             try:
                 os.unlink(db_file)
-            except OSError:
-                pass
+            except OSError as exc:
+                print(f"[WARN] Failed to remove temporary DB file '{db_file}': {exc}", file=sys.stderr)
         sys.exit(0)
 
     signal.signal(signal.SIGINT, _cleanup)
@@ -585,8 +585,8 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
         if db_file and os.path.exists(db_file):
             try:
                 os.unlink(db_file)
-            except OSError:
-                pass
+            except OSError as exc:
+                print(f"[WARN] Failed to remove temporary DB file '{db_file}': {exc}", file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -413,7 +413,7 @@ def _render_markdown(
 
 # ── Page definitions ───────────────────────────────────────────────────────
 
-def _local_pages(analysis_id: int, api_key: str = _LOCAL_API_KEY) -> list[dict]:
+def _local_pages(analysis_id: int) -> list[dict]:
     """로컬 측정 대상 페이지 목록 / List of pages to measure locally."""
     return [
         {"page": "/login", "url": f"{LOCAL_URL}/login"},
@@ -428,11 +428,11 @@ def _local_pages(analysis_id: int, api_key: str = _LOCAL_API_KEY) -> list[dict]:
             "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/analyses/{analysis_id}",
         },
         {"page": "/repos/owner%2Ftestrepo/settings", "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/settings"},
-        {"page": "/api/repos", "url": f"{LOCAL_URL}/api/repos", "api_only": True, "api_key": api_key},
+        {"page": "/api/repos", "url": f"{LOCAL_URL}/api/repos", "api_only": True},
         {
             "page": "/api/repos/owner%2Ftestrepo/report",
             "url": f"{LOCAL_URL}/api/repos/owner%2Ftestrepo/report",
-            "api_only": True, "api_key": api_key,
+            "api_only": True,
         },
     ]
 

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -37,6 +37,9 @@ except ImportError:
 LOCAL_PORT = 8002
 LOCAL_URL = f"http://127.0.0.1:{LOCAL_PORT}"
 PROD_URL = os.environ.get("PERF_PROD_URL", "https://scamanager-production.up.railway.app")
+# 운영 API 키 — X-Api-Key 헤더로 전달 (없으면 401 예상)
+# Production API key — passed as X-Api-Key header (401 expected if absent).
+PERF_API_KEY = os.environ.get("PERF_API_KEY", "")
 
 THRESHOLDS_LOCAL = {"ttfb": 500, "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3000}
 THRESHOLDS_PROD  = {"ttfb": 300, "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3000}
@@ -226,6 +229,33 @@ def _measure_page(pg, url: str, runs: int = 3) -> dict:
     return stats
 
 
+def _api_ttfb(url: str, api_key: str) -> dict:
+    """API 엔드포인트 TTFB 전용 측정 (X-Api-Key 헤더 사용).
+    TTFB-only measurement for API endpoints (uses X-Api-Key header).
+    """
+    times: list[float] = []
+    status = None
+    for _ in range(3):
+        try:
+            start = time.perf_counter()
+            r = requests.get(url, headers={"X-Api-Key": api_key}, timeout=10)
+            times.append((time.perf_counter() - start) * 1000)
+            status = r.status_code
+        except Exception:  # noqa: BLE001
+            pass
+    avg = round(sum(times) / len(times)) if times else None
+    return {
+        "ttfb": {
+            "avg": avg,
+            "min": round(min(times)) if times else None,
+            "max": round(max(times)) if times else None,
+        },
+        "fcp": {}, "lcp": {}, "dcl": {}, "load": {},
+        "slow_requests": [],
+        "status": status,
+    }
+
+
 def _prod_ttfb(url: str) -> dict:
     """운영 인증 페이지 TTFB 전용 측정 (requests 라이브러리, 리다이렉트 미추적).
     TTFB-only measurement for production auth pages (no credentials — measures redirect).
@@ -327,6 +357,31 @@ def _render_markdown(
             "",
         ]
 
+    # 로컬 vs 운영 비교 표 (양쪽 결과 모두 있을 때만) / Local vs prod comparison table (only when both present)
+    if local_results and prod_results:
+        local_map = {r["page"]: r for r in local_results}
+        prod_map  = {r["page"]: r for r in prod_results}
+        common_pages = [p for p in local_map if p in prod_map]
+        if common_pages:
+            cmp_rows = [
+                "| 페이지 | 로컬 Load | 운영 Load | 배율 |",
+                "|--------|----------|----------|------|",
+            ]
+            for page in common_pages:
+                local_load = (local_map[page]["metrics"].get("load") or {}).get("avg")
+                prod_load  = (prod_map[page]["metrics"].get("load") or {}).get("avg")
+                if local_load is not None and prod_load is not None and local_load > 0:
+                    ratio = f"{prod_load / local_load:.1f}x"
+                else:
+                    ratio = "—"
+                cmp_rows.append(
+                    f"| {page} | {_fmt(local_load)} | {_fmt(prod_load)} | {ratio} |"
+                )
+            lines += [
+                "## 📊 로컬 vs 운영 비교",
+                "",
+            ] + cmp_rows + [""]
+
     # 임계값 초과 항목 / Threshold violations
     violations = []
     for r in (local_results or []):
@@ -365,7 +420,7 @@ def _render_markdown(
         lines += [
             "## 🔍 느린 API 엔드포인트 (> 500ms)",
             "",
-            "| 엔드포인트 | 응답 시간 |",
+            "| 엔드포인트 | 평균 응답 |",
             "|-----------|---------|",
         ] + slow_all + [""]
 
@@ -374,7 +429,7 @@ def _render_markdown(
 
 # ── Page definitions ───────────────────────────────────────────────────────
 
-def _local_pages(analysis_id: int) -> list[dict]:
+def _local_pages(analysis_id: int, api_key: str = "perf-api-key") -> list[dict]:
     """로컬 측정 대상 페이지 목록 / List of pages to measure locally."""
     return [
         {"page": "/login",                              "url": f"{LOCAL_URL}/login"},
@@ -385,6 +440,9 @@ def _local_pages(analysis_id: int) -> list[dict]:
         {"page": "/repos/owner%2Ftestrepo",             "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo"},
         {"page": "/repos/owner%2Ftestrepo/insights",    "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/insights"},
         {"page": f"/repos/.../analyses/{analysis_id}",  "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/analyses/{analysis_id}"},
+        {"page": "/repos/owner%2Ftestrepo/settings",    "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/settings"},
+        {"page": "/api/repos",                          "url": f"{LOCAL_URL}/api/repos",                         "api_only": True, "api_key": api_key},
+        {"page": "/api/repos/owner%2Ftestrepo/report",  "url": f"{LOCAL_URL}/api/repos/owner%2Ftestrepo/report", "api_only": True, "api_key": api_key},
     ]
 
 
@@ -398,6 +456,9 @@ def _prod_pages() -> list[dict]:
         # 인증 필요 — TTFB only / Auth-required — TTFB only
         {"page": "/dashboard",  "url": f"{PROD_URL}/dashboard",  "auth_only": True},
         {"page": "/repos/add",  "url": f"{PROD_URL}/repos/add",  "auth_only": True},
+        # API 엔드포인트 — X-Api-Key 헤더, TTFB only / API endpoints — X-Api-Key header, TTFB only
+        {"page": "/api/repos",                         "url": f"{PROD_URL}/api/repos",                         "api_only": True},
+        {"page": "/api/repos/owner%2Ftestrepo/report", "url": f"{PROD_URL}/api/repos/owner%2Ftestrepo/report",  "api_only": True},
     ]
 
 
@@ -448,13 +509,17 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
             server = _start_local_server(db_path)
             print(f"  ✓ 로컬 서버 준비 (port {LOCAL_PORT})")
 
+            pages_to_measure = _local_pages(analysis_id)
+            browser_pages = [p for p in pages_to_measure if not p.get("api_only")]
+            api_pages_local = [p for p in pages_to_measure if p.get("api_only")]
+
             with sync_playwright() as pw:
                 browser = pw.chromium.launch(headless=True)
                 ctx = browser.new_context()
                 pg = ctx.new_page()
                 pg.add_init_script(_LCP_INIT_JS)
 
-                for page_def in _local_pages(analysis_id):
+                for page_def in browser_pages:
                     print(f"  측정 중: {page_def['page']}")
                     metrics = _measure_page(pg, page_def["url"])
                     local_results.append({"page": page_def["page"], "metrics": metrics})
@@ -462,14 +527,20 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
                 ctx.close()
                 browser.close()
 
+            for page_def in api_pages_local:
+                print(f"  측정 중 (API TTFB): {page_def['page']}")
+                metrics = _api_ttfb(page_def["url"], page_def.get("api_key", "perf-api-key"))
+                local_results.append({"page": page_def["page"], "metrics": metrics, "auth_only": True})
+
             server.should_exit = True
             print("  ✓ 로컬 서버 종료")
 
         if run_prod:
             print(f"\n▶ 운영 서버 측정 중... / Measuring production: {PROD_URL}")
-            pages = _prod_pages()
-            public_pages = [p for p in pages if not p.get("auth_only")]
-            auth_pages   = [p for p in pages if p.get("auth_only")]
+            prod_pages_all = _prod_pages()
+            public_pages   = [p for p in prod_pages_all if not p.get("auth_only") and not p.get("api_only")]
+            auth_pages     = [p for p in prod_pages_all if p.get("auth_only")]
+            api_pages_prod = [p for p in prod_pages_all if p.get("api_only")]
 
             with sync_playwright() as pw:
                 browser = pw.chromium.launch(headless=True)
@@ -493,6 +564,11 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
                     "metrics": metrics,
                     "auth_only": True,
                 })
+
+            for page_def in api_pages_prod:
+                print(f"  측정 중 (API TTFB): {page_def['page']}")
+                metrics = _api_ttfb(page_def["url"], PERF_API_KEY)
+                prod_results.append({"page": page_def["page"], "metrics": metrics, "auth_only": True})
 
         report = _render_markdown(
             local_results if run_local else None,

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -524,8 +524,8 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
 
                 ctx.close()
                 browser.close()
-
-            for page_def in api_pages_local:
+            for idx, page_def in enumerate(api_pages_local, start=1):
+                print(f"  측정 중 (API TTFB) [{idx}/{len(api_pages_local)}]")
                 print(f"  측정 중 (API TTFB): {page_def['page']}")
                 metrics = _http_ttfb(page_def["url"], headers={"X-Api-Key": page_def.get("api_key", _LOCAL_API_KEY)})
                 local_results.append({"page": page_def["page"], "metrics": metrics, "auth_only": True})

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -493,8 +493,6 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
     signal.signal(signal.SIGTERM, _cleanup)
 
     try:
-        analysis_id = 1  # 운영 전용 모드에서는 사용되지 않음 / unused in prod-only mode
-
         if run_local:
             print("▶ 로컬 서버 시작 중... / Starting local server...")
             # fd를 즉시 닫아 Windows SQLite 잠금 방지 / Close fd immediately to avoid SQLite file lock on Windows

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -517,7 +517,8 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
                 pg.add_init_script(_LCP_INIT_JS)
 
                 for page_def in browser_pages:
-                    print(f"  측정 중: {page_def['page']}")
+                    page_label = str(page_def.get("page", "")).replace("\n", "").replace("\r", "")
+                    print(f"  측정 중: {page_label}")
                     metrics = _measure_page(pg, page_def["url"])
                     local_results.append({"page": page_def["page"], "metrics": metrics})
 

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -236,15 +236,22 @@ def _measure_page(pg, url: str, runs: int = 3) -> dict:
 def _http_ttfb(url: str, *, headers: dict | None = None, allow_redirects: bool = True) -> dict:
     """HTTP TTFB 전용 측정 — requests 라이브러리, 3회 평균.
     TTFB-only measurement via requests library, 3-run average.
+
+    stream=True + response.elapsed 로 첫 응답 헤더 수신 시점만 측정 (strict TTFB).
+    Uses stream=True + response.elapsed to measure only the first response header receipt (strict TTFB).
     """
     times: list[float] = []
     status = None
     for _ in range(3):
         try:
-            start = time.perf_counter()
-            r = requests.get(url, headers=headers or {}, allow_redirects=allow_redirects, timeout=10)
-            times.append((time.perf_counter() - start) * 1000)
-            status = r.status_code
+            # stream=True: 응답 헤더만 수신 후 반환 — body 다운로드 제외 (strict TTFB)
+            # stream=True: returns after receiving headers only — excludes body download (strict TTFB)
+            with requests.get(
+                url, headers=headers or {}, allow_redirects=allow_redirects,
+                timeout=10, stream=True,
+            ) as r:
+                times.append(r.elapsed.total_seconds() * 1000)
+                status = r.status_code
         except Exception:  # noqa: BLE001
             pass
     avg = round(sum(times) / len(times)) if times else None
@@ -490,7 +497,9 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
 
         if run_local:
             print("▶ 로컬 서버 시작 중... / Starting local server...")
-            _, db_path = tempfile.mkstemp(suffix=".db", prefix="perf_")
+            # fd를 즉시 닫아 Windows SQLite 잠금 방지 / Close fd immediately to avoid SQLite file lock on Windows
+            fd, db_path = tempfile.mkstemp(suffix=".db", prefix="perf_")
+            os.close(fd)
             db_file = db_path
             _setup_db(db_path)
             analysis_id = _seed_data(db_path)

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -189,7 +189,7 @@ def _measure_one(pg, url: str) -> dict:
     slow: list[dict] = []
 
     def _on_finished(req):
-        t = req.timing()
+        t = req.timing
         dur = t.get("responseEnd", 0) - t.get("requestStart", 0)
         if dur > 500:
             slow.append({"url": req.url, "ms": round(dur)})

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -42,7 +42,10 @@ PROD_URL = os.environ.get("PERF_PROD_URL", "https://scamanager-production.up.rai
 PERF_API_KEY = os.environ.get("PERF_API_KEY", "")
 
 THRESHOLDS_LOCAL = {"ttfb": 500, "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3000}
-THRESHOLDS_PROD  = {"ttfb": 300, "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3000}
+THRESHOLDS_PROD = {"ttfb": 300, "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3000}
+
+# 로컬 테스트용 더미 API 키 / Dummy API key for local test server
+_LOCAL_API_KEY = "perf-api-key"
 
 _LCP_INIT_JS = """
     window._perf_lcp = null;
@@ -57,6 +60,7 @@ _LCP_INIT_JS = """
 """
 
 # ── DB / Server setup ──────────────────────────────────────────────────────
+
 
 def _setup_db(db_path: str) -> None:
     """SQLite DB 생성 — ORM 스키마 직접 적용.
@@ -125,7 +129,7 @@ def _start_local_server(db_path: str):
         "GITHUB_TOKEN": "perf-test-token",
         "TELEGRAM_BOT_TOKEN": "1234567890:AAperftest",
         "TELEGRAM_CHAT_ID": "-100000000",
-        "API_KEY": "perf-api-key",
+        "API_KEY": _LOCAL_API_KEY,
         "GITHUB_CLIENT_ID": "perf-github-client-id",
         "GITHUB_CLIENT_SECRET": "perf-github-client-secret",
         "SESSION_SECRET": "perf-session-secret-32chars-long!!",
@@ -229,43 +233,16 @@ def _measure_page(pg, url: str, runs: int = 3) -> dict:
     return stats
 
 
-def _api_ttfb(url: str, api_key: str) -> dict:
-    """API 엔드포인트 TTFB 전용 측정 (X-Api-Key 헤더 사용).
-    TTFB-only measurement for API endpoints (uses X-Api-Key header).
+def _http_ttfb(url: str, *, headers: dict | None = None, allow_redirects: bool = True) -> dict:
+    """HTTP TTFB 전용 측정 — requests 라이브러리, 3회 평균.
+    TTFB-only measurement via requests library, 3-run average.
     """
     times: list[float] = []
     status = None
     for _ in range(3):
         try:
             start = time.perf_counter()
-            r = requests.get(url, headers={"X-Api-Key": api_key}, timeout=10)
-            times.append((time.perf_counter() - start) * 1000)
-            status = r.status_code
-        except Exception:  # noqa: BLE001
-            pass
-    avg = round(sum(times) / len(times)) if times else None
-    return {
-        "ttfb": {
-            "avg": avg,
-            "min": round(min(times)) if times else None,
-            "max": round(max(times)) if times else None,
-        },
-        "fcp": {}, "lcp": {}, "dcl": {}, "load": {},
-        "slow_requests": [],
-        "status": status,
-    }
-
-
-def _prod_ttfb(url: str) -> dict:
-    """운영 인증 페이지 TTFB 전용 측정 (requests 라이브러리, 리다이렉트 미추적).
-    TTFB-only measurement for production auth pages (no credentials — measures redirect).
-    """
-    times: list[float] = []
-    status = None
-    for _ in range(3):
-        try:
-            start = time.perf_counter()
-            r = requests.get(url, allow_redirects=False, timeout=10)
+            r = requests.get(url, headers=headers or {}, allow_redirects=allow_redirects, timeout=10)
             times.append((time.perf_counter() - start) * 1000)
             status = r.status_code
         except Exception:  # noqa: BLE001
@@ -285,7 +262,7 @@ def _prod_ttfb(url: str) -> dict:
 
 # ── Report generation ──────────────────────────────────────────────────────
 
-def _fmt(v) -> str:
+def _fmt(v: int | None) -> str:
     """ms 값을 사람이 읽기 좋은 문자열로 변환 / Format ms value for humans."""
     if v is None:
         return "—"
@@ -360,7 +337,7 @@ def _render_markdown(
     # 로컬 vs 운영 비교 표 (양쪽 결과 모두 있을 때만) / Local vs prod comparison table (only when both present)
     if local_results and prod_results:
         local_map = {r["page"]: r for r in local_results}
-        prod_map  = {r["page"]: r for r in prod_results}
+        prod_map = {r["page"]: r for r in prod_results}
         common_pages = [p for p in local_map if p in prod_map]
         if common_pages:
             cmp_rows = [
@@ -369,7 +346,7 @@ def _render_markdown(
             ]
             for page in common_pages:
                 local_load = (local_map[page]["metrics"].get("load") or {}).get("avg")
-                prod_load  = (prod_map[page]["metrics"].get("load") or {}).get("avg")
+                prod_load = (prod_map[page]["metrics"].get("load") or {}).get("avg")
                 if local_load is not None and prod_load is not None and local_load > 0:
                     ratio = f"{prod_load / local_load:.1f}x"
                 else:
@@ -429,20 +406,27 @@ def _render_markdown(
 
 # ── Page definitions ───────────────────────────────────────────────────────
 
-def _local_pages(analysis_id: int, api_key: str = "perf-api-key") -> list[dict]:
+def _local_pages(analysis_id: int, api_key: str = _LOCAL_API_KEY) -> list[dict]:
     """로컬 측정 대상 페이지 목록 / List of pages to measure locally."""
     return [
-        {"page": "/login",                              "url": f"{LOCAL_URL}/login"},
-        {"page": "/",                                   "url": f"{LOCAL_URL}/"},
-        {"page": "/health",                             "url": f"{LOCAL_URL}/health"},
-        {"page": "/dashboard",                          "url": f"{LOCAL_URL}/dashboard"},
-        {"page": "/repos/add",                          "url": f"{LOCAL_URL}/repos/add"},
-        {"page": "/repos/owner%2Ftestrepo",             "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo"},
-        {"page": "/repos/owner%2Ftestrepo/insights",    "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/insights"},
-        {"page": f"/repos/.../analyses/{analysis_id}",  "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/analyses/{analysis_id}"},
-        {"page": "/repos/owner%2Ftestrepo/settings",    "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/settings"},
-        {"page": "/api/repos",                          "url": f"{LOCAL_URL}/api/repos",                         "api_only": True, "api_key": api_key},
-        {"page": "/api/repos/owner%2Ftestrepo/report",  "url": f"{LOCAL_URL}/api/repos/owner%2Ftestrepo/report", "api_only": True, "api_key": api_key},
+        {"page": "/login", "url": f"{LOCAL_URL}/login"},
+        {"page": "/", "url": f"{LOCAL_URL}/"},
+        {"page": "/health", "url": f"{LOCAL_URL}/health"},
+        {"page": "/dashboard", "url": f"{LOCAL_URL}/dashboard"},
+        {"page": "/repos/add", "url": f"{LOCAL_URL}/repos/add"},
+        {"page": "/repos/owner%2Ftestrepo", "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo"},
+        {"page": "/repos/owner%2Ftestrepo/insights", "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/insights"},
+        {
+            "page": f"/repos/.../analyses/{analysis_id}",
+            "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/analyses/{analysis_id}",
+        },
+        {"page": "/repos/owner%2Ftestrepo/settings", "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/settings"},
+        {"page": "/api/repos", "url": f"{LOCAL_URL}/api/repos", "api_only": True, "api_key": api_key},
+        {
+            "page": "/api/repos/owner%2Ftestrepo/report",
+            "url": f"{LOCAL_URL}/api/repos/owner%2Ftestrepo/report",
+            "api_only": True, "api_key": api_key,
+        },
     ]
 
 
@@ -450,15 +434,19 @@ def _prod_pages() -> list[dict]:
     """운영 측정 대상 페이지 목록 / List of production pages to measure."""
     return [
         # 공개 페이지 — 전체 측정 / Public pages — full measurement
-        {"page": "/login",    "url": f"{PROD_URL}/login",    "auth_only": False},
-        {"page": "/",         "url": f"{PROD_URL}/",         "auth_only": False},
-        {"page": "/health",   "url": f"{PROD_URL}/health",   "auth_only": False},
+        {"page": "/login", "url": f"{PROD_URL}/login", "auth_only": False},
+        {"page": "/", "url": f"{PROD_URL}/", "auth_only": False},
+        {"page": "/health", "url": f"{PROD_URL}/health", "auth_only": False},
         # 인증 필요 — TTFB only / Auth-required — TTFB only
-        {"page": "/dashboard",  "url": f"{PROD_URL}/dashboard",  "auth_only": True},
-        {"page": "/repos/add",  "url": f"{PROD_URL}/repos/add",  "auth_only": True},
+        {"page": "/dashboard", "url": f"{PROD_URL}/dashboard", "auth_only": True},
+        {"page": "/repos/add", "url": f"{PROD_URL}/repos/add", "auth_only": True},
         # API 엔드포인트 — X-Api-Key 헤더, TTFB only / API endpoints — X-Api-Key header, TTFB only
-        {"page": "/api/repos",                         "url": f"{PROD_URL}/api/repos",                         "api_only": True},
-        {"page": "/api/repos/owner%2Ftestrepo/report", "url": f"{PROD_URL}/api/repos/owner%2Ftestrepo/report",  "api_only": True},
+        {"page": "/api/repos", "url": f"{PROD_URL}/api/repos", "api_only": True},
+        {
+            "page": "/api/repos/owner%2Ftestrepo/report",
+            "url": f"{PROD_URL}/api/repos/owner%2Ftestrepo/report",
+            "api_only": True,
+        },
     ]
 
 
@@ -469,7 +457,7 @@ def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="SCAManager 페이지 성능 측정")
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--local-only", action="store_true", help="로컬 측정만")
-    group.add_argument("--prod-only",  action="store_true", help="운영 측정만")
+    group.add_argument("--prod-only", action="store_true", help="운영 측정만")
     return parser.parse_args()
 
 
@@ -477,12 +465,12 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
     """성능 측정 메인 진입점 / Main entry point for performance measurement."""
     args = _parse_args()
     run_local = not args.prod_only
-    run_prod  = not args.local_only
+    run_prod = not args.local_only
 
     server = None
     db_file = None
     local_results: list[dict] = []
-    prod_results:  list[dict] = []
+    prod_results: list[dict] = []
 
     def _cleanup(signum=None, frame=None):  # noqa: ARG001
         if server:
@@ -498,7 +486,7 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
     signal.signal(signal.SIGTERM, _cleanup)
 
     try:
-        analysis_id = 1
+        analysis_id = 1  # 운영 전용 모드에서는 사용되지 않음 / unused in prod-only mode
 
         if run_local:
             print("▶ 로컬 서버 시작 중... / Starting local server...")
@@ -529,7 +517,7 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
 
             for page_def in api_pages_local:
                 print(f"  측정 중 (API TTFB): {page_def['page']}")
-                metrics = _api_ttfb(page_def["url"], page_def.get("api_key", "perf-api-key"))
+                metrics = _http_ttfb(page_def["url"], headers={"X-Api-Key": page_def.get("api_key", _LOCAL_API_KEY)})
                 local_results.append({"page": page_def["page"], "metrics": metrics, "auth_only": True})
 
             server.should_exit = True
@@ -538,8 +526,8 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
         if run_prod:
             print(f"\n▶ 운영 서버 측정 중... / Measuring production: {PROD_URL}")
             prod_pages_all = _prod_pages()
-            public_pages   = [p for p in prod_pages_all if not p.get("auth_only") and not p.get("api_only")]
-            auth_pages     = [p for p in prod_pages_all if p.get("auth_only")]
+            public_pages = [p for p in prod_pages_all if not p.get("auth_only") and not p.get("api_only")]
+            auth_pages = [p for p in prod_pages_all if p.get("auth_only")]
             api_pages_prod = [p for p in prod_pages_all if p.get("api_only")]
 
             with sync_playwright() as pw:
@@ -558,7 +546,7 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
 
             for page_def in auth_pages:
                 print(f"  측정 중 (TTFB only): {page_def['page']}")
-                metrics = _prod_ttfb(page_def["url"])
+                metrics = _http_ttfb(page_def["url"], allow_redirects=False)
                 prod_results.append({
                     "page": page_def["page"],
                     "metrics": metrics,
@@ -567,16 +555,17 @@ def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-man
 
             for page_def in api_pages_prod:
                 print(f"  측정 중 (API TTFB): {page_def['page']}")
-                metrics = _api_ttfb(page_def["url"], PERF_API_KEY)
+                metrics = _http_ttfb(page_def["url"], headers={"X-Api-Key": PERF_API_KEY})
                 prod_results.append({"page": page_def["page"], "metrics": metrics, "auth_only": True})
 
         report = _render_markdown(
             local_results if run_local else None,
-            prod_results  if run_prod  else None,
+            prod_results if run_prod else None,
         )
 
         ts = datetime.now().strftime("%Y-%m-%d-%H%M")
-        report_path = Path("docs/reports") / f"perf-{ts}.md"
+        # 스크립트 위치 기준으로 프로젝트 루트 결정 / Resolve project root from script location
+        report_path = Path(__file__).parent.parent / "docs" / "reports" / f"perf-{ts}.md"
         report_path.parent.mkdir(parents=True, exist_ok=True)
         report_path.write_text(report, encoding="utf-8")
         print(f"\n✅ 리포트 저장: {report_path}")

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -1,0 +1,520 @@
+#!/usr/bin/env python3
+"""SCAManager 페이지 성능 측정 스크립트 — 로컬 + 운영 양쪽 측정.
+SCAManager page performance measurement script — measures both local and production.
+
+Usage:
+    python scripts/perf_measure.py               # 로컬 + 운영 / local + production
+    python scripts/perf_measure.py --local-only  # 로컬만 / local only
+    python scripts/perf_measure.py --prod-only   # 운영만 / production only
+"""
+import argparse
+import asyncio
+import importlib
+import json
+import os
+import pkgutil
+import signal
+import sys
+import tempfile
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+
+import requests
+
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError:
+    print("ERROR: playwright not installed.")
+    print("Run: pip install playwright && playwright install chromium")
+    sys.exit(1)
+
+# ── Constants ──────────────────────────────────────────────────────────────
+
+# E2E 포트(8001)와 구분 — 동시 실행 시 충돌 방지
+# Different from E2E port 8001 — prevents conflict during concurrent runs.
+LOCAL_PORT = 8002
+LOCAL_URL = f"http://127.0.0.1:{LOCAL_PORT}"
+PROD_URL = os.environ.get("PERF_PROD_URL", "https://scamanager-production.up.railway.app")
+
+THRESHOLDS_LOCAL = {"ttfb": 500, "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3000}
+THRESHOLDS_PROD  = {"ttfb": 300, "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3000}
+
+_LCP_INIT_JS = """
+    window._perf_lcp = null;
+    try {
+        new PerformanceObserver((list) => {
+            const entries = list.getEntries();
+            if (entries.length > 0) {
+                window._perf_lcp = entries[entries.length - 1].startTime;
+            }
+        }).observe({ type: 'largest-contentful-paint', buffered: true });
+    } catch(e) {}
+"""
+
+# ── DB / Server setup ──────────────────────────────────────────────────────
+
+def _setup_db(db_path: str) -> None:
+    """SQLite DB 생성 — ORM 스키마 직접 적용.
+    Create SQLite DB with ORM schema applied directly (bypasses Alembic SQLite issues).
+    """
+    from sqlalchemy import create_engine  # noqa: PLC0415
+    from src.database import Base  # noqa: PLC0415
+    import src.models as _models_pkg  # noqa: PLC0415
+
+    for _, name, _ in pkgutil.iter_modules(_models_pkg.__path__):
+        importlib.import_module(f"src.models.{name}")
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+    engine.dispose()
+
+
+def _seed_data(db_path: str) -> int:
+    """User + Repo + Analysis 시딩 — analysis_id 반환.
+    Seed User + Repo + Analysis records — returns analysis_id.
+    """
+    from sqlalchemy import create_engine, text  # noqa: PLC0415
+
+    engine = create_engine(f"sqlite:///{db_path}")
+    with engine.connect() as conn:
+        conn.execute(text("""
+            INSERT OR IGNORE INTO users
+                (id, github_id, github_login, github_access_token, email, display_name, created_at)
+            VALUES
+                (1, 'perf-uid', 'perf-tester', 'gho_perf',
+                 'perf@test.com', 'Perf Test User', datetime('now'))
+        """))
+        conn.execute(text("""
+            INSERT OR IGNORE INTO repositories
+                (full_name, user_id, webhook_secret, created_at)
+            VALUES ('owner/testrepo', 1, 'perf-secret', datetime('now'))
+        """))
+        conn.commit()
+        repo_id = conn.execute(text(
+            "SELECT id FROM repositories WHERE full_name='owner/testrepo'"
+        )).fetchone()[0]
+        conn.execute(text("""
+            INSERT OR IGNORE INTO analyses
+                (repo_id, commit_sha, commit_message, score, grade, result, author_login, created_at)
+            VALUES
+                (:rid, 'perf-sha-001', 'perf: standalone script seed',
+                 85, 'B', :res, 'perf-tester', datetime('now'))
+        """), {"rid": repo_id, "res": json.dumps({"summary": "perf test"})})
+        conn.commit()
+        analysis_row = conn.execute(text(
+            "SELECT id FROM analyses WHERE repo_id=:rid AND commit_sha='perf-sha-001'"
+        ), {"rid": repo_id}).fetchone()
+        if analysis_row is None:
+            raise RuntimeError("_seed_data: analysis row not found after INSERT")
+    engine.dispose()
+    return analysis_row[0]
+
+
+def _start_local_server(db_path: str):
+    """uvicorn 서버를 별도 스레드에서 시작하고 server 객체를 반환한다.
+    Start uvicorn server in a background thread and return the server object.
+    """
+    os.environ.update({
+        "DATABASE_URL": f"sqlite:///{db_path}",
+        "GITHUB_WEBHOOK_SECRET": "perf-test-secret",
+        "GITHUB_TOKEN": "perf-test-token",
+        "TELEGRAM_BOT_TOKEN": "1234567890:AAperftest",
+        "TELEGRAM_CHAT_ID": "-100000000",
+        "API_KEY": "perf-api-key",
+        "GITHUB_CLIENT_ID": "perf-github-client-id",
+        "GITHUB_CLIENT_SECRET": "perf-github-client-secret",
+        "SESSION_SECRET": "perf-session-secret-32chars-long!!",
+    })
+
+    # pydantic-settings 캐시 무효화 / Invalidate pydantic-settings cache.
+    for mod_name in list(sys.modules.keys()):
+        if mod_name.startswith("src."):
+            del sys.modules[mod_name]
+
+    import uvicorn  # noqa: PLC0415
+    from src.main import app  # noqa: PLC0415
+    from src.auth.session import require_login, CurrentUser  # noqa: PLC0415
+
+    _user = CurrentUser(
+        id=1,
+        github_login="perf-tester",
+        email="perf@test.com",
+        display_name="Perf Test User",
+        plaintext_token="gho_perf_test_token",
+    )
+    app.dependency_overrides[require_login] = lambda: _user
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=LOCAL_PORT, log_level="error")
+    server = uvicorn.Server(config)
+
+    def _run():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(server.serve())
+        finally:
+            loop.close()
+
+    threading.Thread(target=_run, daemon=True).start()
+
+    # 서버 준비 대기 (최대 30초) / Wait for server readiness (up to 30s).
+    for _ in range(60):
+        try:
+            r = requests.get(f"{LOCAL_URL}/health", timeout=1)
+            if r.status_code == 200:
+                return server
+        except Exception:  # noqa: BLE001
+            pass
+        time.sleep(0.5)
+
+    server.should_exit = True
+    raise RuntimeError(f"Local server failed to start on port {LOCAL_PORT} within 30s")
+
+
+# ── Measurement helpers ────────────────────────────────────────────────────
+
+def _measure_one(pg, url: str) -> dict:
+    """단일 측정 — TTFB/FCP/LCP/DCL/Load(ms) + 느린 요청 목록 반환.
+    Single measurement — returns TTFB/FCP/LCP/DCL/Load(ms) + slow request list.
+    """
+    slow: list[dict] = []
+
+    def _on_finished(req):
+        t = req.timing()
+        dur = t.get("responseEnd", 0) - t.get("requestStart", 0)
+        if dur > 500:
+            slow.append({"url": req.url, "ms": round(dur)})
+
+    pg.on("requestfinished", _on_finished)
+    try:
+        pg.goto(url, wait_until="networkidle", timeout=30_000)
+        metrics = pg.evaluate("""() => {
+            const nav = performance.getEntriesByType('navigation')[0] || {};
+            const fcp = performance.getEntriesByType('paint')
+                .find(e => e.name === 'first-contentful-paint');
+            return {
+                ttfb: Math.round((nav.responseStart || 0) - (nav.fetchStart || 0)),
+                dcl:  Math.round((nav.domContentLoadedEventEnd || 0) - (nav.startTime || 0)),
+                load: Math.round((nav.loadEventEnd || 0) - (nav.startTime || 0)),
+                fcp:  fcp ? Math.round(fcp.startTime) : null,
+                lcp:  (typeof window._perf_lcp === 'number')
+                          ? Math.round(window._perf_lcp) : null,
+            };
+        }""")
+        metrics["slow_requests"] = slow[:]
+        return metrics
+    finally:
+        pg.remove_listener("requestfinished", _on_finished)
+
+
+def _measure_page(pg, url: str, runs: int = 3) -> dict:
+    """N회 측정 후 avg/min/max 통계 반환.
+    Returns avg/min/max stats over N runs.
+    """
+    results = [_measure_one(pg, url) for _ in range(runs)]
+    stats: dict = {}
+    for key in ("ttfb", "fcp", "lcp", "dcl", "load"):
+        vals = [r[key] for r in results if r.get(key) is not None]
+        stats[key] = {
+            "avg": round(sum(vals) / len(vals)) if vals else None,
+            "min": min(vals) if vals else None,
+            "max": max(vals) if vals else None,
+        }
+    stats["slow_requests"] = [req for r in results for req in r.get("slow_requests", [])]
+    return stats
+
+
+def _prod_ttfb(url: str) -> dict:
+    """운영 인증 페이지 TTFB 전용 측정 (requests 라이브러리, 리다이렉트 미추적).
+    TTFB-only measurement for production auth pages (no credentials — measures redirect).
+    """
+    times: list[float] = []
+    status = None
+    for _ in range(3):
+        try:
+            start = time.perf_counter()
+            r = requests.get(url, allow_redirects=False, timeout=10)
+            times.append((time.perf_counter() - start) * 1000)
+            status = r.status_code
+        except Exception:  # noqa: BLE001
+            pass
+    avg = round(sum(times) / len(times)) if times else None
+    return {
+        "ttfb": {
+            "avg": avg,
+            "min": round(min(times)) if times else None,
+            "max": round(max(times)) if times else None,
+        },
+        "fcp": {}, "lcp": {}, "dcl": {}, "load": {},
+        "slow_requests": [],
+        "status": status,
+    }
+
+
+# ── Report generation ──────────────────────────────────────────────────────
+
+def _fmt(v) -> str:
+    """ms 값을 사람이 읽기 좋은 문자열로 변환 / Format ms value for humans."""
+    if v is None:
+        return "—"
+    return f"{v}ms" if v < 1000 else f"{v / 1000:.1f}s"
+
+
+def _verdict(metrics: dict, thresholds: dict) -> str:
+    """임계값 초과 시 🔴, 이내 시 ✅ 반환 / Return 🔴 if any threshold exceeded, else ✅."""
+    for key in ("ttfb", "fcp", "lcp", "dcl", "load"):
+        avg = (metrics.get(key) or {}).get("avg")
+        if avg is not None and avg > thresholds.get(key, 9_999):
+            return "🔴"
+    return "✅"
+
+
+def _render_table(results: list[dict], thresholds: dict) -> str:
+    """결과 목록을 Markdown 표로 변환 / Convert result list to a Markdown table."""
+    rows = [
+        "| 페이지 | TTFB avg | FCP avg | LCP avg | DCL avg | Load avg | 판정 |",
+        "|--------|----------|---------|---------|---------|----------|------|",
+    ]
+    for r in results:
+        m = r["metrics"]
+        if r.get("auth_only"):
+            rows.append(
+                f"| {r['page']} | {_fmt((m.get('ttfb') or {}).get('avg'))} "
+                f"| — | — | — | — | *(auth-only)* |"
+            )
+        else:
+            rows.append(
+                f"| {r['page']} "
+                f"| {_fmt((m.get('ttfb') or {}).get('avg'))} "
+                f"| {_fmt((m.get('fcp') or {}).get('avg'))} "
+                f"| {_fmt((m.get('lcp') or {}).get('avg'))} "
+                f"| {_fmt((m.get('dcl') or {}).get('avg'))} "
+                f"| {_fmt((m.get('load') or {}).get('avg'))} "
+                f"| {_verdict(m, thresholds)} |"
+            )
+    return "\n".join(rows)
+
+
+def _render_markdown(
+    local_results: list[dict] | None,
+    prod_results: list[dict] | None,
+) -> str:
+    """전체 Markdown 리포트 생성.
+    Generate full Markdown performance report.
+    """
+    ts = datetime.now().strftime("%Y-%m-%d %H:%M")
+    lines = [
+        "# SCAManager 페이지 성능 리포트",
+        f"측정일시: {ts} | 반복: 3회 | 브라우저: Chromium headless",
+        "",
+    ]
+
+    if local_results:
+        lines += [
+            "## 🏠 로컬 E2E 서버 (SQLite)",
+            "",
+            _render_table(local_results, THRESHOLDS_LOCAL),
+            "",
+        ]
+
+    if prod_results:
+        lines += [
+            "## 🌐 운영 서버 (Railway)",
+            "",
+            _render_table(prod_results, THRESHOLDS_PROD),
+            "",
+        ]
+
+    # 임계값 초과 항목 / Threshold violations
+    violations = []
+    for r in (local_results or []):
+        if r.get("auth_only"):
+            continue
+        m = r["metrics"]
+        for key, thr in THRESHOLDS_LOCAL.items():
+            avg = (m.get(key) or {}).get("avg")
+            if avg is not None and avg > thr:
+                violations.append(
+                    f"- 🏠 {r['page']} **{key.upper()}**: {_fmt(avg)} (>{_fmt(thr)})"
+                )
+    for r in (prod_results or []):
+        if r.get("auth_only"):
+            continue
+        m = r["metrics"]
+        for key, thr in THRESHOLDS_PROD.items():
+            avg = (m.get(key) or {}).get("avg")
+            if avg is not None and avg > thr:
+                violations.append(
+                    f"- 🌐 {r['page']} **{key.upper()}**: {_fmt(avg)} (>{_fmt(thr)})"
+                )
+
+    if violations:
+        lines += ["## 🔴 임계값 초과 항목", ""] + violations + [""]
+    else:
+        lines += ["## ✅ 모든 페이지 임계값 이내", ""]
+
+    # 느린 API 엔드포인트 / Slow API endpoints
+    slow_all = []
+    for r in (local_results or []) + (prod_results or []):
+        for req in r.get("metrics", {}).get("slow_requests", []):
+            slow_all.append(f"| {req['url']} | {req['ms']}ms |")
+
+    if slow_all:
+        lines += [
+            "## 🔍 느린 API 엔드포인트 (> 500ms)",
+            "",
+            "| 엔드포인트 | 응답 시간 |",
+            "|-----------|---------|",
+        ] + slow_all + [""]
+
+    return "\n".join(lines)
+
+
+# ── Page definitions ───────────────────────────────────────────────────────
+
+def _local_pages(analysis_id: int) -> list[dict]:
+    """로컬 측정 대상 페이지 목록 / List of pages to measure locally."""
+    return [
+        {"page": "/login",                              "url": f"{LOCAL_URL}/login"},
+        {"page": "/",                                   "url": f"{LOCAL_URL}/"},
+        {"page": "/health",                             "url": f"{LOCAL_URL}/health"},
+        {"page": "/dashboard",                          "url": f"{LOCAL_URL}/dashboard"},
+        {"page": "/repos/add",                          "url": f"{LOCAL_URL}/repos/add"},
+        {"page": "/repos/owner%2Ftestrepo",             "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo"},
+        {"page": "/repos/owner%2Ftestrepo/insights",    "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/insights"},
+        {"page": f"/repos/.../analyses/{analysis_id}",  "url": f"{LOCAL_URL}/repos/owner%2Ftestrepo/analyses/{analysis_id}"},
+    ]
+
+
+def _prod_pages() -> list[dict]:
+    """운영 측정 대상 페이지 목록 / List of production pages to measure."""
+    return [
+        # 공개 페이지 — 전체 측정 / Public pages — full measurement
+        {"page": "/login",    "url": f"{PROD_URL}/login",    "auth_only": False},
+        {"page": "/",         "url": f"{PROD_URL}/",         "auth_only": False},
+        {"page": "/health",   "url": f"{PROD_URL}/health",   "auth_only": False},
+        # 인증 필요 — TTFB only / Auth-required — TTFB only
+        {"page": "/dashboard",  "url": f"{PROD_URL}/dashboard",  "auth_only": True},
+        {"page": "/repos/add",  "url": f"{PROD_URL}/repos/add",  "auth_only": True},
+    ]
+
+
+# ── Main ───────────────────────────────────────────────────────────────────
+
+def _parse_args() -> argparse.Namespace:
+    """CLI 인수 파싱 / Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description="SCAManager 페이지 성능 측정")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--local-only", action="store_true", help="로컬 측정만")
+    group.add_argument("--prod-only",  action="store_true", help="운영 측정만")
+    return parser.parse_args()
+
+
+def main() -> None:  # pylint: disable=too-many-locals,too-many-branches,too-many-statements
+    """성능 측정 메인 진입점 / Main entry point for performance measurement."""
+    args = _parse_args()
+    run_local = not args.prod_only
+    run_prod  = not args.local_only
+
+    server = None
+    db_file = None
+    local_results: list[dict] = []
+    prod_results:  list[dict] = []
+
+    def _cleanup(signum=None, frame=None):  # noqa: ARG001
+        if server:
+            server.should_exit = True
+        if db_file and os.path.exists(db_file):
+            try:
+                os.unlink(db_file)
+            except OSError:
+                pass
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _cleanup)
+    signal.signal(signal.SIGTERM, _cleanup)
+
+    try:
+        analysis_id = 1
+
+        if run_local:
+            print("▶ 로컬 서버 시작 중... / Starting local server...")
+            _, db_path = tempfile.mkstemp(suffix=".db", prefix="perf_")
+            db_file = db_path
+            _setup_db(db_path)
+            analysis_id = _seed_data(db_path)
+            server = _start_local_server(db_path)
+            print(f"  ✓ 로컬 서버 준비 (port {LOCAL_PORT})")
+
+            with sync_playwright() as pw:
+                browser = pw.chromium.launch(headless=True)
+                ctx = browser.new_context()
+                pg = ctx.new_page()
+                pg.add_init_script(_LCP_INIT_JS)
+
+                for page_def in _local_pages(analysis_id):
+                    print(f"  측정 중: {page_def['page']}")
+                    metrics = _measure_page(pg, page_def["url"])
+                    local_results.append({"page": page_def["page"], "metrics": metrics})
+
+                ctx.close()
+                browser.close()
+
+            server.should_exit = True
+            print("  ✓ 로컬 서버 종료")
+
+        if run_prod:
+            print(f"\n▶ 운영 서버 측정 중... / Measuring production: {PROD_URL}")
+            pages = _prod_pages()
+            public_pages = [p for p in pages if not p.get("auth_only")]
+            auth_pages   = [p for p in pages if p.get("auth_only")]
+
+            with sync_playwright() as pw:
+                browser = pw.chromium.launch(headless=True)
+                ctx = browser.new_context()
+                pg = ctx.new_page()
+                pg.add_init_script(_LCP_INIT_JS)
+
+                for page_def in public_pages:
+                    print(f"  측정 중: {page_def['page']}")
+                    metrics = _measure_page(pg, page_def["url"])
+                    prod_results.append({"page": page_def["page"], "metrics": metrics})
+
+                ctx.close()
+                browser.close()
+
+            for page_def in auth_pages:
+                print(f"  측정 중 (TTFB only): {page_def['page']}")
+                metrics = _prod_ttfb(page_def["url"])
+                prod_results.append({
+                    "page": page_def["page"],
+                    "metrics": metrics,
+                    "auth_only": True,
+                })
+
+        report = _render_markdown(
+            local_results if run_local else None,
+            prod_results  if run_prod  else None,
+        )
+
+        ts = datetime.now().strftime("%Y-%m-%d-%H%M")
+        report_path = Path("docs/reports") / f"perf-{ts}.md"
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(report, encoding="utf-8")
+        print(f"\n✅ 리포트 저장: {report_path}")
+        print("\n" + report)
+
+    finally:
+        if server:
+            server.should_exit = True
+        if db_file and os.path.exists(db_file):
+            try:
+                os.unlink(db_file)
+            except OSError:
+                pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`e2e/test_performance.py`** — 12개 `@pytest.mark.perf` 테스트 (TTFB/FCP/LCP/DCL/Load 임계값 검증, Playwright Chromium headless, 3회 측정 avg/min/max)
- **`e2e/conftest.py`** — `_seed_analysis()` 헬퍼 + `seeded_analysis` session-scope fixture 추가 (분석 상세 페이지 URL 시딩)
- **`scripts/perf_measure.py`** — 독립 실행 측정 스크립트 (로컬 SQLite 서버 자동 시작/종료 + 운영 Railway URL TTFB 측정, `--local-only` / `--prod-only` / default 양쪽)
- **`pytest.ini` + `e2e/pytest.ini`** — `perf` 마커 등록
- **`Makefile`** — `make test-perf` / `make perf-report` 타깃 추가
- **`docs/reports/perf-2026-05-18-2314.md`** — 첫 번째 성능 리포트 (로컬 11페이지, 전부 ✅ 임계값 이내)

## 첫 리포트 결과 요약 (로컬 SQLite, 2026-05-18)

| 페이지 | TTFB avg | Load avg | 판정 |
|--------|----------|----------|------|
| /login | 18ms | 363ms | ✅ |
| / (landing) | 5ms | 154ms | ✅ |
| /dashboard | 51ms | 148ms | ✅ |
| /repos/{name} | 13ms | 103ms | ✅ |
| /repos/{name}/analyses/{id} | 26ms | 41ms | ✅ |

⚠️ **느린 API 포착**: `/api/github/repos` ~510ms (GitHub 프록시 호출 — 운영 환경 개선 검토 필요)

## 측정 지표 (Option C 정밀 측정)
- TTFB (`responseStart - fetchStart`, Web Vitals 표준 기준)
- FCP (`PerformanceObserver paint` 타입)
- LCP (`PerformanceObserver largest-contentful-paint`, `buffered: true`)
- DCL / Load (Navigation Timing Level 2)
- 페이지당 3회 측정 → avg / min / max
- 느린 API 캡처 (> 500ms)

## 사용법

```bash
make test-perf                              # E2E 성능 테스트 (로컬)
make perf-report                            # 로컬+운영 리포트 생성
python scripts/perf_measure.py --local-only  # 로컬만
PERF_API_KEY=<키> python scripts/perf_measure.py  # 운영 포함
```

## 🔍 사용자 검증 필요

- [ ] `make test-perf` 실행 후 12개 테스트 모두 통과 확인
- [ ] `python scripts/perf_measure.py --local-only` 실행 — 리포트 내용 적절성 확인
- [ ] `PERF_PROD_URL` + `PERF_API_KEY` 환경변수 설정 후 운영 측정 실행 확인
- [ ] `docs/reports/perf-2026-05-18-2314.md` 에서 `/api/github/repos` 500ms+ 항목 — 운영에서 확인 필요

🤖 Generated with [Claude Code](https://claude.ai/claude-code)