### PR TITLE
feat(insight): API 에러 빈도 추적 — InsightNarrativeCache 에러 컬럼 3개 + 0033 마이그레이션

### DIFF
--- a/alembic/versions/0033_insight_error_tracking.py
+++ b/alembic/versions/0033_insight_error_tracking.py
@@ -1,0 +1,70 @@
+"""InsightNarrativeCache 에러 추적 컬럼 3개 추가.
+
+Add 3 error-tracking columns to insight_narrative_cache:
+  last_error_at   — 마지막 에러 발생 시각 / timestamp of last error
+  error_count     — 누적 에러 횟수 / cumulative error count
+  last_error_type — 마지막 에러 유형 문자열 / last error type string
+
+Revision ID: 0033insighterror
+Revises: 0032reviewmodel
+Create Date: 2026-05-20
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+# ─── revision identifiers ──────────────────────────────────────────────────────
+revision = "0033insighterror"
+down_revision = "0032reviewmodel"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    from src.shared.alembic_dialect import is_postgresql  # noqa: PLC0415
+
+    bind = op.get_bind()
+
+    op.add_column(
+        "insight_narrative_cache",
+        sa.Column("last_error_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "insight_narrative_cache",
+        sa.Column(
+            "error_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "insight_narrative_cache",
+        sa.Column("last_error_type", sa.String(100), nullable=True),
+    )
+
+    if is_postgresql(bind):
+        # PostgreSQL: 인덱스 추가 (에러 빈도 쿼리 최적화)
+        # PostgreSQL: add index for error frequency queries
+        op.create_index(
+            "ix_insight_cache_last_error_at",
+            "insight_narrative_cache",
+            ["last_error_at"],
+        )
+
+
+def downgrade() -> None:
+    from src.shared.alembic_dialect import is_postgresql  # noqa: PLC0415
+
+    bind = op.get_bind()
+
+    if is_postgresql(bind):
+        op.drop_index(
+            "ix_insight_cache_last_error_at",
+            table_name="insight_narrative_cache",
+        )
+
+    op.drop_column("insight_narrative_cache", "last_error_type")
+    op.drop_column("insight_narrative_cache", "error_count")
+    op.drop_column("insight_narrative_cache", "last_error_at")

--- a/src/models/insight_narrative_cache.py
+++ b/src/models/insight_narrative_cache.py
@@ -4,6 +4,8 @@ InsightNarrativeCache ORM — Insight mode Claude AI narrative 1h TTL cache.
 
 0031 — `repo_id` nullable FK 추가 (repo_id=NULL: 전체 대시보드 캐시, repo_id=N: 리포별 캐시).
 0031 — Add nullable `repo_id` FK (NULL=global dashboard cache, N=repo-specific cache).
+0033 — 에러 추적 컬럼 3개 추가 (last_error_at / error_count / last_error_type).
+0033 — Add 3 error-tracking columns (last_error_at / error_count / last_error_type).
 """
 from datetime import datetime, timezone
 
@@ -49,3 +51,11 @@ class InsightNarrativeCache(Base):
         DateTime, default=lambda: datetime.now(timezone.utc), nullable=False,
     )
     expires_at = Column(DateTime, nullable=False, index=True)
+
+    # 0033 — 에러 추적 컬럼: api_error / parse_error / no_data 발생 시 갱신
+    # 0033 — Error tracking columns: updated on api_error / parse_error / no_data
+    last_error_at = Column(DateTime, nullable=True)
+    error_count = Column(Integer, nullable=False, default=0, server_default="0")
+    # 예외 클래스명 또는 status 문자열 (예: "APITimeoutError", "api_error", "no_data")
+    # Exception class name or status string (e.g. "APITimeoutError", "api_error", "no_data")
+    last_error_type = Column(String(100), nullable=True)

--- a/src/repositories/insight_narrative_cache_repo.py
+++ b/src/repositories/insight_narrative_cache_repo.py
@@ -3,6 +3,8 @@
 Cycle 74 PR-B Phase 2-B 🅑 — Insight 모드 Claude AI 호출 빈도 제한 (60% 절감).
 0031 — repo-scoped cache helpers 추가 (get_fresh_repo / upsert_repo / invalidate_repo).
 0031 — Add repo-scoped cache helpers (get_fresh_repo / upsert_repo / invalidate_repo).
