### PR TITLE
fix(analyzer): cppcheck/shellcheck severity .lower() 방어적 정규화 + api.md cross-ref (#563)

### DIFF
--- a/.claude/rules/api.md
+++ b/.claude/rules/api.md
@@ -40,3 +40,4 @@ paths:
 - 🔴 **`asyncio.gather` 내부 shared Session 금지 (사이클 113 P0-H)**: `asyncio.gather()` 로 동시 실행되는 코루틴들이 단일 `Session` 인스턴스를 공유하면 SQLAlchemy identity map 오염 + 동시 `commit()` 충돌 발생. 각 코루틴은 `with SessionLocal() as db:` 블록을 독립적으로 열어야 함. 전례: `src/gate/engine.py` — `_run_approve_decision` + `_run_auto_merge` 를 gather 전에 db 파라미터 제거 후 각 함수 내부에서 독립 Session 생성으로 수정 (사이클 113 P0-H).
   - **올바른 패턴**: `await asyncio.gather(_run_approve_decision(...), _run_auto_merge(...))` — 각 함수 내부에서 `with SessionLocal() as db:` 독립 사용
   - **금지 패턴**: `await asyncio.gather(_run_approve_decision(db=db, ...), _run_auto_merge(db=db, ...))` — 동일 db 공유
+  - 교차 참조: [`.claude/rules/pipeline.md`](.claude/rules/pipeline.md) (파이프라인 레이어 동일 규칙 — 사이클 115 PR #556 추가)

--- a/src/analyzer/io/tools/cppcheck.py
+++ b/src/analyzer/io/tools/cppcheck.py
@@ -73,7 +73,7 @@ def _parse_cppcheck_xml(xml_text: str, language: str) -> list[AnalysisIssue]:
     issues: list[AnalysisIssue] = []
     for err in root.findall(".//error"):
         sev = err.get("severity", "warning")
-        severity = Severity.ERROR if sev == "error" else Severity.WARNING
+        severity = Severity.ERROR if sev.lower() == "error" else Severity.WARNING
         message = err.get("msg", "") or err.get("verbose", "") or err.get("id", "")
         line = 0
         loc = err.find("location")

--- a/src/analyzer/io/tools/shellcheck.py
+++ b/src/analyzer/io/tools/shellcheck.py
@@ -43,7 +43,7 @@ class _ShellCheckAnalyzer:
             issues = []
             for item in data:
                 level = item.get("level", "warning")
-                severity = Severity.ERROR if level == "error" else Severity.WARNING
+                severity = Severity.ERROR if level.lower() == "error" else Severity.WARNING
                 issues.append(AnalysisIssue(
                     tool="shellcheck",
                     severity=severity,


### PR DESCRIPTION
## 사이클 116 Tier C 이행 — 방어적 하드닝

### 변경 요약

| 파일 | 변경 내용 | 사유 |
|------|----------|------|
| `src/analyzer/io/tools/cppcheck.py:76` | `sev == "error"` → `sev.lower() == "error"` | 비표준 대문자 severity 출력 방어 |
| `src/analyzer/io/tools/shellcheck.py:46` | `level == "error"` → `level.lower() == "error"` | 동일 패턴 통일 |
| `.claude/rules/api.md` | asyncio.gather 규칙 하단 `pipeline.md` 역방향 cross-ref 추가 | 양방향 참조 완성 |

### 배경

- `cppcheck`/`shellcheck` 는 표준 출력 형식이 소문자(`error`/`warning`)이나, 비표준 빌드나 커스텀 룰 사용 시 대문자 출력 가능
- `repo_insight_service.py`(PR #558)에서 `.upper() in ("HIGH","ERROR")` 로 정규화한 것과 일관성을 위해 `.lower()` 방어 추가
- `api.md`의 `asyncio.gather` 규칙이 `pipeline.md`를 단방향 참조(pipeline → api)만 하고 있어 역방향 추가

### 테스트

- `tests/unit/analyzer/` — 804 passed (변동 없음)
- 실질 버그 없음 — 방어적 hardening

### 🔍 사용자 검증 필요

- 코드 변경 사항이 의도와 일치하는지 diff 검토 (`.lower()` 추가 2줄)