### PR TITLE
fix(auth): 로그아웃 후 landing.html CSS 깨짐 — HX-Redirect 적용

### DIFF
--- a/src/auth/github.py
+++ b/src/auth/github.py
@@ -2,7 +2,7 @@
 import logging
 from authlib.integrations.starlette_client import OAuth, OAuthError
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, RedirectResponse, Response
+from fastapi.responses import RedirectResponse, Response
 from fastapi.templating import Jinja2Templates
 
 from sqlalchemy import update

--- a/src/auth/github.py
+++ b/src/auth/github.py
@@ -2,7 +2,7 @@
 import logging
 from authlib.integrations.starlette_client import OAuth, OAuthError
 from fastapi import APIRouter, Request
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, RedirectResponse, Response
 from fastapi.templating import Jinja2Templates
 
 from sqlalchemy import update
@@ -124,8 +124,8 @@ async def auth_callback(request: Request):
 @router.post("/auth/logout")
 async def logout(request: Request):
     """세션 초기화 후 / (랜딩 페이지) 리다이렉트.
-    /login 은 사이클 117 이후 /auth/github 로 301 redirect 되므로 직접 / 로 이동.
-    Redirect to / (landing page) — /login now 301-redirects to /auth/github (cycle 117).
+    HTMX hx-boost 요청은 HX-Redirect 헤더로 전체 페이지 재로드 — landing.html 독립 <head> CSS 보존.
+    Redirect to /. HTMX requests use HX-Redirect for full reload so landing.html <head> CSS applies.
     """
     user_id = request.session.get("user_id")
     if user_id:
@@ -137,4 +137,10 @@ async def logout(request: Request):
             )
             db.commit()
     request.session.clear()
+    if request.headers.get("HX-Request"):
+        # hx-boost body-swap 대신 window.location 전체 재로드 유도
+        # Force full page navigation instead of body-swap so landing.html CSS applies
+        resp = Response(status_code=200)
+        resp.headers["HX-Redirect"] = "/"
+        return resp
     return RedirectResponse(url="/", status_code=302)

--- a/tests/unit/auth/test_github.py
+++ b/tests/unit/auth/test_github.py
@@ -35,12 +35,23 @@ def test_login_redirects_if_already_authenticated():
 
 
 def test_logout_clears_session_and_redirects():
-    """POST /auth/logout은 세션을 초기화하고 / 로 리다이렉트한다 (사이클 117 fix — /login은 301).
-    POST /auth/logout clears session and redirects to / (cycle 117 fix — /login is now 301).
+    """POST /auth/logout은 세션을 초기화하고 / 로 302 리다이렉트한다 (비-HTMX 요청).
+    POST /auth/logout clears session and 302-redirects to / for non-HTMX requests.
     """
     r = client.post("/auth/logout", follow_redirects=False)
     assert r.status_code == 302
     assert r.headers["location"] == "/"
+
+
+def test_logout_with_htmx_returns_hx_redirect():
+    """HTMX 요청(HX-Request 헤더)이면 200 + HX-Redirect: / 를 반환한다.
+    HTMX request (HX-Request header) returns 200 + HX-Redirect: / for full page reload.
+    hx-boost body-swap 대신 window.location 전체 재로드 → landing.html <head> CSS 적용 보장.
+    Forces window.location reload instead of body-swap so landing.html <head> CSS applies.
+    """
+    r = client.post("/auth/logout", follow_redirects=False, headers={"HX-Request": "true"})
+    assert r.status_code == 200
+    assert r.headers.get("HX-Redirect") == "/"
 
 
 def test_logout_with_user_id_deletes_token_from_db():


### PR DESCRIPTION
## Summary

- **원인**: hx-boost가 logout POST를 가로채 302 리다이렉트를 따라가 landing.html의 `<body>`만 현재 페이지에 스왑 → landing.html의 독립 `<head>` CSS(`<style>` 블록, 외부 폰트 등)가 미적용되어 레이아웃 깨짐
- **수정**: `logout` 엔드포인트에서 `HX-Request` 헤더 감지 시 `200 + HX-Redirect: /` 응답 반환 → HTMX가 body-swap 대신 `window.location` 전체 재로드 수행
- 비-HTMX 요청(직접 POST)은 기존 302 리다이렉트 그대로 유지

## 변경 파일

- `src/auth/github.py`: `logout` — `HX-Request` 헤더 분기 추가 (HTMX → `HX-Redirect`, 기타 → 302)
- `tests/unit/auth/test_github.py`: `test_logout_with_htmx_returns_hx_redirect` 신규 테스트 추가

## 🔍 사용자 검증 필요

- [ ] Railway 배포 후 로그인 → 로그아웃 시 landing.html이 정상 CSS로 표시되는지 확인
- [ ] 로그아웃 후 "로그인" 링크가 작동하는지 확인 (`/auth/github`로 이동)

🤖 Generated with [Claude Code](https://claude.com/claude-code)