+0033 — record_error / record_error_repo 추가 (에러 빈도 추적).
+0033 — Add record_error / record_error_repo (error frequency tracking).
 """
 from __future__ import annotations
 
@@ -199,6 +201,87 @@ def upsert_repo(
     db.commit()
     db.refresh(row)
     return row
+
+
+def record_error(
+    db: Session,
+    *,
+    user_id: int,
+    days: int,
+    language: str = "en",
+    error_type: str,
+    now: datetime | None = None,
+) -> None:
+    """전체 대시보드 에러 발생 시 호출 — row 없으면 생성, 있으면 카운터 증가.
+
+    Call on dashboard insight error — creates row if absent, increments counter.
+    성공 응답 캐시와 달리 expires_at 을 현재 시각으로 설정해 즉시 만료 상태 유지.
+    Unlike success cache, sets expires_at = now so it never blocks a fresh retry.
+    """
+    now = now or datetime.now(timezone.utc)
+    existing = (
+        db.query(InsightNarrativeCache)
+        .filter(
+            InsightNarrativeCache.user_id == user_id,
+            InsightNarrativeCache.days == days,
+            InsightNarrativeCache.repo_id.is_(None),
+            InsightNarrativeCache.language == language,
+        )
+        .first()
+    )
+    if existing is not None:
+        existing.last_error_at = now
+        existing.error_count = (existing.error_count or 0) + 1
+        existing.last_error_type = error_type
+    else:
+        # 에러 전용 row — response_json 은 빈 dict, expires_at = now (즉시 만료)
+        # Error-only row — response_json empty dict, expires_at = now (immediately expired)
+        existing = InsightNarrativeCache(
+            user_id=user_id, days=days, language=language, repo_id=None,
+            response_json={}, created_at=now, expires_at=now,
+            last_error_at=now, error_count=1, last_error_type=error_type,
+        )
+        db.add(existing)
+    db.commit()
+
+
+def record_error_repo(
+    db: Session,
+    *,
+    user_id: int,
+    repo_id: int,
+    days: int,
+    language: str = "en",
+    error_type: str,
+    now: datetime | None = None,
+) -> None:
+    """리포별 insight 에러 발생 시 호출 — row 없으면 생성, 있으면 카운터 증가.
+
+    Call on repo insight error — creates row if absent, increments counter.
+    """
+    now = now or datetime.now(timezone.utc)
+    existing = (
+        db.query(InsightNarrativeCache)
+        .filter(
+            InsightNarrativeCache.user_id == user_id,
+            InsightNarrativeCache.repo_id == repo_id,
+            InsightNarrativeCache.days == days,
+            InsightNarrativeCache.language == language,
+        )
+        .first()
+    )
+    if existing is not None:
+        existing.last_error_at = now
+        existing.error_count = (existing.error_count or 0) + 1
+        existing.last_error_type = error_type
+    else:
+        existing = InsightNarrativeCache(
+            user_id=user_id, repo_id=repo_id, days=days, language=language,
+            response_json={}, created_at=now, expires_at=now,
+            last_error_at=now, error_count=1, last_error_type=error_type,
+        )
+        db.add(existing)
+    db.commit()
 
 
 def invalidate_repo(

--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -838,6 +838,11 @@ async def insight_narrative(  # pylint: disable=too-many-locals
     # 데이터 0건이면 Claude API 호출 비용 발생 안 시킴 (cost-saver early return)
     # Skip Claude API call when there's no data (cost-saver early return)
     if int(kpi.get("analysis_count", {}).get("value", 0) or 0) == 0:
+        if user_id is not None:
+            from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+            insight_narrative_cache_repo.record_error(
+                db, user_id=user_id, days=days, error_type="no_data", now=_now,
+            )
         return _build_insight_response(status="no_data", days=days)
 
     user_prompt = _build_insight_user_prompt(
@@ -851,10 +856,20 @@ async def insight_narrative(  # pylint: disable=too-many-locals
     # Phase 2 d-🅓 (Cycle 74) — Insight-only Haiku (67% cheaper, AI review keeps Sonnet)
     text = await _call_insight_claude_api(client, settings.claude_insight_model, user_prompt)
     if text is None:
+        if user_id is not None:
+            from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+            insight_narrative_cache_repo.record_error(
+                db, user_id=user_id, days=days, error_type="api_error", now=_now,
+            )
         return _build_insight_response(status="api_error", days=days)
 
     cards = _parse_insight_cards(text)
     if cards is None:
+        if user_id is not None:
+            from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+            insight_narrative_cache_repo.record_error(
+                db, user_id=user_id, days=days, error_type="parse_error", now=_now,
+            )
         return _build_insight_response(status="parse_error", days=days)
 
     response = _build_insight_response(status="success", days=days, cards=cards)

--- a/src/services/repo_insight_service.py
+++ b/src/services/repo_insight_service.py
@@ -348,6 +348,12 @@ async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many
                 return cached
 
     if not kpi.get("analysis_count"):
+        if user_id is not None:
+            from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+            insight_narrative_cache_repo.record_error_repo(
+                db, user_id=user_id, repo_id=repo_id, days=days,
+                error_type="no_data", now=_now,
+            )
         return {"text": "", "status": "no_data"}
 
     user_prompt = (
@@ -385,7 +391,7 @@ async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many
         raw = response.content[0].text
         data = json.loads(_extract_narrative_json(raw))
         result: dict[str, Any] = {"text": str(data.get("text", raw)), "status": "success"}
-    except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+    except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
         duration_ms = (time.perf_counter() - start) * 1000
         log_claude_api_call(
             model=settings.claude_insight_model,
@@ -393,8 +399,15 @@ async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many
             input_tokens=0,
             output_tokens=0,
             status="error",
+            error_type=type(exc).__name__,
         )
         logger.exception("repo_insight_narrative API call failed")
+        if user_id is not None:
+            from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+            insight_narrative_cache_repo.record_error_repo(
+                db, user_id=user_id, repo_id=repo_id, days=days,
+                error_type=type(exc).__name__, now=_now,
+            )
         return {"text": "", "status": "api_error"}
 
     if user_id is not None:

--- a/tests/unit/repositories/test_insight_error_tracking.py
+++ b/tests/unit/repositories/test_insight_error_tracking.py
@@ -26,7 +26,6 @@ from sqlalchemy.pool import StaticPool
 from src.database import Base
 from src.models.analysis import Analysis  # noqa: F401  (Base.metadata 등록)
 from src.models.insight_narrative_cache import InsightNarrativeCache
-from src.models.user import User  # noqa: F401
 from src.repositories import insight_narrative_cache_repo
 
 

--- a/tests/unit/repositories/test_insight_error_tracking.py
+++ b/tests/unit/repositories/test_insight_error_tracking.py
@@ -26,7 +26,6 @@ from sqlalchemy.pool import StaticPool
 from src.database import Base
 from src.models.analysis import Analysis  # noqa: F401  (Base.metadata 등록)
 from src.models.insight_narrative_cache import InsightNarrativeCache
-from src.models.repository import Repository  # noqa: F401
 from src.models.user import User  # noqa: F401
 from src.repositories import insight_narrative_cache_repo
 

--- a/tests/unit/repositories/test_insight_error_tracking.py
+++ b/tests/unit/repositories/test_insight_error_tracking.py
@@ -1,0 +1,326 @@
+"""InsightNarrativeCache 에러 추적 컬럼 단위 테스트 — 0033 마이그레이션 페어.
+
+Unit tests for record_error / record_error_repo repository helpers (0033 migration pair).
+
+검증 케이스:
+  1. record_error — 신규 row 생성 (user_id=N, repo_id=None)
+  2. record_error — 기존 row 카운터 증가
+  3. record_error — expires_at = now (즉시 만료, 재시도 차단 없음)
+  4. record_error — 다른 user_id row 에 영향 없음
+  5. record_error — language 파라미터 분리 (en vs ko 별개 row)
+  6. record_error_repo — 신규 row 생성 (user_id=N, repo_id=M)
+  7. record_error_repo — 기존 row 카운터 증가
+  8. record_error_repo — repo_id=None 전체 row 와 충돌 없음
+  9. record_error — 성공 캐시 row 존재 시 덮어쓰지 않고 갱신만
+ 10. record_error_repo — 여러 에러 유형 순차 기록 (type 변경 추적)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base
+from src.models.analysis import Analysis  # noqa: F401  (Base.metadata 등록)
+from src.models.insight_narrative_cache import InsightNarrativeCache
+from src.models.repository import Repository  # noqa: F401
+from src.models.user import User  # noqa: F401
+from src.repositories import insight_narrative_cache_repo
+
+
+# ─── Fixture ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션.
+
+    In-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ─── record_error (전체 대시보드 — repo_id=None) ──────────────────────────────
+
+
+def test_record_error_creates_new_row(db):
+    """record_error — 기존 row 없을 때 신규 row 생성 확인.
+
+    When no existing row, record_error must insert a new row with:
+      - error_count = 1
+      - last_error_type = supplied type
+      - last_error_at set
+      - repo_id = None (dashboard-scoped)
+    """
+    now = _now()
+    insight_narrative_cache_repo.record_error(
+        db, user_id=1, days=7, language="en", error_type="api_error", now=now,
+    )
+
+    rows = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == 1,
+        InsightNarrativeCache.days == 7,
+        InsightNarrativeCache.repo_id.is_(None),
+    ).all()
+
+    assert len(rows) == 1, f"Expected 1 row, got {len(rows)}"
+    row = rows[0]
+    assert row.error_count == 1
+    assert row.last_error_type == "api_error"
+    assert row.last_error_at is not None
+    assert row.repo_id is None
+    assert row.language == "en"
+
+
+def test_record_error_increments_existing_counter(db):
+    """record_error — 기존 row 있을 때 error_count 증가 확인.
+
+    When a row already exists, record_error must increment error_count (not insert new).
+    """
+    now = _now()
+    # 1차 에러 기록
+    insight_narrative_cache_repo.record_error(
+        db, user_id=2, days=30, language="en", error_type="api_error", now=now,
+    )
+    # 2차 에러 기록 (동일 키)
+    insight_narrative_cache_repo.record_error(
+        db, user_id=2, days=30, language="en", error_type="APITimeoutError",
+        now=now + timedelta(minutes=5),
+    )
+
+    rows = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == 2,
+        InsightNarrativeCache.days == 30,
+        InsightNarrativeCache.repo_id.is_(None),
+    ).all()
+
+    assert len(rows) == 1, f"Expected 1 row (not 2), got {len(rows)}"
+    assert rows[0].error_count == 2
+    assert rows[0].last_error_type == "APITimeoutError"  # 최신 유형으로 갱신
+
+
+def test_record_error_expires_at_now(db):
+    """record_error — expires_at = now (즉시 만료) 확인.
+
+    The error row must be immediately expired (expires_at <= now)
+    so it never blocks a fresh retry attempt.
+    """
+    now = _now()
+    insight_narrative_cache_repo.record_error(
+        db, user_id=3, days=7, language="en", error_type="api_error", now=now,
+    )
+
+    row = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == 3,
+        InsightNarrativeCache.days == 7,
+        InsightNarrativeCache.repo_id.is_(None),
+    ).first()
+
+    assert row is not None
+    expires = row.expires_at
+    if expires.tzinfo is None:
+        expires = expires.replace(tzinfo=timezone.utc)
+    # expires_at 는 now 이하여야 함 (즉시 만료)
+    assert expires <= now + timedelta(seconds=1), (
+        f"expires_at={expires} should be <= now={now} (immediately expired)"
+    )
+
+
+def test_record_error_does_not_affect_other_users(db):
+    """record_error — 다른 user_id row 에 영향 없음.
+
+    Recording an error for user_id=4 must not create or modify rows for user_id=5.
+    """
+    now = _now()
+    insight_narrative_cache_repo.record_error(
+        db, user_id=4, days=7, language="en", error_type="no_data", now=now,
+    )
+
+    # user_id=5 row 없어야 함
+    count = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == 5,
+    ).count()
+    assert count == 0, f"Expected 0 rows for user_id=5, got {count}"
+
+
+def test_record_error_language_isolation(db):
+    """record_error — language 파라미터로 다른 row 생성 확인.
+
+    record_error with language='en' and language='ko' must create two separate rows.
+    """
+    now = _now()
+    insight_narrative_cache_repo.record_error(
+        db, user_id=6, days=7, language="en", error_type="api_error", now=now,
+    )
+    insight_narrative_cache_repo.record_error(
+        db, user_id=6, days=7, language="ko", error_type="api_error", now=now,
+    )
+
+    rows = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == 6,
+        InsightNarrativeCache.days == 7,
+        InsightNarrativeCache.repo_id.is_(None),
+    ).all()
+
+    assert len(rows) == 2, f"Expected 2 language-isolated rows, got {len(rows)}"
+    languages = {r.language for r in rows}
+    assert languages == {"en", "ko"}
+
+
+def test_record_error_updates_existing_success_row(db):
+    """record_error — 성공 캐시 row 에 에러 정보 갱신 (덮어쓰기 아님).
+
+    When a success-cached row already exists, record_error must update its
+    error fields without replacing response_json or resetting expires_at of
+    the existing entry (it sets expires_at=now to invalidate it on error-only rows,
+    but updates existing rows which may have had a valid expires_at).
+    Crucially, the row count remains 1 (no duplicate insert).
+    """
+    now = _now()
+    # 먼저 성공 캐시 row 삽입
+    insight_narrative_cache_repo.upsert(
+        db, user_id=7, days=7, language="en",
+        response={"status": "success", "positive_highlights": ["A"]},
+        now=now - timedelta(minutes=30),
+    )
+
+    # 에러 발생 기록
+    insight_narrative_cache_repo.record_error(
+        db, user_id=7, days=7, language="en", error_type="parse_error", now=now,
+    )
+
+    rows = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == 7,
+        InsightNarrativeCache.days == 7,
+        InsightNarrativeCache.repo_id.is_(None),
+    ).all()
+
+    # row 중복 없이 1개
+    assert len(rows) == 1, f"Expected 1 row (no duplicate insert), got {len(rows)}"
+    row = rows[0]
+    assert row.error_count == 1
+    assert row.last_error_type == "parse_error"
+    # response_json 은 기존 success 데이터 보존
+    assert row.response_json.get("status") == "success"
+
+
+# ─── record_error_repo (리포별 — repo_id=M) ───────────────────────────────────
+
+
+def test_record_error_repo_creates_new_row(db):
+    """record_error_repo — repo_id 포함 신규 row 생성 확인.
+
+    record_error_repo must create a row with the correct repo_id != None.
+    """
+    now = _now()
+    insight_narrative_cache_repo.record_error_repo(
+        db, user_id=10, repo_id=99, days=7, language="en",
+        error_type="api_error", now=now,
+    )
+
+    row = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == 10,
+        InsightNarrativeCache.repo_id == 99,
+        InsightNarrativeCache.days == 7,
+    ).first()
+
+    assert row is not None
+    assert row.repo_id == 99
+    assert row.error_count == 1
+    assert row.last_error_type == "api_error"
+
+
+def test_record_error_repo_increments_counter(db):
+    """record_error_repo — 두 번 호출 시 error_count 2로 증가.
+
+    Calling record_error_repo twice for the same key must increment error_count to 2.
+    """
+    now = _now()
+    insight_narrative_cache_repo.record_error_repo(
+        db, user_id=11, repo_id=100, days=7, language="en",
+        error_type="api_error", now=now,
+    )
+    insight_narrative_cache_repo.record_error_repo(
+        db, user_id=11, repo_id=100, days=7, language="en",
+        error_type="APIConnectionError", now=now + timedelta(minutes=10),
+    )
+
+    rows = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == 11,
+        InsightNarrativeCache.repo_id == 100,
+        InsightNarrativeCache.days == 7,
+    ).all()
+
+    assert len(rows) == 1
+    assert rows[0].error_count == 2
+    assert rows[0].last_error_type == "APIConnectionError"
+
+
+def test_record_error_repo_no_conflict_with_dashboard_row(db):
+    """record_error_repo — repo_id=None 전체 row 와 충돌 없음.
+
+    A repo-scoped error row (repo_id=99) must coexist with a dashboard-scoped
+    error row (repo_id=None) for the same user without collision.
+    """
+    now = _now()
+    # 전체 대시보드 에러
+    insight_narrative_cache_repo.record_error(
+        db, user_id=12, days=7, language="en", error_type="api_error", now=now,
+    )
+    # 리포별 에러
+    insight_narrative_cache_repo.record_error_repo(
+        db, user_id=12, repo_id=200, days=7, language="en",
+        error_type="api_error", now=now,
+    )
+
+    all_rows = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == 12,
+        InsightNarrativeCache.days == 7,
+    ).all()
+
+    assert len(all_rows) == 2, f"Expected 2 rows (dashboard + repo), got {len(all_rows)}"
+    repo_ids = {r.repo_id for r in all_rows}
+    assert None in repo_ids, "Expected a dashboard row (repo_id=None)"
+    assert 200 in repo_ids, "Expected a repo row (repo_id=200)"
+
+
+def test_record_error_repo_multiple_error_types(db):
+    """record_error_repo — 여러 에러 유형 순차 기록 시 last_error_type 최신 유형 추적.
+
+    Sequential calls with different error types must update last_error_type each time.
+    """
+    now = _now()
+    error_sequence = ["APIStatusError", "APITimeoutError", "InternalServerError"]
+
+    for i, etype in enumerate(error_sequence):
+        insight_narrative_cache_repo.record_error_repo(
+            db, user_id=13, repo_id=300, days=14, language="en",
+            error_type=etype, now=now + timedelta(minutes=i * 5),
+        )
+
+    row = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == 13,
+        InsightNarrativeCache.repo_id == 300,
+        InsightNarrativeCache.days == 14,
+    ).first()
+
+    assert row is not None
+    assert row.error_count == 3, f"Expected error_count=3, got {row.error_count}"
+    assert row.last_error_type == "InternalServerError", (
+        f"Expected last_error_type='InternalServerError', got '{row.last_error_type}'"
+    )

