### PR TITLE
fix(ui): 페이지 이동 후 테마 변경 시 차트 미반영 수정 (3파일)

### DIFF
--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -691,38 +691,43 @@
 <script src="/static/vendor/chart.umd.min.js"></script>
 <script>
 (function() {
+  /* TREND/CURRENT_ID/REPO_NAME — Jinja 주입값, 스크립트 최초 실행 시 1회 확정
+     Jinja-injected values fixed at script execution time — not re-read on theme change */
   var TREND = {{ trend_data | tojson }};
   var CURRENT_ID = {{ analysis.id }};
   var REPO_NAME = {{ repo_name | tojson }};
 
-  var canvas = document.getElementById('trendChart');
-  if (!canvas) return;
+  /* 차트 빌드 함수 — themechange 마다 재호출 가능하도록 named function으로 분리
+     Named function so it can be re-invoked on themechange (theme color re-read) */
+  function _buildAnalysisChart() {
+    var canvas = document.getElementById('trendChart');
+    if (!canvas) return;
 
-  var s = getComputedStyle(document.body);
-  /* --accent-rgb 기반 accent 색상 (테마 호환) / --accent-rgb based accent color (theme compatible) */
-  var accentRgb = s.getPropertyValue('--accent-rgb').trim();
-  var accent = accentRgb ? ('rgb(' + accentRgb + ')') : (s.getPropertyValue('--accent').trim() || '#6366f1');
-  var muted  = s.getPropertyValue('--text-2').trim() || s.getPropertyValue('--text-muted').trim() || '#64748b';
-  var border = s.getPropertyValue('--border-subtle').trim() || s.getPropertyValue('--border').trim() || '#2d3748';
-  /* PR-3 F3: tooltip 색을 테마 토큰에서 동적 read — 라이트/claude-dark 부조화 해소
-     PR-3 F3: tooltip colors read from theme tokens — light/claude-dark harmony */
-  var tipBg   = s.getPropertyValue('--bg-card').trim() || '#1c1c23';
-  var tipText = s.getPropertyValue('--text-1').trim() || s.getPropertyValue('--text-primary').trim() || '#e2e2e8';
-  /* Step D: 현재 분석 강조 색을 var(--danger) 에서 읽기 (3-테마 + claude-dark 호환)
-     Step D: read current-point highlight from var(--danger) for theme harmony */
-  var dangerColor = s.getPropertyValue('--danger').trim() || '#ef4444';
+    var s = getComputedStyle(document.body);
+    /* --accent-rgb 기반 accent 색상 (테마 호환) / --accent-rgb based accent color (theme compatible) */
+    var accentRgb = s.getPropertyValue('--accent-rgb').trim();
+    var accent = accentRgb ? ('rgb(' + accentRgb + ')') : (s.getPropertyValue('--accent').trim() || '#6366f1');
+    var muted  = s.getPropertyValue('--text-2').trim() || s.getPropertyValue('--text-muted').trim() || '#64748b';
+    var border = s.getPropertyValue('--border-subtle').trim() || s.getPropertyValue('--border').trim() || '#2d3748';
+    /* PR-3 F3: tooltip 색을 테마 토큰에서 동적 read — 라이트/claude-dark 부조화 해소
+       PR-3 F3: tooltip colors read from theme tokens — light/claude-dark harmony */
+    var tipBg   = s.getPropertyValue('--bg-card').trim() || '#1c1c23';
+    var tipText = s.getPropertyValue('--text-1').trim() || s.getPropertyValue('--text-primary').trim() || '#e2e2e8';
+    /* Step D: 현재 분석 강조 색을 var(--danger) 에서 읽기 (3-테마 + claude-dark 호환)
+       Step D: read current-point highlight from var(--danger) for theme harmony */
+    var dangerColor = s.getPropertyValue('--danger').trim() || '#ef4444';
 
-  /* --bg-base 토큰에서 포인트 테두리 색상 읽기 (4-테마 자동 호환)
-     Read point border color from --bg-base token (auto 4-theme compat) */
-  var bgBase = getComputedStyle(document.documentElement).getPropertyValue('--bg-base').trim() || '#ffffff';
-  var pointColors  = TREND.map(function(t) { return t.id === CURRENT_ID ? dangerColor : accent; });
-  var pointRadii   = TREND.map(function(t) { return t.id === CURRENT_ID ? 7 : 3; });
-  var pointBorders = TREND.map(function(t) { return t.id === CURRENT_ID ? bgBase : accent; });
+    /* --bg-base: themes.css 가 body[data-theme]에 정의 → documentElement 아닌 body 기준
+       --bg-base defined on body[data-theme] in themes.css — read from body, not documentElement */
+    var bgBase = s.getPropertyValue('--bg-base').trim() || '#07070f';
+    var pointColors  = TREND.map(function(t) { return t.id === CURRENT_ID ? dangerColor : accent; });
+    var pointRadii   = TREND.map(function(t) { return t.id === CURRENT_ID ? 7 : 3; });
+    var pointBorders = TREND.map(function(t) { return t.id === CURRENT_ID ? bgBase : accent; });
 
-  // 동일 canvas 재사용 전 기존 Chart 인스턴스 제거 (hx-boost 재방문 대비)
-  // Destroy existing Chart instance before reuse (guard for hx-boost re-navigation)
-  var _existing = (window.Chart && Chart.getChart) ? Chart.getChart(canvas) : null;
-  if (_existing) _existing.destroy();
+    /* 동일 canvas 재사용 전 기존 Chart 인스턴스 제거 (hx-boost 재방문 + themechange 재빌드 대비)
+       Destroy existing instance before rebuild (guard for hx-boost re-navigation & theme rebuild) */
+    var _existing = (window.Chart && Chart.getChart) ? Chart.getChart(canvas) : null;
+    if (_existing) _existing.destroy();
 
   new Chart(canvas, {
     type: 'line',
@@ -791,6 +796,19 @@
       maintainAspectRatio: false
     }
   });
+  } // end _buildAnalysisChart
+
+  /* 최초 렌더 / Initial render */
+  _buildAnalysisChart();
+
+  /* themechange — remove-before-add 패턴 (ui.md: _<pageScope><Domain>Handler)
+     hx-boost 재방문 시 stale closure 방지 + 테마 전환 시 차트 색상 재빌드
+     Prevent stale closure on hx-boost revisit; rebuild chart colors on theme change */
+  if (document._adThemeHandler) {
+    document.removeEventListener('themechange', document._adThemeHandler);
+  }
+  document._adThemeHandler = _buildAnalysisChart;
+  document.addEventListener('themechange', document._adThemeHandler);
 })();
 </script>
 {% endif %}

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1187,8 +1187,13 @@
   // Trend data (server-injected) — autoescape safe
   const trendData = {{ trend | tojson }};
 
