### PR TITLE
fix(cycle115-P1): --bg-2 CSS alias + GateDecision assertion + cross-ref docs

### DIFF
--- a/.claude/rules/pipeline.md
+++ b/.claude/rules/pipeline.md
@@ -33,3 +33,4 @@ paths:
 - **Railway Webhook 토큰 인증**: `POST /webhooks/railway/{token}` 엔드포인트는 DB에서 `railway_webhook_token == token` 조회 후 `config is None → 404` 처리. `railway_api_token`은 Fernet 암호화 저장 — `decrypt_token()`으로 백그라운드 핸들러에 전달.
 - **5-way 동기화 Railway 확장**: `railway_deploy_alerts`가 ORM/RepoConfigData/API body/settings 폼/PRESETS 5-way 동기화 적용 대상.
 - **RailwayDeployEvent nested 구조**: `src/railway_client/models.py`의 `RailwayDeployEvent`는 3-그룹 nested dataclass — `event.project.project_id`, `event.commit.commit_sha` 등 sub-dataclass 경로로 접근. 평면(`event.project_id`) 접근은 2026-04-22 이후 제거됨. 신규 필드 추가 시 `RailwayProjectInfo` 또는 `RailwayCommitInfo`에 삽입.
+- **asyncio.gather 내 Session 공유 금지**: `gather()` 내 코루틴은 각각 독립 `with SessionLocal() as db:` 사용 의무 — 세션 공유 시 트랜잭션 충돌. 교차 참조: [`.claude/rules/api.md`](.claude/rules/api.md) (사이클 113 P0-H 학습).

--- a/docs/runbooks/workflow.md
+++ b/docs/runbooks/workflow.md
@@ -40,6 +40,7 @@
 
 > 파일 분석 시 전체 읽기 원칙: import 미사용 여부, 함수 사용처 등을 판단할 때 `grep -n` 실측 의무.
 > 파일 앞부분만 읽고 판단하는 것은 false-positive 원인 — 사이클 113 `test_performance.py` 사고 학습.
+> → CLAUDE.md 정책 6 (line:span 인용 시 `grep -n` 실측 의무) 와 동일 원칙.
 
 ---
 

--- a/src/static/css/themes.css
+++ b/src/static/css/themes.css
@@ -11,6 +11,7 @@
   --bg-nav:         rgba(7,7,15,0.85);
   --bg-input:       rgba(255,255,255,0.06);
   --bg-input-focus: rgba(255,255,255,0.1);
+  --bg-2:           var(--bg-card);
   --text-1:         #f0f0f8;
   --text-2:         #8b8b9e;
   --text-3:         #6b6b7e;
@@ -68,6 +69,7 @@
   --bg-nav:         rgba(246,246,253,0.85);
   --bg-input:       #f0f0f8;
   --bg-input-focus: #ffffff;
+  --bg-2:           var(--bg-card);
   --text-1:         #0f0f1a;
   --text-2:         #5c5c7a;
   --text-3:         #9090aa;
@@ -123,6 +125,7 @@
   --bg-nav:         rgba(240,236,255,0.85);
   --bg-input:       rgba(255,255,255,0.6);
   --bg-input-focus: rgba(255,255,255,0.9);
+  --bg-2:           var(--bg-card);
   --text-1:         #1e0a4a;
   --text-2:         #6b4fa0;
   --text-3:         #a08cc0;
@@ -178,6 +181,7 @@
   --bg-nav:         rgba(30,30,46,0.92);
   --bg-input:       #313244;
   --bg-input-focus: #45475a;
+  --bg-2:           var(--bg-card);
   --text-1:         #cdd6f4;
   --text-2:         #a6adc8;
   --text-3:         #7f849c;

--- a/tests/unit/github_client/test_checks.py
+++ b/tests/unit/github_client/test_checks.py
@@ -551,3 +551,81 @@ async def test_get_required_check_contexts_caches_result():
     assert result2 == {"CI / test"}
     # 캐시 적중으로 API는 1회만 호출 / API called only once due to cache hit.
     assert mock_client.get.call_count == 1
