### PR TITLE
chore: 사이클 106 회고 반영 — 7개 항목 + Codex NG 수정

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -15,6 +15,7 @@ paths:
 - **테스트 환경 변수**: `tests/conftest.py`가 `os.environ.setdefault`로 환경변수를 주입함. src 모듈은 import 시점에 `Settings()`를 인스턴스화하므로 conftest가 반드시 먼저 실행되어야 함.
 - **E2E 격리**: `e2e/`를 최상위 별도 디렉토리로 분리 (`tests/` 아래 금지) — `tests/e2e/`가 있으면 `asyncio_mode=auto`와 `sys.modules` 삭제가 충돌해 단위 테스트 98개 실패. E2E 서버는 `uvicorn.Server.serve()`를 `asyncio.new_event_loop()` + `loop.run_until_complete()`로 실행.
 - 🔴 **e2e ↔ tests/integration 동시 실행 금지**: `e2e/pytest.ini` 가 의도적으로 asyncio_mode 미설정 (위 E2E 격리 사유) — `pytest e2e/ tests/integration/` 같은 동시 실행 시 integration 의 async 테스트가 sync 처럼 실행 → "coroutine was never awaited" RuntimeWarning + fail. 분리 실행 default — `make test-e2e` (e2e) ↔ `pytest tests/` 또는 CI command (testpaths=tests, e2e 자동 격리).
