### PR TITLE
perf: /api/github/repos TTL 캐시 추가 — GitHub API 중복 호출 방지

### DIFF
--- a/src/ui/routes/add_repo.py
+++ b/src/ui/routes/add_repo.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import secrets
+import time
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -20,6 +21,13 @@ from src.repositories import repo_config_repo, repository_repo
 from src.ui._helpers import GITHUB_WEBHOOK_PATH, get_locale, templates, webhook_base_url
 
 router = APIRouter()
+
+# user_id → (repos_list, expiry_monotonic) — GitHub API 중복 호출 방지 TTL 캐시
+# user_id → (repos_list, expiry_monotonic) — TTL cache to avoid redundant GitHub API calls.
+_user_repos_cache: dict[int, tuple[list[dict], float]] = {}
+# _required_contexts_cache / _webhook_secret_cache 와 동일 5분 TTL
+# Same 5-minute TTL as _required_contexts_cache / _webhook_secret_cache.
+_USER_REPOS_CACHE_TTL = 300
 
 
 @router.get("/repos/add", response_class=HTMLResponse)
@@ -44,19 +52,29 @@ async def github_repos_list(
     # Return empty list if token missing (prevent 401 propagation)
     if not current_user.plaintext_token:
         return []
+
+    # GitHub API 응답은 TTL 캐시로 재사용 — existing_names 는 항상 최신 DB 조회
+    # Reuse GitHub API response via TTL cache — existing_names always queries fresh DB.
+    now = time.monotonic()
+    cached = _user_repos_cache.get(current_user.id)
+    if cached and now < cached[1]:
+        all_repos = cached[0]
+    else:
+        try:
+            all_repos = await list_user_repos(current_user.plaintext_token)
+        except Exception:
+            # GitHub API 오류(401/403/429/timeout) 시 빈 목록 반환
+            # Return empty list on GitHub API error (401/403/429/timeout)
+            return []
+        _user_repos_cache[current_user.id] = (all_repos, now + _USER_REPOS_CACHE_TTL)
+
     with SessionLocal() as db:
         existing_names = {
             r.full_name for r in db.query(Repository).filter(
                 Repository.user_id == current_user.id
             ).all()
         }
-    try:
-        repos = await list_user_repos(current_user.plaintext_token)
-    except Exception:
-        # GitHub API 오류(401/403/429/timeout) 시 빈 목록 반환
-        # Return empty list on GitHub API error (401/403/429/timeout)
-        return []
-    return [r for r in repos if r["full_name"] not in existing_names]
+    return [r for r in all_repos if r["full_name"] not in existing_names]
 
 
 @router.post("/repos/add")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ os.environ["GITHUB_CLIENT_SECRET"] = "test-github-client-secret"
 os.environ["SESSION_SECRET"] = "test-session-secret-32-chars-long!"
 
 from src.main import app
+from src.ui.routes import add_repo as _add_repo_module
 from src.webhook import router as webhook_router
 
 
@@ -28,6 +29,15 @@ def _clear_webhook_secret_cache():
     webhook_router._webhook_secret_cache.clear()
     yield
     webhook_router._webhook_secret_cache.clear()
+
+
+@pytest.fixture(autouse=True)
+def _clear_user_repos_cache():
+    # GitHub 리포 TTL 캐시 — 테스트 간 격리 보장
+    # Clear GitHub repos TTL cache to ensure test isolation.
+    _add_repo_module._user_repos_cache.clear()
+    yield
+    _add_repo_module._user_repos_cache.clear()
 
 
 @pytest.fixture

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -596,6 +596,50 @@ def test_api_github_repos_excludes_already_registered():
     assert "owner/repo-a" in full_names
 
 
+def test_api_github_repos_cache_hit():
+    """두 번 호출 시 list_user_repos는 1회만 실행된다 (캐시 히트)."""
+    from unittest.mock import AsyncMock, patch
+
+    mock_repos = [{"full_name": "owner/repo-a", "private": False, "description": ""}]
+
+    with patch("src.ui.routes.add_repo.list_user_repos", new_callable=AsyncMock, return_value=mock_repos) as mock_fn:
+        with patch("src.ui.routes.add_repo.SessionLocal") as mock_sl:
+            mock_db = MagicMock()
+            mock_db.query.return_value.filter.return_value.all.return_value = []
+            mock_sl.return_value.__enter__.return_value = mock_db
+            client.get("/api/github/repos")
+            client.get("/api/github/repos")
+
+    # 두 번 호출해도 GitHub API는 1회만 호출 (2번째는 캐시 히트)
+    # GitHub API called only once despite two requests (second hits cache).
+    assert mock_fn.call_count == 1
+
+
+def test_api_github_repos_cache_expired():
+    """캐시 만료 후 list_user_repos가 재호출된다."""
+    from unittest.mock import AsyncMock, patch
+    import src.ui.routes.add_repo as _mod
+
+    mock_repos = [{"full_name": "owner/repo-a", "private": False, "description": ""}]
+
+    with patch("src.ui.routes.add_repo.list_user_repos", new_callable=AsyncMock, return_value=mock_repos) as mock_fn:
+        with patch("src.ui.routes.add_repo.SessionLocal") as mock_sl:
+            mock_db = MagicMock()
+            mock_db.query.return_value.filter.return_value.all.return_value = []
+            mock_sl.return_value.__enter__.return_value = mock_db
+            client.get("/api/github/repos")
+            # 캐시 만료 시뮬레이션 — expiry를 과거로 강제 조작
+            # Simulate expiry by forcing the cached timestamp into the past.
+            for uid in list(_mod._user_repos_cache):
+                repos_list, _ = _mod._user_repos_cache[uid]
+                _mod._user_repos_cache[uid] = (repos_list, 0.0)
+            client.get("/api/github/repos")
+
+    # 만료 후 재호출 — GitHub API 2회
+    # After expiry, API is called again — total 2 calls.
+    assert mock_fn.call_count == 2
+
+
 def test_add_repo_post_creates_repo_and_webhook():
     """POST /repos/add는 리포를 DB에 저장하고 Webhook을 생성한 후 리다이렉트한다."""
     from unittest.mock import AsyncMock, patch, MagicMock


### PR DESCRIPTION
## Summary

- `/api/github/repos` 엔드포인트가 매 요청마다 GitHub API를 호출해 ~510ms 지연 발생
- `user_id` 키 기반 5분 TTL 캐시(`_user_repos_cache`)를 추가해 두 번째 요청부터 캐시 히트
- `existing_names` (등록된 리포 목록)은 캐시 제외 — 리포 등록 직후 즉시 드롭다운에서 제외됨
- 기존 `_webhook_secret_cache` / `_required_contexts_cache` 와 동일한 TTL 패턴 사용

## 변경 파일

| 파일 | 내용 |
|------|------|
| `src/ui/routes/add_repo.py` | `_user_repos_cache` dict + 5분 TTL 캐시 로직 추가 |
| `tests/conftest.py` | `_clear_user_repos_cache` autouse fixture (테스트 격리) |
| `tests/unit/ui/test_router.py` | 캐시 히트(1회 API 호출) + 만료(2회 API 호출) 테스트 2건 |

## Test plan

- [x] `make test` — 2966 passed, 4 skipped (기존 2964 + 신규 2)
- [x] Codex mutual 검증 OK

## 🔍 사용자 검증 필요

- [ ] `/repos/add` 페이지에서 리포 추가 후 드롭다운 즉시 갱신 확인 (캐시가 GitHub 목록만 유지, DB 필터는 매번 최신)

🤖 Generated with [Claude Code](https://claude.com/claude-code)