### PR TITLE
fix(auth): 로그아웃 후 / 리다이렉트 — /login 301 체인 해소

### DIFF
--- a/src/auth/github.py
+++ b/src/auth/github.py
@@ -123,7 +123,10 @@ async def auth_callback(request: Request):
 
 @router.post("/auth/logout")
 async def logout(request: Request):
-    """세션 초기화 후 /login 리다이렉트."""
+    """세션 초기화 후 / (랜딩 페이지) 리다이렉트.
+    /login 은 사이클 117 이후 /auth/github 로 301 redirect 되므로 직접 / 로 이동.
+    Redirect to / (landing page) — /login now 301-redirects to /auth/github (cycle 117).
+    """
     user_id = request.session.get("user_id")
     if user_id:
         # 로그아웃 시 github_access_token 삭제 — 토큰 무기한 잔존 방지
@@ -134,4 +137,4 @@ async def logout(request: Request):
             )
             db.commit()
     request.session.clear()
-    return RedirectResponse(url="/login", status_code=302)
+    return RedirectResponse(url="/", status_code=302)

--- a/tests/unit/auth/test_github.py
+++ b/tests/unit/auth/test_github.py
@@ -35,15 +35,17 @@ def test_login_redirects_if_already_authenticated():
 
 
 def test_logout_clears_session_and_redirects():
-    """POST /auth/logout은 세션을 초기화하고 /login 으로 리다이렉트한다."""
+    """POST /auth/logout은 세션을 초기화하고 / 로 리다이렉트한다 (사이클 117 fix — /login은 301).
+    POST /auth/logout clears session and redirects to / (cycle 117 fix — /login is now 301).
+    """
     r = client.post("/auth/logout", follow_redirects=False)
     assert r.status_code == 302
-    assert "/login" in r.headers["location"]
+    assert r.headers["location"] == "/"
 
 
 def test_logout_with_user_id_deletes_token_from_db():
-    """user_id 가 세션에 있을 때 logout → DB에서 github_access_token 삭제 후 /login 리다이렉트.
-    When user_id exists in session, logout deletes github_access_token from DB and redirects.
+    """user_id 가 세션에 있을 때 logout → DB에서 github_access_token 삭제 후 / 리다이렉트.
+    When user_id exists in session, logout deletes github_access_token from DB and redirects to /.
     """
     import json
     import base64
@@ -67,7 +69,7 @@ def test_logout_with_user_id_deletes_token_from_db():
         )
 
     assert r.status_code == 302
-    assert "/login" in r.headers["location"]
+    assert r.headers["location"] == "/"
     # DB execute (UPDATE users SET github_access_token=NULL) 와 commit 이 호출되어야 한다
     # DB execute (UPDATE users SET github_access_token=NULL) and commit must be called.
     assert mock_db.execute.called


### PR DESCRIPTION
## 원인

사이클 117에서 `/login` → `/auth/github` 301 redirect 로 변경됨.
기존 logout은 `/login` 으로 302 redirect → `/login` 이 다시 `/auth/github` 로 301 redirect
→ 로그아웃 직후 GitHub OAuth 화면으로 이동하는 문제 발생.

## 수정

`logout` 리다이렉트 대상: `/login` → `/` (랜딩 페이지)

세션이 클리어된 상태이므로 `get_current_user` 가 None 반환 → 랜딩 페이지 표시.

## 🔍 사용자 검증 필요

- [ ] 로그인 후 상단 로그아웃 버튼 클릭 → 랜딩 페이지(`/`) 로 이동하는지 확인
- [ ] 로그아웃 후 재로그인(랜딩 페이지 "지금 시작" 또는 "로그인") 가능한지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)