+- **`@pytest.mark.perf` 선택 실행**: `make test-perf` = `pytest e2e/ -m perf -v --timeout=120 -p no:asyncio`. 일반 E2E(`make test-e2e`)와 분리 실행 — CI `testpaths=tests`에 포함되지 않음(자동 격리). `perf` 마커는 루트 `pytest.ini`와 `e2e/pytest.ini` 양쪽 등록됨.
 
 ## Mock + Fixture 패턴
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -356,7 +356,7 @@ GitHub Code Scanning 점검 detail 절차 + 운영 통합 = `docs/runbooks/opera
 - **TDD 우선**: 구현 코드 작성 전 반드시 `test-writer` 에이전트로 테스트를 먼저 작성한다.
 - **Hook 신뢰**: `src/` 파일 편집 후 PostToolUse Hook이 자동 실행하는 pytest 결과를 확인한다. 실패 시 다음 단계로 진행하지 않는다.
 - **Phase 완료 조건**: 테스트 전체 통과 + `/lint` 통과 + (파이프라인 변경 시 `pipeline-reviewer` 승인) 세 조건이 모두 충족될 때만 Phase 완료를 선언한다.
-- **완료 시 필수 6-step**: 작업이 완료되면 반드시 ① 커밋 → ② Codex 검증 의뢰 (push 전, 정책 18) → ③ `git push` → ④ PR 생성(`gh pr create`) → ⑤ `docs/STATE.md` 수치 갱신 → ⑥ **docs/architecture.md 동기화** (신규 파일 추가·삭제·이름 변경 시 `src/` 트리와 `### 핵심 데이터 흐름` 내 언급 갱신) 를 순서대로 수행한다. 예외 없음.
+- **완료 시 필수 6-step**: 작업이 완료되면 반드시 ① 커밋 → ② Codex 검증 의뢰 (push 전, 정책 18) → ③ `git push` → ④ PR 생성(`gh pr create`) → ⑤ `docs/STATE.md` 수치 갱신 + `docs/cycle-history.md` 사이클 이력 동기화 → ⑥ **docs/architecture.md 동기화** (신규 파일 추가·삭제·이름 변경 시 `src/` 트리와 `### 핵심 데이터 흐름` 내 언급 갱신) 를 순서대로 수행한다. 예외 없음.
 - **README.md 배지 동기화**: 테스트 수·pylint·커버리지 수치가 바뀌면 `README.md` 21~25줄 배지도 함께 갱신한다. 수치 출처는 항상 `docs/STATE.md`.
 - **CLAUDE.md 아키텍처 동기화 체크리스트**: `src/` 하위에 파일 추가 시 아래 항목을 순서대로 확인한다. 누락 시 다음 Phase 착수 전 반드시 보완한다. **전례 3건** (Phase 11 PR #73 / 2026-05-01 UI 감사 cleanup PR-D1 / 2026-05-05 사이클 78~82 5+1 cross-verify 환경변수 4건 누락).
 

--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ test-e2e-headed:
 test-perf:
 	python -m pytest e2e/ -m perf -v --timeout=120 -p no:asyncio
 
-# 성능 리포트 생성 (로컬 + 운영)
-# Generate performance report (local + production).
+# 성능 리포트 생성 (로컬 + 운영) — PYTHONIOENCODING=utf-8 로 Windows UnicodeEncodeError 방지
+# Generate performance report (local + production) — PYTHONIOENCODING=utf-8 prevents Windows UnicodeEncodeError.
 perf-report:
-	python scripts/perf_measure.py
+	PYTHONIOENCODING=utf-8 python scripts/perf_measure.py

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,7 +2,7 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-05-18 기준 — **사이클 106**: 페이지 성능 측정 E2E + 독립 스크립트 (#500)): 130+ PR #188~#500 — 누적 정책 본문 19건 + 메모리 19건. 전체 2968 수집 (2964 passed, 4 skipped, 단위 2814 + 통합 154) / E2E 111 (99 표준 + 12 perf) / pylint **10.00/10**
+## 현재 수치 (2026-05-18 기준 — **사이클 106**: 페이지 성능 측정 E2E + 독립 스크립트 (#500)): 130+ PR #188~#502 — 누적 정책 본문 19건 + 메모리 19건. 전체 2968 수집 (2964 passed, 4 skipped, 단위 2814 + 통합 154) / E2E 111 (99 표준 + 12 perf) / pylint **10.00/10**
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
@@ -61,7 +61,7 @@
 ## 작업 이력
 
 - **그룹 13~61** (2026-04 ~ 2026-05-02): [docs/_archive/STATE-groups-13-61-2026-05.md](_archive/STATE-groups-13-61-2026-05.md)
-- **사이클 62~92** (2026-05-03 ~ 2026-05-11): [docs/cycle-history.md](cycle-history.md)
+- **사이클 62~106** (2026-05-03 ~ 2026-05-18): [docs/cycle-history.md](cycle-history.md)
 - **사이클 106** (2026-05-18): 페이지 성능 측정 E2E + 독립 스크립트 (#500) — `e2e/test_performance.py` 12개 `@pytest.mark.perf` 테스트 (TTFB/FCP/LCP/DCL/Load, 3회 avg/min/max, Playwright Chromium headless, `analysis_page` fixture + `seeded_analysis` session-scope) + `scripts/perf_measure.py` 독립 실행 스크립트 (로컬 SQLite 서버 자동 시작·종료, 운영 Railway TTFB, `--local-only`/`--prod-only`, `_http_ttfb` stream=True strict TTFB, Markdown 리포트 `docs/reports/perf-*.md`) + `make test-perf`/`make perf-report` Makefile 타깃. Codex mutual 검증 OK (P1 fd 미닫음 + P2 TTFB 정확도 수정). 첫 리포트: 로컬 11 페이지 전부 ✅, `/api/github/repos` ~510ms 느린 API 포착.
 - **사이클 105** (2026-05-18): CI TruffleHog BASE==HEAD 오류 수정 (#498) — push-to-main 이벤트에서 `base: default_branch`가 HEAD와 동일 커밋을 가리켜 exit 1하던 문제 해소. 인라인 삼항 조건식 → PR/push 이벤트별 2-step 분리 + zero-SHA(첫 push/force-push) if 가드 추가. Codex mutual 검증 2회 (1차 NG→수정→2차 OK). CI TruffleHog + pytest 전체 success 확인.
 - **사이클 104** (2026-05-18): 5+1 다중 에이전트 전체 정합성 감사 + Anthropic 표준 준수 검증 (#490) — P0 5건: `docs/architecture.md` tailwind.css ghost entry 명시 + 함수명 2개 정정 (`enable_or_fallback` / `build_notification_tasks`) + github_client·railway_client 미등재 파일 추가 + E2E/메모리/배지 수치 갱신 (96→99, 18→19, 2967→2968). P1 1건: CLAUDE.md doc-consistency-reviewer 사용 범위 명확화 (cross-verify 6차 금지 → 단독 목적 허용). false-positive 2건 제거. Anthropic 표준 준수도 **93/100** 확인.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,16 @@ src/
 │   ├── generate_illustrations.py # OpenAI DALL-E 3 CLI (--all/--name/--dry-run)
 │   ├── perf_measure.py          # 페이지 성능 측정 독립 스크립트 — 로컬 SQLite 서버 자동 시작·종료 + 운영 Railway TTFB, Markdown 리포트 (사이클 106 #500)
 │   │                            # Standalone page perf script — local SQLite server auto-start/stop + prod Railway TTFB, Markdown report
+│   ├── parse_bandit.py          # bandit 보안 결과 파싱 — JSON 출력 → 이슈 목록 변환
+│   │                            # Parse bandit security results — JSON output → issue list conversion
+│   ├── parse_coverage.py        # 커버리지 결과 파싱 — coverage.py XML → 요약 통계
+│   │                            # Parse coverage results — coverage.py XML → summary stats
+│   ├── benchmark_static_analysis.py # 정적 분석 벤치마크 — 도구별 실행 시간 측정
+│   │                            # Static analysis benchmark — measure per-tool execution time
+│   ├── backfill_repository_user_id.py # repository user_id 백필 — 마이그레이션 보조 스크립트
+│   │                            # Backfill repository user_id — migration helper script
+│   ├── check_memory_refs.py     # 메모리 참조 유효성 검사 — CLAUDE.md/active.md/history.md 슬러그 ↔ 실제 파일 비교 (사이클 101 #469)
+│   │                            # Memory reference validator — slug ↔ actual file cross-check
 │   └── README.md                # 사용자 실행 가이드 + 비용 안내
 ├── config.py                    # pydantic-settings 환경변수 관리, postgres:// URL 자동 변환
 ├── constants.py                 # 전역 상수 단일 출처 — 점수배점/감점가중치/AI기본값/등급/알림한도/HTTP타임아웃/캐시TTL

--- a/docs/cycle-history.md
+++ b/docs/cycle-history.md
@@ -21,6 +21,7 @@
 - [사이클 84 (다국어 i18n 18 PR + 회고 + Tier B)](#사이클-84)
 - [사이클 85~91 (Sentry 제거 + 정책 17 신설 + 정기 검증 + Phase C RLS, 2026-05-06~07)](#사이클-8591)
 - [사이클 92~94 (정기 검증 + 정책 18 + Tailwind v4 빌드, 2026-05-07~11)](#사이클-9294)
+- [사이클 95~106 (문서 정비 + pylint 10.00 + 성능 측정 E2E, 2026-05-14~18)](#사이클-95106)
 
 ---
 
@@ -123,3 +124,18 @@
 
 - **사이클 93 (정책 18 신설 — Claude ↔ Codex 양방향 mutual 검증 의무, 2026-05-09 · #362~#371)** — CI 분석 사고 직후 mutual 검증 필요성 확인. 정책 18 신설: Claude 작업(로컬 commit) → Codex 검증 → OK 후 push / Codex 작업(로컬 commit) → Claude 검증 → OK 후 push 양방향 대칭 흐름 의무화. 17 정책 cross-reference 표 작성. NEW-P0-N 영역 (#362~#371 일부) 수정.
 - **사이클 94 (mutual 첫 운영 검증 + Tailwind v4 빌드 파이프라인 신설, 2026-05-10 · #372/#375~#379)** — chore/cycle-93-residual-tasks cherry-pick → Codex IDE Extension review NG → `_reset_repo_config()` 헬퍼 신설 → Codex OK → push (mutual 첫 운영 검증, #372). **UI 일러스트 Step 2-B (#375)**: DALL-E 3 5장 + 5페이지 마크업 + 4-테마 호환 CSS (src/static/illustrations/ + css/illustrations.css). **Tailwind v4 Hybrid 빌드 파이프라인 (#376~#378)**: main.css (소스) + css/dist/tailwind.css (빌드 출력) + npm ci && npm run build (Railway buildCommand 체인 추가) + 레이아웃 유틸리티 + CSS var 4-테마 공존. **Railway 빌드 실패 수정 (#379)**: nixpacks.toml `[phases.install]` 직접 작성 → Python venv provider 우선순위 충돌 → pip exit 127 → 제거 후 NIXPACKS Python provider 기본값 위임으로 SUCCESS.
+
+## 사이클 95~106
+
+- **사이클 95 (2026-05-14 · #410~#413)** — 문서 정비 P2: testing.md SessionLocal 경고 추가 / architecture.md mockup-polar.html 항목 / AGENTS.md 중복 표 → 링크 3건 / STATE.md 그룹 13-61 아카이브 / CLAUDE.md HTML 주석 7블록 + line 361 압축 (59줄 절감).
+- **사이클 96 (2026-05-14 · #415, #417)** — pylint 10.00/10 달성: C0415 17건 inline disable + C0301/R0913/R0917/W0718/W0613/E0401 처리. PR-D5 (#417): CLAUDE.md HTML 블록 3·5 → docs/policies/active.md 이전 (#정책-17-why-how + #정책-5-phase-종료-cross-reference 신설).
+- **사이클 97 (2026-05-14 · #420~#431)** — P0 경로 하드코딩 수정 (#420): `.codex/hooks.json` + `doc_review_gate.py` × 2 + `.claude/settings.json` + `CLAUDE.md` `f:/` → `d:/` 전수 교체. 문서 정비 (#421): AGENTS.md 완료 6-step 정정 + `.codex/rules/deploy.md` nixpacks exit127 경고. Issue #408 기능 구현 (#423): MPA 네비게이션 진행 바 + `CachedStaticFiles` + N+1 배치 IN 쿼리 2건 + `compute_score_kpi` 헬퍼 + `recurring_issue_count` 수정. 단위 2912→2914. scripts 경로 동적화 + dashboard async 블로킹 수정 (#426). 랜딩 페이지 신설 (#428) + phantom token 수정 (#429). CodeQL unused import 해소 (#431). 단위 테스트 2914→2917.
+- **사이클 98 (2026-05-15 · #433~#436)** — CodeQL py/exit-from-finally 수정 (#433): `test_router.py` finally 람다 → 명시 함수 2건. HTMX hx-boost 네비게이션 (#434): `htmx.min.js` 1.9.12 vendoring + `<body hx-boost="true">` + Chart.js `destroy()` 가드 + 회귀가드 3건 (단위 2917→2920 추정). hx-boost 후속 (#435): architecture.md 항목 + themechange boolean 플래그. stale closure 완전 수정 (#436): remove-before-add 패턴 3파일 + `.claude/rules/ui.md` 갱신.
+- **사이클 99 (2026-05-15 · #441~#445, docs/cycle99-retro-followup)** — repo_report API 9 + 통합 3 + repository_repo 4 + dashboard repos 5 + mcp 5 테스트 추가 (#441~#443). CodeQL 정비 (#445): `import pytest` 삭제 + false-positive 2건 dismiss. 회고 문서 정비: settings 싱글톤 mock 패턴 + Jinja2 None 함정 경고 + architecture.md 엔드포인트 갱신 + policies/active.md Codex 검증 섹션 추가. 단위 2914→2968 (cherry-pick 수습 포함).
+- **사이클 100 (2026-05-17 · #449)** — pytest 성능 병목 해소: `pytest.ini` `--timeout=30` 전역 적용 + starlette/fastapi DeprecationWarning 필터 + `pytest-timeout>=2.3.0` + `Makefile` `test-local` 타겟 + `test_static_analyzer.py` module-scope fixtures. 테스트 수 변동 없음 (34 passed).
+- **사이클 101 (2026-05-17 · #460~#470)** — 5+1 멀티에이전트 감사 전 항목 수정 (#460~#464): dead assertion 수정 + KeyError 방어 + GITHUB_API URL 상수화 + Gate 임계값 constants.py 단일 출처 + 테마명 정정 + TELEGRAM_WEBHOOK_SECRET 경고 + validate_external_url async화. 단위 2810→2813, 통합 125→154. 문서 감사 후속 (#466~#467): rules/ 경로·timeout·SMTP 정정 + env-vars.md 누락 항목. 회고 자유 발언 이행 (#469~#470): `scripts/check_memory_refs.py` 신설 + `Makefile` `check-memory-refs` + 5+1 에이전트 도메인 분리 표 신설.
+- **사이클 102 (2026-05-17 · #475~#477)** — `.codex/rules/ui.md` 테마명 정정 (#475). CLAUDE.md P2-1 압축: **#476 Phase 1** (~10줄 절감) + **#477 Phase 2** (~7줄 절감) + `docs/policies/history.md` 이전 3건. 5+1 에이전트 검증 + Codex mutual OK. 총 절감 ~17줄.
+- **사이클 103 (2026-05-18 · #479)** — MCP Supabase 직접 조회로 auto-merge 실패 원인 분석 → 3건 코드 수정 + Codex mutual OK 후 머지: `_trigger_retry_for_sha` 조기 반환 제거 + overdue sweep 무조건 실행 + `has_hooks` terminality `terminal` → `retriable` + `should_retry(UNSTABLE_CI, "unknown")` → `True`. 테스트 3파일 갱신 + 신규 1건 추가. 단위 2813→2814.
+- **사이클 104 (2026-05-18 · #490)** — 5+1 다중 에이전트 전체 정합성 감사 + Anthropic 표준 준수 검증: P0 5건 (architecture.md tailwind.css ghost entry + 함수명 2개 + github_client·railway_client 미등재 파일 추가 + 수치 갱신). P1 1건: doc-consistency-reviewer 사용 범위 명확화. false-positive 2건 제거. Anthropic 표준 준수도 **93/100**.
+- **사이클 105 (2026-05-18 · #498)** — CI TruffleHog BASE==HEAD 오류 수정: push-to-main 이벤트에서 `base: default_branch`가 HEAD와 동일 커밋 → exit 1 문제. 인라인 삼항 조건식 → PR/push 이벤트별 2-step 분리 + zero-SHA if 가드. Codex mutual 검증 2회 (1차 NG→수정→2차 OK).
+- **사이클 106 (2026-05-18 · #500)** — 페이지 성능 측정 E2E + 독립 스크립트: `e2e/test_performance.py` 12개 `@pytest.mark.perf` 테스트 (TTFB/FCP/LCP/DCL/Load, 3회 avg/min/max, Playwright Chromium headless) + `scripts/perf_measure.py` 독립 실행 스크립트 (로컬 SQLite 서버 자동 시작·종료, 운영 Railway TTFB, `--local-only`/`--prod-only`, stream=True strict TTFB, Markdown 리포트) + `make test-perf`/`make perf-report` 타깃. Codex mutual 검증 OK. 첫 리포트: 로컬 11 페이지 전부 ✅, `/api/github/repos` ~510ms 느린 API 포착. E2E 99→111 (+12 perf).

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -20,6 +20,7 @@ import threading
 import time
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import requests
 
@@ -274,6 +275,13 @@ def _http_ttfb(url: str, *, headers: dict | None = None, allow_redirects: bool =
 
 # ── Report generation ──────────────────────────────────────────────────────
 
+def _is_health_page(page: str) -> bool:
+    """/health 페이지 여부 정규화 판별 (쿼리 파라미터·trailing slash 무시).
+    Check if page is /health — normalises path (ignores query params and trailing slash).
+    """
+    return urlsplit(str(page)).path.rstrip("/") == "/health"
+
+
 def _fmt(v: int | None) -> str:
     """ms 값을 사람이 읽기 좋은 문자열로 변환 / Format ms value for humans."""
     if v is None:
@@ -291,7 +299,7 @@ def _verdict(metrics: dict, thresholds: dict, page: str = "") -> str:
             continue
         # /health 페이지 TTFB 는 health_ttfb 전용 임계값 적용 (더 엄격한 300ms)
         # For /health page TTFB use health_ttfb threshold (stricter 300ms)
-        if key == "ttfb" and page.endswith("/health") and "health_ttfb" in thresholds:
+        if key == "ttfb" and _is_health_page(page) and "health_ttfb" in thresholds:
             thr = thresholds["health_ttfb"]
         else:
             thr = thresholds.get(key, 9_999)
@@ -391,12 +399,12 @@ def _render_markdown(
             # health_ttfb 는 TTFB 키에 /health 페이지 한정 적용 — 중복 위반 방지
             # health_ttfb applies only to /health TTFB — skip double-counting
             if key == "health_ttfb":
-                if not r["page"].endswith("/health"):
+                if not _is_health_page(r["page"]):
                     continue
                 avg = (m.get("ttfb") or {}).get("avg")
                 report_key = "health_ttfb"
             else:
-                if key == "ttfb" and r["page"].endswith("/health"):
+                if key == "ttfb" and _is_health_page(r["page"]):
                     continue  # /health TTFB handled by health_ttfb entry above
                 avg = (m.get(key) or {}).get("avg")
                 report_key = key

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -41,7 +41,12 @@ PROD_URL = os.environ.get("PERF_PROD_URL", "https://scamanager-production.up.rai
 # Production API key — passed as X-Api-Key header (401 expected if absent).
 PERF_API_KEY = os.environ.get("PERF_API_KEY", "")
 
-THRESHOLDS_LOCAL = {"ttfb": 500, "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3000}
+THRESHOLDS_LOCAL = {
+    "ttfb": 500,
+    "health_ttfb": 300,   # /health 전용 — e2e/test_performance.py THRESHOLDS["health_ttfb"]과 동기
+    # /health-specific — kept in sync with e2e/test_performance.py THRESHOLDS["health_ttfb"]
+    "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3000,
+}
 THRESHOLDS_PROD = {"ttfb": 300, "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3000}
 
 # 로컬 테스트용 더미 API 키 / Dummy API key for local test server
@@ -276,11 +281,21 @@ def _fmt(v: int | None) -> str:
     return f"{v}ms" if v < 1000 else f"{v / 1000:.1f}s"
 
 
-def _verdict(metrics: dict, thresholds: dict) -> str:
-    """임계값 초과 시 🔴, 이내 시 ✅ 반환 / Return 🔴 if any threshold exceeded, else ✅."""
+def _verdict(metrics: dict, thresholds: dict, page: str = "") -> str:
+    """임계값 초과 시 🔴, 이내 시 ✅ 반환 — /health 는 health_ttfb 임계값 적용.
+    Return 🔴 if any threshold exceeded, else ✅ — /health uses health_ttfb threshold.
+    """
     for key in ("ttfb", "fcp", "lcp", "dcl", "load"):
         avg = (metrics.get(key) or {}).get("avg")
-        if avg is not None and avg > thresholds.get(key, 9_999):
+        if avg is None:
+            continue
+        # /health 페이지 TTFB 는 health_ttfb 전용 임계값 적용 (더 엄격한 300ms)
+        # For /health page TTFB use health_ttfb threshold (stricter 300ms)
+        if key == "ttfb" and page.endswith("/health") and "health_ttfb" in thresholds:
+            thr = thresholds["health_ttfb"]
+        else:
+            thr = thresholds.get(key, 9_999)
+        if avg > thr:
             return "🔴"
     return "✅"
 
@@ -306,7 +321,7 @@ def _render_table(results: list[dict], thresholds: dict) -> str:
                 f"| {_fmt((m.get('lcp') or {}).get('avg'))} "
                 f"| {_fmt((m.get('dcl') or {}).get('avg'))} "
                 f"| {_fmt((m.get('load') or {}).get('avg'))} "
-                f"| {_verdict(m, thresholds)} |"
+                f"| {_verdict(m, thresholds, page=r['page'])} |"
             )
     return "\n".join(rows)
 
@@ -373,10 +388,21 @@ def _render_markdown(
             continue
         m = r["metrics"]
         for key, thr in THRESHOLDS_LOCAL.items():
-            avg = (m.get(key) or {}).get("avg")
+            # health_ttfb 는 TTFB 키에 /health 페이지 한정 적용 — 중복 위반 방지
+            # health_ttfb applies only to /health TTFB — skip double-counting
+            if key == "health_ttfb":
+                if not r["page"].endswith("/health"):
+                    continue
+                avg = (m.get("ttfb") or {}).get("avg")
+                report_key = "health_ttfb"
+            else:
+                if key == "ttfb" and r["page"].endswith("/health"):
+                    continue  # /health TTFB handled by health_ttfb entry above
+                avg = (m.get(key) or {}).get("avg")
+                report_key = key
             if avg is not None and avg > thr:
                 violations.append(
-                    f"- 🏠 {r['page']} **{key.upper()}**: {_fmt(avg)} (>{_fmt(thr)})"
+                    f"- 🏠 {r['page']} **{report_key.upper()}**: {_fmt(avg)} (>{_fmt(thr)})"
                 )
     for r in (prod_results or []):
         if r.get("auth_only"):


### PR DESCRIPTION
## Summary

사이클 106 회고 5+1 에이전트 분석 결과 반영 + Codex mutual 검증 NG 수정.

- **P0 수정**: `Makefile` `perf-report:` 타겟에 `PYTHONIOENCODING=utf-8` 추가 — Windows cp949 환경 UnicodeEncodeError 방지
- **P1 수정**: `scripts/perf_measure.py` — `/health` 전용 `health_ttfb: 300ms` 임계값 분리 (`THRESHOLDS_LOCAL`) + `_is_health_page()` 헬퍼 (urlsplit 기반 정규화 — Codex NG 항목 1 수정)
- **문서 규칙**: `.claude/rules/testing.md` — `@pytest.mark.perf` 마커 실행 지침 추가
- **CLAUDE.md 6-step**: ⑤ `docs/STATE.md` 수치 갱신 + `docs/cycle-history.md` 사이클 이력 동기화 추가
- **docs/STATE.md**: PR 헤더 `#188~#500` → `#188~#502` 갱신 + cycle-history.md 아카이브 범위 `62~92` → `62~106`
- **docs/architecture.md**: `scripts/` 섹션 누락 파일 5개 추가 (`parse_bandit.py`, `parse_coverage.py`, `benchmark_static_analysis.py`, `backfill_repository_user_id.py`, `check_memory_refs.py`)
- **docs/cycle-history.md**: 사이클 95~106 이력 12건 추가

## Codex Mutual 검증 (정책 18)

- 1차 Codex 검증: 항목 2(이중 계산 방지) OK / 항목 3(report_key) OK / 항목 1(endswith 엣지 케이스) **NG**
- NG 수정: `endswith("/health")` → `_is_health_page(urlsplit 기반)` 3곳 교체
- 2차 Codex 재검증: 샌드박스 OS 오류 (`CreateProcessAsUserW failed: 1920`) → grep 직접 확인 + 사용자 push 승인으로 대체

## 🔍 사용자 검증 필요

- [ ] Windows 환경에서 `make perf-report` 실행 — UnicodeEncodeError 없이 완료되는지 확인
- [ ] `docs/cycle-history.md` 사이클 95~106 이력 내용 검토 (STATE.md에서 추출, 누락/오류 여부)
- [ ] `CLAUDE.md` 6-step ⑤ cycle-history.md 추가 내용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)