### PR TITLE
feat: 리포별 AI 리뷰 모델 선택 + 월별 비용 추적

### DIFF
--- a/alembic/versions/0032_add_review_model_and_tokens.py
+++ b/alembic/versions/0032_add_review_model_and_tokens.py
@@ -1,0 +1,54 @@
+"""리포별 AI 리뷰 모델 선택 + 분석당 토큰 사용량 추적 컬럼 추가.
+
+Add per-repo review model override + per-analysis token usage tracking columns.
+
+- repo_configs.review_model  — 리포별 Claude 모델 override (NULL = 전역 기본값)
+- analyses.review_model      — 이 분석에 사용된 모델 (비용 역산용)
+- analyses.input_tokens      — Anthropic API 입력 토큰 수
+- analyses.output_tokens     — Anthropic API 출력 토큰 수
+
+Revision ID: 0032reviewmodel
+Revises: 0031repoinsights
+Create Date: 2026-05-19
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from src.shared.alembic_dialect import is_postgresql
+
+revision = "0032reviewmodel"
+down_revision = "0031repoinsights"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # repo_configs — 리포별 모델 override
+    # repo_configs — per-repo model override
+    op.add_column("repo_configs", sa.Column("review_model", sa.String(50), nullable=True))
+
+    # analyses — 토큰 사용량 + 모델명 추적
+    # analyses — token usage + model name tracking
+    op.add_column("analyses", sa.Column("review_model", sa.String(50), nullable=True))
+    op.add_column("analyses", sa.Column("input_tokens", sa.Integer(), nullable=True))
+    op.add_column("analyses", sa.Column("output_tokens", sa.Integer(), nullable=True))
+
+    # PostgreSQL 전용 인덱스: 월별 토큰 합산 쿼리 성능 개선
+    # PostgreSQL-only index: speeds up monthly token aggregation queries
+    if is_postgresql(op.get_bind()):
+        op.create_index(
+            "ix_analyses_repo_id_created_at_tokens",
+            "analyses",
+            ["repo_id", "created_at"],
+            postgresql_where=sa.text("input_tokens IS NOT NULL"),
+        )
+
+
+def downgrade() -> None:
+    if is_postgresql(op.get_bind()):
+        op.drop_index("ix_analyses_repo_id_created_at_tokens", table_name="analyses")
+
+    op.drop_column("analyses", "output_tokens")
+    op.drop_column("analyses", "input_tokens")
+    op.drop_column("analyses", "review_model")
+    op.drop_column("repo_configs", "review_model")

--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -42,6 +42,13 @@ class AiReviewResult:  # pylint: disable=too-many-instance-attributes
     file_feedbacks: list[dict] = field(default_factory=list)  # 파일별 피드백
     status: str = "success"  # "success" | "no_api_key" | "empty_diff" | "api_error" | "parse_error"
     detected_languages: list[str] = field(default_factory=list)  # 감지된 언어 목록
+    # Anthropic API 실제 토큰 사용량 — 비용 추적용 (0 = API 미호출 또는 오류)
+    # Actual Anthropic API token usage — for cost tracking (0 = not called or error)
+    input_tokens: int = 0
+    output_tokens: int = 0
+    # 실제 사용된 모델명 — None = 전역 기본값 사용
+    # Actual model used — None means global default was used
+    used_model: str | None = None
 
 
 async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching + 예외 분기로 인한 누적 (사이클 84 i18n)
@@ -49,6 +56,7 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
     commit_message: str,
     patches: list[tuple[str, str]],
     language: str = "en",
+    model: str | None = None,
 ) -> AiReviewResult:
     """Claude API로 코드를 리뷰하고 점수를 반환한다. API key가 없으면 기본값 반환.
 
@@ -83,7 +91,7 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
     # Set 60s — well above typical 5-15s response, far below SDK default.
     # max_retries=2 — explicit so SDK upgrades cannot silently change retry behavior.
     client = anthropic.AsyncAnthropic(api_key=api_key, timeout=60.0, max_retries=2)
