### PR TITLE
fix(ui): chart 템플릿 htmx 핸들러 버그 수정 6건 (P1+P2)

### DIFF
--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -809,6 +809,16 @@
   }
   document._adThemeHandler = function() { _buildAnalysisChart(false); };
   document.addEventListener('themechange', document._adThemeHandler);
+
+  /* htmx 재방문(historyRestore/afterSettle) 시 차트 재빌드 — remove-before-add 패턴
+     Rebuild chart on htmx historyRestore/afterSettle — remove-before-add pattern */
+  if (document._adHtmxHandler) {
+    document.removeEventListener('htmx:afterSettle', document._adHtmxHandler);
+    document.removeEventListener('htmx:historyRestore', document._adHtmxHandler);
+  }
+  document._adHtmxHandler = function() { _buildAnalysisChart(); };
+  document.addEventListener('htmx:afterSettle', document._adHtmxHandler);
+  document.addEventListener('htmx:historyRestore', document._adHtmxHandler);
 })();
 </script>
 {% endif %}

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -629,7 +629,7 @@
         var cs = getComputedStyle(document.body);
         // CSS 변수로만 색상 결정 — hex 직접 사용 금지 (ui.md 의무)
         // Color determined solely via CSS variables — no hex fallbacks (ui.md rule)
-        var colorBorder = cs.getPropertyValue('--accent-primary').trim() || cs.getPropertyValue('--accent').trim();
+        var colorBorder = cs.getPropertyValue('--accent').trim();
 
         if (window._repoTrendChart) { window._repoTrendChart.destroy(); }
         window._repoTrendChart = new Chart(ctx, {
@@ -665,6 +665,16 @@
       }
       document._reposThemeHandler = function() { buildRepoTrendChart(false); };
       document.addEventListener('themechange', document._reposThemeHandler);
+
+      /* htmx 재방문 시 차트 재빌드 — remove-before-add 패턴
+         Rebuild chart on htmx revisit — remove-before-add pattern */
+      if (document._reposHtmxHandler) {
+        document.removeEventListener('htmx:afterSettle', document._reposHtmxHandler);
+        document.removeEventListener('htmx:historyRestore', document._reposHtmxHandler);
+      }
+      document._reposHtmxHandler = function() { buildRepoTrendChart(false); };
+      document.addEventListener('htmx:afterSettle', document._reposHtmxHandler);
+      document.addEventListener('htmx:historyRestore', document._reposHtmxHandler);
     })();
     </script>
     {% endif %}
@@ -1253,6 +1263,16 @@
   }
   document._dashThemeHandler = function() { buildDashChart(false); };
   document.addEventListener('themechange', document._dashThemeHandler);
+
+  /* htmx 재방문 시 차트 재빌드 — remove-before-add 패턴
+     Rebuild chart on htmx revisit — remove-before-add pattern */
+  if (document._dashHtmxHandler) {
+    document.removeEventListener('htmx:afterSettle', document._dashHtmxHandler);
+    document.removeEventListener('htmx:historyRestore', document._dashHtmxHandler);
+  }
+  document._dashHtmxHandler = function() { buildDashChart(false); };
+  document.addEventListener('htmx:afterSettle', document._dashHtmxHandler);
+  document.addEventListener('htmx:historyRestore', document._dashHtmxHandler);
 </script>
 {% endif %}
 

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -884,7 +884,7 @@ function applyFilters() {
   var chartData = filtered.slice().sort(function(a, b) {
     return (a.created_at || '') < (b.created_at || '') ? -1 : 1;
   });
-  buildChart(chartData);
+  buildChart(chartData, false);
 }
 
 // ── 정렬 헤더 ─────────────────────────────────────────

--- a/src/templates/repo_insights.html
+++ b/src/templates/repo_insights.html
@@ -256,7 +256,7 @@
     document.removeEventListener('htmx:afterSettle', document._riHtmxHandler);
     document.removeEventListener('htmx:historyRestore', document._riHtmxHandler);
   }
-  document._riHtmxHandler = buildRiChart;
+  document._riHtmxHandler = function() { buildRiChart(false); };
   document.addEventListener('htmx:afterSettle', document._riHtmxHandler);
   document.addEventListener('htmx:historyRestore', document._riHtmxHandler);
 })();


### PR DESCRIPTION
## Summary

- **analysis_detail.html (P1-4)**: `htmx:afterSettle` / `htmx:historyRestore` 핸들러 추가 — 뒤로가기 후 차트 미복원 버그 수정 (remove-before-add 패턴)
- **dashboard.html (P2-5)**: `--accent-primary` 미정의 phantom 토큰 제거 → `--accent`만 사용
- **dashboard.html (P2-6a)**: repos trend 차트 `htmx:afterSettle` / `htmx:historyRestore` 핸들러 추가
- **dashboard.html (P2-6b)**: overview dash 차트 `htmx:afterSettle` / `htmx:historyRestore` 핸들러 추가
- **repo_detail.html (P2-2)**: `applyFilters()` 내 `buildChart(chartData)` → `buildChart(chartData, false)` — 필터 적용 시 800ms 불필요 애니메이션 제거
- **repo_insights.html (P2-4)**: `_riHtmxHandler = buildRiChart` 직접 참조 → `function() { buildRiChart(false); }` 래퍼로 변경 — animate 파라미터 미전달 버그 수정

## 🔍 사용자 검증 필요

> ⚠️ **Claude 시각 검증 불가** (정책 11): 아래 항목은 정적 코드만 검증됨. 4-테마 × 데스크탑/모바일 8 조합 시각 정합성은 사용자 브라우저에서 직접 확인 필요.

**뒤로가기 후 차트 복원 검증 (htmx historyRestore)**
- [ ] dark 테마 + 데스크탑: analysis_detail → 다른 페이지 → 뒤로가기 → 차트 정상 표시
- [ ] light 테마 + 데스크탑: dashboard (repos 모드) → 뒤로가기 → repos trend 차트 정상
- [ ] pastel 테마 + 데스크탑: dashboard (overview 모드) → 뒤로가기 → dash 차트 정상
- [ ] catppuccin 테마 + 데스크탑: repo_insights → 뒤로가기 → 차트 정상 (animate=false)

**필터 애니메이션 및 모바일 검증**
- [ ] dark 테마 + 모바일: repo_detail 필터 변경 시 차트 즉시 갱신 (애니메이션 없음 정상)
- [ ] light 테마 + 모바일: analysis_detail htmx 재방문 후 차트 복원
- [ ] pastel 테마 + 모바일: dashboard repos/dash 차트 htmx 재방문 복원
- [ ] catppuccin 테마 + 모바일: repo_insights 뒤로가기 후 차트 색상 정상

**accent 토큰 검증 (P2-5)**
- [ ] dashboard repos 차트 테두리 색상이 4개 테마 모두에서 정상 표시 (`--accent` 토큰 기반)

## Test Results

- 2966 passed, 4 skipped (전체 테스트 통과)
- 변경 대상: HTML 템플릿 4개 (JS 핸들러 수정, 비즈니스 로직 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)