### PR TITLE
fix(ui): base.html 프로그레스 바 뒤로가기 시 mid-animation 고착 수정

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -996,6 +996,9 @@
       // hx-boost 네비게이션 완료 → 프로그레스 바 완료 (실제 지연 제거 핵심)
       // hx-boost navigation settled → finish progress bar (key to real latency elimination)
       document.addEventListener('htmx:afterSettle', _finishProgress);
+      // 뒤로가기(historyRestore) 시 mid-animation 고착 방지
+      // Prevent progress bar from freezing mid-animation on back navigation
+      document.addEventListener('htmx:historyRestore', _finishProgress);
 
       // 일반 페이지 언로드 폴백 (외부 링크, HTMX 미개입 경우)
       // Fallback for non-HTMX navigations (external links, forms bypassing HTMX)


### PR DESCRIPTION
## 수정 내용

브라우저 뒤로가기(`htmx:historyRestore`) 시 프로그레스 바가 mid-animation 상태로 화면에 고착되는 버그 수정.

### 원인
`_finishProgress()`가 `htmx:afterSettle`에만 등록되어 있고 `htmx:historyRestore`에는 미등록. 사용자가 링크 클릭(progress 0→70% 애니메이션 시작) 후 뒤로가기를 누르면 프로그레스 바가 완료되지 않고 화면에 남음.

### 수정
```js
document.addEventListener('htmx:historyRestore', _finishProgress);
```
`htmx:afterSettle` 바로 아래에 추가. `_finishProgress`는 RAF 취소 → `scaleX(1)` → 200ms 후 `is-loading` 제거로 자연스럽게 페이드아웃.

### Codex 검증 결과
- `_finishProgress` vs `_resetProgress` 선택: `_finishProgress` 정확 (afterSettle과 동일 완료 경로)
- remove-before-add 불필요 확인 (IIFE 단일 실행, 중복 등록 경로 없음)
- BFCache `pageshow persisted` → `_resetProgress` 분리 유지 확인
- VERDICT: OK

## 🔍 사용자 검증 필요 (정책 11)

| 시나리오 | 확인 |
|---------|------|
| 링크 클릭 직후 즉시 뒤로가기 → 프로그레스 바 사라짐 확인 | [ ] |
| 일반 페이지 이동 프로그레스 바 정상 동작 확인 (회귀 없음) | [ ] |

> ⚠️ Claude는 정적 코드 검증만 가능. 실제 브라우저 동작은 사용자 직접 확인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)