### PR TITLE
fix(ui): base.html hx-boost 핸들러 누적 등록 버그 수정 (P1)

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -789,7 +789,11 @@
         }
       });
     });
-    document.addEventListener('click', () => { switcher.classList.remove('open'); toggleBtn.setAttribute('aria-expanded', 'false'); });
+    if (document._themeCloseHandler) {
+      document.removeEventListener('click', document._themeCloseHandler);
+    }
+    document._themeCloseHandler = function() { switcher.classList.remove('open'); toggleBtn.setAttribute('aria-expanded', 'false'); };
+    document.addEventListener('click', document._themeCloseHandler);
 
     // Phase 2 PR-4 (사이클 84) — 다국어 i18n 헤더 dropdown
     // Phase 2 PR-4 (Cycle 84) — i18n header dropdown
@@ -862,10 +866,14 @@
         });
       });
 
-      document.addEventListener('click', () => {
+      if (document._langCloseHandler) {
+        document.removeEventListener('click', document._langCloseHandler);
+      }
+      document._langCloseHandler = function() {
         langSwitcher.classList.remove('open');
         langToggle.setAttribute('aria-expanded', 'false');
-      });
+      };
+      document.addEventListener('click', document._langCloseHandler);
     })();
 
     // 모바일 햄버거
@@ -878,13 +886,17 @@
         hamburger.setAttribute('aria-expanded', String(open));
         hamburger.textContent = open ? '✕' : '☰';
       });
-      document.addEventListener('click', () => {
+      if (document._hamburgerCloseHandler) {
+        document.removeEventListener('click', document._hamburgerCloseHandler);
+      }
+      document._hamburgerCloseHandler = function() {
         if (navLinks.classList.contains('open')) {
           navLinks.classList.remove('open');
           hamburger.setAttribute('aria-expanded', 'false');
           hamburger.textContent = '☰';
         }
-      });
+      };
+      document.addEventListener('click', document._hamburgerCloseHandler);
     }
 
     // ── Animation framework ──────────────────────────────────────────────────
@@ -951,6 +963,7 @@
       var _raf, _pct = 0;
 
       function _startProgress() {
+        cancelAnimationFrame(_raf);
         var b = _bar(); if (!b) return;
         _pct = 0;
         b.classList.add('is-loading');
@@ -1013,10 +1026,17 @@
 
       // 일반 페이지 언로드 폴백 (외부 링크, HTMX 미개입 경우)
       // Fallback for non-HTMX navigations (external links, forms bypassing HTMX)
-      window.addEventListener('beforeunload', _finishProgress);
-      window.addEventListener('pageshow', function(e) {
-        if (e.persisted) _resetProgress();
-      });
+      if (globalThis._progressBeforeUnloadHandler) {
+        globalThis.removeEventListener('beforeunload', globalThis._progressBeforeUnloadHandler);
+      }
+      globalThis._progressBeforeUnloadHandler = _finishProgress;
+      globalThis.addEventListener('beforeunload', globalThis._progressBeforeUnloadHandler);
+
+      if (globalThis._progressPageShowHandler) {
+        globalThis.removeEventListener('pageshow', globalThis._progressPageShowHandler);
+      }
+      globalThis._progressPageShowHandler = function(e) { if (e.persisted) _resetProgress(); };
+      globalThis.addEventListener('pageshow', globalThis._progressPageShowHandler);
     })();
 
     // Chart.js 전역 애니메이션 기본값 (차트 라이브러리가 로드된 경우에만)


### PR DESCRIPTION
## 요약

hx-boost 페이지 재방문 시 이벤트 핸들러가 누적 등록되는 버그 5건을 수정합니다.
remove-before-add 패턴 및 RAF 경쟁 방지 패턴 적용.

### 수정 목록

| # | 대상 | 버그 | 수정 |
|---|------|------|------|
| P1-1 | `_startProgress()` | RAF 경쟁: 직전 `_raf` 취소 없이 새 루프 시작 → 다중 tick 누적 | `cancelAnimationFrame(_raf)` 선행 호출 추가 |
| P1-2 | 햄버거 닫힘 핸들러 | hx-boost 재방문마다 `click` 핸들러 중복 등록 | `document._hamburgerCloseHandler` remove-before-add 패턴 |
| P1-3a | 테마 드롭다운 닫힘 핸들러 | 동일 | `document._themeCloseHandler` remove-before-add 패턴 |
| P1-3b | 언어 드롭다운 닫힘 핸들러 | 동일 | `document._langCloseHandler` remove-before-add 패턴 |
| P2-1 | `beforeunload` / `pageshow` | 재방문마다 핸들러 누적 등록 | `globalThis._progressBeforeUnloadHandler` / `_progressPageShowHandler` remove-before-add 패턴 |

> Fix 5는 linter 권고(`javascript:S7764`)에 따라 `window` → `globalThis`로 통일.

## 테스트

- `python -m pytest tests/ -x -q` → **2966 passed, 4 skipped** (전체 통과)

## 🔍 사용자 검증 필요

이 PR은 HTML/JS 변경으로 Claude는 시각 검증이 불가합니다.

### 정책 11 — 시각 검증 체크리스트 (4-테마 × 2-레이아웃 = 8 조합)

| # | 테마 | 레이아웃 | 검증 항목 |
|---|------|---------|---------|
| 1 | dark | 데스크탑 | hx-boost 재방문 후 테마/언어/햄버거 드롭다운 정상 닫힘 |
| 2 | dark | 모바일 | 햄버거 열기/닫기 재방문 후 정상 동작 |
| 3 | light | 데스크탑 | 동일 |
| 4 | light | 모바일 | 동일 |
| 5 | pastel | 데스크탑 | 동일 |
| 6 | pastel | 모바일 | 동일 |
| 7 | catppuccin | 데스크탑 | 동일 |
| 8 | catppuccin | 모바일 | 동일 |

### 재현 시나리오

1. 여러 페이지를 hx-boost 링크로 빠르게 왔다갔다 (5회 이상)
2. 테마 드롭다운 토글 → 클릭 밖 닫힘이 1번만 실행되는지 확인
3. 언어 드롭다운 동일 확인
4. 모바일: 햄버거 열기 → 외부 클릭 닫힘 1번만 실행 확인
5. 페이지 로딩 바(progress bar)가 여러 번 왔다갔다 후에도 매끄럽게 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)