### PR TITLE
feat: LANG_NAMES DRY 해소 + _INSIGHT_SYSTEM_PROMPT 언어 중립화 (사이클 112 P1)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,7 +50,8 @@ src/
 │   ├── anthropic_caching.py     # build_cached_system_param() — Anthropic prompt cache 5분 ephemeral
 │   ├── rls_context.py           # contextvars 기반 request scope user_id (Phase 3 postlude)
 │   ├── feature_kill_switch.py   # is_disabled(feature) helper (Cycle 78 NEW-P0-2)
-│   └── alembic_dialect.py       # is_postgresql(bind_or_conn) (Cycle 82 PR 1 — 사용처 12)
+│   ├── alembic_dialect.py       # is_postgresql(bind_or_conn) (Cycle 82 PR 1 — 사용처 12)
+│   └── lang_names.py            # LANG_NAMES dict — locale 코드 → Claude 프롬프트 언어명 (단일 출처)
 ├── middleware/
 │   ├── rls_session.py           # RLSSessionMiddleware (ASGI, BaseHTTPMiddleware 우회)
 │   └── locale.py                # LocaleMiddleware — 5단계 locale 감지 (Cookie > Accept-Language q-weight > User > settings > fallback)

--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -37,6 +37,7 @@ from src.models.repository import Repository
 from src.scorer.calculator import calculate_grade
 from src.shared.anthropic_caching import build_cached_system_param
 from src.shared.claude_metrics import extract_anthropic_usage, log_claude_api_call
+from src.shared.lang_names import LANG_NAMES
 
 logger = logging.getLogger(__name__)
 
@@ -588,9 +589,6 @@ def _score_trend(score_delta: float | None) -> str:
 
 # ─── Phase 3 PR 2: Insight 모드 narrative ──────────────────────────────────
 
-# 지원 언어 코드 → Claude 프롬프트 언어명 매핑 (repo_insight_service 와 동일 집합)
-# Locale code → language name for Claude prompts (same set as repo_insight_service).
-_DASHBOARD_LANG_NAMES: dict[str, str] = {"ko": "Korean", "en": "English", "ja": "Japanese"}
 
 # Phase 2 신규 1 (사이클 74) — Anthropic prompt caching ≥ 1024 토큰 권장 충족.
 # JSON Schema + 분류 가이드 보강으로 cache hit rate 활성화 (silent fallback 차단).