+
+
+# ── 사이클 113 P0-B 회귀 가드 — 3상태 (waiting/pending/requested) ────────
+# ── Cycle 113 P0-B regression guard — 3 new in-progress states ────────────
+
+
+@pytest.mark.parametrize("status", ["waiting", "pending", "requested"])
+async def test_get_ci_status_running_when_check_in_new_in_progress_states(status):
+    """사이클 113 P0-B 회귀 가드 — waiting/pending/requested 는 running으로 분류.
+    Cycle 113 P0-B regression guard — waiting/pending/requested must be classified as running.
+
+    `_classify_check_runs()` 의 status in ("in_progress", "queued", "waiting", "pending", "requested")
+    조건에서 사이클 113에 추가된 3상태를 검증한다.
+    향후 리팩토링 시 이 3상태가 무음으로 제거되는 것을 방지한다.
+
+    Validates the 3 states added in cycle 113 to the condition
+    `status in ("in_progress", "queued", "waiting", "pending", "requested")`.
+    Prevents silent removal of these 3 states during future refactoring.
+    """
+    # 대상 상태만 가진 체크런 1개로 세팅 / Single check run with the target status only.
+    check_runs_body = {
+        "check_runs": [_check_run("CI / build", status, None)],
+        "total_count": 1,
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        side_effect=[
+            _resp(200, check_runs_body),  # check-runs 1페이지 / check-runs page 1
+        ]
+    )
+
+    with patch("src.github_client.checks.get_http_client", return_value=mock_client):
+        result = await get_ci_status(TOKEN, REPO, SHA)
+
+    # waiting/pending/requested 모두 "running" 으로 분류되어야 함
+    # All of waiting/pending/requested must be classified as "running".
+    assert result == "running", (
+        f"status={status!r} must be classified as 'running' "
+        f"(cycle 113 P0-B regression guard)"
+    )
+    # check-runs 1회만 호출 — 레거시 API 미호출 / Only check-runs called — no legacy API call.
+    assert mock_client.get.call_count == 1
+
+
+@pytest.mark.parametrize("status", ["waiting", "pending", "requested"])
+async def test_get_ci_status_new_states_do_not_fall_through_to_failed(status):
+    """사이클 113 P0-B 부정 케이스 — 3상태는 'failed'/'unknown'으로 빠지지 않는다.
+    Cycle 113 P0-B negative guard — 3 states must NOT fall through to 'failed' or 'unknown'.
+
+    `_classify_check_runs()` 에서 신규 3상태가 running 분기에 포함되지 않을 경우
+    completed 가 아닌 체크런은 기본값(failed 또는 unknown)으로 떨어진다.
+    이 테스트는 그 회귀를 명시적으로 차단한다.
+
+    If the 3 new states were missing from the running branch, non-completed
+    check runs would fall through to the default (failed or unknown).
+    This test explicitly blocks that regression.
+    """
+    check_runs_body = {
+        "check_runs": [_check_run("CI / deploy", status, None)],
+        "total_count": 1,
+    }
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(
+        side_effect=[
+            _resp(200, check_runs_body),
+        ]
+    )
+
+    with patch("src.github_client.checks.get_http_client", return_value=mock_client):
+        result = await get_ci_status(TOKEN, REPO, SHA)
+
+    # "failed" 또는 "unknown" 으로 빠지지 않아야 함 / Must NOT be 'failed' or 'unknown'.
+    assert result not in ("failed", "unknown"), (
+        f"status={status!r} must not fall through to 'failed'/'unknown' "
+        f"(cycle 113 P0-B regression guard)"
+    )

--- a/tests/unit/webhook/test_telegram_provider.py
+++ b/tests/unit/webhook/test_telegram_provider.py
@@ -79,13 +79,14 @@ async def test_handle_gate_callback_approve_with_auto_merge():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision"):
+            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.webhook.providers.telegram.merge_pr", new_callable=AsyncMock) as mock_merge:
                         with patch("src.webhook.providers.telegram.log_merge_attempt") as mock_log:
                             mock_merge.return_value = (True, None, "abc123")
                             await handle_gate_callback(analysis_id=42, decision="approve",
                                                        decided_by="john")
+                            mock_save.assert_called_once()
                             mock_merge.assert_called_once()
                             mock_log.assert_called_once()
                             _, kw = mock_log.call_args
@@ -105,11 +106,12 @@ async def test_handle_gate_callback_approve_without_auto_merge():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=False)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision"):
+            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.webhook.providers.telegram.merge_pr", new_callable=AsyncMock) as mock_merge:
                         await handle_gate_callback(analysis_id=42, decision="approve",
                                                    decided_by="john")
+                        mock_save.assert_called_once()
                         mock_merge.assert_not_called()
 
 
@@ -125,11 +127,12 @@ async def test_handle_gate_callback_reject_does_not_merge():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision"):
+            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.webhook.providers.telegram.merge_pr", new_callable=AsyncMock) as mock_merge:
                         await handle_gate_callback(analysis_id=42, decision="reject",
                                                    decided_by="john")
+                        mock_save.assert_called_once()
                         mock_merge.assert_not_called()
 
 


### PR DESCRIPTION
## 🔍 사용자 검증 필요 (정책 11 — 8 조합 시각 체크리스트)

| 테마 | 모바일 | 데스크탑 |
|------|--------|---------|
| dark | ☐ `--bg-2` dashboard 배경 정상 렌더링 | ☐ |
| light | ☐ | ☐ |
| pastel | ☐ | ☐ |
| catppuccin | ☐ | ☐ |

> `--bg-2`는 `var(--bg-card)` alias — 기존 fallback과 동일하므로 시각 변화 없음 예상.

## Summary

- **A.2** `src/static/css/themes.css` — `--bg-2: var(--bg-card)` alias를 4개 테마 블록(dark/light/pastel/catppuccin)에 추가. 사이클 114 P1-B 팬텀 토큰 수정.
- **A.3** `tests/unit/webhook/test_telegram_provider.py` — `save_gate_decision` 3개 semi-auto gate 콜백 테스트에 `mock_save.assert_called_once()` assertion 추가. GateDecision 영속성 회귀 가드 (사이클 114 P1-C).
- **C.1** `.claude/rules/pipeline.md` — `asyncio.gather` 내 Session 공유 금지 규칙에 `api.md` 교차 참조 추가 (사이클 113 P0-H).
- **C.2** `docs/runbooks/workflow.md` — 전체 읽기 원칙에 CLAUDE.md 정책 6 교차 참조 추가.

## Test plan

- [x] `pytest tests/unit/webhook/test_telegram_provider.py` — 26 passed
- [ ] PR #555 (`test/cycle115-classify-check-runs-guard`) — `_classify_check_runs` 3상태 회귀 가드 6 케이스 (별도 PR)
- [ ] Railway 배포 후 4-테마 `--bg-2` 렌더링 확인 (시각 변화 없음 예상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)