### PR TITLE
test(retro113): P0 회귀 가드 테스트 5건 — Bearer/severity/to_thread/unique/CSS

### DIFF
--- a/tests/unit/api/test_hook.py
+++ b/tests/unit/api/test_hook.py
@@ -362,3 +362,81 @@ def test_hook_result_unknown_repo_returns_404():
 
     assert r.status_code == 404
     mock_db.add.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# T-1: Bearer 헤더 인증 3시나리오 회귀 가드 (사이클 113 P0-A)
+# T-1: Bearer header auth 3-scenario regression guard (Cycle 113 P0-A)
+# ------------------------------------------------------------------
+
+def test_verify_with_bearer_header_only():
+    """Authorization: Bearer 헤더만으로 verify 성공 → 200 {"status": "active"}.
+    Verify succeeds with only an Authorization: Bearer header — returns 200 {"status": "active"}.
+
+    사이클 113 P0-A 회귀 가드: hook.py 가 Authorization 헤더에서 bearer_token을 파싱 후
+    effective_token으로 사용하는지 검증한다.
+    Cycle 113 P0-A regression guard: verifies hook.py parses bearer_token from
+    Authorization header and uses it as effective_token.
+    """
+    mock_db = MagicMock()
+    mock_config = MagicMock()
+    mock_config.hook_token = "bearer-only-token"
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_config
+
+    with patch("src.api.hook.SessionLocal", return_value=_make_session_mock(mock_db)):
+        with patch("src.api.hook.repo_config_repo.find_by_full_name", return_value=mock_config):
+            r = client.get(
+                "/api/hook/verify",
+                params={"repo": "owner/repo"},
+                headers={"Authorization": "Bearer bearer-only-token"},
+            )
+
+    assert r.status_code == 200
+    assert r.json()["status"] == "active"
+
+
+def test_verify_bearer_takes_priority_over_query_param():
+    """Bearer와 ?token= 동시 존재 시 Bearer가 우선 처리되어 올바른 token으로 인증된다.
+    When both Bearer header and ?token= query param are present, Bearer takes priority.
+
+    사이클 113 P0-A 회귀 가드: effective_token = bearer_token or token 우선순위 검증.
+    Cycle 113 P0-A regression guard: verifies effective_token = bearer_token or token priority.
+    """
+    mock_db = MagicMock()
+    mock_config = MagicMock()
+    # hook_token이 Bearer 값과 일치 → Bearer 우선 사용 시 200
+    # hook_token matches Bearer value → 200 when Bearer takes priority
+    mock_config.hook_token = "correct-bearer-token"
+
+    with patch("src.api.hook.SessionLocal", return_value=_make_session_mock(mock_db)):
+        with patch("src.api.hook.repo_config_repo.find_by_full_name", return_value=mock_config):
+            r = client.get(
+                "/api/hook/verify",
+                params={"repo": "owner/repo", "token": "wrong-query-token"},
+                headers={"Authorization": "Bearer correct-bearer-token"},
+            )
+
+    # Bearer 값이 hook_token과 일치하므로 200 반환 (query param 무시)
+    # Bearer matches hook_token → 200 (query param ignored)
+    assert r.status_code == 200
+    assert r.json()["status"] == "active"
+
+
+def test_verify_no_token_returns_401():
+    """Authorization 헤더도 ?token= 쿼리도 없으면 401 반환.
+    Returns 401 when neither Authorization header nor ?token= query param is present.
+
+    사이클 113 P0-A 회귀 가드: effective_token이 None이면 HTTPException(401) 발화 검증.
+    Cycle 113 P0-A regression guard: verifies HTTPException(401) raised when effective_token is None.
+    """
+    mock_db = MagicMock()
+
+    with patch("src.api.hook.SessionLocal", return_value=_make_session_mock(mock_db)):
+        r = client.get(
+            "/api/hook/verify",
+            params={"repo": "owner/repo"},
+            # Authorization 헤더 없음, token 쿼리 없음
+            # No Authorization header, no token query param
+        )
+
+    assert r.status_code == 401

--- a/tests/unit/api/test_users_api.py
+++ b/tests/unit/api/test_users_api.py
@@ -162,3 +162,46 @@ def test_post_telegram_otp_uses_secrets_for_randomness():
     # Only digit chars — guaranteed by secrets.choice("0123456789").
     assert all(c in "0123456789" for c in otp)
     assert len(otp) == 6