+  /* --d-accent 등 .dashboard-page scoped 토큰은 documentElement에서 읽으면 빈 값 반환
+     (CSS 변수는 하위→상위 방향 상속 불가). .dashboard-page 요소 기준으로 읽어야 올바른 값 반환.
+     Scoped tokens like --d-accent must be read from .dashboard-page element —
+     CSS custom props don't inherit upward to documentElement. */
   function readVar(name, fallback) {
-    const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    var el = document.querySelector('.dashboard-page') || document.body;
+    const v = getComputedStyle(el).getPropertyValue(name).trim();
     return v || fallback;
   }
 

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -626,7 +626,7 @@
       function buildRepoTrendChart() {
         var ctx = document.getElementById('repoTrendChart');
         if (!ctx) return;
-        var cs = getComputedStyle(document.documentElement);
+        var cs = getComputedStyle(document.body);
         // CSS 변수로만 색상 결정 — hex 직접 사용 금지 (ui.md 의무)
         // Color determined solely via CSS variables — no hex fallbacks (ui.md rule)
         var colorBorder = cs.getPropertyValue('--accent-primary').trim() || cs.getPropertyValue('--accent').trim();

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -633,13 +633,23 @@
     });
   }
 
-  /* hx-boost 재방문 시 stale closure 방지 — remove-before-add 패턴
-     Prevent stale closure on hx-boost revisit — remove-before-add pattern */
+  /* themechange — remove-before-add 패턴: hx-boost 재방문 시 stale closure 방지
+     themechange remove-before-add: prevent stale closure on hx-boost revisit */
   if (document._repoThemeHandler) {
     document.removeEventListener('themechange', document._repoThemeHandler);
   }
   document._repoThemeHandler = function() { buildChart(); };
   document.addEventListener('themechange', document._repoThemeHandler);