-    model = settings.claude_review_model
+    model = model or settings.claude_review_model
     # Phase 4 PR-12 — language 별 system prompt (출력 언어 지시 포함).
     # Phase 4 PR-12 — per-language system prompt (with output language directive).
     system_text = get_system_prompt(language)
@@ -117,6 +125,9 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
         )
         result = _parse_response(response.content[0].text)
         result.detected_languages = languages
+        result.input_tokens = input_tokens
+        result.output_tokens = output_tokens
+        result.used_model = model
         return result
     except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
         # anthropic/httpx 는 다양한 예외를 발생시킬 수 있음 — 모두 graceful fallback

--- a/src/api/repos.py
+++ b/src/api/repos.py
@@ -41,6 +41,9 @@ class RepoConfigUpdate(BaseModel):
     # Phase 1 PR-1c (사이클 84) — 다국어 지원 리포별 알림 언어 override
     # NULL = 사용자 preferred_language fallback (Phase 3 PR-9~11 알림 채널 영역)
     notification_language: str | None = None
+    # 리포별 Claude 코드리뷰 모델 override (Alembic 0032)
+    # NULL = settings.claude_review_model 전역 기본값 사용
+    review_model: str | None = None
     # leaderboard_opt_in 폐기 (그룹 60 사용자 결정 정정 — alembic 0025)
 
     @model_validator(mode="after")

--- a/src/config_manager/manager.py
+++ b/src/config_manager/manager.py
@@ -33,6 +33,9 @@ class RepoConfigData:  # pylint: disable=too-many-instance-attributes
     # Phase 1 PR-1c (사이클 84) — 다국어 지원 리포별 알림 언어 override
     # NULL = 사용자 preferred_language fallback (Phase 3 PR-9~11 알림 채널 영역)
     notification_language: str | None = None
+    # 리포별 Claude 코드리뷰 모델 override (Alembic 0032)
+    # NULL = settings.claude_review_model 전역 기본값 사용
+    review_model: str | None = None
     # leaderboard_opt_in 폐기 (그룹 60 사용자 결정 정정 — alembic 0025)
 
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -123,3 +123,39 @@ MAX_BOT_EVENTS_PER_HOUR: int = 6
 SKIP_CI_MARKERS: tuple[str, ...] = ("[skip ci]", "[skip-sca]", "[ci skip]")
 # 커밋 메시지에 이 문자열이 포함되면 분석 skip
 # If any of these strings appear in a commit message, analysis is skipped
+
+# ── Claude AI 모델 목록 + 요금 (Anthropic 공식 기준, USD/1M 토큰) ─────────
+# ── Claude AI model catalog + pricing (Anthropic official, USD per 1M tokens) ─
+# 출처: https://www.anthropic.com/pricing (2025-05 기준 — 실제 청구와 다를 수 있음)
+# Source: https://www.anthropic.com/pricing (as of 2025-05 — actual billing may differ)
+CLAUDE_MODELS: list[dict] = [
+    {
+        "id": "claude-haiku-4-5-20251001",
+        "label": "Claude Haiku 4.5 (빠름/저렴 · Fast/Cheap)",
+        "input_price": 0.80,
+        "output_price": 4.00,
+    },
+    {
+        "id": "claude-sonnet-4-6",
+        "label": "Claude Sonnet 4.6 (균형 · Balanced) ★기본값",
+        "input_price": 3.00,
+        "output_price": 15.00,
+    },
+    {
+        "id": "claude-opus-4-7",
+        "label": "Claude Opus 4.7 (고품질 · High Quality)",
+        "input_price": 15.00,
+        "output_price": 75.00,
+    },
+]
+
+# 모델 ID → 가격 딕셔너리 (빠른 조회용)
+# Model ID → pricing dict (for fast lookup)
+CLAUDE_MODEL_PRICING: dict[str, dict[str, float]] = {
+    m["id"]: {"input": m["input_price"], "output": m["output_price"]}
+    for m in CLAUDE_MODELS
+}
+
+# 모델 미등록 시 fallback (Sonnet 기준)
+# Fallback pricing when model not in registry (Sonnet tier)
+CLAUDE_PRICING_FALLBACK: dict[str, float] = {"input": 3.00, "output": 15.00}

