### PR TITLE
chore(e2e): _perf_helpers.py 공통 헬퍼 추출 — 중복 58줄 제거

### DIFF
--- a/e2e/_perf_helpers.py
+++ b/e2e/_perf_helpers.py
@@ -1,0 +1,68 @@
+"""E2E + 성능 스크립트 공용 헬퍼 — LCP observer, 단일 측정, 통계 집계.
+Shared helpers for E2E and perf scripts — LCP observer, single measurement, stats aggregation.
+"""
+
+# LCP PerformanceObserver 주입 스크립트 — page.add_init_script() 에 전달
+# LCP PerformanceObserver injection script — pass to page.add_init_script()
+LCP_INIT_JS = """
+    window._perf_lcp = null;
+    try {
+        new PerformanceObserver((list) => {
+            const entries = list.getEntries();
+            if (entries.length > 0) {
+                window._perf_lcp = entries[entries.length - 1].startTime;
+            }
+        }).observe({ type: 'largest-contentful-paint', buffered: true });
+    } catch(e) {}
+"""
+
+
+def measure_one(pg, url: str) -> dict:
+    """단일 측정 — TTFB/FCP/LCP/DCL/Load(ms) + 느린 요청 목록 반환.
+    Single measurement — returns TTFB/FCP/LCP/DCL/Load(ms) + slow request list.
+    """
+    slow: list[dict] = []
+
+    def _on_finished(req):
+        t = req.timing
+        dur = t.get("responseEnd", 0) - t.get("requestStart", 0)
+        if dur > 500:
+            slow.append({"url": req.url, "ms": round(dur)})
+
+    pg.on("requestfinished", _on_finished)
+    try:
+        pg.goto(url, wait_until="networkidle", timeout=30_000)
+        metrics = pg.evaluate("""() => {
+            const nav = performance.getEntriesByType('navigation')[0] || {};
+            const fcp = performance.getEntriesByType('paint')
+                .find(e => e.name === 'first-contentful-paint');
+            return {
+                ttfb: Math.round((nav.responseStart || 0) - (nav.fetchStart || 0)),
+                dcl:  Math.round((nav.domContentLoadedEventEnd || 0) - (nav.startTime || 0)),
+                load: Math.round((nav.loadEventEnd || 0) - (nav.startTime || 0)),
+                fcp:  fcp ? Math.round(fcp.startTime) : null,
+                lcp:  (typeof window._perf_lcp === 'number')
+                          ? Math.round(window._perf_lcp) : null,
+            };
+        }""")
+        metrics["slow_requests"] = slow[:]
+        return metrics
+    finally:
+        pg.remove_listener("requestfinished", _on_finished)
+
+
+def measure_page(pg, url: str, runs: int = 3) -> dict:
+    """N회 측정 후 avg/min/max 통계 반환.
+    Returns avg/min/max stats over N runs.
+    """
+    results = [measure_one(pg, url) for _ in range(runs)]
+    stats: dict = {}
+    for key in ("ttfb", "fcp", "lcp", "dcl", "load"):
+        vals = [r[key] for r in results if r.get(key) is not None]
+        stats[key] = {
+            "avg": round(sum(vals) / len(vals)) if vals else None,
+            "min": min(vals) if vals else None,
+            "max": max(vals) if vals else None,
+        }
+    stats["slow_requests"] = [req for r in results for req in r.get("slow_requests", [])]
+    return stats

--- a/e2e/test_performance.py
+++ b/e2e/test_performance.py
@@ -6,6 +6,10 @@ import time
 import pytest
 import requests
 
