### PR TITLE
fix(p0-e/g): CSS --bg-2 폴백 + bandit severity HIGH/ERROR 비교 정규화

### DIFF
--- a/src/notifier/github_issue.py
+++ b/src/notifier/github_issue.py
@@ -22,9 +22,17 @@ _BOT_PR_PREFIXES: tuple[str, ...] = ("claude-fix/", "bot/", "renovate/", "depend
 
 
 def _bandit_high_issues(result: dict) -> list[dict]:
-    """result["issues"]에서 bandit HIGH severity 이슈만 추출한다."""
+    """result["issues"]에서 bandit HIGH severity 이슈만 추출한다.
+
+    registry.py 의 Severity.ERROR = "error" 로 저장되므로 대소문자 정규화 후 비교한다.
+    Severity.ERROR = "error" in registry.py — normalise to uppercase before comparing.
+    """
     issues = result.get("issues") or []
-    return [i for i in issues if i.get("tool") == "bandit" and i.get("severity") == "HIGH"]
+    return [
+        i for i in issues
+        if i.get("tool") == "bandit"
+        and i.get("severity", "").upper() in ("HIGH", "ERROR")
+    ]
 
 
 def _build_issue_body(  # pylint: disable=too-many-locals,too-many-positional-arguments
@@ -153,7 +161,7 @@ class _IssueNotifier:
         if is_bot_pr:
             return False
         has_bandit_high = any(
-            i.get("severity") == "HIGH" and i.get("tool") == "bandit"
+            i.get("severity", "").upper() in ("HIGH", "ERROR") and i.get("tool") == "bandit"
             for i in (ctx.result_dict.get("issues") or [])
         )
         return ctx.score_result.total < ctx.config.reject_threshold or has_bandit_high

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -434,13 +434,13 @@
   .repos-warning-link:hover { text-decoration: underline; }
   .repos-warning-score { margin-left: auto; color: var(--text-2); font-size: 12px; }
   .repos-selector-form { margin-bottom: 24px; }
-  .repos-selector { width: 100%; padding: 10px 14px; background: var(--bg-2); border: 1px solid var(--border-subtle); border-radius: 8px; color: var(--text-1); font-size: 14px; cursor: pointer; }
+  .repos-selector { width: 100%; padding: 10px 14px; background: var(--bg-2, var(--bg-input)); border: 1px solid var(--border-subtle); border-radius: 8px; color: var(--text-1); font-size: 14px; cursor: pointer; }
   @media (max-width: 768px) { .repos-selector { min-height: 44px; font-size: 16px; } }
   .repos-report-title { font-size: 18px; font-weight: 700; margin-bottom: 20px; color: var(--text-1); }
   .repos-section { margin-bottom: 28px; }
   .repos-section h3 { font-size: 14px; font-weight: 600; color: var(--text-2); text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 12px; }
   .repos-category-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; }
-  .repos-cat-card { background: var(--bg-2); border-radius: 8px; padding: 14px; text-align: center; }
+  .repos-cat-card { background: var(--bg-2, var(--bg-card)); border-radius: 8px; padding: 14px; text-align: center; }
   .repos-cat-value { font-size: 28px; font-weight: 700; }
   .repos-cat-label { font-size: 11px; color: var(--text-2); margin-top: 4px; }
   .repos-cat-security-error .repos-cat-value { color: var(--danger); }
@@ -449,7 +449,7 @@
   .repos-cat-quality-warn .repos-cat-value { color: var(--text-2); }
   .repos-suggestions { list-style: none; padding: 0; }
   .repos-suggestion-item { display: flex; align-items: flex-start; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--border-color-subtle, rgba(255,255,255,0.05)); font-size: 13px; }
-  .repos-suggestion-count { flex-shrink: 0; background: var(--bg-2); border-radius: 4px; padding: 2px 6px; font-size: 11px; color: var(--text-2); }
+  .repos-suggestion-count { flex-shrink: 0; background: var(--bg-2, var(--bg-card)); border-radius: 4px; padding: 2px 6px; font-size: 11px; color: var(--text-2); }
   .repos-suggestion-text { color: var(--text-1); }
   .repos-recommendations { list-style: none; padding: 0; }
   .repos-rec-item { display: flex; align-items: center; gap: 10px; padding: 8px 0; border-bottom: 1px solid var(--border-color-subtle, rgba(255,255,255,0.05)); font-size: 13px; }


### PR DESCRIPTION
## Summary

- **P0-E** (`src/templates/dashboard.html`): `var(--bg-2)` CSS 변수 폴백 추가 — tokens.css에 미정의 변수 사용으로 투명 배경 발생
- **P0-G** (`src/notifier/github_issue.py`): bandit severity 비교를 `in ("HIGH", "ERROR")`로 정규화 — `registry.py`가 `Severity.ERROR = "error"` 소문자로 저장하므로 `== "HIGH"` 비교 시 항상 False → GitHub Issue 미생성

## Changes

| 파일 | 변경 |
|------|------|
| `src/templates/dashboard.html` | `var(--bg-2)` → `var(--bg-2, var(--bg-input/card))` (3곳) |
| `src/notifier/github_issue.py` | `== "HIGH"` → `.upper() in ("HIGH", "ERROR")` (`_bandit_high_issues` + `is_enabled`) |

## 🔍 사용자 검증 필요

- [ ] Dashboard repos 페이지 `.repos-selector`, `.repos-cat-card` 배경색 정상 표시 확인 (4테마 × 모바일/데스크탑)
- [ ] bandit HIGH severity 이슈 포함 분석 후 GitHub Issue 생성 여부 확인

## Test plan

- `pytest tests/ -k "github_issue or notif"` — 267 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)