+
+  /* htmx 재방문(historyRestore/afterSettle) 시 차트 재빌드 — remove-before-add 패턴
+     Rebuild chart on htmx historyRestore (back button) & afterSettle — remove-before-add */
+  if (document._repoHtmxHandler) {
+    document.removeEventListener('htmx:afterSettle', document._repoHtmxHandler);
+    document.removeEventListener('htmx:historyRestore', document._repoHtmxHandler);
+  }
+  document._repoHtmxHandler = function() { buildChart(); };
+  document.addEventListener('htmx:afterSettle', document._repoHtmxHandler);
+  document.addEventListener('htmx:historyRestore', document._repoHtmxHandler);
 </script>
 <script>
 // ── 데이터 주입 ──────────────────────────────────────

--- a/src/templates/repo_insights.html
+++ b/src/templates/repo_insights.html
@@ -204,7 +204,7 @@
   const breakdown = {{ breakdown | tojson }};
 
   function readVar(name, fallback) {
-    const v = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+    const v = getComputedStyle(document.body).getPropertyValue(name).trim();
     return v || fallback;
   }
 
@@ -249,6 +249,16 @@
   }
   document._riThemeHandler = buildRiChart;
   document.addEventListener('themechange', document._riThemeHandler);
+
+  /* htmx 재방문(historyRestore/afterSettle) 시 차트 재빌드 — remove-before-add 패턴
+     Rebuild chart on htmx historyRestore (back button) & afterSettle — remove-before-add */
+  if (document._riHtmxHandler) {
+    document.removeEventListener('htmx:afterSettle', document._riHtmxHandler);
+    document.removeEventListener('htmx:historyRestore', document._riHtmxHandler);
+  }
+  document._riHtmxHandler = buildRiChart;
+  document.addEventListener('htmx:afterSettle', document._riHtmxHandler);
+  document.addEventListener('htmx:historyRestore', document._riHtmxHandler);
 })();
 </script>
 {% endif %}


### PR DESCRIPTION
## 🎯 수정 내용

페이지 간 이동 후 테마를 변경했을 때 차트가 제대로 갱신되지 않는 버그 3건 수정.

### P0 — analysis_detail.html: themechange 핸들러 완전 부재
- 차트 초기화가 IIFE 단독 실행 → 이름 있는 함수 `_buildAnalysisChart()`로 추출
- `document._adThemeHandler` remove-before-add 패턴으로 등록
- `bgBase` CSS var를 `documentElement` → `document.body`로 수정 (themes.css는 `body[data-theme]`에 정의)

### P0 — repo_detail.html: htmx:historyRestore 미처리
- 브라우저 뒤로가기 시 `htmx:historyRestore`가 발화하지만 인라인 스크립트 미재실행
- `_repoHtmxHandler` remove-before-add로 `htmx:afterSettle` + `htmx:historyRestore` 등록

### P1 — dashboard.html: scoped CSS 토큰 읽기 대상 오류
- `readVar()`: `documentElement` → `.dashboard-page || body` (`--d-*` 토큰은 `.dashboard-page`에 scoped)
- `buildRepoTrendChart()`: 동일 이유로 `documentElement` → `body` (Codex NG Finding 1)

## 🔍 검증

- **5+1 다중 에이전트 조사** (이전 대화): P0×2 + P1×1 확인, 허위 양성 2건 기각
- **Codex mutual 검증**: 1차 VERDICT: NG (Finding 1 미수정) → 수정 후 VERDICT: OK
- **themes.css 실측**: `body[data-theme="..."]` 선택자에 정의, `html`/`:root` 아님 확인

## 🔍 사용자 검증 필요 (정책 11 — 8 조합 체크리스트)

| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] analysis_detail 테마 변경 후 차트 색 갱신 | [ ] |
| light | [ ] repo_detail 뒤로가기 후 테마 변경 | [ ] |
| pastel | [ ] dashboard repos 탭 테마 변경 | [ ] |
| catppuccin | [ ] | [ ] |

- [ ] 페이지 이동 순서: repo_detail → analysis_detail → 뒤로가기 → 테마 변경 → 차트 확인
- [ ] dashboard repos 탭 활성화 상태에서 테마 변경 → 선 색상 갱신 확인

> ⚠️ Claude는 정적 코드 검증만 가능. 실제 테마 토글 + 차트 색 반영은 사용자 직접 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)