@@ -622,17 +620,17 @@ _INSIGHT_SYSTEM_PROMPT = (
     "auto-merge failures or retry exhaustion. Cite the failing rule or repo.\n"
     "3. key_metrics (list[dict], exactly 4 items): 📊 numeric highlights — "
     'each item must be {"label": str, "value": str, "delta": str}. The label '
-    "is the metric name in Korean (e.g. 평균 점수). The value is the current "
+    "is the metric name in the response language. The value is the current "
     "window value as a string (e.g. 87.5). The delta uses + / - prefix vs "
     "the previous window (e.g. +2.3 or -5). If no prior window data, use 0.\n"
     "4. next_actions (list[str], length 2 to 4): 💬 suggested next moves — "
     "specific, actionable, prioritized for the next 1-7 days. Tie each "
     "action to a card 1 strength to amplify or a card 2 focus area to fix. "
     "Avoid generic advice ('write more tests') — name the file, repo, or "
-    "rule (e.g. 'src/foo.py 의 pylint W0611 4건 일괄 정리').\n\n"
+    "rule (e.g. 'src/foo.py pylint W0611 4 occurrences').\n\n"
     "Tone: concise, encouraging but honest. Refer to actual numbers from the "
-    "user prompt rather than generic advice. Each list item ≤ 80 Korean "
-    "characters. Use full sentences ending with appropriate Korean particles.\n\n"
+    "user prompt rather than generic advice. Each list item ≤ 80 characters. "
+    "Use full sentences.\n\n"
     'Return strict JSON conforming to: {"positive_highlights": list[str], '
     '"focus_areas": list[str], "key_metrics": list[{"label": str, "value": '
     'str, "delta": str}], "next_actions": list[str]}.'
@@ -704,7 +702,7 @@ def _build_insight_user_prompt(
         "frequent_issues": frequent,
         "auto_merge": auto_merge,
     }
-    lang_name = _DASHBOARD_LANG_NAMES.get(language, "Korean")
+    lang_name = LANG_NAMES.get(language, "Korean")
     return (
         f"다음은 최근 {days}일간의 dashboard 데이터입니다. "
         f"위 4 카드 JSON 형식으로 narrative 를 생성해주세요. "

--- a/src/services/repo_insight_service.py
+++ b/src/services/repo_insight_service.py
@@ -22,16 +22,13 @@ from src.config import settings
 from src.models.analysis import Analysis
 from src.scorer.calculator import calculate_grade
 from src.shared.claude_metrics import extract_anthropic_usage, log_claude_api_call
+from src.shared.lang_names import LANG_NAMES
 
 logger = logging.getLogger(__name__)
 
 # 집계 최대 분석 건수 — Python 루프 O(N×이슈수) 상한
 # Max analyses per aggregation — caps Python loop O(N×issues)
 _MAX_ANALYSES = 30
-
-# 지원 언어 코드 → Claude 프롬프트 언어명 매핑
-# Mapping from locale code to the language name used in Claude prompts.
-_LANG_NAMES: dict[str, str] = {"ko": "Korean", "en": "English", "ja": "Japanese"}
 
 
 def _fetch_analyses(
@@ -371,7 +368,7 @@ async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many
         f"({kpi.get('top_recurring_count')} times)\n"
         f"Top 5 issues: {json.dumps(recurring[:5], ensure_ascii=False)}\n\n"
         f"Please provide a 2-3 paragraph diagnostic narrative "
-        f"in {_LANG_NAMES.get(language, 'Korean')} summarizing "
+        f"in {LANG_NAMES.get(language, 'Korean')} summarizing "
         "this repository's code quality status, key recurring problems, and concrete "
         "next steps. Respond with strict JSON only: {\"text\": \"...narrative...\"}"
     )

--- a/src/shared/lang_names.py
+++ b/src/shared/lang_names.py
@@ -1,0 +1,11 @@
+"""다국어 insight 프롬프트 언어명 매핑 — 단일 출처 상수.
+
+Single-source locale-code → Claude prompt language name mapping.
+두 서비스(dashboard_service, repo_insight_service)에서 공유.
+Shared by dashboard_service and repo_insight_service.
+"""
+from __future__ import annotations
+
+# 지원 locale 코드 → Claude 프롬프트 언어명 매핑
+# Mapping from supported locale codes to language names used in Claude prompts.
+LANG_NAMES: dict[str, str] = {"ko": "Korean", "en": "English", "ja": "Japanese"}

--- a/tests/unit/services/test_insight_system_prompt.py
+++ b/tests/unit/services/test_insight_system_prompt.py
@@ -1,0 +1,107 @@
+"""dashboard_service._INSIGHT_SYSTEM_PROMPT 언어 중립화 검증.
+
+Verifies that the system prompt no longer contains Korean-language-specific
+hardcoded instructions, ensuring language-neutral phrasing after the refactor.
+
+Target lines (before fix):
+  625: "is the metric name in Korean (e.g. 평균 점수)."
+  634: "Each list item ≤ 80 Korean characters."
+  635: "Use full sentences ending with appropriate Korean particles."
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ─── _INSIGHT_SYSTEM_PROMPT 언어 중립화 검증 ────────────────────────────────
+
+
+def _get_system_prompt() -> str:
+    """dashboard_service 모듈에서 _INSIGHT_SYSTEM_PROMPT 문자열을 추출.
+
+    Extracts the _INSIGHT_SYSTEM_PROMPT constant from dashboard_service.
+    """
+    import src.services.dashboard_service as m
+
+    assert hasattr(m, "_INSIGHT_SYSTEM_PROMPT"), (
+        "_INSIGHT_SYSTEM_PROMPT constant not found in dashboard_service."
+    )
+    return m._INSIGHT_SYSTEM_PROMPT  # type: ignore[attr-defined]
+
+
+def test_system_prompt_no_korean_label_instruction():
+    """_INSIGHT_SYSTEM_PROMPT에 'in Korean (e.g.' 구절이 없어야 함.
+
+    The phrase 'in Korean (e.g.' must be removed from the system prompt.
+    Current (Red): 'is the metric name in Korean (e.g. 평균 점수).'
+    Target (Green): 'is the metric name in the response language.'
+    """
+    prompt = _get_system_prompt()
+
+    assert "in Korean (e.g." not in prompt, (
+        "_INSIGHT_SYSTEM_PROMPT still contains 'in Korean (e.g.' — "
+        "replace with 'in the response language.'"
+    )
+
+
+def test_system_prompt_no_korean_characters():
+    """_INSIGHT_SYSTEM_PROMPT에 'Korean characters' 구절이 없어야 함.
+
+    The phrase 'Korean characters' must be removed from the system prompt.
+    Current (Red): 'Each list item ≤ 80 Korean characters.'
+    Target (Green): 'Each list item ≤ 80 characters.'
+    """
+    prompt = _get_system_prompt()
+
+    assert "Korean characters" not in prompt, (
+        "_INSIGHT_SYSTEM_PROMPT still contains 'Korean characters' — "
+        "replace with '80 characters.' (language-neutral)."
+    )
+
+
+def test_system_prompt_no_korean_particles():
+    """_INSIGHT_SYSTEM_PROMPT에 'Korean particles' 구절이 없어야 함.
+
+    The phrase 'Korean particles' must be removed from the system prompt.
+    Current (Red): 'Use full sentences ending with appropriate Korean particles.'
+    Target (Green): 'Use full sentences.'
+    """
+    prompt = _get_system_prompt()
+
+    assert "Korean particles" not in prompt, (
+        "_INSIGHT_SYSTEM_PROMPT still contains 'Korean particles' — "
+        "replace with 'Use full sentences.' (language-neutral)."
+    )
+
+
+def test_system_prompt_retains_structure_fields():
+    """언어 중립화 후에도 JSON 구조 필드 지시(positive_highlights 등)는 보존되어야 함.
+
+    Removing Korean-specific phrases must not accidentally remove the
+    JSON schema instructions that callers depend on.
+    """
+    prompt = _get_system_prompt()
+
+    # JSON 스키마 필드 4개가 여전히 존재하는지 확인 (회귀 방지)
+    # Verify the four JSON schema fields remain after the edit (regression guard).
+    for field in ("positive_highlights", "focus_areas", "key_metrics", "next_actions"):
+        assert field in prompt, (
+            f"_INSIGHT_SYSTEM_PROMPT lost required JSON field '{field}' "
+            "during the language-neutral refactor."
+        )
+
+
+def test_system_prompt_language_neutral_replacement_present():
+    """언어 중립 대체 구절 'response language'가 삽입되어 있어야 함.
+
+    After the fix, the prompt must contain 'response language' to indicate
+    language-neutral instruction.
+    Current (Red): phrase absent.
+    Target (Green): 'is the metric name in the response language.'
+    """
+    prompt = _get_system_prompt()
+
+    assert "response language" in prompt, (
+        "_INSIGHT_SYSTEM_PROMPT is missing 'response language' — "
+        "the Korean-neutral replacement phrase has not been added yet."
+    )

--- a/tests/unit/services/test_insight_system_prompt.py
+++ b/tests/unit/services/test_insight_system_prompt.py
@@ -10,8 +10,6 @@ Target lines (before fix):
 """
 from __future__ import annotations
 
-import pytest
-
 
 # ─── _INSIGHT_SYSTEM_PROMPT 언어 중립화 검증 ────────────────────────────────
 

--- a/tests/unit/shared/test_lang_names.py
+++ b/tests/unit/shared/test_lang_names.py
@@ -1,0 +1,134 @@
+"""src/shared/lang_names.py 모듈 및 서비스 DRY 통합 검증.
+
+Verifies that the shared LANG_NAMES constant exists with correct values,
+and that both services import from the shared module rather than defining
+their own duplicate dictionaries.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ─── LANG_NAMES 상수 기본 검증 ──────────────────────────────────────────────
+
+
+def test_lang_names_importable_from_shared():
+    """from src.shared.lang_names import LANG_NAMES가 ImportError 없이 성공해야 함.
+
+    The import must succeed without ImportError — the module does not yet exist (Red).
+    """
+    from src.shared.lang_names import LANG_NAMES  # noqa: F401
+
+
+def test_lang_names_has_three_languages():
+    """LANG_NAMES에 'ko', 'en', 'ja' 세 키가 모두 존재해야 함.
+
+    LANG_NAMES must contain exactly the three language keys: 'ko', 'en', 'ja'.
+    """
+    from src.shared.lang_names import LANG_NAMES
+
+    assert "ko" in LANG_NAMES
+    assert "en" in LANG_NAMES
+    assert "ja" in LANG_NAMES
+
+
+def test_lang_names_values():
+    """각 키의 값이 'Korean', 'English', 'Japanese'여야 함.
+
+    Each key must map to the correct English language name.
+    """
+    from src.shared.lang_names import LANG_NAMES
+
+    assert LANG_NAMES["ko"] == "Korean"
+    assert LANG_NAMES["en"] == "English"
+    assert LANG_NAMES["ja"] == "Japanese"
+
+
+def test_lang_names_is_dict():
+    """LANG_NAMES가 dict 타입이어야 함.
+
+    LANG_NAMES must be a plain dict (not a subclass or other mapping).
+    """
+    from src.shared.lang_names import LANG_NAMES
+
+    assert isinstance(LANG_NAMES, dict)
+
+
+# ─── repo_insight_service DRY 검증 ─────────────────────────────────────────
+
+
+def test_repo_insight_service_uses_shared_lang_names():
+    """repo_insight_service에 _LANG_NAMES 직접 정의가 없고 shared LANG_NAMES를 사용해야 함.
+
+    After the refactor, _LANG_NAMES must not be a module-level attribute;
+    LANG_NAMES (imported from shared) must be present instead.
+    """
+    import src.services.repo_insight_service as m
+
+    # 구현 전(Red): _LANG_NAMES 직접 정의 존재 → hasattr True → 테스트 실패 예상
+    # Pre-implementation (Red): _LANG_NAMES defined directly → test fails.
+    assert not hasattr(m, "_LANG_NAMES"), (
+        "repo_insight_service still defines _LANG_NAMES directly. "
+        "Replace with `from src.shared.lang_names import LANG_NAMES`."
+    )
+
+    # 구현 후(Green): shared에서 import한 LANG_NAMES가 모듈 네임스페이스에 있어야 함
+    # Post-implementation (Green): LANG_NAMES imported from shared must be present.
+    assert hasattr(m, "LANG_NAMES"), (
+        "repo_insight_service must import LANG_NAMES from src.shared.lang_names."
+    )
+
+
+def test_repo_insight_service_lang_names_values_match_shared():
+    """repo_insight_service의 LANG_NAMES가 shared 모듈과 동일 객체여야 함.
+
+    The LANG_NAMES in repo_insight_service must be the exact same object
+    imported from src.shared.lang_names (not a copy with different content).
+    """
+    import src.services.repo_insight_service as m
+    from src.shared.lang_names import LANG_NAMES
+
+    assert m.LANG_NAMES is LANG_NAMES, (
+        "repo_insight_service.LANG_NAMES must be the same object as "
+        "src.shared.lang_names.LANG_NAMES (identity check)."
+    )
+
+
+# ─── dashboard_service DRY 검증 ────────────────────────────────────────────
+
+
+def test_dashboard_service_uses_shared_lang_names():
+    """dashboard_service에 _DASHBOARD_LANG_NAMES 직접 정의가 없고 shared LANG_NAMES를 사용해야 함.
+
+    After the refactor, _DASHBOARD_LANG_NAMES must not be a module-level attribute;
+    LANG_NAMES (imported from shared) must be present instead.
+    """
+    import src.services.dashboard_service as m
+
+    # 구현 전(Red): _DASHBOARD_LANG_NAMES 직접 정의 존재 → hasattr True → 테스트 실패 예상
+    # Pre-implementation (Red): _DASHBOARD_LANG_NAMES defined directly → test fails.
+    assert not hasattr(m, "_DASHBOARD_LANG_NAMES"), (
+        "dashboard_service still defines _DASHBOARD_LANG_NAMES directly. "
+        "Replace with `from src.shared.lang_names import LANG_NAMES`."
+    )
+
+    # 구현 후(Green): shared에서 import한 LANG_NAMES가 모듈 네임스페이스에 있어야 함
+    # Post-implementation (Green): LANG_NAMES imported from shared must be present.
+    assert hasattr(m, "LANG_NAMES"), (
+        "dashboard_service must import LANG_NAMES from src.shared.lang_names."
+    )
+
+
+def test_dashboard_service_lang_names_values_match_shared():
+    """dashboard_service의 LANG_NAMES가 shared 모듈과 동일 객체여야 함.
+
+    The LANG_NAMES in dashboard_service must be the exact same object
+    imported from src.shared.lang_names (not a locally-defined copy).
+    """
+    import src.services.dashboard_service as m
+    from src.shared.lang_names import LANG_NAMES
+
+    assert m.LANG_NAMES is LANG_NAMES, (
+        "dashboard_service.LANG_NAMES must be the same object as "
+        "src.shared.lang_names.LANG_NAMES (identity check)."
+    )

--- a/tests/unit/shared/test_lang_names.py
+++ b/tests/unit/shared/test_lang_names.py
@@ -6,8 +6,6 @@ their own duplicate dictionaries.
 """
 from __future__ import annotations
 
-import pytest
-
 
 # ─── LANG_NAMES 상수 기본 검증 ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

사이클 111 5+1 회고 P1 2건 처리:

- **`src/shared/lang_names.py` 신규**: `LANG_NAMES = {"ko": "Korean", "en": "English", "ja": "Japanese"}` 단일 출처 상수
- **DRY 해소**: `repo_insight_service._LANG_NAMES` + `dashboard_service._DASHBOARD_LANG_NAMES` → 공유 모듈 import로 교체
- **언어 중립화**: `_INSIGHT_SYSTEM_PROMPT` Korean 고정 구절 3개소 교체
  - `"is the metric name in Korean (e.g. 평균 점수)"` → `"is the metric name in the response language"`
  - `"Each list item ≤ 80 Korean characters"` → `"Each list item ≤ 80 characters"`
  - `"Use full sentences ending with appropriate Korean particles"` → `"Use full sentences"`
- **TDD 테스트 13건 신규**:
  - `tests/unit/shared/test_lang_names.py` (8건): LANG_NAMES 임포트/값/사용처 검증
  - `tests/unit/services/test_insight_system_prompt.py` (5건): system prompt 언어 중립 검증
- **architecture.md**: `shared/lang_names.py` 항목 추가

## 테스트

```
tests/unit/shared/test_lang_names.py ......... 8 passed
tests/unit/services/test_insight_system_prompt.py ..... 5 passed
tests/unit/services/test_insight_language_prompt.py ....... 7 passed
pylint src/ → 10.00/10
```

## Codex mutual 검증

Codex 검증 완료: 정적 코드 검사 6개 항목 전부 통과 + 테스트 20건 전부 그린 → **OK**

## 🔍 사용자 검증 필요

- [ ] insight 모드 영어/일본어 locale에서 key_metrics label이 해당 언어로 생성되는지 운영 확인 (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)