--- a/tests/unit/services/test_insight_api_error_network.py
+++ b/tests/unit/services/test_insight_api_error_network.py
@@ -1,0 +1,213 @@
+"""insight_narrative — httpx/asyncio 네트워크 레벨 예외 api_error 경로 단위 테스트.
+
+검증 대상:
+    src/services/dashboard_service.py::insight_narrative (→ _call_insight_claude_api)
+
+검증 케이스 (3종):
+    1. httpx.ConnectError("Connection refused") — 연결 거부
+    2. httpx.ReadTimeout()                     — 읽기 타임아웃
+    3. asyncio.TimeoutError()                  — asyncio 타임아웃
+
+`_call_insight_claude_api` 의 `except Exception` 범위는 httpx.ConnectError /
+httpx.ReadTimeout / asyncio.TimeoutError 를 모두 포함 → 각 케이스에서
+status="api_error" + 4 카드 빈 list 를 반환하고 예외를 propagate 하지 않아야 한다.
+
+Network-level exception api_error path tests for insight_narrative.
+The broad `except Exception` in `_call_insight_claude_api` must catch all three
+exception types and map them to status="api_error" without propagating.
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from src.database import Base
+from src.models.analysis import Analysis  # noqa: F401  (Base.metadata 등록 / register on metadata)
+from src.models.repository import Repository  # noqa: F401
+from src.models.user import User  # noqa: F401
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션.
+
+    Provides an in-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def seeded_repo(db):
+    """user + repo 1건 seed — Analysis FK 충족용.
+
+    Seeds one user + one repo so Analysis rows have valid FKs.
+    """
+    user = User(github_id=99, github_login="nettest", email="net@x.com", display_name="NetTest")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    repo = Repository(full_name="nettest/repo", user_id=user.id)
+    db.add(repo)
+    db.commit()
+    db.refresh(repo)
+    return repo
+
+
+def _make_analysis(
+    db: Session,
+    repo_id: int,
+    score: int,
+    *,
+    offset_hours: int = 0,
+    result: dict[str, Any] | None = None,
+) -> Analysis:
+    """Analysis 레코드 헬퍼 — 점수 / created_at offset / result dict 주입 가능.
+
+    Helper to insert an Analysis row with score / created_at offset / result dict.
+    """
+    created = datetime.now(timezone.utc) - timedelta(hours=offset_hours)
+    a = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{uuid.uuid4().hex}",
+        score=score,
+        grade="B",
+        result=result or {},
+        created_at=created,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def _seed_two_analyses(db: Session, repo_id: int) -> None:
+    """API 호출 도달에 필요한 최소 Analysis 2건 seed (analysis_count > 0 조건 충족).
+
+    Seeds 2 Analysis rows so kpi["analysis_count"]["value"] > 0
+    and the function reaches the Claude API call.
+    """
+    _make_analysis(db, repo_id, 80, offset_hours=1)
+    _make_analysis(db, repo_id, 85, offset_hours=2)
+
+
+# ─── 공통 assertion 헬퍼 ────────────────────────────────────────────────────
+
+
+def _assert_api_error_response(result: dict[str, Any]) -> None:
+    """api_error status + 4 카드 빈 list 공통 검증.
+
+    Asserts the standard api_error response shape: status + empty 4 cards.
+    """
+    assert result["status"] == "api_error", (
+        f"Expected status='api_error' but got '{result['status']}'"
+    )
+    assert result["positive_highlights"] == [], (
+        f"Expected empty positive_highlights, got: {result['positive_highlights']}"
+    )
+    assert result["focus_areas"] == [], (
+        f"Expected empty focus_areas, got: {result['focus_areas']}"
+    )
+    assert result["key_metrics"] == [], (
+        f"Expected empty key_metrics, got: {result['key_metrics']}"
+    )
+    assert result["next_actions"] == [], (
+        f"Expected empty next_actions, got: {result['next_actions']}"
+    )
+
+
+# ─── Tests ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_api_error_on_connect_error(db, seeded_repo):
+    """httpx.ConnectError("Connection refused") → status=api_error + 4 카드 빈 list.
+
+    ConnectError 는 네트워크 수준 연결 거부 — `except Exception` 범위 포함 검증.
+    ConnectError is a network-level connection refusal — must be caught by `except Exception`.
+    """
+    _seed_two_analyses(db, seeded_repo.id)
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        side_effect=httpx.ConnectError("Connection refused")
+    )
+
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative  # noqa: PLC0415
+
+        # 예외가 호출자에게 propagate 되면 안 됨
+        # Exception must NOT propagate to the caller
+        result = await insight_narrative(db, days=7, api_key="sk-test")
+
+    _assert_api_error_response(result)
+
+
+@pytest.mark.asyncio
+async def test_api_error_on_read_timeout(db, seeded_repo):
+    """httpx.ReadTimeout() → status=api_error + 4 카드 빈 list.
+
+    ReadTimeout 은 응답 수신 중 타임아웃 — `except Exception` 범위 포함 검증.
+    ReadTimeout is a receive-side timeout — must be caught by `except Exception`.
+    """
+    _seed_two_analyses(db, seeded_repo.id)
+
+    fake_client = MagicMock()
+    # httpx.ReadTimeout 생성자 시그니처: ReadTimeout(message, *, request=None)
+    # httpx.ReadTimeout constructor signature: ReadTimeout(message, *, request=None)
+    fake_client.messages.create = AsyncMock(
+        side_effect=httpx.ReadTimeout("Read timeout")
+    )
+
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative  # noqa: PLC0415
+
+        result = await insight_narrative(db, days=7, api_key="sk-test")
+
+    _assert_api_error_response(result)
+
+
+@pytest.mark.asyncio
+async def test_api_error_on_asyncio_timeout(db, seeded_repo):
+    """asyncio.TimeoutError() → status=api_error + 4 카드 빈 list.
+
+    asyncio.TimeoutError 는 asyncio.wait_for 또는 anyio 타임아웃 경로 — `except Exception` 범위 포함 검증.
+    asyncio.TimeoutError arises from asyncio.wait_for / anyio timeout — must be caught by `except Exception`.
+    """
+    _seed_two_analyses(db, seeded_repo.id)
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(
+        side_effect=asyncio.TimeoutError()
+    )
+
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative  # noqa: PLC0415
+
+        result = await insight_narrative(db, days=7, api_key="sk-test")
+
+    _assert_api_error_response(result)

--- a/tests/unit/services/test_insight_api_error_sdk_exceptions.py
+++ b/tests/unit/services/test_insight_api_error_sdk_exceptions.py
@@ -1,0 +1,290 @@
+"""insight_narrative — Anthropic SDK 예외 타입별 api_error 경로 검증.
+
+Verifies that each Anthropic SDK exception type results in status='api_error'.
+
+검증 대상:
+    src/services/dashboard_service.py::insight_narrative()
+    src/services/dashboard_service.py::_call_insight_claude_api()
+
+담당 케이스 (5종):
+    1. anthropic.APITimeoutError       — 타임아웃
+    2. anthropic.RateLimitError        — rate limit 429
+    3. anthropic.APIConnectionError    — 네트워크 연결 실패
+    4. anthropic.InternalServerError   — Anthropic 5xx
+    5. anthropic.AuthenticationError   — 잘못된 API key
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import anthropic
+import httpx
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from src.database import Base
+from src.models.analysis import Analysis  # noqa: F401  (Base.metadata 등록 / register on metadata)
+from src.models.merge_attempt import MergeAttempt  # noqa: F401
+from src.models.repository import Repository  # noqa: F401
+from src.models.user import User  # noqa: F401
+
+
+# ─── httpx 객체 헬퍼 ─────────────────────────────────────────────────────────
+
+
+def _fake_request() -> httpx.Request:
+    """Anthropic SDK 예외 생성자에 필요한 dummy httpx.Request.
+
+    Dummy httpx.Request required by Anthropic SDK exception constructors.
+    """
+    return httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+
+
+def _fake_response(status_code: int) -> httpx.Response:
+    """Anthropic SDK 예외 생성자에 필요한 dummy httpx.Response.
+
+    Dummy httpx.Response required by Anthropic SDK exception constructors.
+    """
+    return httpx.Response(
+        status_code,
+        request=_fake_request(),
+        json={"error": {"type": "test_error", "message": "test"}},
+    )
+
+
+# ─── Anthropic SDK 예외 인스턴스 팩토리 ────────────────────────────────────────
+
+
+def _make_timeout_error() -> anthropic.APITimeoutError:
+    """anthropic.APITimeoutError 인스턴스 생성.
+
+    Instantiate anthropic.APITimeoutError.
+    """
+    return anthropic.APITimeoutError(request=_fake_request())
+
+
+def _make_rate_limit_error() -> anthropic.RateLimitError:
+    """anthropic.RateLimitError (HTTP 429) 인스턴스 생성.
+
+    Instantiate anthropic.RateLimitError (HTTP 429).
+    """
+    return anthropic.RateLimitError(
+        "Rate limit exceeded",
+        response=_fake_response(429),
+        body={"error": {"type": "rate_limit_error"}},
+    )
+
+
+def _make_connection_error() -> anthropic.APIConnectionError:
+    """anthropic.APIConnectionError (네트워크 연결 실패) 인스턴스 생성.
+
+    Instantiate anthropic.APIConnectionError (network connection failure).
+    """
+    return anthropic.APIConnectionError(
+        message="Connection error.",
+        request=_fake_request(),
+    )
+
+
+def _make_internal_server_error() -> anthropic.InternalServerError:
+    """anthropic.InternalServerError (5xx) 인스턴스 생성.
+
+    Instantiate anthropic.InternalServerError (5xx).
+    """
+    return anthropic.InternalServerError(
+        "Internal server error",
+        response=_fake_response(500),
+        body={"error": {"type": "internal_server_error"}},
+    )
+
+
+def _make_authentication_error() -> anthropic.AuthenticationError:
+    """anthropic.AuthenticationError (잘못된 API key) 인스턴스 생성.
+
+    Instantiate anthropic.AuthenticationError (invalid API key).
+    """
+    return anthropic.AuthenticationError(
+        "Invalid API key",
+        response=_fake_response(401),
+        body={"error": {"type": "authentication_error"}},
+    )
+
+
+# ─── DB Fixtures ─────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션.
+
+    Provides an in-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def seeded_repo(db):
+    """Analysis FK 충족을 위한 user + repo 1건 seed.
+
+    Seeds one user + one repo so Analysis rows have valid FKs.
+    """
+    user = User(github_id=42, github_login="tester", email="tester@x.com", display_name="Tester")
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    repo = Repository(full_name="tester/sdk-exc-repo", user_id=user.id)
+    db.add(repo)
+    db.commit()
+    db.refresh(repo)
+    return repo
+
+
+def _seed_analyses(db: Session, repo_id: int, count: int = 2) -> None:
+    """Claude API 호출 경로에 도달하도록 Analysis rows를 최소 2건 seed.
+
+    Seeds Analysis rows so the no_data early return is bypassed and
+    the code reaches the Claude API call path.
+    """
+    for i in range(count):
+        created = datetime.now(timezone.utc) - timedelta(hours=i * 6)
+        a = Analysis(
+            repo_id=repo_id,
+            commit_sha=f"sha-{uuid.uuid4().hex}",
+            score=80 + i,
+            grade="B",
+            result={"issues": []},
+            created_at=created,
+        )
+        db.add(a)
+    db.commit()
+
+
+# ─── 공용 assertion 헬퍼 ───────────────────────────────────────────────────
+
+
+def _assert_api_error_response(result: dict) -> None:
+    """api_error status + 4 카드 모두 빈 list 검증.
+
+    Asserts status=='api_error' and all 4 card lists are empty.
+    """
+    assert result["status"] == "api_error", (
+        f"Expected status='api_error' but got '{result['status']}'"
+    )
+    assert result["positive_highlights"] == [], f"positive_highlights should be empty: {result['positive_highlights']}"
+    assert result["focus_areas"] == [], f"focus_areas should be empty: {result['focus_areas']}"
+    assert result["key_metrics"] == [], f"key_metrics should be empty: {result['key_metrics']}"
+    assert result["next_actions"] == [], f"next_actions should be empty: {result['next_actions']}"
+
+
+# ─── 공용 테스트 헬퍼 ─────────────────────────────────────────────────────────
+
+
+async def _run_insight_with_sdk_exc(db: Session, repo_id: int, exc: Exception) -> dict:
+    """Analysis seed + SDK 예외 side_effect → insight_narrative 실행.
+
+    Seeds data, patches AsyncAnthropic so messages.create raises exc,
+    then calls insight_narrative and returns the result.
+    """
+    _seed_analyses(db, repo_id)
+
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(side_effect=exc)
+
+    with patch(
+        "src.services.dashboard_service.anthropic.AsyncAnthropic",
+        return_value=fake_client,
+    ):
+        from src.services.dashboard_service import insight_narrative  # noqa: PLC0415
+        result = await insight_narrative(db, days=7, api_key="sk-test-key")
+
+    return result
+
+
+# ─── 케이스 1: APITimeoutError ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_api_timeout_error_returns_api_error(db, seeded_repo):
+    """anthropic.APITimeoutError 발생 시 status='api_error' + 4 카드 빈 list.
+
+    When messages.create raises APITimeoutError, insight_narrative must return
+    status='api_error' with all 4 card lists empty (no exception propagation).
+    """
+    exc = _make_timeout_error()
+    result = await _run_insight_with_sdk_exc(db, seeded_repo.id, exc)
+    _assert_api_error_response(result)
+
+
+# ─── 케이스 2: RateLimitError ─────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_error_returns_api_error(db, seeded_repo):
+    """anthropic.RateLimitError (429) 발생 시 status='api_error' + 4 카드 빈 list.
+
+    When messages.create raises RateLimitError (HTTP 429), insight_narrative must
+    return status='api_error' with all 4 card lists empty.
+    """
+    exc = _make_rate_limit_error()
+    result = await _run_insight_with_sdk_exc(db, seeded_repo.id, exc)
+    _assert_api_error_response(result)
+
+
+# ─── 케이스 3: APIConnectionError ────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_api_connection_error_returns_api_error(db, seeded_repo):
+    """anthropic.APIConnectionError (네트워크 실패) 발생 시 status='api_error' + 4 카드 빈 list.
+
+    When messages.create raises APIConnectionError (network failure), insight_narrative
+    must return status='api_error' with all 4 card lists empty.
+    """
+    exc = _make_connection_error()
+    result = await _run_insight_with_sdk_exc(db, seeded_repo.id, exc)
+    _assert_api_error_response(result)
+
+
+# ─── 케이스 4: InternalServerError ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_internal_server_error_returns_api_error(db, seeded_repo):
+    """anthropic.InternalServerError (5xx) 발생 시 status='api_error' + 4 카드 빈 list.
+
+    When messages.create raises InternalServerError (HTTP 5xx), insight_narrative
+    must return status='api_error' with all 4 card lists empty.
+    """
+    exc = _make_internal_server_error()
+    result = await _run_insight_with_sdk_exc(db, seeded_repo.id, exc)
+    _assert_api_error_response(result)
+
+
+# ─── 케이스 5: AuthenticationError ──────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_authentication_error_returns_api_error(db, seeded_repo):
+    """anthropic.AuthenticationError (잘못된 API key) 발생 시 status 확인.
+
+    When messages.create raises AuthenticationError (invalid API key), verifies
+    the returned status. Per the implementation, _call_insight_claude_api catches ALL
+    exceptions and returns None → insight_narrative maps None to 'api_error'.
+    AuthenticationError would only return 'no_api_key' if caught BEFORE the API call
+    (i.e. at the key presence check), but here the key is non-empty, so the
+    exception occurs at call-time and must yield 'api_error'.
+    """
+    exc = _make_authentication_error()
+    result = await _run_insight_with_sdk_exc(db, seeded_repo.id, exc)
+    # AuthenticationError at call-time (non-empty key supplied) → api_error path
+    # AuthenticationError 가 call-time 에 발생하면 (비어있지 않은 key) → api_error 경로
+    _assert_api_error_response(result)

