### PR TITLE
fix(retro113): P1 빠른 수정 3건 — env/architecture/bandit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,10 @@ STRICT_TOKEN_ENCRYPTION=0
 # HMAC secret for Telegram webhook signature (unset = no signature check — required in production)
 TELEGRAM_WEBHOOK_SECRET=
 
+# n8n Webhook HMAC 서명 시크릿 (미설정 시 서명 검증 없이 모든 요청 수락 — 운영 필수)
+# HMAC secret for n8n webhook signature (unset = no signature check — required in production)
+N8N_WEBHOOK_SECRET=
+
 # === 운영 cron API 인증 ===
 # Operational cron API authentication
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,7 @@ src/
 ├── auth/
 │   ├── session.py               # get_current_user() + require_login + require_admin (3-layer SaaS 검증)
 │   └── github.py                # /login, /auth/github, /auth/callback, /auth/logout
-├── models/                      # 10 ORM 모델 — repository, analysis, analysis_feedback, repo_config, gate_decision, merge_attempt, merge_retry, security_alert_log, insight_narrative_cache (0031: repo_id FK; 0033: last_error_at/error_count/last_error_type), user
+├── models/                      # 10 ORM 모델 — repository, analysis, analysis_feedback, repo_config, gate_decision (0034: analysis_id UNIQUE constraint), merge_attempt, merge_retry, security_alert_log, insight_narrative_cache (0031: repo_id FK; 0033: last_error_at/error_count/last_error_type), user
 ├── webhook/
 │   ├── _helpers.py              # get_webhook_secret() + cache (TTL 300s)
 │   ├── validator.py             # HMAC-SHA256 서명 검증

--- a/src/analyzer/io/tools/python.py
+++ b/src/analyzer/io/tools/python.py
@@ -132,7 +132,7 @@ class _BanditAnalyzer:
             return [
                 AnalysisIssue(
                     tool="bandit",
-                    severity=Severity.ERROR if item["issue_severity"] == "HIGH" else Severity.WARNING,
+                    severity=Severity.ERROR if item["issue_severity"].upper() == "HIGH" else Severity.WARNING,
                     message=item["issue_text"],
                     line=item["line_number"],
                     category=self.category,


### PR DESCRIPTION
## Summary

사이클 113 회고 5+1 다중 에이전트 결과 — P1 빠른 수정 3건.

| 항목 | 파일 | 수정 내용 |
|------|------|----------|
| D-1 | `.env.example` | `N8N_WEBHOOK_SECRET=` 추가 — `env-vars.md:29` + `config.py:44` 와 3-way 동기화 |
| D-2 | `docs/architecture.md:75` | `gate_decision (0034: analysis_id UNIQUE constraint)` 반영 |
| C-1 | `src/analyzer/io/tools/python.py:135` | `item["issue_severity"].upper() == "HIGH"` — 대소문자 방어 추가 |

## Code Scanning 처리 완료 (별도)

모든 5개 Code Scanning alerts 처리 완료:
- Alert #422 (`e2e/test_performance.py`) — false-positive dismiss (time/requests 모두 test_health_ttfb에서 실사용)
- Alert #423, #421 — false-positive dismiss
- Alert #420, #416 — ORM side-effect import, used-in-tests dismiss

## 🔍 사용자 검증 필요

- `.env.example` `N8N_WEBHOOK_SECRET` 항목 확인
- Railway 환경에서 n8n webhook 사용 시 해당 변수 설정 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)