### PR TITLE
fix(security): RLS SET LOCAL f-string → 파라미터화 쿼리 (P0)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -254,7 +254,9 @@ def _set_rls_user_id_per_query(  # pylint: disable=too-many-arguments,too-many-p
         # Even if contextvars introspection fails, keep the query path alive
         return
     val = str(user_id) if user_id else ""
-    cursor.execute(f"SET LOCAL app.user_id = '{val}'")
+    # f-string SQL 인젝션 방지 — 파라미터화 쿼리로 안전하게 처리
+    # Prevent f-string SQL injection — use parameterized query
+    cursor.execute("SET LOCAL app.user_id = %s", (val,))
 
 
 # 운영 engine 에 listener 등록 — PG 환경에서만 실효 (SQLite skip 분기 내장)

--- a/tests/unit/test_rls_event_listener.py
+++ b/tests/unit/test_rls_event_listener.py
@@ -86,7 +86,7 @@ def test_listener_emits_set_local_on_postgresql_with_user_id(
     _set_rls_user_id_per_query(
         mock_pg_conn, mock_cursor, "SELECT 1", {}, None, False
     )
-    mock_cursor.execute.assert_called_once_with("SET LOCAL app.user_id = '42'")
+    mock_cursor.execute.assert_called_once_with("SET LOCAL app.user_id = %s", ("42",))
 
 
 # ---------------------------------------------------------------------------
@@ -101,7 +101,7 @@ def test_listener_emits_empty_on_postgresql_no_user(mock_pg_conn, mock_cursor):
     _set_rls_user_id_per_query(
         mock_pg_conn, mock_cursor, "SELECT 1", {}, None, False
     )
-    mock_cursor.execute.assert_called_once_with("SET LOCAL app.user_id = ''")
+    mock_cursor.execute.assert_called_once_with("SET LOCAL app.user_id = %s", ("",))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 변경 내용

`src/database.py`의 `_set_rls_user_id_per_query` 함수에서 RLS user_id 컨텍스트를 PostgreSQL에 전달하는 `SET LOCAL` 구문이 f-string 직접 보간 방식으로 작성되어 있어 SQL 인젝션 취약점이 존재했습니다. psycopg2 파라미터화 쿼리(`%s`) 방식으로 교체하여 차단합니다.

### 수정 파일

- `src/database.py` — `SET LOCAL app.user_id = '{val}'` → `SET LOCAL app.user_id = %s` + `(val,)` 파라미터
- `tests/unit/test_rls_event_listener.py` — assert 2건을 새 호출 시그니처에 동기화

### 테스트 결과

- 전체 2966 테스트 통과, 4 skipped
- 관련 테스트: `tests/unit/test_rls_event_listener.py` (B.2, B.3 케이스)

---

## 🔍 사용자 검증 필요

| # | 확인 항목 | 방법 |
|---|-----------|------|
| 1 | `src/database.py:257` 파라미터화 쿼리 수정 확인 | 파일 직접 확인 |
| 2 | 단위 테스트 전체 통과 확인 | `make test` |
| 3 | Railway PostgreSQL 환경에서 RLS `SET LOCAL app.user_id` 여전히 정상 동작 확인 | 배포 후 인증된 사용자로 대시보드 접근 → 본인 리포만 조회되는지 확인 |