+from e2e._perf_helpers import LCP_INIT_JS as _LCP_INIT_JS
+from e2e._perf_helpers import measure_one as _measure_one
+from e2e._perf_helpers import measure_page as _measure_page
+
 THRESHOLDS = {
     "ttfb": 500,   # ms — 로컬 SQLite 기준 완화값 / relaxed for local SQLite
     "fcp":  1500,
@@ -14,69 +18,6 @@ THRESHOLDS = {
     "load": 3000,
     "health_ttfb": 300,   # /health endpoint — tighter TTFB budget / tighter for health check
 }
-
-_LCP_INIT_JS = """
-    window._perf_lcp = null;
-    try {
-        new PerformanceObserver((list) => {
-            const entries = list.getEntries();
-            if (entries.length > 0) {
-                window._perf_lcp = entries[entries.length - 1].startTime;
-            }
-        }).observe({ type: 'largest-contentful-paint', buffered: true });
-    } catch(e) {}
-"""
-
-
-def _measure_one(pg, url: str) -> dict:
-    """단일 측정 — TTFB/FCP/LCP/DCL/Load(ms) + 느린 요청 목록 반환.
-    Single measurement — TTFB/FCP/LCP/DCL/Load(ms) + slow request list.
-    """
-    slow: list[dict] = []
-
-    def _on_finished(req):
-        t = req.timing
-        dur = t.get("responseEnd", 0) - t.get("requestStart", 0)
-        if dur > 500:
-            slow.append({"url": req.url, "ms": round(dur)})
-
-    pg.on("requestfinished", _on_finished)
-    try:
-        pg.goto(url, wait_until="networkidle", timeout=30_000)
-        metrics = pg.evaluate("""() => {
-            const nav = performance.getEntriesByType('navigation')[0] || {};
-            const fcp = performance.getEntriesByType('paint')
-                .find(e => e.name === 'first-contentful-paint');
-            return {
-                ttfb: Math.round((nav.responseStart || 0) - (nav.fetchStart || 0)),
-                dcl:  Math.round((nav.domContentLoadedEventEnd || 0) - (nav.startTime || 0)),
-                load: Math.round((nav.loadEventEnd || 0) - (nav.startTime || 0)),
-                fcp:  fcp ? Math.round(fcp.startTime) : null,
-                lcp:  (typeof window._perf_lcp === 'number')
-                          ? Math.round(window._perf_lcp) : null,
-            };
-        }""")
-        metrics["slow_requests"] = slow[:]
-        return metrics
-    finally:
-        pg.remove_listener("requestfinished", _on_finished)
-
-
-def _measure_page(pg, url: str, runs: int = 3) -> dict:
-    """N회 측정 후 avg/min/max 통계 반환.
-    Returns avg/min/max stats over N runs.
-    """
-    results = [_measure_one(pg, url) for _ in range(runs)]
-    stats: dict = {}
-    for key in ("ttfb", "fcp", "lcp", "dcl", "load"):
-        vals = [r[key] for r in results if r.get(key) is not None]
-        stats[key] = {
-            "avg": round(sum(vals) / len(vals)) if vals else None,
-            "min": min(vals) if vals else None,
-            "max": max(vals) if vals else None,
-        }
-    stats["slow_requests"] = [req for r in results for req in r.get("slow_requests", [])]
-    return stats
 
 
 # ── Fixtures ─────────────────────────────────────────────────────────────

--- a/scripts/perf_measure.py
+++ b/scripts/perf_measure.py
@@ -24,6 +24,10 @@ from urllib.parse import urlsplit
 
 import requests
 
+from e2e._perf_helpers import LCP_INIT_JS as _LCP_INIT_JS
+from e2e._perf_helpers import measure_one as _measure_one
+from e2e._perf_helpers import measure_page as _measure_page
+
 try:
     from playwright.sync_api import sync_playwright
 except ImportError:
@@ -52,18 +56,6 @@ THRESHOLDS_PROD = {"ttfb": 300, "fcp": 1500, "lcp": 2500, "dcl": 1500, "load": 3
 
 # 로컬 테스트용 더미 API 키 / Dummy API key for local test server
 _LOCAL_API_KEY = "perf-api-key"
-
-_LCP_INIT_JS = """
-    window._perf_lcp = null;
-    try {
-        new PerformanceObserver((list) => {
-            const entries = list.getEntries();
-            if (entries.length > 0) {
-                window._perf_lcp = entries[entries.length - 1].startTime;
-            }
-        }).observe({ type: 'largest-contentful-paint', buffered: true });
-    } catch(e) {}
-"""
 
 # ── DB / Server setup ──────────────────────────────────────────────────────
 
@@ -187,57 +179,6 @@ def _start_local_server(db_path: str):
 
 
 # ── Measurement helpers ────────────────────────────────────────────────────
-
-def _measure_one(pg, url: str) -> dict:
-    """단일 측정 — TTFB/FCP/LCP/DCL/Load(ms) + 느린 요청 목록 반환.
-    Single measurement — returns TTFB/FCP/LCP/DCL/Load(ms) + slow request list.
-    """
-    slow: list[dict] = []
-
-    def _on_finished(req):
-        t = req.timing
-        dur = t.get("responseEnd", 0) - t.get("requestStart", 0)
-        if dur > 500:
-            slow.append({"url": req.url, "ms": round(dur)})
-
-    pg.on("requestfinished", _on_finished)
-    try:
-        pg.goto(url, wait_until="networkidle", timeout=30_000)
-        metrics = pg.evaluate("""() => {
-            const nav = performance.getEntriesByType('navigation')[0] || {};
-            const fcp = performance.getEntriesByType('paint')
-                .find(e => e.name === 'first-contentful-paint');
-            return {
-                ttfb: Math.round((nav.responseStart || 0) - (nav.fetchStart || 0)),
-                dcl:  Math.round((nav.domContentLoadedEventEnd || 0) - (nav.startTime || 0)),
-                load: Math.round((nav.loadEventEnd || 0) - (nav.startTime || 0)),
-                fcp:  fcp ? Math.round(fcp.startTime) : null,
-                lcp:  (typeof window._perf_lcp === 'number')
-                          ? Math.round(window._perf_lcp) : null,
-            };
-        }""")
-        metrics["slow_requests"] = slow[:]
-        return metrics
-    finally:
-        pg.remove_listener("requestfinished", _on_finished)
-
-
-def _measure_page(pg, url: str, runs: int = 3) -> dict:
-    """N회 측정 후 avg/min/max 통계 반환.
-    Returns avg/min/max stats over N runs.
-    """
-    results = [_measure_one(pg, url) for _ in range(runs)]
-    stats: dict = {}
-    for key in ("ttfb", "fcp", "lcp", "dcl", "load"):
-        vals = [r[key] for r in results if r.get(key) is not None]
-        stats[key] = {
-            "avg": round(sum(vals) / len(vals)) if vals else None,
-            "min": min(vals) if vals else None,
-            "max": max(vals) if vals else None,
-        }
-    stats["slow_requests"] = [req for r in results for req in r.get("slow_requests", [])]
-    return stats
-
 
 def _http_ttfb(url: str, *, headers: dict | None = None, allow_redirects: bool = True) -> dict:
     """HTTP TTFB 전용 측정 — requests 라이브러리, 3회 평균.


### PR DESCRIPTION
## Summary

- `e2e/_perf_helpers.py` 신설 — `LCP_INIT_JS`, `measure_one()`, `measure_page()` 공통 3종
- `e2e/test_performance.py`: 중복 정의 삭제 → `from e2e._perf_helpers import ...` 로 교체
- `scripts/perf_measure.py`: 중복 정의 삭제 → `from e2e._perf_helpers import ...` 로 교체
- 총 -58줄 (기능 변경 없음)

## 변경 없는 동작

| 항목 | 결과 |
|------|------|
| `e2e/_perf_helpers.py` pylint | 10.00/10 |
| import 동작 확인 | `python -c "from e2e._perf_helpers import ..."` OK |
| `scripts.perf_measure` import 확인 | `_LCP_INIT_JS`, `_measure_one`, `_measure_page` 정상 바인딩 |

## 🔍 사용자 검증 필요

- [ ] `make test-perf` (perf 마커 E2E) — Playwright + 로컬 서버 환경에서 정상 실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)