### PR TITLE
fix(p0-a): gate_decisions.analysis_id UNIQUE constraint + migration 0034

### DIFF
--- a/alembic/versions/0034_gate_decisions_unique_analysis_id.py
+++ b/alembic/versions/0034_gate_decisions_unique_analysis_id.py
@@ -1,0 +1,64 @@
+"""gate_decisions unique constraint on analysis_id
+
+save_gate_decision() 은 분석 당 1건 upsert 로 동작하므로 UNIQUE constraint 필수.
+0002 에서 생성된 ix_gate_decisions_analysis_id (non-unique 인덱스) 를 제거하고
+UNIQUE constraint (uq_gate_decisions_analysis_id) 로 대체한다.
+중복 행이 존재하는 경우 최신 id 를 보존하고 구 중복을 제거한다.
+
+save_gate_decision() operates as a per-analysis upsert, so a UNIQUE constraint
+is required. Drops the non-unique index from 0002 and replaces it with a
+UNIQUE constraint. Duplicate rows (if any) are pruned, keeping the latest id.
+
+Revision ID: 0034
+Revises: 0033insighterror
+Create Date: 2026-05-21
+"""
+from alembic import op
+
+from src.shared.alembic_dialect import is_postgresql
+
+revision = '0034'
+down_revision = '0033insighterror'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # SQLite 는 ALTER TABLE 로 UNIQUE constraint 추가 불가 (DDL 제한).
+    # 운영 DB (PostgreSQL) 만 처리. 단위 테스트는 ORM Base.metadata.create_all 로
+    # unique=True 가 자동 적용됨.
+    # SQLite cannot add UNIQUE constraints via ALTER TABLE.
+    # Production (PostgreSQL) only. Tests get unique=True from ORM create_all.
+    if not is_postgresql(op.get_bind()):
+        return
+
+    # 중복 행 제거 — 동일 analysis_id 중 최신 id 만 보존
+    # Prune duplicate rows: keep only the row with the highest id per analysis_id
+    op.execute("""
+        DELETE FROM gate_decisions
+        WHERE id NOT IN (
+            SELECT MAX(id) FROM gate_decisions GROUP BY analysis_id
+        )
+    """)
+
+    # 0002 에서 생성된 non-unique 인덱스 제거 (UNIQUE constraint 가 인덱스를 대체)
+    # Drop the non-unique index created in 0002 (the UNIQUE constraint creates its own index)
+    op.drop_index('ix_gate_decisions_analysis_id', table_name='gate_decisions')
+
+    # UNIQUE constraint 추가
+    # Add UNIQUE constraint
+    op.create_unique_constraint(
+        'uq_gate_decisions_analysis_id',
+        'gate_decisions',
+        ['analysis_id'],
+    )
+
+
+def downgrade() -> None:
+    # SQLite 분기 보존 (upgrade 와 대칭)
+    # Mirror the SQLite guard from upgrade
+    if not is_postgresql(op.get_bind()):
+        return
+
+    op.drop_constraint('uq_gate_decisions_analysis_id', 'gate_decisions', type_='unique')
+    op.create_index('ix_gate_decisions_analysis_id', 'gate_decisions', ['analysis_id'], unique=False)

--- a/src/models/gate_decision.py
+++ b/src/models/gate_decision.py
@@ -15,13 +15,17 @@ class GateDecision(Base):
     # `delete_repo_cascade` (ui/_helpers.py) 가 application-level 보완 중이지만,
     # 다른 경로 (admin script, future API) 에서 Analysis 삭제 시 안전망 필요.
     # MergeAttempt/MergeRetryQueue/AnalysisFeedback 은 이미 CASCADE — 일관성 확보.
+    # P0-A: unique=True 추가 — save_gate_decision() 은 분석 당 1건 upsert 이므로
+    # UNIQUE constraint 필수. unique=True 는 자동으로 인덱스를 생성하므로 index=True 제거.
     # Phase H — Critical C7: add ondelete=CASCADE so direct Analysis deletion
     # propagates here too (mirrors MergeAttempt/MergeRetryQueue/AnalysisFeedback).
+    # P0-A: unique=True enforces one gate_decision per analysis (upsert semantic).
+    # unique=True implies an index, so index=True is dropped.
     analysis_id = Column(
         Integer,
         ForeignKey("analyses.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
+        unique=True,
     )
     decision = Column(String, nullable=False)   # "approve" | "reject" | "skip"
     mode = Column(String, nullable=False)        # "auto" | "manual"


### PR DESCRIPTION
## Summary

`gate_decisions.analysis_id`에 UNIQUE constraint가 없어 `save_gate_decision()` upsert 의미론이 DB 레벨에서 보장되지 않았습니다. migration 0034로 기존 중복 행 제거 후 UNIQUE constraint를 추가합니다.

## Changes

| 파일 | 변경 |
|------|------|
| `src/models/gate_decision.py` | `index=True` → `unique=True` (`unique=True`가 인덱스 자동 생성) |
| `alembic/versions/0034_gate_decisions_unique_analysis_id.py` | 중복 행 제거 → 기존 non-unique 인덱스 삭제 → UNIQUE constraint 추가 |

## Migration 상세

```sql
-- 중복 제거 (최신 id 보존)
DELETE FROM gate_decisions WHERE id NOT IN (SELECT MAX(id) FROM gate_decisions GROUP BY analysis_id);
-- 기존 인덱스 제거
DROP INDEX ix_gate_decisions_analysis_id;
-- UNIQUE constraint 추가
ALTER TABLE gate_decisions ADD CONSTRAINT uq_gate_decisions_analysis_id UNIQUE (analysis_id);
```

SQLite dialect는 `is_postgresql()` 분기로 자동 skip (단위 테스트 호환 유지).

## 🔍 사용자 검증 필요

- [ ] Railway 배포 후 migration 0034 정상 적용 확인 (`alembic current`)
- [ ] gate_decisions 테이블에 중복 analysis_id 행이 없는지 확인 (배포 전 선택적)

## Test plan

- `pytest tests/ -k "gate_decision"` — 17 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)