### PR TITLE
fix(p0-b/j): GitHub check status 누락 + TELEGRAM_WEBHOOK_SECRET .env.example 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,10 @@ TOKEN_ENCRYPTION_KEY=
 # Strict encryption mode (1=reject unencrypted tokens with 503, 0=warn and allow)
 STRICT_TOKEN_ENCRYPTION=0
 
+# Telegram Webhook HMAC 서명 시크릿 (미설정 시 서명 검증 없이 모든 요청 수락 — 운영 필수)
+# HMAC secret for Telegram webhook signature (unset = no signature check — required in production)
+TELEGRAM_WEBHOOK_SECRET=
+
 # === 운영 cron API 인증 ===
 # Operational cron API authentication
 

--- a/src/github_client/checks.py
+++ b/src/github_client/checks.py
@@ -154,7 +154,9 @@ def _classify_check_runs(check_runs: list[dict]) -> str:
     for run in check_runs:
         status = run.get("status", "")
         # 진행 중 또는 대기 중 → 'running' / In-progress or queued → 'running'
-        if status in ("in_progress", "queued"):
+        # GitHub API 반환 가능 상태: in_progress, queued, waiting, pending, requested
+        # All non-completed GitHub check statuses: in_progress, queued, waiting, pending, requested
+        if status in ("in_progress", "queued", "waiting", "pending", "requested"):
             return "running"
 
     # 모두 completed — conclusion 확인 / All completed — check conclusions


### PR DESCRIPTION
## Summary

- **P0-B** (`src/github_client/checks.py`): `_classify_check_runs()`의 in-progress 판별에 `"waiting"`, `"pending"`, `"requested"` 3개 상태 추가 — 누락 시 CI 진행 중 PR에서 auto-merge가 조기 트리거됨
- **P0-J** (`.env.example`): `TELEGRAM_WEBHOOK_SECRET` 항목 추가 — 미설정 배포 시 `/webhooks/telegram` HMAC 검증 무력화

## Changes

| 파일 | 변경 |
|------|------|
| `src/github_client/checks.py` | `in_progress, queued` → `in_progress, queued, waiting, pending, requested` |
| `.env.example` | `TELEGRAM_WEBHOOK_SECRET=` 항목 + 이중 언어 주석 추가 |

## 🔍 사용자 검증 필요

- [ ] Railway 운영 환경에서 `TELEGRAM_WEBHOOK_SECRET` 환경변수 설정 여부 확인
- [ ] CI 진행 중 PR에서 auto-merge가 대기 상태를 올바르게 유지하는지 확인

## Test plan

- `pytest tests/ -k "check"` — 119 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)