### PR TITLE
fix(settings): AI 리뷰 모델 선택기를 위험 구역 바로 위 독립 카드로 이동

### DIFF
--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -1110,25 +1110,6 @@
         {{ 'settings_page.inbound.behavior_notice' | i18n_args(locale | default('ko')) | safe }}
       </p>
 
-      {# AI 리뷰 모델 선택 — Alembic 0032 #}
-      <div class="s-section-label">AI 코드리뷰 모델</div>
-      <div class="field-row">
-        <select name="review_model" form="settingsForm" class="field-input" style="max-width:420px;">
-          <option value="">전역 기본값 사용</option>
-          {% for m in claude_models %}
-          <option value="{{ m.id }}" {% if config.review_model == m.id %}selected{% endif %}>{{ m.label }}</option>
-          {% endfor %}
-        </select>
-        <span class="field-hint">
-          리포별 AI 리뷰 모델을 선택합니다.
-          Haiku → 빠름·저렴 ($0.80/1M) · Sonnet → 균형 ($3/1M) · Opus → 고품질 ($15/1M).
-          비어두면 서버 전역 기본값(claude-sonnet-4-6)을 따릅니다.
-          ※ 가격은 Anthropic 공식 기준 (실제 청구와 다를 수 있습니다).
-        </span>
-      </div>
-
-      <div class="s-divider"></div>
-
       <div class="s-section-label">{{ 'settings_page.inbound.section_github_webhook' | i18n_args(locale | default('ko')) }}</div>
       <div class="hook-btns" style="margin-bottom:.5rem;">
         <button type="submit" class="hook-btn" form="reinstall_webhook_form"
@@ -1186,6 +1167,31 @@
       <span class="field-hint">{{ 'settings_page.inbound.railway_webhook_pending' | i18n_args(locale | default('ko')) }}</span>
       {% endif %}
 
+    </div>
+  </div>
+
+  {# AI 리뷰 모델 선택 카드 — Alembic 0032 / 위험 구역 바로 위 #}
+  <div class="s-card adv-only" style="margin-bottom:1rem;">
+    <div class="s-card-hdr" style="background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 80%, #000), var(--accent));">
+      <span class="hdr-icon">🤖</span>
+      <span class="hdr-title">AI 코드리뷰 모델</span>
+      <span class="hdr-badge">고급</span>
+    </div>
+    <div class="s-card-body">
+      <div class="field-row">
+        <select name="review_model" form="settingsForm" class="field-input" style="max-width:420px;">
+          <option value="">전역 기본값 사용</option>
+          {% for m in claude_models %}
+          <option value="{{ m.id }}" {% if config.review_model == m.id %}selected{% endif %}>{{ m.label }}</option>
+          {% endfor %}
+        </select>
+        <span class="field-hint">
+          리포별 AI 리뷰 모델을 선택합니다.
+          Haiku → 빠름·저렴 ($0.80/1M) · Sonnet → 균형 ($3/1M) · Opus → 고품질 ($15/1M).
+          비어두면 서버 전역 기본값(claude-sonnet-4-6)을 따릅니다.
+          ※ 가격은 Anthropic 공식 기준 (실제 청구와 다를 수 있습니다).
+        </span>
+      </div>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

- AI 리뷰 모델 선택기를 통합·인증 카드(Card ⑥) 내부에서 제거
- 위험 구역(Danger Zone) 바로 위에 독립 카드 `🤖 AI 코드리뷰 모델`로 재배치
- 기능·로직·5-way sync 변경 없음 — UI 위치 이동 전용

## Context

PR #529에서 AI 리뷰 모델 선택기를 통합·인증 카드 안에 배치했으나,
사용자 피드백으로 "위험 구역 섹션 바로 위가 적절한 위치"로 결정.
PR #529 머지 후 위치 조정 fix-up으로 별도 PR 진행.

## 🔍 사용자 검증 필요

- [ ] Settings 페이지에서 `🤖 AI 코드리뷰 모델` 카드가 위험 구역 바로 위에 표시되는지 확인
- [ ] 통합·인증 카드(GitHub Webhook 섹션)에 모델 선택기가 더 이상 없는지 확인
- [ ] 모델 선택 후 저장 시 정상 반영되는지 확인

⚠️ **Claude 시각 검증 불가** — 4-테마 × 모바일/데스크탑 8 조합은 사용자 직접 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)