+
+
+# ── T-3: asyncio.to_thread 래핑 검증 (사이클 113 P0-D 회귀 가드) ──
+# ── T-3: asyncio.to_thread wrapping verification (Cycle 113 P0-D regression guard) ──
+
+
+async def test_post_telegram_otp_wraps_db_in_to_thread():
+    """issue_telegram_otp이 DB 저장을 asyncio.to_thread로 래핑하는지 검증한다.
+    Verifies that issue_telegram_otp wraps DB save in asyncio.to_thread.
+
+    사이클 113 P0-D 회귀 가드: 동기 SQLAlchemy 호출이 async 엔드포인트에서 이벤트 루프를
+    블로킹하지 않도록 asyncio.to_thread로 wrap 되어야 한다.
+    Cycle 113 P0-D regression guard: sync SQLAlchemy must be wrapped in asyncio.to_thread
+    inside async endpoints to avoid event loop blocking.
+    """
+    import asyncio
+    from src.api.users import issue_telegram_otp
+
+    to_thread_calls: list[str] = []
+    real_to_thread = asyncio.to_thread
+
+    async def _spy(fn, *args, **kwargs):
+        # 호출된 함수 이름 기록 — _do_save 클로저 확인
+        # Record the name of the called function — checks for _do_save closure
+        to_thread_calls.append(getattr(fn, "__name__", repr(fn)))
+        return await real_to_thread(fn, *args, **kwargs)
+
+    mock_db = MagicMock()
+    mock_db.execute.return_value = None
+    mock_db.commit.return_value = None
+
+    with patch("src.api.users.asyncio.to_thread", side_effect=_spy):
+        with patch("src.api.users.SessionLocal", return_value=_make_db_session_mock(mock_db)):
+            # issue_telegram_otp 직접 호출 — TestClient는 ASGI event loop 별도 관리
+            # Call issue_telegram_otp directly — TestClient manages its own ASGI event loop
+            await issue_telegram_otp(current_user=_FAKE_USER)
+
+    # asyncio.to_thread가 최소 1번 호출 — _do_save 클로저가 wrap됨
+    # asyncio.to_thread must be called at least once — _do_save closure is wrapped
+    assert len(to_thread_calls) >= 1
+    # 호출된 함수 이름이 "_do_save" 포함
+    # The called function name must include "_do_save"
+    assert any("_do_save" in name for name in to_thread_calls)

