### PR TITLE
fix(perf): requests.Session 재사용 + pre-commit 주석 보강

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,10 @@ repos:
         description: |
           환경변수에 실제 값이 하드코딩된 경우 차단.
           os.getenv() 또는 os.environ 참조 방식만 허용.
-          README/docs/tests 는 문서 예시값 허용을 위해 제외.
+          README/docs 는 문서 예시값 허용을 위해 제외.
+          tests/e2e 제외 사유: Python os.environ["KEY"] = "value" 형식은 값 앞뒤 따옴표로 인해
+          패턴 [^${'"\s]{10,} 이 매칭되지 않아 실질적 탐지 불필요.
+          단, .env 스타일 KEY=value (따옴표 없음) 형식은 매칭되므로 forward-looking 보호로 제외 유지.
 
   # Layer 1-C: 기본 코드 품질 훅
   # Layer 1-C: Basic code quality hooks

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -257,14 +257,16 @@ def _http_ttfb(url: str, *, headers: dict | None = None, allow_redirects: bool =
             pass
         for _ in range(3):
             try:
-                # stream=True: 응답 헤더만 수신 후 반환 — body 다운로드 제외 (strict TTFB)
-                # stream=True: returns after receiving headers only — excludes body download (strict TTFB)
+                # stream=True: 응답 헤더만 수신 후 반환 — r.elapsed 는 헤더 수신 시점까지만 측정 (strict TTFB)
+                # stream=True: r.elapsed captures only time-to-headers receipt (strict TTFB)
                 with session.get(
                     url, headers=headers or {}, allow_redirects=allow_redirects,
                     timeout=10, stream=True,
                 ) as r:
                     times.append(r.elapsed.total_seconds() * 1000)
                     status = r.status_code
+                    r.content  # 커넥션 풀 반환 보장 — body 소비 후 안전 반환 (미소비 시 소켓 파기)
+                    # Drain body so urllib3 returns the connection to the pool (undrained = socket discarded)
             except Exception:  # noqa: BLE001
                 pass
     avg = round(sum(times) / len(times)) if times else None

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -248,18 +248,25 @@ def _http_ttfb(url: str, *, headers: dict | None = None, allow_redirects: bool =
     """
     times: list[float] = []
     status = None
-    for _ in range(3):
+    with requests.Session() as session:
+        # 워밍업 — TCP 연결 수립, Windows IPv6→IPv4 DNS fallback 지연 제거, 측정값 제외
+        # Warmup — establish TCP connection, eliminates Windows IPv6→IPv4 DNS fallback latency, excluded from measurements
         try:
-            # stream=True: 응답 헤더만 수신 후 반환 — body 다운로드 제외 (strict TTFB)
-            # stream=True: returns after receiving headers only — excludes body download (strict TTFB)
-            with requests.get(
-                url, headers=headers or {}, allow_redirects=allow_redirects,
-                timeout=10, stream=True,
-            ) as r:
-                times.append(r.elapsed.total_seconds() * 1000)
-                status = r.status_code
+            session.get(url, headers=headers or {}, allow_redirects=allow_redirects, timeout=10)
         except Exception:  # noqa: BLE001
             pass
+        for _ in range(3):
+            try:
+                # stream=True: 응답 헤더만 수신 후 반환 — body 다운로드 제외 (strict TTFB)
+                # stream=True: returns after receiving headers only — excludes body download (strict TTFB)
+                with session.get(
+                    url, headers=headers or {}, allow_redirects=allow_redirects,
+                    timeout=10, stream=True,
+                ) as r:
+                    times.append(r.elapsed.total_seconds() * 1000)
+                    status = r.status_code
+            except Exception:  # noqa: BLE001
+                pass
     avg = round(sum(times) / len(times)) if times else None
     return {
         "ttfb": {


### PR DESCRIPTION
## 변경 내용

### 1. `scripts/perf_measure.py` — `_http_ttfb()` Session 재사용 + warmup

**문제**: `requests.get()` 매 호출마다 새 TCP 연결 수립 → Windows IPv6→IPv4 DNS fallback 지연 (~667ms/req) 발생.

**수정**:
- `requests.Session()` 컨텍스트 매니저로 커넥션 풀 공유
- warmup 1회(측정 제외) → 첫 timed 요청부터 재사용 커넥션 적용
- `r.content` drain 추가 → `stream=True` 미소비 시 소켓 파기 방지, 커넥션 풀 반환 보장

`r.elapsed`는 body 소비와 무관하게 헤더 수신 시점까지만 측정(strict TTFB 유지).

> PR #504 `test_health_ttfb`에서 동일 패턴 적용 — 동일 근거 일관 적용.

### 2. `.pre-commit-config.yaml` — `check-secrets-in-diff` description 보강

`tests/` 및 `e2e/` 제외 사유를 명시:
- Python `os.environ["KEY"] = "value"` 형식은 값 앞뒤 따옴표로 인해 `[^${'"\s]{10,}` 패턴 불일치 → 실질적 탐지 불필요
- `.env` 스타일 `KEY=value` (따옴표 없음) 형식은 매칭되므로 forward-looking 보호로 제외 유지

## 테스트

- `pytest tests/` → 2966 passed, 4 skipped ✅
- pre-commit 전체 통과 ✅
- Codex mutual 검증 OK ✅ (Policy 18)

## 🔍 사용자 검증 필요

- [ ] `make test-perf` 실행 시 TTFB 수치 안정성 확인 (Windows 환경)