### PR TITLE
chore: README.md 배지 사이클 111 수치 동기화

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
-[![Tests](https://img.shields.io/badge/Tests-2970_total_(2816_unit_+_154_integration)-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
-[![E2E](https://img.shields.io/badge/E2E-99_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
+[![Tests](https://img.shields.io/badge/Tests-3055_total_(2907_unit_+_154_integration)-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
+[![E2E](https://img.shields.io/badge/E2E-111_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)
 [![Coverage](https://img.shields.io/badge/Coverage-95%25-brightgreen?style=flat-square&logo=codecov&logoColor=white)](tests/)


### PR DESCRIPTION
## Summary

- Tests 배지: 2970 (2816 unit + 154 integration) → **3055 (2907 unit + 154 integration)**
- E2E 배지: 99 → **111** (+12 `@pytest.mark.perf` — 사이클 106 #500)

수치 출처: `docs/STATE.md` (PR #537 머지 후 최신값)

## 🔍 사용자 검증 필요

| # | 항목 |
|---|------|
| 1 | README.md 배지 숫자가 올바르게 표시되는지 확인 |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)