--- a/tests/unit/services/test_insight_api_error_sdk_exceptions.py
+++ b/tests/unit/services/test_insight_api_error_sdk_exceptions.py
@@ -28,7 +28,6 @@ from sqlalchemy.orm import Session
 
 from src.database import Base
 from src.models.analysis import Analysis  # noqa: F401  (Base.metadata 등록 / register on metadata)
-from src.models.merge_attempt import MergeAttempt  # noqa: F401
 from src.models.repository import Repository  # noqa: F401
 from src.models.user import User  # noqa: F401
 

--- a/tests/unit/services/test_insight_cache_error_recovery.py
+++ b/tests/unit/services/test_insight_cache_error_recovery.py
@@ -1,0 +1,337 @@
+"""insight_narrative 캐시 레이어 + api_error 상호작용 단위 테스트.
+
+Unit tests for insight_narrative cache layer + api_error interaction.
+
+검증 케이스 (2종):
+    케이스 1 — api_error 발생 시 cache upsert 호출 안 됨
+        : API → RuntimeError → api_error 반환, upsert 0회
+        : 두 번째 호출도 cache miss → API 다시 호출됨 (upsert 여전히 0회)
+
+    케이스 2 — api_error 후 재시도 시 success 복구
+        : 첫 번째 API → RuntimeError → api_error
+        : 두 번째 API → valid JSON → success 반환 + upsert 1회
+
+두 케이스 모두:
+    - in-memory SQLite + User / Repository / Analysis / InsightNarrativeCache ORM 테이블
+    - `insight_narrative_cache_repo.upsert` mock 으로 호출 횟수 검증
+    - `_call_insight_claude_api` 를 직접 patch 해 `side_effect` 로 순서 제어
+      (anthropic.AsyncAnthropic 생성 우회)
+
+Both test cases use:
+    - in-memory SQLite with User / Repository / Analysis / InsightNarrativeCache ORM tables
+    - Mocked `insight_narrative_cache_repo.upsert` to assert call count
+    - Direct patch of `_call_insight_claude_api` with `side_effect` for sequence control
+"""
+# pylint: disable=redefined-outer-name
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base
+from src.models.analysis import Analysis  # noqa: F401  (Base.metadata 등록 / register on metadata)
+from src.models.insight_narrative_cache import InsightNarrativeCache  # noqa: F401
+from src.models.repository import Repository  # noqa: F401
+from src.models.user import User  # noqa: F401
+from src.services import dashboard_service
+
+
+# ─── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db():
+    """모든 ORM 테이블이 생성된 in-memory SQLite 세션.
+
+    Provides an in-memory SQLite session with all ORM tables created.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def seeded_user_and_repo(db):
+    """user + repo 1건 seed — user_id 명시 케이스의 FK 충족용.
+
+    Seeds one user + one repo for user_id-scoped test cases.
+    """
+    user = User(
+        github_id="cache_error_uid_1",
+        github_login="cache_error_user",
+        email="cache_error@x.com",
+        display_name="CacheErrorUser",
+    )
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    repo = Repository(full_name="cache_error_user/repo", user_id=user.id)
+    db.add(repo)
+    db.commit()
+    db.refresh(repo)
+
+    return user, repo
+
+
+def _make_analysis(
+    db: Session,
+    repo_id: int,
+    score: int,
+    *,
+    offset_hours: int = 0,
+    result: dict[str, Any] | None = None,
+) -> Analysis:
+    """Analysis 레코드 헬퍼 — 점수 / created_at offset / result dict 주입 가능.
+
+    Helper to insert an Analysis row with configurable score / created_at / result.
+    """
+    created = datetime.now(timezone.utc) - timedelta(hours=offset_hours)
+    a = Analysis(
+        repo_id=repo_id,
+        commit_sha=f"sha-{uuid.uuid4().hex}",
+        score=score,
+        grade="B",
+        result=result or {},
+        created_at=created,
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+def _seed_two_analyses(db: Session, repo_id: int) -> None:
+    """kpi["analysis_count"]["value"] > 0 조건 충족을 위한 최소 Analysis 2건 seed.
+
+    Seeds 2 Analysis rows so the function passes the no_data guard and reaches
+    the Claude API call.
+    """
+    _make_analysis(db, repo_id, 80, offset_hours=1)
+    _make_analysis(db, repo_id, 85, offset_hours=2)
+
+
+def _make_valid_json() -> str:
+    """유효한 4 카드 JSON 문자열 반환 (parse_insight_cards 통과).
+
+    Returns a valid 4-card JSON string that passes _parse_insight_cards.
+    """
+    return (
+        '{"positive_highlights":["강점 항목 1","강점 항목 2","강점 항목 3"],'
+        '"focus_areas":["개선 항목 1","개선 항목 2","개선 항목 3"],'
+        '"key_metrics":['
+        '{"label":"평균 점수","value":"82.5","delta":"+2.5"},'
+        '{"label":"분석 건수","value":"2","delta":"0"},'
+        '{"label":"보안 HIGH","value":"0","delta":"0"},'
+        '{"label":"활성 리포","value":"1","delta":"0"}],'
+        '"next_actions":["다음 액션 1","다음 액션 2"]}'
+    )
+
+
+# ─── 케이스 1: api_error 발생 시 cache upsert 호출 안 됨 ────────────────────
+
+
+@pytest.mark.asyncio
+async def test_api_error_does_not_call_upsert(db, seeded_user_and_repo):
+    """api_error 반환 시 insight_narrative_cache_repo.upsert 가 호출되지 않음.
+
+    When _call_insight_claude_api returns None (mapped to api_error),
+    the cache upsert must NOT be called — error responses must never be cached.
+
+    Code-level guard (dashboard_service.py line 861-867):
+        if text is None:
+            return _build_insight_response(status="api_error", days=days)  # upsert 도달 X
+        ...
+        if user_id is not None:
+            insight_narrative_cache_repo.upsert(...)  # 이 줄에 도달하지 않음
+    """
+    user, repo = seeded_user_and_repo
+    _seed_two_analyses(db, repo.id)
+
+    # _call_insight_claude_api 가 None 을 반환하도록 mock
+    # Mock _call_insight_claude_api to return None (simulates RuntimeError caught internally)
+    with patch.object(
+        dashboard_service, "_call_insight_claude_api",
+        new=AsyncMock(return_value=None),
+    ) as mock_api, \
+         patch(
+             "src.repositories.insight_narrative_cache_repo.upsert",
+         ) as mock_upsert:
+        result = await dashboard_service.insight_narrative(
+            db, days=7, user_id=user.id, api_key="sk-test",
+        )
+
+    # api_error 반환 확인
+    # Assert api_error is returned
+    assert result["status"] == "api_error", (
+        f"Expected status='api_error', got '{result['status']}'"
+    )
+    assert result["positive_highlights"] == []
+    assert result["focus_areas"] == []
+    assert result["key_metrics"] == []
+    assert result["next_actions"] == []
+
+    # upsert 가 한 번도 호출되지 않았는지 확인
+    # Assert upsert was NOT called
+    mock_upsert.assert_not_called()
+
+    # _call_insight_claude_api 는 1회 호출됨 (캐시 없으므로 API 도달)
+    # _call_insight_claude_api was called exactly once (no cache hit)
+    mock_api.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_api_error_second_call_retries_api_not_cached(db, seeded_user_and_repo):
+    """api_error 후 두 번째 호출 시 캐시 없으므로 API 다시 호출됨.
+
+    After an api_error, there is no cached entry, so the second call must
+    invoke the Claude API again (no stale cache served).
+
+    케이스 1 연장: 1차 api_error → 캐시 row 0개 → 2차 호출 시 API 재호출 확인.
+    Case 1 extension: first api_error → 0 cache rows → second call hits API again.
+    """
+    user, repo = seeded_user_and_repo
+    _seed_two_analyses(db, repo.id)
+
+    # 두 번 모두 None 반환 (api_error 지속)
+    # Both calls return None (persistent api_error)
+    with patch.object(
+        dashboard_service, "_call_insight_claude_api",
+        new=AsyncMock(return_value=None),
+    ) as mock_api, \
+         patch(
+             "src.repositories.insight_narrative_cache_repo.upsert",
+         ) as mock_upsert:
+        result1 = await dashboard_service.insight_narrative(
+            db, days=7, user_id=user.id, api_key="sk-test",
+        )
+        result2 = await dashboard_service.insight_narrative(
+            db, days=7, user_id=user.id, api_key="sk-test",
+        )
+
+    # 두 결과 모두 api_error
+    # Both results should be api_error
+    assert result1["status"] == "api_error"
+    assert result2["status"] == "api_error"
+
+    # upsert 전혀 호출 안 됨 (두 호출 합산)
+    # upsert never called across both invocations
+    mock_upsert.assert_not_called()
+
+    # API 는 두 번 호출됨 — 캐시가 없어 매번 도달
+    # API called twice — no cache entry means each call reaches the API
+    assert mock_api.await_count == 2, (
+        f"Expected 2 API calls (no cache between retries), got {mock_api.await_count}"
+    )
+
+    # DB 에 에러 추적 row 1개 존재 (0033 — record_error 신설)
+    # After 0033: record_error creates 1 immediately-expired error-tracking row
+    rows = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == user.id,
+    ).all()
+    assert len(rows) == 1, f"Expected 1 error-tracking row after api_error, found {len(rows)}"
+    row = rows[0]
+    # 에러 추적 row 는 즉시 만료 상태여야 함 (get_fresh 차단 없음)
+    # Error-tracking row must be immediately expired (never blocks fresh retry)
+    expires = row.expires_at
+    if expires.tzinfo is None:
+        expires = expires.replace(tzinfo=timezone.utc)
+    assert expires <= datetime.now(timezone.utc) + timedelta(seconds=2), (
+        "Error-tracking row must be immediately expired"
+    )
+    assert row.error_count >= 2, "Both api_error calls should be counted"
+
+
+# ─── 케이스 2: api_error 후 재시도 시 success 복구 ─────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_api_error_then_success_recovery(db, seeded_user_and_repo):
+    """첫 번째 api_error 후 두 번째 호출이 success 로 복구됨.
+
+    First call: _call_insight_claude_api returns None → api_error (no cache write).
+    Second call: _call_insight_claude_api returns valid JSON → success + cache upsert.
+
+    side_effect=[None, valid_json] 패턴으로 순서 제어.
+    Uses side_effect=[None, valid_json] to control the call sequence.
+
+    Code-level trace:
+        1st call: text=None → return api_error (upsert 건너뜀)
+        2nd call: get_fresh → None (캐시 없음) → text=valid_json → parse → upsert 호출
+    """
+    user, repo = seeded_user_and_repo
+    _seed_two_analyses(db, repo.id)
+
+    valid_json = _make_valid_json()
+
+    # side_effect 순서: 1차=None(api_error), 2차=valid JSON(success)
+    # side_effect order: 1st=None (api_error), 2nd=valid JSON (success)
+    with patch.object(
+        dashboard_service, "_call_insight_claude_api",
+        new=AsyncMock(side_effect=[None, valid_json]),
+    ) as mock_api:
+        # 1차 호출 — api_error 예상
+        # First call — expect api_error
+        result1 = await dashboard_service.insight_narrative(
+            db, days=7, user_id=user.id, api_key="sk-test",
+        )
+
+        # 2차 호출 — success 예상
+        # Second call — expect success
+        result2 = await dashboard_service.insight_narrative(
+            db, days=7, user_id=user.id, api_key="sk-test",
+        )
+
+    # 1차 결과: api_error + 4 카드 빈 list
+    # First result: api_error + empty 4 cards
+    assert result1["status"] == "api_error", (
+        f"Expected 1st call status='api_error', got '{result1['status']}'"
+    )
+    assert result1["positive_highlights"] == []
+    assert result1["focus_areas"] == []
+    assert result1["key_metrics"] == []
+    assert result1["next_actions"] == []
+
+    # 2차 결과: success + 내용 있는 카드
+    # Second result: success + populated cards
+    assert result2["status"] == "success", (
+        f"Expected 2nd call status='success', got '{result2['status']}'"
+    )
+    assert len(result2["positive_highlights"]) > 0, (
+        "Expected non-empty positive_highlights on success recovery"
+    )
+    assert len(result2["focus_areas"]) > 0
+    assert len(result2["key_metrics"]) == 4
+    assert len(result2["next_actions"]) > 0
+
+    # API 정확히 2회 호출 확인 (side_effect 소진)
+    # Confirm exactly 2 API calls (side_effect exhausted)
+    assert mock_api.await_count == 2, (
+        f"Expected 2 API calls total, got {mock_api.await_count}"
+    )
+
+    # 2차 success 후 DB 에 캐시 row 1개 저장됨
+    # After 2nd success, exactly 1 cache row should exist in DB
+    rows = db.query(InsightNarrativeCache).filter(
+        InsightNarrativeCache.user_id == user.id,
+        InsightNarrativeCache.days == 7,
+    ).all()
+    assert len(rows) == 1, (
+        f"Expected 1 cache row after success recovery, found {len(rows)}"
+    )
+    cached_response = rows[0].response_json
+    assert cached_response["status"] == "success"
+    assert len(cached_response["positive_highlights"]) > 0

--- a/tests/unit/services/test_insight_parse_edge_cases.py
+++ b/tests/unit/services/test_insight_parse_edge_cases.py
@@ -1,0 +1,382 @@
+"""insight_narrative — Claude 응답 파싱 경계 케이스 단위 테스트.
+
+unit tests for Claude response parsing edge cases in insight_narrative.
+
+검증 대상:
+    src/services/dashboard_service.py::_extract_insight_json()
+    src/services/dashboard_service.py::_parse_insight_cards()
+
+담당 케이스 4종:
+    1. 빈 문자열 응답 → parse_error
+    2. JSON 포맷이지만 필수 키 누락 (positive_highlights, focus_areas 만 있고
+       key_metrics, next_actions 없음) → success (빈 list 허용 — get() 기본값)
+    3. 마크다운 코드블록 안에 JSON (```json ... ```) → success (코드 블록 제거 지원)
+    4. 앞뒤 prose가 붙은 JSON → success (_extract_insight_json first/last { } fallback)
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.services.dashboard_service import (
+    _extract_insight_json,
+    _parse_insight_cards,
+)
+
+
+# ─── 공유 헬퍼 ─────────────────────────────────────────────────────────────
+
+
+_FULL_VALID_JSON = json.dumps(
+    {
+        "positive_highlights": ["강점 1", "강점 2", "강점 3"],
+        "focus_areas": ["개선 1", "개선 2", "개선 3"],
+        "key_metrics": [
+            {"label": "평균 점수", "value": "84.2", "delta": "+3.1"},
+            {"label": "분석 건수", "value": "5", "delta": "+2"},
+            {"label": "보안 HIGH", "value": "0", "delta": "0"},
+            {"label": "Auto-merge 성공", "value": "100%", "delta": "+10%"},
+        ],
+        "next_actions": ["액션 1", "액션 2"],
+    },
+    ensure_ascii=False,
+)
+
+
+def _make_anthropic_response(text: str) -> MagicMock:
+    """Anthropic Messages API 응답 mock — content[0].text 형식.
+
+    Builds a MagicMock matching the Anthropic Messages API response shape.
+    """
+    fake_msg = MagicMock()
+    text_block = MagicMock()
+    text_block.text = text
+    fake_msg.content = [text_block]
+    fake_msg.usage = MagicMock(
+        input_tokens=100,
+        output_tokens=50,
+        cache_read_input_tokens=0,
+        cache_creation_input_tokens=100,
+    )
+    return fake_msg
+
+
+# ─── Case 1: 빈 문자열 응답 ────────────────────────────────────────────────
+
+
+class TestEmptyStringResponse:
+    """Case 1 — 빈 문자열 응답은 parse_error 를 반환해야 한다.
+
+    Case 1 — Empty string response must yield parse_error.
+    """
+
+    def test_extract_insight_json_returns_empty_string_for_empty_input(self):
+        """`_extract_insight_json("")` → 빈 문자열 반환 (JSON 없음).
+
+        Confirm _extract_insight_json returns empty string for empty input.
+        """
+        result = _extract_insight_json("")
+        assert result == ""
+
+    def test_parse_insight_cards_returns_none_for_empty_string(self):
+        """`_parse_insight_cards("")` → None (json.loads 실패 → parse_error 경로).
+
+        _parse_insight_cards on empty string returns None, triggering parse_error downstream.
+        """
+        result = _parse_insight_cards("")
+        assert result is None
+
+    def test_parse_insight_cards_none_maps_to_parse_error_contract(self):
+        """None 반환은 insight_narrative 에서 parse_error 로 매핑됨을 명시적으로 검증.
+
+        Explicitly verify that a None return maps to parse_error in insight_narrative flow.
+        The actual mapping lives at dashboard_service.py line ~856:
+            if cards is None:
+                return _build_insight_response(status="parse_error", days=days)
+        """
+        # _make_anthropic_response 를 통한 end-to-end 파싱 경로 재현
+        # Reproduce end-to-end parsing path via the mock response helper
+        response = _make_anthropic_response("")
+        text = response.content[0].text
+        cards = _parse_insight_cards(text)
+        assert cards is None, (
+            "빈 문자열 응답은 _parse_insight_cards 에서 None 을 반환해 "
+            "insight_narrative 의 parse_error 경로로 진입해야 합니다."
+        )
+
+
+# ─── Case 2: 필수 키 누락 JSON ─────────────────────────────────────────────
+
+
+class TestMissingRequiredKeysJson:
+    """Case 2 — 필수 키 일부 누락 JSON 처리 검증.
+
+    Case 2 — JSON missing required keys (key_metrics, next_actions).
+
+    _parse_insight_cards 는 json.loads 성공 후 data.get() 기본값 빈 list 사용 →
+    키 누락 시에도 success 경로 (None 반환 X, 빈 list 포함 dict 반환).
+    _parse_insight_cards uses data.get() with empty list defaults after json.loads,
+    so missing keys produce success (empty lists), not parse_error.
+    """
+
+    _PARTIAL_JSON = json.dumps(
+        {
+            "positive_highlights": ["강점 1", "강점 2"],
+            "focus_areas": ["개선 1", "개선 2"],
+            # key_metrics, next_actions 의도적 누락
+            # key_metrics and next_actions intentionally omitted
+        },
+        ensure_ascii=False,
+    )
+
+    def test_extract_insight_json_returns_raw_json_for_well_formed_input(self):
+        """`_extract_insight_json` 은 유효한 JSON 문자열을 그대로 반환.
+
+        _extract_insight_json returns the raw JSON string unchanged for well-formed input.
+        """
+        result = _extract_insight_json(self._PARTIAL_JSON)
+        # first { ~ last } 추출 — 원본과 동일해야 함
+        # First { to last } extraction — must equal the original
+        assert json.loads(result) == json.loads(self._PARTIAL_JSON)
+
+    def test_parse_insight_cards_returns_dict_not_none_for_partial_keys(self):
+        """`_parse_insight_cards` 는 키 누락 JSON 에도 None 이 아닌 dict 반환.
+
+        _parse_insight_cards returns a dict (not None) even when required keys are missing.
+        This is a success path — missing keys default to empty lists via data.get().
+        """
+        result = _parse_insight_cards(self._PARTIAL_JSON)
+        assert result is not None, (
+            "키 누락 JSON 은 json.loads 자체는 성공하므로 None 이 아닌 dict 를 반환해야 합니다. "
+            "insight_narrative 는 success 상태로 진행합니다."
+        )
+        assert isinstance(result, dict)
+
+    def test_parse_insight_cards_fills_missing_keys_with_empty_lists(self):
+        """누락된 key_metrics, next_actions 는 빈 list 로 채워져야 한다.
+
+        Missing key_metrics and next_actions must be filled with empty lists.
+        """
+        result = _parse_insight_cards(self._PARTIAL_JSON)
+        assert result is not None
+        # 존재하는 키는 원본 값 유지
+        # Existing keys preserve their original values
+        assert result["positive_highlights"] == ["강점 1", "강점 2"]
+        assert result["focus_areas"] == ["개선 1", "개선 2"]
+        # 누락 키는 빈 list 기본값
+        # Missing keys default to empty list
+        assert result["key_metrics"] == []
+        assert result["next_actions"] == []
+
+    def test_partial_json_status_is_success_not_parse_error(self):
+        """키 누락 JSON 의 status 가 success 임을 명시적으로 기록.
+
+        Explicitly document that partial-key JSON yields status=success (not parse_error).
+        This is intentional: _parse_insight_cards does not enforce schema strictness —
+        it uses .get() defaults. The system prompt instructs Claude to include all keys,
+        but the parser is lenient on the reader side.
+        """
+        cards = _parse_insight_cards(self._PARTIAL_JSON)
+        # None 이 아니면 insight_narrative 는 success 로 진행 (parse_error 아님)
+        # Non-None cards → insight_narrative proceeds to success (not parse_error)
+        assert cards is not None
+        # status 매핑은 insight_narrative 내부 로직이므로 여기서는 None 여부만 확인
+        # Status mapping is internal to insight_narrative; only check None vs dict here
+
+
+# ─── Case 3: 마크다운 코드블록 안에 JSON ───────────────────────────────────
+
+
+class TestMarkdownCodeBlockJson:
+    """Case 3 — 마크다운 코드블록 패턴 ``json ... `` 처리 검증.
+
+    Case 3 — Markdown fenced code block pattern handling.
+
+    많은 LLM 이 ``json\\n{...}\\n`` 형식으로 응답함.
+    _extract_insight_json 은 re.search(r"``(?:json)?\\s*(\\{.*?\\})\\s*``") 으로
+    코드 블록 제거를 지원하므로 → success 경로.
+
+    Many LLMs respond with ``json\\n{...}\\n`` format.
+    _extract_insight_json uses a regex to strip fenced blocks → success path.
+    """
+
+    _CODE_BLOCK_RESPONSE = f"```json\n{_FULL_VALID_JSON}\n```"
+    _CODE_BLOCK_NO_LANG = f"```\n{_FULL_VALID_JSON}\n```"
+
+    def test_extract_insight_json_strips_json_code_block(self):
+        """`_extract_insight_json` 은 ```json ... ``` 블록에서 JSON 본문을 추출한다.
+
+        _extract_insight_json extracts JSON body from ```json ... ``` fenced block.
+        """
+        result = _extract_insight_json(self._CODE_BLOCK_RESPONSE)
+        parsed = json.loads(result)
+        assert "positive_highlights" in parsed
+        assert "key_metrics" in parsed
+
+    def test_extract_insight_json_strips_bare_code_block(self):
+        """`_extract_insight_json` 은 언어 지정 없는 ``` ... ``` 블록도 처리한다.
+
+        _extract_insight_json handles bare ``` ... ``` block (no language specifier).
+        """
+        result = _extract_insight_json(self._CODE_BLOCK_NO_LANG)
+        parsed = json.loads(result)
+        assert "positive_highlights" in parsed
+
+    def test_parse_insight_cards_succeeds_for_code_block_response(self):
+        """`_parse_insight_cards` 는 코드블록 응답에서 4 카드 dict 를 반환한다.
+
+        _parse_insight_cards returns a 4-card dict for a code-block-wrapped response.
+        This is the key behavior: Claude often returns JSON inside ```json``` blocks,
+        and the parser must handle this gracefully (not return None / parse_error).
+        """
+        result = _parse_insight_cards(self._CODE_BLOCK_RESPONSE)
+        assert result is not None, (
+            "마크다운 코드블록 응답은 parse_error 가 아닌 success 여야 합니다. "
+            "_extract_insight_json 의 regex 가 코드 블록 제거를 지원합니다."
+        )
+        assert len(result["positive_highlights"]) == 3
+        assert len(result["focus_areas"]) == 3
+        assert len(result["key_metrics"]) == 4
+        assert len(result["next_actions"]) == 2
+
+    def test_parse_insight_cards_via_mock_response_code_block(self):
+        """_make_anthropic_response 경유 코드블록 파싱 — end-to-end 재현.
+
+        End-to-end reproduction via _make_anthropic_response with a code-block payload.
+        """
+        response = _make_anthropic_response(self._CODE_BLOCK_RESPONSE)
+        text = response.content[0].text
+        cards = _parse_insight_cards(text)
+        assert cards is not None
+        # key_metrics 4건 존재 + label 필드 검증
+        # Verify 4 key_metrics items with label fields
+        assert all("label" in m for m in cards["key_metrics"])
+
+
+# ─── Case 4: 앞뒤 prose가 붙은 JSON ──────────────────────────────────────
+
+
+class TestProseWrappedJson:
+    """Case 4 — 앞뒤 prose 텍스트로 감싸진 JSON 처리 검증.
+
+    Case 4 — JSON wrapped by leading/trailing prose text.
+
+    일부 LLM 이 "Here is the analysis:\\n{...}\\nHope this helps!" 형식으로 응답.
+    _extract_insight_json 은 first `{` ~ last `}` fallback 으로 추출 → success 경로.
+
+    Some LLMs respond with prose before/after the JSON.
+    _extract_insight_json uses first `{` to last `}` fallback → success path.
+    """
+
+    _PROSE_WRAPPED_RESPONSE = (
+        "Here is the analysis:\n"
+        + _FULL_VALID_JSON
+        + "\nHope this helps!"
+    )
+
+    _KOREAN_PROSE_WRAPPED_RESPONSE = (
+        "다음은 분석 결과입니다.\n\n"
+        + _FULL_VALID_JSON
+        + "\n\n이상입니다. 도움이 되길 바랍니다."
+    )
+
+    def test_extract_insight_json_extracts_from_prose_wrapped_response(self):
+        """`_extract_insight_json` 은 앞뒤 prose 텍스트에서 JSON 본문을 추출한다.
+
+        _extract_insight_json extracts JSON body from leading/trailing prose.
+        Uses first `{` to last `}` substring extraction as fallback.
+        """
+        result = _extract_insight_json(self._PROSE_WRAPPED_RESPONSE)
+        parsed = json.loads(result)
+        assert "positive_highlights" in parsed
+        assert "next_actions" in parsed
+
+    def test_extract_insight_json_handles_korean_prose(self):
+        """한국어 prose 앞뒤에 감싸인 JSON 도 추출 가능해야 한다.
+
+        _extract_insight_json handles JSON wrapped by Korean prose text.
+        """
+        result = _extract_insight_json(self._KOREAN_PROSE_WRAPPED_RESPONSE)
+        parsed = json.loads(result)
+        assert "key_metrics" in parsed
+
+    def test_parse_insight_cards_succeeds_for_prose_wrapped_response(self):
+        """`_parse_insight_cards` 는 prose 감싸인 응답에서 4 카드 dict 를 반환한다.
+
+        _parse_insight_cards returns a 4-card dict for a prose-wrapped response.
+        This confirms the first/last { } fallback in _extract_insight_json works correctly.
+        """
+        result = _parse_insight_cards(self._PROSE_WRAPPED_RESPONSE)
+        assert result is not None, (
+            "앞뒤 prose 감싸인 응답은 parse_error 가 아닌 success 여야 합니다. "
+            "_extract_insight_json 의 first/last { } fallback 이 지원합니다."
+        )
+        assert len(result["positive_highlights"]) == 3
+        assert len(result["key_metrics"]) == 4
+
+    def test_parse_insight_cards_via_mock_response_prose_wrapped(self):
+        """_make_anthropic_response 경유 prose 감싸인 파싱 — end-to-end 재현.
+
+        End-to-end reproduction via _make_anthropic_response with prose-wrapped payload.
+        """
+        response = _make_anthropic_response(self._PROSE_WRAPPED_RESPONSE)
+        text = response.content[0].text
+        cards = _parse_insight_cards(text)
+        assert cards is not None
+        # next_actions 2건 존재 + str 타입 검증
+        # Verify 2 next_actions items with str type
+        assert len(cards["next_actions"]) == 2
+        assert all(isinstance(s, str) for s in cards["next_actions"])
+
+
+# ─── 크로스-케이스 요약 테스트 ──────────────────────────────────────────────
+
+
+class TestParseSummaryMatrix:
+    """4 케이스 요약 — _parse_insight_cards 반환값 / None 여부 matrix.
+
+    Summary matrix test for all 4 cases:
+    - empty string    → None  (parse_error)
+    - partial keys    → dict  (success, missing keys filled with [])
+    - code block      → dict  (success, fenced block stripped)
+    - prose wrapped   → dict  (success, first/last {} fallback)
+    """
+
+    _PARTIAL_JSON = json.dumps(
+        {"positive_highlights": [], "focus_areas": []}, ensure_ascii=False
+    )
+    _CODE_BLOCK = f"```json\n{_FULL_VALID_JSON}\n```"
+    _PROSE_WRAPPED = "Analysis:\n" + _FULL_VALID_JSON + "\nDone."
+
+    @pytest.mark.parametrize(
+        "text, expect_none, case_label",
+        [
+            ("", True, "빈 문자열 → parse_error (None)"),
+            (_PARTIAL_JSON, False, "필수 키 누락 JSON → success (dict, 빈 list 기본값)"),
+            (_CODE_BLOCK, False, "마크다운 코드블록 → success (코드 블록 제거)"),
+            (_PROSE_WRAPPED, False, "앞뒤 prose → success (first/last {} fallback)"),
+        ],
+    )
+    def test_parse_matrix(self, text: str, expect_none: bool, case_label: str):
+        """4 케이스 파라미터화 요약 테스트.
+
+        Parameterized summary test for all 4 parsing edge cases.
+        """
+        result = _parse_insight_cards(text)
+        if expect_none:
+            assert result is None, (
+                f"케이스 [{case_label}]: None 을 기대했으나 {result!r} 를 반환했습니다."
+            )
+        else:
+            assert result is not None, (
+                f"케이스 [{case_label}]: dict 를 기대했으나 None 을 반환했습니다."
+            )
+            assert isinstance(result, dict)
+            # 4 카드 키 모두 존재 검증
+            # Verify all 4 card keys are present
+            for key in ("positive_highlights", "focus_areas", "key_metrics", "next_actions"):
+                assert key in result, (
+                    f"케이스 [{case_label}]: 카드 키 '{key}' 가 결과에 없습니다."
+                )