--- a/src/models/analysis.py
+++ b/src/models/analysis.py
@@ -46,4 +46,12 @@ class Analysis(Base):
         index=True,
     )
 
+    # 리뷰에 사용된 Claude 모델 — 비용 계산용 (Alembic 0032)
+    # Claude model used for this review — for cost calculation (Alembic 0032)
+    review_model = Column(String(50), nullable=True)
+    # Anthropic API 실제 토큰 사용량 — 비용 계산용 (Alembic 0032)
+    # Actual Anthropic API token usage — for cost calculation (Alembic 0032)
+    input_tokens = Column(Integer, nullable=True)
+    output_tokens = Column(Integer, nullable=True)
+
     repository = relationship("Repository", back_populates="analyses")

--- a/src/models/repo_config.py
+++ b/src/models/repo_config.py
@@ -43,6 +43,12 @@ class RepoConfig(Base):
     # Nullable=True (NULL = 사용자 preferred_language fallback / NULL = fallback to user)
     notification_language = Column(String(5), nullable=True)
 
+    # 리포별 Claude 코드리뷰 모델 override (Alembic 0032)
+    # Per-repo Claude review model override (Alembic 0032)
+    # NULL = settings.claude_review_model 전역 기본값 사용
+    # NULL = fall back to settings.claude_review_model global default
+    review_model = Column(String(50), nullable=True)
+
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime, default=lambda: datetime.now(timezone.utc),
                         onupdate=lambda: datetime.now(timezone.utc))

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -400,6 +400,28 @@
   </div>
 </div>
 
+<!-- 이번 달 AI 리뷰 예상 비용 (Alembic 0032) -->
+<div class="card reveal" style="padding:1rem 1.5rem;margin-bottom:1rem;">
+  <div style="display:flex;align-items:center;gap:.6rem;flex-wrap:wrap;">
+    <span style="font-size:13px;font-weight:600;color:var(--text-1);">이번 달 AI 리뷰 예상 비용</span>
+    <span style="font-size:11px;color:var(--text-2);">({{ monthly_cost_month }} 01일 ~ 말일, 서버사이드 Webhook 분석 기준)</span>
+    {% if monthly_token_count > 0 %}
+    <span style="margin-left:auto;font-size:15px;font-weight:700;color:var(--accent);">
+      ${{ "%.4f"|format(monthly_cost_usd) }}
+    </span>
+    <span style="font-size:12px;color:var(--text-2);">
+      (입력+출력 {{ "{:,}".format(monthly_token_count) }} 토큰)
+    </span>
+    {% else %}
+    <span style="margin-left:auto;font-size:13px;color:var(--text-2);">데이터 없음 — 이번 달 토큰 추적 분석이 아직 없습니다.</span>
+    {% endif %}
+  </div>
+  <p style="font-size:11px;color:var(--text-2);margin:.4rem 0 0;">
+    ※ Anthropic 공식 요금 기준 추정값입니다. 실제 청구금액과 다를 수 있으며, pre-push 훅 비용(사용자 API 키)은 포함되지 않습니다.
+    모델 변경: <a href="/repos/{{ repo_name }}/settings" style="color:var(--accent);">설정 페이지</a>
+  </p>
+</div>
+
 <!-- 분석 이력 / Analysis history / Phase 2 PR-7 — i18n + data-i18n-* (JS 동적 텍스트 서버 주입 — XSS 차단) -->
 <div class="card history-card reveal" style="padding:1.25rem 1.5rem;"
      data-i18n-history-recent="{{ 'repo_detail.history_count_recent' | i18n_args(locale | default('ko'), count='__N__') }}"

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -1110,6 +1110,25 @@
         {{ 'settings_page.inbound.behavior_notice' | i18n_args(locale | default('ko')) | safe }}
       </p>
 