--- a/tests/unit/models/test_gate_decision.py
+++ b/tests/unit/models/test_gate_decision.py
@@ -1,0 +1,150 @@
+"""GateDecision 모델 단위 테스트 — unique constraint + CASCADE 검증.
+GateDecision model unit tests — unique constraint and CASCADE verification.
+
+사이클 113 P0-E 회귀 가드: analysis_id UNIQUE constraint가 DB 레벨에서 실제로
+IntegrityError를 발화하는지 검증한다. upsert semantic에 필수 (분석 1건 당 1건).
+Cycle 113 P0-E regression guard: verifies that the analysis_id UNIQUE constraint
+actually raises IntegrityError at the DB level. Required for upsert semantics (1 per analysis).
+"""
+from __future__ import annotations
+
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "")
+os.environ.setdefault("API_KEY", "")
+os.environ.setdefault("GITHUB_CLIENT_ID", "test-github-client-id")
+os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-github-client-secret")
+os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import StaticPool
+
+from src.database import Base
+from src.models.analysis import Analysis
+from src.models.gate_decision import GateDecision
+from src.models.repository import Repository
+from src.models.user import User
+
+
+# ─── Fixture ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def db():
+    """단일 connection 공유 SQLite in-memory 세션 (StaticPool).
+    SQLite in-memory session with shared single connection (StaticPool).
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture()
+def analysis(db: Session) -> Analysis:
+    """테스트용 Analysis 레코드 (Repository + User 포함).
+    Analysis record for tests (with Repository and User).
+    """
+    user = User(github_id=1, github_login="tester", email="t@x.com", display_name="Tester")
+    db.add(user)
+    db.flush()
+
+    repo = Repository(full_name="owner/repo", user_id=user.id)
+    db.add(repo)
+    db.flush()
+
+    a = Analysis(
+        repo_id=repo.id,
+        commit_sha="abc123",
+        score=80,
+        grade="B",
+        result={},
+    )
+    db.add(a)
+    db.commit()
+    db.refresh(a)
+    return a
+
+
+# ─── T-4: analysis_id UNIQUE constraint 회귀 가드 ──────────────────────────
+
+
+def test_gate_decision_analysis_id_unique_constraint(db: Session, analysis: Analysis):
+    """동일 analysis_id로 GateDecision 2건 삽입 시 IntegrityError 발생.
+    Inserting two GateDecisions with the same analysis_id raises IntegrityError.
+
+    사이클 113 P0-E 회귀 가드: GateDecision.analysis_id에 unique=True 제약이
+    실제 DB 레벨에서 작동함을 검증한다. 제약이 없으면 save_gate_decision()의
+    upsert semantic이 깨져 중복 결정 레코드가 생성될 수 있다.
+    Cycle 113 P0-E regression guard: verifies unique=True constraint on
+    GateDecision.analysis_id works at the DB level. Without this constraint,
+    the upsert semantic of save_gate_decision() breaks, allowing duplicate records.
+    """
+    first = GateDecision(
+        analysis_id=analysis.id,
+        decision="approve",
+        mode="auto",
+        decided_by="bot",
+    )
+    db.add(first)
+    db.commit()
+
+    # 동일 analysis_id로 두 번째 삽입 시도
+    # Attempt second insert with same analysis_id
+    second = GateDecision(
+        analysis_id=analysis.id,
+        decision="reject",
+        mode="manual",
+        decided_by="bot",
+    )
+    db.add(second)
+
+    # UNIQUE constraint 위반 → IntegrityError
+    # UNIQUE constraint violation → IntegrityError
+    with pytest.raises(IntegrityError):
+        db.commit()
+
+
+def test_gate_decision_different_analyses_allowed(db: Session, analysis: Analysis):
+    """서로 다른 analysis_id로는 GateDecision 각 1건씩 정상 삽입된다.
+    GateDecision records for different analysis_ids are inserted successfully.
+
+    UNIQUE constraint가 같은 analysis_id에 대해서만 작동하고
+    다른 analysis_id는 허용하는지 검증한다.
+    Verifies the UNIQUE constraint only blocks same analysis_id,
+    while different analysis_ids are permitted.
+    """
+    # 두 번째 Analysis 레코드 생성
+    # Create a second Analysis record
+    a2 = Analysis(
+        repo_id=analysis.repo_id,
+        commit_sha="def456",
+        score=70,
+        grade="C",
+        result={},
+    )
+    db.add(a2)
+    db.commit()
+    db.refresh(a2)
+
+    gd1 = GateDecision(analysis_id=analysis.id, decision="approve", mode="auto", decided_by="bot")
+    gd2 = GateDecision(analysis_id=a2.id, decision="reject", mode="auto", decided_by="bot")
+    db.add(gd1)
+    db.add(gd2)
+    db.commit()  # 두 건 모두 정상 삽입 — IntegrityError 없어야 함
+
+    count = db.query(GateDecision).count()
+    assert count == 2

--- a/tests/unit/services/test_dashboard_service.py
+++ b/tests/unit/services/test_dashboard_service.py
@@ -304,3 +304,65 @@ class TestFrequentIssuesV2:
         from src.services.dashboard_service import frequent_issues_v2
 
         assert frequent_issues_v2(db, days=7) == []
+
+
+# ─── T-2: _count_high_security — severity="error" 소문자 회귀 가드 (사이클 113 P0-C) ──
+
+
+class TestCountHighSecurityErrorSeverity:
+    """_count_high_security — bandit이 저장하는 severity="error" 소문자 포함 검증.
+
+    Verify _count_high_security counts bandit issues stored as severity="error" (lowercase).
+
+    사이클 113 P0-C 회귀 가드: bandit 파서가 issue_severity=="HIGH"를
+    Severity.ERROR="error"(소문자)로 변환 저장하므로 두 형태를 모두 카운트해야 한다.
+    Cycle 113 P0-C regression guard: bandit parser converts issue_severity=="HIGH"
+    to Severity.ERROR="error" (lowercase), so both forms must be counted.
+    """
+
+    def test_high_security_issues_count_error_severity(self, db, repos):
+        """bandit이 Severity.ERROR="error" (소문자)로 저장한 이슈도 high_security_issues에 포함됨.
+        Issues stored as severity="error" (lowercase) by bandit parser are counted in high_security_issues.
+        """
+        from src.services.dashboard_service import dashboard_kpi
+
+        now = __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
+        result_data = {
+            "issues": [
+                # bandit 파서가 HIGH → Severity.ERROR="error"(소문자)로 저장하는 패턴
+                # bandit parser stores HIGH → Severity.ERROR="error" (lowercase)
+                {"category": "security", "severity": "error", "tool": "bandit", "message": "B608"},
+                # 대문자 "HIGH"도 함께 포함 (혼재 시 양쪽 카운트)
+                # Uppercase "HIGH" mixed in — both forms should be counted
+                {"category": "security", "severity": "HIGH", "tool": "bandit", "message": "B102"},
+                # security가 아닌 카테고리는 제외
+                # Non-security category excluded
+                {"category": "code_quality", "severity": "error", "tool": "pylint", "message": "C0103"},
+            ]
+        }
+        _make_analysis(db, repos[0].id, 75, offset_hours=1, result=result_data)
+
+        result = dashboard_kpi(db, days=7, now=now)
+        # severity="error"(소문자) + severity="HIGH" 합산 → 2건
+        # severity="error" (lowercase) + severity="HIGH" → total 2
+        assert result["high_security_issues"]["value"] == 2
+
+    def test_high_security_issues_excludes_low_severity(self, db, repos):
+        """severity="low" 이슈는 high_security_issues에서 제외된다.
+        Issues with severity="low" are excluded from high_security_issues count.
+        """
+        from src.services.dashboard_service import dashboard_kpi
+
+        now = __import__("datetime").datetime.now(__import__("datetime").timezone.utc)
+        result_data = {
+            "issues": [
+                {"category": "security", "severity": "LOW", "tool": "bandit", "message": "B404"},
+                {"category": "security", "severity": "MEDIUM", "tool": "bandit", "message": "B301"},
+            ]
+        }
+        _make_analysis(db, repos[0].id, 90, offset_hours=1, result=result_data)
+
+        result = dashboard_kpi(db, days=7, now=now)
+        # LOW/MEDIUM severity 보안 이슈는 카운트 0
+        # LOW/MEDIUM severity security issues → count 0
+        assert result["high_security_issues"]["value"] == 0

--- a/tests/unit/ui/test_dashboard_css_bg2_fallback.py
+++ b/tests/unit/ui/test_dashboard_css_bg2_fallback.py
@@ -1,0 +1,76 @@
+"""회귀 가드 — dashboard.html CSS --bg-2 폴백 변수 검증.
+Regression guard — dashboard.html CSS --bg-2 fallback variable verification.
+
+사이클 113 P0-F 회귀 가드: dashboard.html 의 repos-selector / repos-cat-card /
+repos-suggestion-count 3개 CSS 선택자에 var(--bg-2, ...) 폴백이 존재하는지 검증한다.
+--bg-2 가 정의되지 않은 테마(legacy/커스텀)에서 시각 깨짐을 방지한다.
+Cycle 113 P0-F regression guard: verifies that the 3 CSS selectors in dashboard.html
+(repos-selector / repos-cat-card / repos-suggestion-count) contain var(--bg-2, ...) fallbacks.
+Prevents visual breakage in themes that do not define --bg-2.
+
+검증 방법:
+  template 파일 텍스트 직접 검사 — FastAPI app import 없이 정적 검사.
+  실제 브라우저 렌더링 없이 폴백 패턴 회귀 차단.
+
+Verification method:
+  Direct template file text inspection — no FastAPI app import needed.
+  Catches fallback pattern regressions without browser rendering.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+# 템플릿 파일 경로 — 프로젝트 루트 기준
+# Template file path — relative to project root
+_DASHBOARD_TMPL = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "src" / "templates" / "dashboard.html"
+)
+
+
+def test_dashboard_html_bg2_fallback_input_variant_present():
+    """dashboard.html에 repos-selector 용 var(--bg-2, var(--bg-input)) 폴백이 존재한다.
+    dashboard.html contains var(--bg-2, var(--bg-input)) fallback for repos-selector.
+
+    사이클 113 P0-F: --bg-2 미정의 테마에서 input 배경색 폴백 보장.
+    Cycle 113 P0-F: ensures input background color fallback when --bg-2 is undefined.
+    """
+    content = _DASHBOARD_TMPL.read_text(encoding="utf-8")
+    assert "var(--bg-2, var(--bg-input))" in content, (
+        "dashboard.html에 var(--bg-2, var(--bg-input)) 폴백이 없습니다. "
+        "repos-selector 배경색 폴백이 제거됐을 수 있습니다."
+    )
+
+
+def test_dashboard_html_bg2_fallback_card_variant_present():
+    """dashboard.html에 repos-cat-card 및 repos-suggestion-count 용
+    var(--bg-2, var(--bg-card)) 폴백이 존재한다.
+    dashboard.html contains var(--bg-2, var(--bg-card)) fallback for
+    repos-cat-card and repos-suggestion-count selectors.
+
+    사이클 113 P0-F: --bg-2 미정의 테마에서 카드 배경색 폴백 보장.
+    Cycle 113 P0-F: ensures card background color fallback when --bg-2 is undefined.
+    """
+    content = _DASHBOARD_TMPL.read_text(encoding="utf-8")
+    assert "var(--bg-2, var(--bg-card))" in content, (
+        "dashboard.html에 var(--bg-2, var(--bg-card)) 폴백이 없습니다. "
+        "repos-cat-card 또는 repos-suggestion-count 배경색 폴백이 제거됐을 수 있습니다."
+    )
+
+
+def test_dashboard_html_bg2_fallback_all_three_selectors():
+    """dashboard.html의 --bg-2 폴백이 3개 선택자 모두에 적용됐는지 총 개수로 검증한다.
+    Verifies the total count of --bg-2 fallbacks covers all 3 expected selectors.
+
+    사이클 113 P0-F: var(--bg-2, ... 패턴이 최소 3회 등장해야 3개 선택자 모두 적용된 것.
+    Cycle 113 P0-F: var(--bg-2, ... pattern must appear at least 3 times to cover all selectors.
+    """
+    content = _DASHBOARD_TMPL.read_text(encoding="utf-8")
+    # "var(--bg-2," 패턴이 3개 이상 존재해야 함 (각 CSS 선택자 1건)
+    # "var(--bg-2," pattern must appear at least 3 times (one per CSS selector)
+    count = content.count("var(--bg-2,")
+    assert count >= 3, (
+        f"dashboard.html에 var(--bg-2, 폴백이 {count}개만 존재합니다. "
+        f"최소 3개 선택자 모두 폴백이 필요합니다."
+    )


