### PR TITLE
fix(security): _resolve_token plaintext_token 직접 확인 (#521 P1)

### DIFF
--- a/src/services/security_scan_service.py
+++ b/src/services/security_scan_service.py
@@ -48,9 +48,13 @@ def _resolve_token(user) -> str | None:
 
     User token first + global fallback (merge_retry_service._resolve_github_token pattern).
     """
-    if user is not None and getattr(user, "github_access_token", None):
+    if user is not None:
         try:
-            return user.plaintext_token
+            # plaintext_token 직접 체크 — None 이면 env fallback 진행
+            # Check plaintext_token directly — fall through to env if None
+            token = user.plaintext_token
+            if token:
+                return token
         except Exception:  # pylint: disable=broad-except  # noqa: BLE001
             return None
     return os.environ.get("GITHUB_TOKEN") or None

--- a/tests/unit/services/test_security_scan_service.py
+++ b/tests/unit/services/test_security_scan_service.py
@@ -162,3 +162,16 @@ async def test_scan_all_repos_iterates_repos(monkeypatch):
         totals = await security_scan_service.scan_all_repos(fake_db)
     assert totals["repos"] == 2
     assert totals["code_scanning"] == 2
+
+
+def test_resolve_token_user_plaintext_none_falls_back_to_env(monkeypatch):
+    """user.plaintext_token=None 이어도 GITHUB_TOKEN 환경변수 fallback 보장.
+    Falls back to GITHUB_TOKEN env when user.plaintext_token is None, even if github_access_token exists."""
+    class _U:
+        # 암호화된 blob 은 있으나 복호화 결과가 None 인 경우
+        # Encrypted blob exists but decryption result is None
+        github_access_token = "encrypted_blob"
+        plaintext_token = None
+    monkeypatch.setenv("GITHUB_TOKEN", "fallback_global_pat")
+    token = security_scan_service._resolve_token(_U())  # noqa: SLF001
+    assert token == "fallback_global_pat"


### PR DESCRIPTION
## 변경 요약
- `security_scan_service._resolve_token()` 에서 암호화된 `github_access_token` blob 직접 접근 제거
- `user.plaintext_token` 직접 체크 → None 시 `GITHUB_TOKEN` env fallback 보장
- `merge_retry_service._resolve_github_token` 패턴과 일치

## 수정 전/후
```python
# Before (잘못된 패턴)
if user is not None and getattr(user, "github_access_token", None):
    try:
        return user.plaintext_token
    except Exception:
        return None

# After (올바른 패턴)
if user is not None:
    try:
        token = user.plaintext_token
        if token:
            return token
    except Exception:
        return None
```

## 버그 재현 케이스
`github_access_token` 이 설정된 User 에서 `plaintext_token` 이 None 이면 기존 코드는 env fallback 없이 None 반환 → 보안 스캔 silent skip 발생.

## 테스트
- 신규 테스트 1건: `test_resolve_token_user_plaintext_none_falls_back_to_env`
  - `github_access_token` 존재 + `plaintext_token=None` 시 env fallback 검증 (TDD RED→GREEN)
- 기존 테스트 15건 전체 통과 (16/16)

## 🔍 사용자 검증 필요
- [ ] Railway 운영 환경에서 보안 스캔 API 호출 정상 동작 확인 (github_access_token 있는 사용자)
- [ ] GitHub token이 없는 사용자의 경우 전역 GITHUB_TOKEN fallback 동작 확인

## Code Scanning open alerts
- 현재 open alert: 0건

Closes #521 (P1)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)