### PR TITLE
fix(ui): 점수 추이 차트 빈 상태 가시성 개선

### DIFF
--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -93,19 +93,21 @@
     position: relative;
     height: clamp(200px, 30vw, 320px);
   }
-  /* 빈 상태 / Empty state */
+  /* 빈 상태 — position absolute로 컨테이너 전체 채움 / Empty state fills container via absolute */
   .chart-empty-state {
     display: none;
+    position: absolute;
+    inset: 0;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: clamp(200px, 30vw, 320px);
     gap: .75rem;
     color: var(--text-2);
-    opacity: .45;
+    opacity: .75;
   }
   .chart-empty-state svg { width: 40px; height: 40px; }
   .chart-empty-state span { font-size: 13px; }
+  .chart-empty-state .chart-empty-sub { font-size: 11px; opacity: .7; }
   .history-header {
     display: flex;
     align-items: center;
@@ -381,6 +383,7 @@
         <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
       </svg>
       <span id="chartEmptyText">분석 이력이 없습니다</span>
+      <span class="chart-empty-sub">Push 또는 PR 이벤트 후 첫 분석이 완료되면 차트가 표시됩니다</span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 문제

`xzawed/SCAManager`처럼 분석 이력이 없는 리포에서 차트 영역이 빈 어두운 사각형으로 표시됨.
- `buildChart([])` 호출 시 canvas를 숨기고 `#chartEmpty`를 `display:flex`로 변경하지만
- `opacity: .45`가 적용되어 어두운 배경에서 SVG/텍스트가 거의 보이지 않았음
- `position: absolute` 없이 자체 `height: clamp(...)` 사용 → 컨테이너와 정합이 불완전했음

## 수정 내용

| 항목 | 이전 | 수정 후 |
|------|------|---------|
| `opacity` | `.45` (거의 투명) | `.75` (가독 가능) |
| `position` | 기본 (in-flow) | `absolute; inset: 0` (컨테이너 정확히 채움) |
| 자체 `height` | `clamp(200px, 30vw, 320px)` | 제거 (`inset: 0`이 담당) |
| 서브텍스트 | 없음 | "Push 또는 PR 이벤트 후 첫 분석이 완료되면 차트가 표시됩니다" |

## 동작 확인

- **데이터 있을 때**: canvas 표시 + empty state `display:none` → 기존 차트 정상 렌더
- **데이터 없을 때**: canvas `display:none` + empty state `display:flex; position:absolute; inset:0` → 컨테이너 전체에 아이콘+텍스트 표시

JS/백엔드 변경 없음. CSS + HTML only.

## 🔍 사용자 검증 필요

> 정책 11 — Claude는 시각 정합성을 코드로만 검증. 4-테마 × 모바일/데스크탑 8조합 확인 필요.

- [ ] dark 테마: 차트 없는 리포 방문 시 빈 상태 아이콘+텍스트+서브텍스트 표시 확인
- [ ] light 테마: 동일 확인
- [ ] glass / claude-dark 테마: opacity .75에서 대비 적절한지 확인
- [ ] 모바일(768px 이하): 서브텍스트 줄바꿈 없이 읽기 가능한지 확인

🔍 Codex 검증: VERDICT OK (push 전)