### PR TITLE
fix(tests): InsightNarrativeCache import 누락 — TestRepoInsightNarrative 전 케이스 복구

### DIFF
--- a/tests/unit/services/test_repo_insight_service.py
+++ b/tests/unit/services/test_repo_insight_service.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 import src.models  # noqa: F401  side-effect: populate Base.metadata
 from src.database import Base
 from src.models.analysis import Analysis
+from src.models.insight_narrative_cache import InsightNarrativeCache  # noqa: F401
 from src.models.repository import Repository
 from src.models.user import User
 


### PR DESCRIPTION
## Summary

`test_repo_insight_service.py`의 `TestRepoInsightNarrative` 클래스 전체 테스트가 `no such table: insight_narrative_cache` 오류로 실패 중이었음.

**원인**: `src/models/__init__.py` 가 비어 있어 `import src.models` (side-effect 의도)가 실제로 아무 ORM도 Base.metadata에 등록하지 않음. `InsightNarrativeCache` ORM 미등록 상태에서 `Base.metadata.create_all(engine)` 호출 → 테이블 미생성.

**수정**: `from src.models.insight_narrative_cache import InsightNarrativeCache  # noqa: F401` 명시 import 추가. 사이클 110 PR #531(0033 마이그레이션)에서 ORM이 추가됐지만 이 테스트 파일에 미반영된 상태.

## Test plan

- [x] `pytest tests/unit/services/test_repo_insight_service.py` — **24 passed** (기존 23 passed + 1 failed → 전체 통과)

## 🔍 사용자 검증 필요

없음 (tests-only 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)