### PR DESCRIPTION
## Summary

사이클 113 P0 버그 수정 후 누락된 회귀 가드 테스트 5건을 추가한다.

- **T-1 (P0-A)** `tests/unit/api/test_hook.py` — Bearer 헤더 인증 3시나리오: Bearer only 200, Bearer 우선(query param 무시), 토큰 없음 401
- **T-2 (P0-C)** `tests/unit/services/test_dashboard_service.py` — `_count_high_security`: bandit 파서가 severity="HIGH"를 "error"(소문자)로 저장해도 카운트됨을 검증 (LOW/MEDIUM 제외 보조 케이스 포함)
- **T-3 (P0-D)** `tests/unit/api/test_users_api.py` — `issue_telegram_otp`이 DB 저장을 `asyncio.to_thread`로 래핑하는지 spy 패턴으로 검증
- **T-4 (P0-E)** `tests/unit/models/test_gate_decision.py` (신규) — `GateDecision.analysis_id` UNIQUE constraint가 DB 레벨에서 `IntegrityError`를 발화하는지 SQLite in-memory로 검증
- **T-5 (P0-F)** `tests/unit/ui/test_dashboard_css_bg2_fallback.py` (신규) — `dashboard.html` CSS `var(--bg-2, var(--bg-input))` / `var(--bg-2, var(--bg-card))` 폴백 3개 선택자 정적 검증

