### PR TITLE
fix(auth): 사이클 117 P0 — noreply 이메일 fallback 테스트 + 배너 URL 잔존 버그 수정

### DIFF
--- a/src/templates/landing.html
+++ b/src/templates/landing.html
@@ -495,7 +495,7 @@
       일시적인 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.
     {% endif %}
   </span>
-  <button class="banner-close" aria-label="닫기" onclick="document.getElementById('authErrorBanner').remove()">✕</button>
+  <button class="banner-close" aria-label="닫기" onclick="document.getElementById('authErrorBanner').remove(); history.replaceState(null,'',location.pathname)">✕</button>
 </div>
 {% endif %}
 

--- a/tests/unit/auth/test_github.py
+++ b/tests/unit/auth/test_github.py
@@ -248,6 +248,42 @@ def test_callback_no_primary_email_uses_fallback():
     assert captured["user"].email == "fallback@example.com"
 
 
+def test_callback_no_email_anywhere_uses_noreply_address():
+    """primary+verified 이메일도 없고 user_info["email"]도 None인 경우
+    {github_id}@users.noreply.github.com 을 사용해야 한다.
+    When no primary+verified email exists and user_info["email"] is None,
+    must fall back to {github_id}@users.noreply.github.com.
+    """
+    from src.models.user import User  # noqa: PLC0415
+    mock_token = {"access_token": "gho_token"}
+    mock_user_info = MagicMock()
+    mock_user_info.json.return_value = {
+        "id": 99999, "login": "noemailuser", "name": "No Email", "email": None
+    }
+    mock_emails_resp = MagicMock()
+    mock_emails_resp.json.return_value = []  # 이메일 목록 비어있음 / empty email list
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = None
+    captured = {}
+
+    def capture_add(obj):
+        if isinstance(obj, User):
+            captured["user"] = obj
+
+    mock_db.add.side_effect = capture_add
+
+    with patch("src.auth.github.oauth.github.authorize_access_token",
+               new_callable=AsyncMock, return_value=mock_token):
+        with patch("src.auth.github.oauth.github.get",
+                   new_callable=AsyncMock, side_effect=[mock_user_info, mock_emails_resp]):
+            with patch("src.auth.github.SessionLocal") as mock_sl:
+                mock_sl.return_value.__enter__.return_value = mock_db
+                client.get("/auth/callback?code=test&state=test", follow_redirects=False)
+
+    assert captured.get("user") is not None
+    assert captured["user"].email == "99999@users.noreply.github.com"
+
+
 # ---------------------------------------------------------------------------
 # OAuth 리다이렉트 URI 보안 분기 — app_base_url 설정 여부
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 변경 요약

사이클 117 회고 P0 2건 대응.

- **P0-1** `tests/unit/auth/test_github.py`: `test_callback_no_email_anywhere_uses_noreply_address` 추가 — primary+verified 이메일 없음 + `user_info["email"]=None` 케이스에서 `{github_id}@users.noreply.github.com` fallback 경로 단위 테스트 (기존 `test_callback_no_primary_email_uses_fallback` 는 `user_info["email"]` 이 있는 경우만 커버, 이번 테스트는 완전 없는 경우 커버)
- **P0-2** `src/templates/landing.html:498`: 에러 배너 닫기 onclick에 `history.replaceState(null,'',location.pathname)` 추가 — 배너를 DOM에서 제거해도 `?error=oauth_failed` 쿼리 파라미터가 URL에 잔존해 새로고침 시 배너 재표시되는 버그 수정

## 테스트

- `tests/unit/auth/test_github.py` 29/29 PASSED (신규 1건 포함)

## 🔍 사용자 검증 필요

| 조합 | 항목 |
|------|------|
| 브라우저 직접 | `/?error=oauth_failed` 접속 → 배너 표시 → ✕ 클릭 → URL이 `/?error=...` 없이 `/` 로 변경되는지 확인 |
| 브라우저 직접 | 배너 닫은 뒤 새로고침 → 배너가 재표시되지 않는지 확인 |

## Codex 검증 상태

Codex 플러그인 2회 시도 실패 (모델 미지원 + 샌드박스 권한 오류) → Claude 자체 검증으로 대체 (사용자 명시 지시 적용):
- `src/auth/github.py:74-79` 코드 경로 ↔ 테스트 mock 인자 일치 확인
- `history.replaceState` 부작용 분석 (히스토리 스택 교체만, HTMX 미간섭)
- 29개 기존 테스트 전체 PASSED 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)