### PR TITLE
fix(codeql): unused import 제거 — get_current_user (alert #429)

### DIFF
--- a/src/auth/github.py
+++ b/src/auth/github.py
@@ -12,7 +12,6 @@ from src.crypto import encrypt_token
 from src.database import SessionLocal
 from src.models.user import User
 from src.repositories import user_repo
-from src.auth.session import get_current_user
 
 logger = logging.getLogger(__name__)
 

--- a/tests/unit/auth/test_github.py
+++ b/tests/unit/auth/test_github.py
@@ -641,25 +641,10 @@ def test_require_login_redirects_to_auth_github():
 def test_login_route_redirects_301_to_auth_github():
     """GET /login 이 301 리다이렉트 + Location: /auth/github 를 반환해야 한다.
     GET /login must return 301 redirect with Location: /auth/github.
-
-    현재 동작: login.html 200 렌더링 (github.py:40-49)
-    변경 예정: 301 Moved Permanently → /auth/github
-    Current: renders login.html 200 — Expected after change: 301 to /auth/github
     """
-    # 미인증 상태에서 /login 접근 — get_current_user 가 None 반환하도록 patch
-    # Unauthenticated /login access — patch get_current_user to return None
-    with patch("src.auth.github.get_current_user", return_value=None):
-        r = client.get("/login", follow_redirects=False)
-
-    # 변경 후 기대값: 301 + Location: /auth/github
-    # After change: 301 + Location: /auth/github
-    assert r.status_code == 301, (
-        f"301 기대, 실제: {r.status_code}\n"
-        f"(현재 200 login.html — github.py:40 변경 전 Red 단계)"
-    )
-    assert r.headers.get("location") == "/auth/github", (
-        f"Location '/auth/github' 기대, 실제: {r.headers.get('location')!r}"
-    )
+    r = client.get("/login", follow_redirects=False)
+    assert r.status_code == 301
+    assert r.headers.get("location") == "/auth/github"
 
 
 def test_auth_callback_oauth_error_redirects_to_landing():


### PR DESCRIPTION
## Summary

- `src/auth/github.py`: `get_current_user` import 제거 (CodeQL alert #429 실제 수정)
  - 사이클 117 `/login` 301 redirect 전환 후 해당 import가 미사용 상태
- `tests/unit/auth/test_github.py`: `test_login_route_redirects_301_to_auth_github`의 불필요한 `patch("src.auth.github.get_current_user")` 래퍼 제거 + 구버전 주석 정리
- CodeQL alert #426/#427 (`InsightNarrativeCache` in test files): false positive dismiss — ORM 테이블 생성용 side-effect import, `# noqa: F401` 이미 존재

## Code Scanning 결과

| Alert | 조치 |
|-------|------|
| #429 `src/auth/github.py` unused import | ✅ 실제 제거 |
| #426 `test_repo_insight_service.py` | ✅ false positive dismiss |
| #427 `test_dashboard_service_user_id_filter.py` | ✅ false positive dismiss |

## 🔍 사용자 검증 필요

- [ ] 특별한 시각 확인 불필요 (코드 정리 전용)

🤖 Generated with [Claude Code](https://claude.com/claude-code)