### PR TITLE
fix(hook): replace claude -p with direct Anthropic API call (2025-06-15 billing change)

### DIFF
--- a/src/github_client/repos.py
+++ b/src/github_client/repos.py
@@ -144,7 +144,6 @@ ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
 CONFIG="${ROOT}/.scamanager/config.json"
 
 [ -f "${CONFIG}" ] || exit 0
-command -v claude &>/dev/null || exit 0
 command -v python3 &>/dev/null || exit 0
 
 # config.json에서 값 추출 — python3 -c 에 CONFIG를 argv로 전달해 경로 주입 방지
@@ -196,9 +195,42 @@ prompt = (
 sys.stdout.write(prompt)
 " > "${TMPFILE}"
 
-# claude -p 에 프롬프트를 stdin으로 전달 (argv 주입 차단)
-RESULT=$(claude -p < "${TMPFILE}" 2>/dev/null) || true
-[ -z "${RESULT}" ] && echo "⚠️  [SCAManager] claude CLI 실행 실패 또는 빈 응답 — 코드리뷰를 건너뜁니다." >&2
+# Anthropic API 직접 호출 — claude -p 대체 (2025-06-15 Agent SDK 크레딧 분리 대응)
+# Direct Anthropic API call — replaces claude -p (Agent SDK billing split from 2025-06-15)
+[ -n "${ANTHROPIC_API_KEY:-}" ] || {
+  echo "⚠️  [SCAManager] ANTHROPIC_API_KEY 환경변수 미설정 — 코드리뷰를 건너뜁니다." >&2
+  rm -f "${TMPFILE}"
+  exit 0
+}
+REVIEW_MODEL="${SCAMANAGER_REVIEW_MODEL:-claude-haiku-4-5-20251001}"
+RESULT=$(python3 -c "
+import json, sys, os, urllib.request
+key = os.environ.get('ANTHROPIC_API_KEY', '')
+model = sys.argv[2]
+with open(sys.argv[1]) as f:
+    prompt = f.read()
+payload = json.dumps({
+    'model': model,
+    'max_tokens': 2048,
+    'messages': [{'role': 'user', 'content': prompt}]
+}).encode()
+req = urllib.request.Request(
+    'https://api.anthropic.com/v1/messages',
+    data=payload,
+    headers={
+        'x-api-key': key,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+    }
+)
+try:
+    with urllib.request.urlopen(req, timeout=60) as r:
+        d = json.loads(r.read())
+        print(d['content'][0]['text'])
+except Exception:
+    pass
+" "${TMPFILE}" "${REVIEW_MODEL}" 2>/dev/null) || true
+[ -z "${RESULT}" ] && echo "⚠️  [SCAManager] Anthropic API 호출 실패 또는 빈 응답 — 코드리뷰를 건너뜁니다." >&2
 rm -f "${TMPFILE}"
 
 if [ -n "${RESULT}" ]; then

--- a/tests/unit/github_client/test_github_repos.py
+++ b/tests/unit/github_client/test_github_repos.py
@@ -256,3 +256,38 @@ async def test_commit_scamanager_files_returns_false_on_error():
         )
 
     assert result is False
+
+
+# ------------------------------------------------------------------
+# _INSTALL_HOOK_SH 회귀 테스트 — Agent SDK 요금 분리 대응 (2025-06-15)
+# Regression tests for _INSTALL_HOOK_SH — Agent SDK billing split 2025-06-15
+# ------------------------------------------------------------------
+
+def test_install_hook_sh_no_claude_p():
+    from src.github_client.repos import _INSTALL_HOOK_SH
+    non_comment = [l for l in _INSTALL_HOOK_SH.splitlines() if not l.lstrip().startswith('#')]
+    assert not any('claude -p' in l for l in non_comment)
+
+
+def test_install_hook_sh_uses_anthropic_api():
+    """pre-push hook 스크립트가 Anthropic API를 직접 호출해야 한다."""
+    from src.github_client.repos import _INSTALL_HOOK_SH
+    assert "api.anthropic.com/v1/messages" in _INSTALL_HOOK_SH, (
+        "hook 스크립트에 Anthropic API 엔드포인트가 없음"
+    )
+
+
+def test_install_hook_sh_reads_anthropic_api_key():
+    """pre-push hook 스크립트가 ANTHROPIC_API_KEY 환경변수를 사용해야 한다."""
+    from src.github_client.repos import _INSTALL_HOOK_SH
+    assert "ANTHROPIC_API_KEY" in _INSTALL_HOOK_SH, (
+        "hook 스크립트에 ANTHROPIC_API_KEY 참조가 없음"
+    )
+
+
+def test_install_hook_sh_no_claude_command_check():
+    """pre-push hook 스크립트에 claude CLI 존재 여부 체크가 없어야 한다."""
+    from src.github_client.repos import _INSTALL_HOOK_SH
+    assert "command -v claude" not in _INSTALL_HOOK_SH, (
+        "hook 스크립트에 'command -v claude' 발견 — claude CLI 불필요하므로 제거 필수"
+    )


### PR DESCRIPTION
## 배경

2025-06-15부터 `claude -p` (Claude Code CLI) 호출이 **Agent SDK 크레딧 풀** (별도 $200)에서 청구되어, hook을 사용하는 각 사용자의 크레딧이 소모됩니다.

기존 Anthropic API 구독($200 = 280만 토큰 포함)을 계속 활용하려면 `claude -p` 대신 Anthropic API를 직접 호출해야 합니다.

## 변경 내용

`src/github_client/repos.py` — `_INSTALL_HOOK_SH` (사용자 로컬에 설치되는 `pre-push` git hook)

| 항목 | 이전 | 이후 |
|------|------|------|
| AI 호출 방식 | `claude -p < ${TMPFILE}` | `urllib` + Anthropic API 직접 호출 |
| 인증 | Claude Code CLI 세션 | `ANTHROPIC_API_KEY` 환경변수 |
| CLI 의존성 | `command -v claude` 필수 | 제거 (python3만 필요) |
| 모델 | Claude Code 설정값 | `claude-haiku-4-5-20251001` (기본값, `SCAMANAGER_REVIEW_MODEL`로 오버라이드 가능) |
| 외부 라이브러리 | 없음 | 없음 (`urllib` = Python stdlib) |

### 사용자 마이그레이션 안내

기존 hook 사용자는 다음을 추가하면 됩니다:
```bash
export ANTHROPIC_API_KEY=sk-ant-api03-...   # ~/.bashrc 또는 ~/.zshrc
```
미설정 시 hook은 graceful skip (코드리뷰 없이 push 진행).

## 테스트

```
test_install_hook_sh_no_claude_p          PASSED  — 실행 구문에 claude -p 없음
test_install_hook_sh_uses_anthropic_api   PASSED  — api.anthropic.com/v1/messages 포함
test_install_hook_sh_reads_anthropic_api_key PASSED — ANTHROPIC_API_KEY 참조 포함
test_install_hook_sh_no_claude_command_check PASSED — command -v claude 없음
전체 단위 테스트: 2825 passed
```

## 🔍 사용자 검증 필요

| 검증 항목 | 방법 |
|----------|------|
| `ANTHROPIC_API_KEY` 설정 후 `git push` 시 코드리뷰 터미널 출력 확인 | 로컬 테스트 |
| 미설정 시 graceful skip 메시지 출력 확인 | `unset ANTHROPIC_API_KEY && git push` |
| `SCAMANAGER_REVIEW_MODEL=claude-sonnet-4-6` 오버라이드 동작 확인 | 선택 사항 |

> **기존 hook 설치자**: 리포 설정 페이지에서 hook 재설치 필요 (`.scamanager/install-hook.sh` 갱신)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)