--- a/tests/unit/ui/test_dashboard_insight_error_states.py
+++ b/tests/unit/ui/test_dashboard_insight_error_states.py
@@ -27,7 +27,6 @@ from src.main import app
 # ORM metadata 등록 (모듈 최상단 import — pytest collection 시점에 등록).
 # Register ORM metadata at module import time (pytest collection).
 from src.models.analysis import Analysis as _AnalysisModel  # noqa: E402, F401
-from src.models.repository import Repository as _RepoModel  # noqa: E402, F401
 from src.models.user import User as _UserModel  # noqa: E402, F401
 
 _TEST_USER = CurrentUser(

--- a/tests/unit/ui/test_dashboard_insight_error_states.py
+++ b/tests/unit/ui/test_dashboard_insight_error_states.py
@@ -1,0 +1,529 @@
+"""대시보드 insight api_error 상태 처리 검증 — 케이스 2종.
+Dashboard insight api_error state handling verification — 2 cases.
+
+케이스 1: 라우트 레벨 — api_error 응답이 템플릿에 올바르게 전달됨
+Case 1: Route level — api_error response correctly forwarded to template context
+
+케이스 2: 템플릿 레벨 — api_error 텍스트 렌더링 (Jinja2 직접 렌더)
+Case 2: Template level — api_error text rendering (Jinja2 direct render)
+
+대상 파일:
+- src/ui/routes/dashboard.py — insight 탭 처리 부분
+- src/templates/dashboard.html — api_error 렌더링 부분
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.responses import HTMLResponse
+from fastapi.testclient import TestClient
+from jinja2 import Environment, FileSystemLoader, Undefined
+
+from src.auth.session import CurrentUser, require_login
+from src.main import app
+
+# ORM metadata 등록 (모듈 최상단 import — pytest collection 시점에 등록).
+# Register ORM metadata at module import time (pytest collection).
+from src.database import Base  # noqa: E402
+from src.models.analysis import Analysis as _AnalysisModel  # noqa: E402, F401
+from src.models.repository import Repository as _RepoModel  # noqa: E402, F401
+from src.models.user import User as _UserModel  # noqa: E402, F401
+
+_TEST_USER = CurrentUser(
+    id=1,
+    github_login="tester",
+    email="t@x.com",
+    display_name="Tester",
+    plaintext_token="",
+)
+
+
+@contextmanager
+def _ctx(db):
+    """SessionLocal 컨텍스트 매니저 mock 헬퍼.
+    SessionLocal context manager mock helper.
+    """
+    yield db
+
+
+@pytest.fixture(autouse=True)
+def _override_login():
+    """모든 테스트에서 require_login override → _TEST_USER 주입.
+    Override require_login in all tests → inject _TEST_USER.
+    """
+    _prev = app.dependency_overrides.get(require_login)
+    app.dependency_overrides[require_login] = lambda: _TEST_USER
+    yield
+    if _prev is not None:
+        app.dependency_overrides[require_login] = _prev
+    else:
+        app.dependency_overrides.pop(require_login, None)
+
+
+# ─── 케이스 1: 라우트 레벨 — api_error context 전달 검증 ──────────────────────
+# Case 1: Route level — api_error context forwarding verification
+
+
+def test_route_insight_api_error_forwarded_to_template():
+    """케이스 1a: insight.status='api_error' 가 template context 에 올바르게 전달됨.
+
+    Case 1a: insight.status='api_error' correctly forwarded to template context.
+
+    검증:
+    - insight_narrative mock → status='api_error' 응답 반환
+    - 라우트가 에러 없이 처리 (200 응답)
+    - context['insight']['status'] == 'api_error' 전달 확인
+    """
+    client = TestClient(app)
+    mock_db = MagicMock()
+    captured: dict = {}
+
+    # api_error 응답 — 실제 insight_narrative 가 반환하는 구조 기반.
+    # api_error response structure mirrors the actual insight_narrative return format.
+    fake_api_error = {
+        "status": "api_error",
+        "positive_highlights": [],
+        "focus_areas": [],
+        "key_metrics": [],
+        "next_actions": [],
+        "generated_at": None,
+        "days": 7,
+    }
+
+    def _capture(request, template_name, context, **kwargs):
+        captured.update(context)
+        return HTMLResponse(content="<html>captured</html>", status_code=200)
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch(
+             "src.ui.routes.dashboard.dashboard_service.insight_narrative",
+             new=AsyncMock(return_value=fake_api_error),
+         ), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse", side_effect=_capture):
+        response = client.get("/dashboard?mode=insight")
+
+    assert response.status_code == 200, (
+        f"api_error insight 처리 중 에러 발생 (기대 200, 실제 {response.status_code})"
+    )
+    assert "insight" in captured, "template context 에 'insight' 키 누락"
+    insight_ctx = captured["insight"]
+    assert insight_ctx["status"] == "api_error", (
+        f"context['insight']['status'] 'api_error' 기대, 실제: {insight_ctx['status']!r}"
+    )
+
+
+def test_route_insight_api_error_mode_and_days_in_context():
+    """케이스 1b: api_error 응답 시 mode='insight' 및 days 값 context 전달 확인.
+
+    Case 1b: mode='insight' and days value present in context when api_error occurs.
+    """
+    client = TestClient(app)
+    mock_db = MagicMock()
+    captured: dict = {}
+
+    fake_api_error = {
+        "status": "api_error",
+        "positive_highlights": [],
+        "focus_areas": [],
+        "key_metrics": [],
+        "next_actions": [],
+        "generated_at": None,
+        "days": 30,
+    }
+
+    def _capture(request, template_name, context, **kwargs):
+        captured.update(context)
+        return HTMLResponse(content="<html>captured</html>", status_code=200)
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch(
+             "src.ui.routes.dashboard.dashboard_service.insight_narrative",
+             new=AsyncMock(return_value=fake_api_error),
+         ), \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse", side_effect=_capture):
+        response = client.get("/dashboard?mode=insight&days=30")
+
+    assert response.status_code == 200
+    assert captured.get("mode") == "insight", (
+        f"mode 'insight' 기대, 실제: {captured.get('mode')!r}"
+    )
+    assert captured.get("days") == 30, (
+        f"days=30 기대, 실제: {captured.get('days')!r}"
+    )
+    # insight 전체 dict 가 그대로 전달 (api_error 포함)
+    # Full insight dict forwarded as-is (including api_error)
+    assert captured["insight"]["status"] == "api_error"
+
+
+def test_route_insight_api_error_overview_services_not_called():
+    """케이스 1c: api_error insight 시 overview 분기 서비스 함수 미호출 확인.
+
+    Case 1c: Overview branch service functions NOT called when insight returns api_error.
+
+    insight 분기가 api_error 를 에러로 인식해 overview 로 폴백하지 않아야 함.
+    The insight branch must NOT fall back to overview when api_error is received.
+    """
+    client = TestClient(app)
+    mock_db = MagicMock()
+
+    fake_api_error = {
+        "status": "api_error",
+        "positive_highlights": [],
+        "focus_areas": [],
+        "key_metrics": [],
+        "next_actions": [],
+        "generated_at": None,
+        "days": 7,
+    }
+
+    with patch("src.ui.routes.dashboard.SessionLocal", return_value=_ctx(mock_db)), \
+         patch(
+             "src.ui.routes.dashboard.dashboard_service.insight_narrative",
+             new=AsyncMock(return_value=fake_api_error),
+         ), \
+         patch(
+             "src.ui.routes.dashboard.dashboard_service.dashboard_kpi",
+             return_value={},
+         ) as mock_kpi, \
+         patch("src.ui.routes.dashboard.templates.TemplateResponse") as mock_tr:
+        mock_tr.return_value = HTMLResponse(content="<html>x</html>", status_code=200)
+        response = client.get("/dashboard?mode=insight")
+
+    assert response.status_code == 200
+    # api_error 는 insight 분기 내 정상 응답 — overview 분기 미진입 (dashboard_kpi 미호출)
+    # api_error is a normal insight response — overview branch NOT entered (dashboard_kpi not called)
+    mock_kpi.assert_not_called(), (
+        "api_error 시 overview 분기 폴백 발생 (dashboard_kpi 호출됨) — 잘못된 에러 처리"
+    )
+
+
+# ─── 케이스 2: 템플릿 레벨 — Jinja2 직접 렌더링 status 분기 검증 ─────────────
+# Case 2: Template level — Jinja2 direct rendering for each status branch
+
+
+@pytest.fixture(scope="module")
+def jinja_env():
+    """실제 dashboard.html 을 렌더할 수 있는 Jinja2 Environment.
+
+    Real Jinja2 Environment capable of rendering dashboard.html.
+    i18n 필터 등록 포함 (templates._helpers 가 등록한 것과 동일 환경).
+    Includes i18n filter registration (same environment as templates._helpers registers).
+    """
+    import os
+    template_dir = os.path.join(
+        os.path.dirname(__file__), "..", "..", "..", "src", "templates"
+    )
+    env = Environment(
+        loader=FileSystemLoader(template_dir),
+        autoescape=True,
+        # Undefined 변수는 빈 문자열로 처리 (렌더 중단 방지)
+        # Treat undefined variables as empty string (prevent render abort)
+        undefined=Undefined,
+    )
+    # i18n 필터 등록 (실제 필터와 동일 구현 사용)
+    # Register i18n filters (same implementation as production)
+    from src.i18n.filters import register_i18n_filters
+    register_i18n_filters(env)
+    return env
+
+
+def _render_insight_section(jinja_env, insight: dict, days: int = 7, locale: str = "ko") -> str:
+    """dashboard.html 의 insight 섹션만 추출하여 렌더링.
+
+    Render only the insight section of dashboard.html.
+
+    직접 템플릿 전체 렌더링 시 다른 섹션의 context 의존성(kpi, trend 등)으로
+    UndefinedError 가 발생할 수 있어 insight 섹션 전용 미니 템플릿 사용.
+    Full template rendering would cause UndefinedError from other sections (kpi, trend etc),
+    so use a minimal template targeting only the insight section.
+
+    실제 dashboard.html 의 insight 분기 조건 코드를 그대로 복사하여 검증.
+    Copies the actual insight branch conditions from dashboard.html for verification.
+    """
+    # 실제 dashboard.html 의 insight 분기 로직 (라인 879~934)
+    # Actual insight branch logic from dashboard.html (lines 879-934)
+    template_source = """
+{% if insight and insight.status == 'success' %}
+<div class="insight-success">AI Insight 성공</div>
+{% elif insight and insight.status == 'no_api_key' %}
+<div class="dash-insight-status">
+  {{ 'dashboard.insight.no_api_key' | i18n_args(locale | default('ko')) }}
+</div>
+{% elif insight and insight.status == 'no_data' %}
+<div class="dash-insight-status">
+  {{ 'dashboard.insight.no_data' | i18n_args(locale | default('ko'), days=days) }}
+</div>
+{% else %}
+<div class="dash-insight-status">
+  {{ 'dashboard.insight.load_failed' | i18n_args(locale | default('ko'), status=(insight.status if insight else 'unknown')) }}
+</div>
+{% endif %}
+"""
+    tmpl = jinja_env.from_string(template_source)
+    return tmpl.render(insight=insight, days=days, locale=locale)
+
+
+def test_template_api_error_renders_load_failed_message(jinja_env):
+    """케이스 2a: status='api_error' → load_failed 메시지 렌더링.
+
+    Case 2a: status='api_error' → load_failed message rendered.
+
+    ko 번역: "⚠️ AI Insight 생성 실패 ({status}) — 잠시 후 다시 시도해주세요."
+    status='api_error' 치환 후: "⚠️ AI Insight 생성 실패 (api_error) — 잠시 후 다시 시도해주세요."
+    """
+    insight = {
+        "status": "api_error",
+        "positive_highlights": [],
+        "focus_areas": [],
+        "key_metrics": [],
+        "next_actions": [],
+        "generated_at": None,
+        "days": 7,
+    }
+    html = _render_insight_section(jinja_env, insight, locale="ko")
+
+    # load_failed 분기 진입 확인 — dash-insight-status div 존재
+    # Confirm load_failed branch entered — dash-insight-status div present
+    assert "dash-insight-status" in html, "load_failed 분기 미진입 (dash-insight-status 없음)"
+
+    # 'api_error' 문자열이 status placeholder 치환으로 포함되어야 함
+    # 'api_error' must be included as the {status} placeholder substitution
+    assert "api_error" in html, (
+        f"status='api_error' 렌더링 시 'api_error' 문자열 미포함\n실제 HTML:\n{html}"
+    )
+
+    # insight-success, no_api_key, no_data 분기가 아님을 확인
+    # Confirm this is NOT the success/no_api_key/no_data branch
+    assert "insight-success" not in html, "api_error 가 success 분기로 잘못 라우팅됨"
+
+
+def test_template_api_error_contains_ai_insight_text(jinja_env):
+    """케이스 2b: api_error 시 'AI Insight' 관련 텍스트 포함 확인 (ko 번역).
+
+    Case 2b: api_error renders text containing 'AI Insight' (ko translation).
+    """
+    insight = {"status": "api_error", "positive_highlights": [], "focus_areas": [],
+               "key_metrics": [], "next_actions": [], "generated_at": None, "days": 7}
+    html = _render_insight_section(jinja_env, insight, locale="ko")
+
+    # ko 번역 = "⚠️ AI Insight 생성 실패 (api_error) — 잠시 후 다시 시도해주세요."
+    # ko translation = "⚠️ AI Insight 생성 실패 (api_error) — 잠시 후 다시 시도해주세요."
+    assert "AI Insight" in html, (
+        f"ko api_error 메시지에 'AI Insight' 미포함\n실제 HTML:\n{html}"
+    )
+    assert "생성 실패" in html or "api_error" in html, (
+        f"ko api_error 메시지에 '생성 실패' 또는 'api_error' 미포함\n실제 HTML:\n{html}"
+    )
+
+
+def test_template_api_error_en_locale(jinja_env):
+    """케이스 2c: en locale 에서 api_error 렌더링 확인.
+
+    Case 2c: api_error rendering in English locale.
+
+    en 번역: "⚠️ AI Insight generation failed ({status}) — please try again later."
+    status='api_error' 치환 후: "⚠️ AI Insight generation failed (api_error) — please try again later."
+    """
+    insight = {"status": "api_error", "positive_highlights": [], "focus_areas": [],
+               "key_metrics": [], "next_actions": [], "generated_at": None, "days": 7}
+    html = _render_insight_section(jinja_env, insight, locale="en")
+
+    assert "api_error" in html, (
+        f"en api_error 메시지에 'api_error' 미포함\n실제 HTML:\n{html}"
+    )
+    # en 번역 확인
+    # English translation verification
+    assert "AI Insight" in html or "generation failed" in html or "load_failed" in html, (
+        f"en api_error 메시지 부적절\n실제 HTML:\n{html}"
+    )
+
+
+def test_template_no_api_key_status(jinja_env):
+    """케이스 2d: status='no_api_key' → no_api_key 분기 전용 메시지 렌더링.
+
+    Case 2d: status='no_api_key' → renders no_api_key branch message.
+
+    ko 번역: "🔑 ANTHROPIC_API_KEY 미설정 — Insight 모드는 AI 분석이 필요합니다."
+    """
+    insight = {"status": "no_api_key", "positive_highlights": [], "focus_areas": [],
+               "key_metrics": [], "next_actions": [], "generated_at": None, "days": 7}
+    html = _render_insight_section(jinja_env, insight, locale="ko")
+
+    # no_api_key 분기 전용 텍스트 확인
+    # Verify no_api_key branch-specific text
+    assert "dash-insight-status" in html
+    # ko 번역에 "ANTHROPIC_API_KEY" 또는 "api_key" 포함
+    # ko translation contains "ANTHROPIC_API_KEY" or "api_key"
+    assert "ANTHROPIC_API_KEY" in html or "api_key" in html.lower(), (
+        f"no_api_key 메시지 미포함\n실제 HTML:\n{html}"
+    )
+    # load_failed 분기 (api_error) 와 다른 텍스트 확인
+    # Different text from load_failed (api_error) branch
+    assert "생성 실패" not in html, (
+        "no_api_key 가 load_failed 분기로 잘못 라우팅됨"
+    )
+
+
+def test_template_no_data_status(jinja_env):
+    """케이스 2e: status='no_data' → no_data 분기 메시지 + days 치환 확인.
+
+    Case 2e: status='no_data' → renders no_data message with days substitution.
+
+    ko 번역: "📭 최근 {days}일 분석 데이터가 부족합니다 — 분석 결과가 누적된 후 다시 시도해주세요."
+    """
+    insight = {"status": "no_data", "positive_highlights": [], "focus_areas": [],
+               "key_metrics": [], "next_actions": [], "generated_at": None, "days": 7}
+    html = _render_insight_section(jinja_env, insight, days=14, locale="ko")
+
+    assert "dash-insight-status" in html
+    # days 변수 치환 확인 (14일)
+    # Verify days variable substitution (14 days)
+    assert "14" in html, (
+        f"no_data 메시지에 days=14 치환 미반영\n실제 HTML:\n{html}"
+    )
+    # "부족" 또는 "데이터" 포함 (ko 번역 확인)
+    # Contains "부족" or "데이터" (ko translation check)
+    assert "데이터" in html or "부족" in html or "no_data" in html.lower(), (
+        f"no_data 메시지 미포함\n실제 HTML:\n{html}"
+    )
+
+
+def test_template_parse_error_status(jinja_env):
+    """케이스 2f: status='parse_error' → load_failed else 분기 + status 치환 확인.
+
+    Case 2f: status='parse_error' → falls into load_failed else branch with status substitution.
+
+    parse_error 는 success/no_api_key/no_data 어느 분기에도 해당하지 않으므로
+    else 분기 (load_failed) 로 라우팅되어야 함.
+    parse_error doesn't match any specific branch, so it must fall into the else (load_failed) branch.
+    """
+    insight = {"status": "parse_error", "positive_highlights": [], "focus_areas": [],
+               "key_metrics": [], "next_actions": [], "generated_at": None, "days": 7}
+    html = _render_insight_section(jinja_env, insight, locale="ko")
+
+    assert "dash-insight-status" in html
+    # parse_error 문자열이 status placeholder 치환으로 포함되어야 함
+    # 'parse_error' must appear as the {status} placeholder substitution
+    assert "parse_error" in html, (
+        f"status='parse_error' 렌더링 시 'parse_error' 미포함\n실제 HTML:\n{html}"
+    )
+
+
+def test_template_success_status_not_load_failed(jinja_env):
+    """케이스 2g: status='success' → success 전용 div, load_failed 분기 미진입 확인.
+
+    Case 2g: status='success' → success-specific div rendered, NOT load_failed branch.
+    """
+    insight = {
+        "status": "success",
+        "positive_highlights": ["좋은 결과"],
+        "focus_areas": ["개선 사항"],
+        "key_metrics": [],
+        "next_actions": ["다음 행동"],
+        "generated_at": "2026-05-19T00:00:00Z",
+        "days": 7,
+    }
+    html = _render_insight_section(jinja_env, insight, locale="ko")
+
+    # success 분기 진입 확인
+    # Confirm success branch entered
+    assert "insight-success" in html, (
+        f"success 분기 미진입 (insight-success div 없음)\n실제 HTML:\n{html}"
+    )
+    # load_failed 메시지 미포함 확인
+    # Confirm load_failed message NOT included
+    assert "생성 실패" not in html, "success 상태에서 load_failed 메시지 렌더링됨"
+    assert "dash-insight-status" not in html, (
+        "success 상태에서 dash-insight-status 분기 진입됨"
+    )
+
+
+def test_template_none_insight_renders_unknown(jinja_env):
+    """케이스 2h: insight=None 시 'unknown' status 로 load_failed 분기 처리.
+
+    Case 2h: insight=None → load_failed branch with 'unknown' status.
+
+    템플릿 코드: insight.status if insight else 'unknown'
+    Template code: insight.status if insight else 'unknown'
+    """
+    html = _render_insight_section(jinja_env, insight=None, locale="ko")
+
+    # None insight → else 분기 → dash-insight-status
+    # None insight → else branch → dash-insight-status
+    assert "dash-insight-status" in html, (
+        f"insight=None 시 dash-insight-status 분기 미진입\n실제 HTML:\n{html}"
+    )
+    # 'unknown' 이 status placeholder 로 치환되어 포함
+    # 'unknown' should appear as the {status} placeholder substitution
+    assert "unknown" in html, (
+        f"insight=None 시 'unknown' status 미포함\n실제 HTML:\n{html}"
+    )
+
+
+# ─── 각 status별 렌더링 텍스트 매핑 요약 테스트 ─────────────────────────────
+# Status-to-rendered-text mapping summary test
+
+
+def test_template_all_status_render_different_messages(jinja_env):
+    """케이스 2i: 모든 status 값이 각각 다른 텍스트를 렌더링하는지 확인.
+
+    Case 2i: All status values render distinct messages.
+
+    상태별 렌더 결과가 서로 다름을 확인하여 분기 정확성 검증.
+    Verifies branch accuracy by confirming each status produces unique output.
+    """
+    # api_error, no_api_key, no_data, parse_error 는 모두 다른 메시지
+    # api_error, no_api_key, no_data, parse_error all produce different messages
+    statuses_and_renders: dict[str, str] = {}
+
+    for status in ("api_error", "no_api_key", "parse_error"):
+        insight = {"status": status, "positive_highlights": [], "focus_areas": [],
+                   "key_metrics": [], "next_actions": [], "generated_at": None, "days": 7}
+        statuses_and_renders[status] = _render_insight_section(
+            jinja_env, insight, days=7, locale="ko"
+        )
+
+    # no_data 는 days placeholder 가 있어 별도 처리
+    # no_data has a days placeholder, handled separately
+    no_data_insight = {"status": "no_data", "positive_highlights": [], "focus_areas": [],
+                       "key_metrics": [], "next_actions": [], "generated_at": None, "days": 7}
+    statuses_and_renders["no_data"] = _render_insight_section(
+        jinja_env, no_data_insight, days=7, locale="ko"
+    )
+
+    # 각 상태별 핵심 포함 문자열 확인
+    # Verify key string included in each status render
+    api_error_html = statuses_and_renders["api_error"]
+    no_api_key_html = statuses_and_renders["no_api_key"]
+    no_data_html = statuses_and_renders["no_data"]
+    parse_error_html = statuses_and_renders["parse_error"]
+
+    # api_error: load_failed + "api_error" 포함
+    # api_error: load_failed + contains "api_error"
+    assert "api_error" in api_error_html, f"api_error 분기 오류:\n{api_error_html}"
+
+    # no_api_key: 전용 메시지 ("ANTHROPIC_API_KEY" 포함)
+    # no_api_key: dedicated message (contains "ANTHROPIC_API_KEY")
+    assert "ANTHROPIC_API_KEY" in no_api_key_html, f"no_api_key 분기 오류:\n{no_api_key_html}"
+
+    # no_data: days 포함 (7일)
+    # no_data: contains days (7 days)
+    assert "7" in no_data_html, f"no_data 분기 오류:\n{no_data_html}"
+
+    # parse_error: load_failed + "parse_error" 포함
+    # parse_error: load_failed + contains "parse_error"
+    assert "parse_error" in parse_error_html, f"parse_error 분기 오류:\n{parse_error_html}"
+
+    # api_error 와 no_api_key 는 다른 메시지
+    # api_error and no_api_key produce different messages
+    assert api_error_html != no_api_key_html, (
+        "api_error 와 no_api_key 가 동일한 HTML 을 렌더링함 — 분기 오류"
+    )
+
+    # api_error 와 no_data 는 다른 메시지
+    # api_error and no_data produce different messages
+    assert api_error_html != no_data_html, (
+        "api_error 와 no_data 가 동일한 HTML 을 렌더링함 — 분기 오류"
+    )

--- a/tests/unit/ui/test_dashboard_insight_error_states.py
+++ b/tests/unit/ui/test_dashboard_insight_error_states.py
@@ -26,7 +26,6 @@ from src.main import app
 
 # ORM metadata 등록 (모듈 최상단 import — pytest collection 시점에 등록).
 # Register ORM metadata at module import time (pytest collection).
-from src.database import Base  # noqa: E402
 from src.models.analysis import Analysis as _AnalysisModel  # noqa: E402, F401
 from src.models.repository import Repository as _RepoModel  # noqa: E402, F401
 from src.models.user import User as _UserModel  # noqa: E402, F401

--- a/tests/unit/ui/test_dashboard_insight_error_states.py
+++ b/tests/unit/ui/test_dashboard_insight_error_states.py
@@ -27,7 +27,6 @@ from src.main import app
 # ORM metadata 등록 (모듈 최상단 import — pytest collection 시점에 등록).
 # Register ORM metadata at module import time (pytest collection).
 from src.models.analysis import Analysis as _AnalysisModel  # noqa: E402, F401
-from src.models.user import User as _UserModel  # noqa: E402, F401
 
 _TEST_USER = CurrentUser(
     id=1,


### PR DESCRIPTION
## 개요

Insight 모드 AI 내러티브(`api_error` / `parse_error` / `no_data`) 발생 시 DB에 에러 빈도를 누적 기록한다.
운영 중 API 에러가 얼마나 자주 발생하는지 파악할 수 없던 문제(현재 Railway 로그만 의존)를 해소한다.
`expires_at = now`(즉시 만료) 설계로 에러 row가 정상 재시도를 차단하지 않는다.

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/models/insight_narrative_cache.py` | ORM에 `last_error_at` / `error_count` / `last_error_type` 3컬럼 추가 |
| `src/repositories/insight_narrative_cache_repo.py` | `record_error` / `record_error_repo` 헬퍼 신설 |
| `src/services/dashboard_service.py` | api_error / parse_error / no_data 경로 3곳에 `record_error` 호출 |
| `src/services/repo_insight_service.py` | no_data / api_error 경로에 `record_error_repo` 호출 + `log_claude_api_call` error_type 누락 버그 수정 |
| `alembic/versions/0033_insight_error_tracking.py` | PG 인덱스 포함 upgrade/downgrade |
| `tests/unit/repositories/test_insight_error_tracking.py` | record_error / record_error_repo 10건 신규 테스트 |
| `tests/unit/services/test_insight_*` (4개) + `tests/unit/ui/test_dashboard_*` | 42건 신규 테스트 (SDK/network/parse/캐시/UI) |

## 핵심 설계

- **에러 row `expires_at = now`**: 즉시 만료 → `get_fresh()` 가 None 반환 → 재시도 차단 없음
- **기존 success row 갱신**: INSERT가 아닌 UPDATE → `response_json` 보존, row 중복 없음
- **키 분리**: `repo_id=None` (전체 대시보드) vs `repo_id=N` (리포별) 충돌 없음

## 테스트

- 42건 신규 테스트 전체 통과 (`python -m pytest tests/unit/repositories/test_insight_error_tracking.py tests/unit/services/test_insight_*` 등)
- 기존 캐시 테스트 1건 업데이트 (`test_insight_cache_error_recovery.py` — 0033 에러 row 생성 반영)

## 🔍 사용자 검증 필요

- [ ] Railway 배포 후 `make migrate` 정상 실행 (0033 마이그레이션 적용 확인)
- [ ] 운영 DB에서 `SELECT user_id, error_count, last_error_type, last_error_at FROM insight_narrative_cache WHERE last_error_at IS NOT NULL` — 2026-05-17 이후 누적 에러 확인

> **Codex mutual 검증**: 샌드박스 파일 접근 차단으로 NG(검증 불가). 사용자 push 직접 승인으로 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)