### PR TITLE
fix(ui): landing.html nav 로그인 버튼 제거 — 혼선 방지

### DIFF
--- a/src/templates/landing.html
+++ b/src/templates/landing.html
@@ -145,20 +145,6 @@
       place-items: center;
       font-size: 14px;
     }
-    .nav-cta {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-    .nav-login {
-      font-size: 0.875rem;
-      color: var(--text-2);
-      padding: 6px 14px;
-      border-radius: 8px;
-      border: 1px solid var(--border-subtle);
-      transition: color 0.2s, border-color 0.2s;
-    }
-    .nav-login:hover { color: var(--text-1); border-color: var(--border-strong); }
 
     /* ── 오류 배너 ──────────────────────────────────────── */
     .auth-error-banner {
@@ -496,9 +482,6 @@
     <div class="nav-logo-icon">🔍</div>
     SCAManager
   </a>
-  <div class="nav-cta">
-    <a href="/auth/github" class="nav-login">로그인</a>
-  </div>
 </nav>
 
 {% if error %}


### PR DESCRIPTION
## Summary

- landing.html 우상단 "로그인" 버튼 제거
- `/auth/github` 연결이 있었으나 히어로의 "지금 시작 →" 버튼과 목적지 동일 → 사용자 혼선
- 단일 CTA("지금 시작")로 단순화

## 변경 파일

- `src/templates/landing.html`: `.nav-cta` div + `.nav-login`/`.nav-cta` CSS 제거

## 🔍 사용자 검증 필요

- [ ] **UI 11 정책**: 로그인 버튼이 nav에서 제거됐는지 확인 (dark/light/pastel/catppuccin × 모바일/데스크탑)
- [ ] "지금 시작 →" 버튼 클릭 시 GitHub OAuth 정상 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)