### PR TITLE
fix: repo_category_breakdown severity .lower() → .upper() 정규화 (사이클 114 신규 발견)

### DIFF
--- a/src/services/repo_insight_service.py
+++ b/src/services/repo_insight_service.py
@@ -280,8 +280,8 @@ def repo_category_breakdown(
             if not isinstance(issue, dict):
                 continue
             category = issue.get("category", "")
-            severity = issue.get("severity", "").lower()
-            is_error = severity in ("error", "high")
+            severity = issue.get("severity", "").upper()
+            is_error = severity in ("HIGH", "ERROR")
             if category == "security":
                 counts["security_error" if is_error else "security_warning"] += 1
             elif category == "code_quality":

--- a/tests/unit/services/test_repo_insight_service.py
+++ b/tests/unit/services/test_repo_insight_service.py
@@ -241,17 +241,18 @@ class TestRepoCategoryBreakdown:
         from src.services.repo_insight_service import repo_category_breakdown
 
         _add_analysis(db, repo.id, result={"issues": [
-            {"category": "security", "severity": "error"},
+            {"category": "security", "severity": "error"},    # 소문자 error
+            {"category": "security", "severity": "HIGH"},     # 대문자 HIGH (bandit 저장 형식)
             {"category": "security", "severity": "warning"},
             {"category": "code_quality", "severity": "error"},
             {"category": "code_quality", "severity": "warning"},
         ]})
         bd = repo_category_breakdown(db, repo.id)
-        assert bd["security_error"] == 1
+        assert bd["security_error"] == 2   # error + HIGH 양쪽 모두 집계
         assert bd["security_warning"] == 1
         assert bd["code_quality_error"] == 1
         assert bd["code_quality_warning"] == 1
-        assert bd["total"] == 4
+        assert bd["total"] == 5
 
     def test_empty_all_zeros(self, db, repo):
         from src.services.repo_insight_service import repo_category_breakdown


### PR DESCRIPTION
## Summary

사이클 114 5+1 회고 신규 발견 항목 수정.

`src/services/repo_insight_service.py`에서 severity 대소문자 정규화 패턴이 이원화:
- **L116**: `issue.get("severity", "").upper() in ("HIGH", "ERROR")` ← 프로젝트 표준
- **L283**: `issue.get("severity", "").lower()` + `in ("error", "high")` ← 비표준

`.upper() in ("HIGH", "ERROR")` 단일 표준으로 통일. 동작은 동일하나 일관성 개선.

## Test plan

- [x] `pytest tests/unit/services/test_repo_insight_service.py::TestRepoCategoryBreakdown` — 3 passed
- [x] `test_counts_by_category_and_severity`에 `"HIGH"` 대문자 케이스 추가 → `security_error == 2` 확인 (회귀 가드 강화)
- [ ] `TestRepoInsightNarrative::test_cache_hit_skips_api_call` 실패 — pre-existing 이슈 (SQLite fixture에 `insight_narrative_cache` 테이블 미생성, 내 변경과 무관)

## 🔍 사용자 검증 필요

- [ ] repo insights 페이지에서 HIGH 심각도 이슈가 정상 집계되는지 확인 (기능 변화 없어야 함)

🤖 Generated with [Claude Code](https://claude.com/claude-code)