+      {# AI 리뷰 모델 선택 — Alembic 0032 #}
+      <div class="s-section-label">AI 코드리뷰 모델</div>
+      <div class="field-row">
+        <select name="review_model" form="settingsForm" class="field-input" style="max-width:420px;">
+          <option value="">전역 기본값 사용</option>
+          {% for m in claude_models %}
+          <option value="{{ m.id }}" {% if config.review_model == m.id %}selected{% endif %}>{{ m.label }}</option>
+          {% endfor %}
+        </select>
+        <span class="field-hint">
+          리포별 AI 리뷰 모델을 선택합니다.
+          Haiku → 빠름·저렴 ($0.80/1M) · Sonnet → 균형 ($3/1M) · Opus → 고품질 ($15/1M).
+          비어두면 서버 전역 기본값(claude-sonnet-4-6)을 따릅니다.
+          ※ 가격은 Anthropic 공식 기준 (실제 청구와 다를 수 있습니다).
+        </span>
+      </div>
+
+      <div class="s-divider"></div>
+
       <div class="s-section-label">{{ 'settings_page.inbound.section_github_webhook' | i18n_args(locale | default('ko')) }}</div>
       <div class="hook-btns" style="margin-bottom:.5rem;">
         <button type="submit" class="hook-btn" form="reinstall_webhook_form"

--- a/src/ui/routes/detail.py
+++ b/src/ui/routes/detail.py
@@ -1,6 +1,7 @@
 """리포 분석 이력 + 분석 상세 페이지 — catch-all `/repos/{name}` 는 마지막에 include."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -8,12 +9,29 @@ from fastapi.responses import HTMLResponse
 from pydantic import BaseModel, Field
 
 from src.auth.session import CurrentUser, require_login
+from src.constants import CLAUDE_MODEL_PRICING, CLAUDE_PRICING_FALLBACK
 from src.database import SessionLocal
 from src.models.analysis import Analysis
 from src.repositories import analysis_feedback_repo
 from src.ui._helpers import get_accessible_repo, get_locale, templates
 
 router = APIRouter()
+
+
+def _calc_monthly_cost(rows: list) -> float:
+    """분석 행 목록에서 Anthropic API 예상 비용(USD)을 계산한다.
+
+    Calculate estimated Anthropic API cost (USD) from a list of analysis rows.
+    입력: (review_model, input_tokens, output_tokens) 튜플 목록
+    Input: list of (review_model, input_tokens, output_tokens) tuples.
+    """
+    total = 0.0
+    for row in rows:
+        pricing = CLAUDE_MODEL_PRICING.get(row.review_model or "", CLAUDE_PRICING_FALLBACK)
+        inp = (row.input_tokens or 0) / 1_000_000
+        out = (row.output_tokens or 0) / 1_000_000
+        total += inp * pricing["input"] + out * pricing["output"]
+    return round(total, 4)
 
 
 class FeedbackRequest(BaseModel):
@@ -154,6 +172,26 @@ def repo_detail(  # pylint: disable=too-many-positional-arguments
             for a in analyses
         ]
         rev = list(reversed(analyses_data))
+
+        # 이번 달 비용 계산 (매월 1일 00:00 UTC ~ 말일 23:59 UTC 기준)
+        # Monthly cost calculation (1st 00:00 UTC to last day of month)
+        now = datetime.now(timezone.utc)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        monthly_analyses = (
+            db.query(Analysis.review_model, Analysis.input_tokens, Analysis.output_tokens)
+            .filter(
+                Analysis.repo_id == repo.id,
+                Analysis.created_at >= month_start,
+                Analysis.input_tokens.isnot(None),
+            )
+            .all()
+        )
+        monthly_cost_usd = _calc_monthly_cost(monthly_analyses)
+        monthly_token_count = sum(
+            (row.input_tokens or 0) + (row.output_tokens or 0)
+            for row in monthly_analyses
+        )
+
     return templates.TemplateResponse(request, "repo_detail.html", {
         "repo_name": repo_name, "analyses": analyses_data,
         "chart_labels": [a["created_at"][:10] if a["created_at"] else "" for a in rev],
@@ -161,4 +199,7 @@ def repo_detail(  # pylint: disable=too-many-positional-arguments
         "hook_installed": bool(hook_installed),
         "current_user": current_user,
         "locale": get_locale(request),
+        "monthly_cost_usd": monthly_cost_usd,
+        "monthly_token_count": monthly_token_count,
+        "monthly_cost_month": now.strftime("%Y-%m"),
     })

--- a/src/ui/routes/settings.py
+++ b/src/ui/routes/settings.py
@@ -14,6 +14,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from src.auth.session import CurrentUser, require_login
 from src.config_manager.manager import RepoConfigData, get_repo_config, upsert_repo_config
 from src.constants import (
+    CLAUDE_MODELS,
     GATE_DEFAULT_APPROVE_THRESHOLD,
     GATE_DEFAULT_REJECT_THRESHOLD,
     GATE_DEFAULT_MERGE_THRESHOLD,
@@ -207,6 +208,7 @@ async def repo_settings(  # pylint: disable=too-many-positional-arguments,too-ma
         "onboarding_needed": onboarding_needed,
         "initial_mode": initial_mode,
         "locale": get_locale(request),
+        "claude_models": CLAUDE_MODELS,
     })
 
 
@@ -245,6 +247,7 @@ async def update_repo_settings(
                 create_issue=form.get("create_issue") == "on",
                 railway_deploy_alerts=form.get("railway_deploy_alerts") == "on",
                 auto_merge_issue_on_failure=form.get("auto_merge_issue_on_failure") == "on",
+                review_model=form.get("review_model") or None,
                 # leaderboard_opt_in 폐기 (그룹 60 사용자 결정 정정 — alembic 0025)
             ))
             # railway_webhook_token, railway_api_token — RepoConfigData 외부 관리

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -347,6 +347,7 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
         params.ai_review, params.score_result, params.analysis_results,
         source="pr" if params.pr_number else "push",
     )
+    ai = params.ai_review
     analysis = analysis_repo.save_new(db, Analysis(
         repo_id=repo.id,
         commit_sha=params.commit_sha,
@@ -356,6 +357,9 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
         grade=params.score_result.grade,
         result=result_dict,
         author_login=params.author_login,
+        review_model=getattr(ai, "used_model", None),
+        input_tokens=getattr(ai, "input_tokens", None) or None,
+        output_tokens=getattr(ai, "output_tokens", None) or None,
     ))
     analysis_id = analysis.id
     try:
@@ -469,12 +473,22 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
             # AI review output language = repo owner's preferred_language. RepoConfig.notification_language
             # is for channel-level (notifier/_language.py) — AI review is DB-stored + reused across channels.
             review_language = _resolve_review_language(repo_name)
+            # 리포별 모델 override 조회 — 실패 시 None (전역 기본값 fallback, 비중요 경로)
+            # Fetch per-repo model override — falls back to None (global default) on error
+            repo_review_model: str | None = None
+            try:
+                with SessionLocal() as db_cfg:
+                    repo_review_model = get_repo_config(db_cfg, repo_name).review_model or None
+            except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                pass  # 모델 조회 실패 = 전역 기본값으로 fallback (분석 중단 불필요)
+
             with stage_timer("analyze", repo=repo_log) as ctx:
                 analysis_results, ai_review = await asyncio.gather(
                     _run_static_analysis(files),
                     review_code(
                         settings.anthropic_api_key, commit_message, patches,
                         language=review_language,
+                        model=repo_review_model,
                     ),
                 )
                 ctx["file_count"] = len(analysis_results)

--- a/tests/unit/templates/test_detail_i18n_render.py
+++ b/tests/unit/templates/test_detail_i18n_render.py
@@ -47,6 +47,10 @@ def _repo_ctx(**overrides) -> dict:
         "chart_labels": ["2026-05-01"],
         "chart_scores": [80],
         "hook_installed": False,
+        # Alembic 0032 — 월별 비용 추적
+        "monthly_cost_usd": 0.0,
+        "monthly_token_count": 0,
+        "monthly_cost_month": "2026-05",
     }
     base.update(overrides)
     return base

--- a/tests/unit/ui/test_repo_detail_template.py
+++ b/tests/unit/ui/test_repo_detail_template.py
@@ -50,6 +50,10 @@ _MINIMAL_CONTEXT = {
     "locale": "ko",
     # repo_id 는 템플릿에서 선택적 사용 — None 허용
     "repo_id": None,
+    # Alembic 0032 — 월별 비용 추적 (빈 값으로 초기화)
+    "monthly_cost_usd": 0.0,
+    "monthly_token_count": 0,
+    "monthly_cost_month": "2026-05",
 }
 
 


### PR DESCRIPTION
## Summary

- **리포별 AI 리뷰 모델 선택**: 설정 페이지의 통합 & 인증 카드에 Claude 모델 드롭다운 추가 (Haiku / Sonnet★기본값 / Opus)
- **실제 토큰 기반 비용 추적**: Anthropic API 응답의 `input_tokens` / `output_tokens`를 `analyses` 테이블에 저장
- **월별 예상 비용 카드**: repo_detail 페이지에 이번 달(1일~말일) 서버사이드 Webhook 분석 비용 표시

## 변경 파일

| 영역 | 파일 | 변경 내용 |
|------|------|----------|
| DB | `alembic/versions/0032_add_review_model_and_tokens.py` | `repo_configs.review_model` + `analyses.review_model/input_tokens/output_tokens` 컬럼 추가 |
| 모델 | `src/models/repo_config.py`, `src/models/analysis.py` | 신규 컬럼 ORM 정의 |
| AI 리뷰 | `src/analyzer/io/ai_review.py` | `AiReviewResult`에 토큰 필드 추가, `review_code(model=)` 파라미터 |
| 파이프라인 | `src/worker/pipeline.py` | 리포 설정에서 모델 조회 + Analysis에 토큰 저장 |
| 설정 | `src/config_manager/manager.py`, `src/ui/routes/settings.py` | `review_model` 필드 연동 |
| 상수 | `src/constants.py` | `CLAUDE_MODELS` / `CLAUDE_MODEL_PRICING` 가격 테이블 |
| UI | `src/templates/settings.html`, `src/templates/repo_detail.html` | 모델 선택 드롭다운 + 비용 카드 |

## 동작 방식

**모델 선택 흐름:**
`설정 페이지 드롭다운` → `repo_configs.review_model` → `pipeline.get_repo_config()` → `review_code(model=...)` → `AiReviewResult.used_model` → `analyses.review_model`

**비용 계산 흐름:**
`analyses.input_tokens + output_tokens + review_model` → `CLAUDE_MODEL_PRICING[model]` → `USD 계산` → `repo_detail.html 카드`

**주의사항:**
- 기존 분석(`input_tokens IS NULL`)은 비용 계산에서 제외 → "데이터 없음" 표시
- pre-push hook 비용(사용자 API 키)은 서버사이드 추적 불가 → 카드에 명시
- 가격 상수는 Anthropic 공식 기준(2025-05) — 실제 청구와 다를 수 있음

## 🔍 사용자 검증 필요

- [ ] 설정 페이지 → "통합 & 인증" 카드 → AI 리뷰 모델 드롭다운이 표시되는지
- [ ] 모델 선택 후 저장 → 재진입 시 선택값 유지되는지
- [ ] repo_detail 페이지 → 차트 아래 비용 카드가 표시되는지 (신규 분석 전: "데이터 없음")
- [ ] Railway 배포 후 DB 마이그레이션(0032) 자동 적용 확인

## UI 시각 검증 체크리스트 (정책 11)

> Claude는 정적 코드만 검증 가능 — 4테마 × 2화면(모바일/데스크탑) 8조합은 사용자 확인 필요

- [ ] dark / light / glass / claude-dark — 모델 선택 드롭다운 가독성
- [ ] 모바일(≤768px) — 드롭다운 너비 (max-width:420px 적용)
- [ ] 비용 카드 — 테마별 accent 색상 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)