### PR TITLE
fix: 5+1 리뷰 P1 3건 수정 + Railway 재배포 트리거

### DIFF
--- a/src/models/insight_narrative_cache.py
+++ b/src/models/insight_narrative_cache.py
@@ -31,6 +31,7 @@ class InsightNarrativeCache(Base):
             "user_id", "days", "language",
         ),
         Index("ix_insight_cache_repo_id", "repo_id"),
+        Index("ix_insight_cache_last_error_at", "last_error_at"),
     )
 
     id = Column(Integer, primary_key=True, index=True)

--- a/src/services/repo_insight_service.py
+++ b/src/services/repo_insight_service.py
@@ -352,7 +352,7 @@ async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many
             from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
             insight_narrative_cache_repo.record_error_repo(
                 db, user_id=user_id, repo_id=repo_id, days=days,
-                error_type="no_data", now=_now,
+                language=language, error_type="no_data", now=_now,
             )
         return {"text": "", "status": "no_data"}
 
@@ -406,7 +406,7 @@ async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many
             from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
             insight_narrative_cache_repo.record_error_repo(
                 db, user_id=user_id, repo_id=repo_id, days=days,
-                error_type=type(exc).__name__, now=_now,
+                language=language, error_type=type(exc).__name__, now=_now,
             )
         return {"text": "", "status": "api_error"}
 

--- a/tests/unit/ui/test_dashboard_insight_error_states.py
+++ b/tests/unit/ui/test_dashboard_insight_error_states.py
@@ -191,7 +191,7 @@ def test_route_insight_api_error_overview_services_not_called():
     assert response.status_code == 200
     # api_error 는 insight 분기 내 정상 응답 — overview 분기 미진입 (dashboard_kpi 미호출)
     # api_error is a normal insight response — overview branch NOT entered (dashboard_kpi not called)
-    mock_kpi.assert_not_called(), (
+    assert not mock_kpi.called, (
         "api_error 시 overview 분기 폴백 발생 (dashboard_kpi 호출됨) — 잘못된 에러 처리"
     )
 


### PR DESCRIPTION
## Summary

5+1 다중 에이전트 코드 리뷰(PR #530/#531/#533 범위)에서 발견된 P1 이슈 3건 수정. Railway 장애(Google Cloud 계정 차단 — 2026-05-19 22:29 UTC) 복구 후 재배포 트리거 목적.

**Railway 이전 실패 원인**: 코드 문제 아님. GCP 계정 차단으로 Railway 인프라 전체 다운 → 빌드 3.5시간 타임아웃.

### P1-A: `record_error_repo` language 인수 누락 (repo_insight_service.py)
- `no_data`/`api_error` 경로 2곳에서 `language=language` 미전달 → 항상 `"en"` 버킷에 에러 기록
- 다국어 사용자(ko 등)의 에러 추적 데이터가 올바른 language 버킷에 저장되지 않는 버그
- `upsert_repo`(성공 경로)는 이미 올바르게 전달 중 — 에러 경로만 누락

### P1-B: `ix_insight_cache_last_error_at` ORM `__table_args__` 동기화 (insight_narrative_cache.py)
- alembic/0033에 `op.create_index` 존재하지만 ORM `__table_args__`에 미정의 (db.md 규칙 위반)
- `Index("ix_insight_cache_last_error_at", "last_error_at")` 추가

### P1-D: dead assert 수정 (test_dashboard_insight_error_states.py:194)
- `mock_kpi.assert_not_called(), ("메시지")` → Python 튜플 표현식 (커스텀 메시지 출력 안 됨)
- `assert not mock_kpi.called, "메시지"` 로 교체

## 🔍 사용자 검증 필요

- [ ] Railway 배포 성공 확인 (`/health` 200 응답)
- [ ] 한국어 사용자(ko)로 Insight 페이지 접속 → API 에러 발생 시 에러 카운터가 ko 버킷에 기록되는지 DB 확인 (선택)

## 리뷰 결과 요약 (5+1 에이전트)

| 구분 | 건수 | 내용 |
|------|------|------|
| P0 | 0 | — |
| P1 | 3건 수정 | language 누락, ORM 인덱스, dead assert |
| P2 (다음 사이클) | 6건 | feedbackInit/historyRestore P2 하향, 인덱스 부분화, i18n badge, user_id 누락 테스트, error_type 트런케이션 |
| 보안 | LGTM | SQL 인젝션·XSS·IDOR 이슈 없음 |

## Test plan
- [x] `pytest tests/` — 3051 passed, 4 skipped (전체 통과)
- [x] 변경 파일 직접 검증: `test_insight_error_tracking`, `test_insight_cache_error_recovery`, `test_dashboard_insight_error_states` 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)