### PR TITLE
test(i18n): i18n_args_filter XSS 가드 커버리지 3건 추가 (#521)

### DIFF
--- a/tests/unit/i18n/test_filters.py
+++ b/tests/unit/i18n/test_filters.py
@@ -61,3 +61,27 @@ def test_filter_with_default_locale_none():
     """locale=None 시 default_locale (en) 사용."""
     result = i18n_filter("dashboard.title", None)
     assert result == "Dashboard"
+
+
+def test_i18n_args_filter_escapes_html_in_str_kwarg():
+    """str kwarg에 HTML 태그가 있으면 이스케이프됨 — XSS 방어.
+    HTML tags in str kwargs are escaped — XSS defence."""
+    result = i18n_args_filter("header.welcome", "en", name="<script>alert(1)</script>")
+    assert "<script>" not in result
+    assert "&lt;script&gt;" in result
+
+
+def test_i18n_args_filter_passes_markup_kwarg_unchanged():
+    """Markup 인스턴스는 의도적 HTML로 간주 — 이스케이프하지 않음.
+    Markup instances are treated as intentional HTML — not escaped."""
+    from markupsafe import Markup
+    result = i18n_args_filter("header.welcome", "en", name=Markup("<b>Alice</b>"))
+    assert "<b>Alice</b>" in result
+    assert "&lt;b&gt;" not in result
+
+
+def test_i18n_args_filter_normal_str_no_html():
+    """HTML 없는 일반 str은 그대로 치환 — 이스케이프 부작용 없음.
+    Plain str without HTML is substituted as-is — no escape side-effects."""
+    result = i18n_args_filter("header.welcome", "en", name="World")
+    assert "World" in result


### PR DESCRIPTION
## 변경 요약
`i18n_args_filter` 의 XSS 방어 로직 3개 분기에 대한 테스트 커버리지 추가.
커버리지 0% → 3개 분기 경로 커버.

## 추가된 테스트
| 테스트 | 검증 내용 |
|--------|---------|
| `test_i18n_args_filter_escapes_html_in_str_kwarg` | str kwarg `<script>` → `&lt;script&gt;` 이스케이프 |
| `test_i18n_args_filter_passes_markup_kwarg_unchanged` | `Markup("<b>")` → `<b>` 그대로 통과 |
| `test_i18n_args_filter_normal_str_no_html` | 일반 str 치환 — 이스케이프 부작용 없음 |

## 🔍 사용자 검증 필요
- [ ] CI 테스트 통과 확인

## Code Scanning open alerts
- 현재 open alert: 0건

Closes #521 (i18n XSS 테스트)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)