## Test Results

모든 테스트 로컬 통과:

```
tests/unit/api/test_hook.py::test_verify_with_bearer_header_only            PASSED
tests/unit/api/test_hook.py::test_verify_bearer_takes_priority_over_query_param PASSED
tests/unit/api/test_hook.py::test_verify_no_token_returns_401               PASSED
tests/unit/services/test_dashboard_service.py::TestCountHighSecurityErrorSeverity::test_high_security_issues_count_error_severity PASSED
tests/unit/services/test_dashboard_service.py::TestCountHighSecurityErrorSeverity::test_high_security_issues_excludes_low_severity PASSED
tests/unit/api/test_users_api.py::test_post_telegram_otp_wraps_db_in_to_thread PASSED
tests/unit/models/test_gate_decision.py::test_gate_decision_analysis_id_unique_constraint PASSED
tests/unit/models/test_gate_decision.py::test_gate_decision_different_analyses_allowed PASSED
tests/unit/ui/test_dashboard_css_bg2_fallback.py::test_dashboard_html_bg2_fallback_input_variant_present PASSED
tests/unit/ui/test_dashboard_css_bg2_fallback.py::test_dashboard_html_bg2_fallback_card_variant_present PASSED
tests/unit/ui/test_dashboard_css_bg2_fallback.py::test_dashboard_html_bg2_fallback_all_three_selectors PASSED
```

## 🔍 사용자 검증 필요

- T-3 (`asyncio.to_thread` spy): `_do_save` 클로저는 이름이 `<locals>._do_save`로 저장되므로 `"_do_save" in name` 조건이 일치함. 향후 함수 이름 변경 시 테스트 수정 필요.
- T-5 (CSS 정적 검증): dashboard.html 수정 시 `var(--bg-2, ...)` 패턴이 보존되는지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)