### PR TITLE
feat(admin): OPERATIONS_DASHBOARD_DISABLED kill-switch 구현

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -37,8 +37,9 @@
 | `SCAMANAGER_SELF_ANALYSIS_DISABLED` | **Loop Guard kill-switch** — `1` 설정 시 모든 webhook 분석 즉시 중단 (202 skipped). Phase 9 자기-분석 루프 사고 발생 시 즉각 차단용. | `0` (기본) / `1` (긴급 중단) |
 | `SECURITY_AUTO_PROCESS_DISABLED` | **Code/Secret Scanning auto-process kill-switch** — `1` 설정 시 `security_scan_service` + `dashboard_service` security 영역 자동 처리 중단 (Cycle 73 #244 신설). false-positive 누적 시 긴급 차단용. | `0` (기본) / `1` (긴급 중단) |
 | `SAAS_MULTITENANT_DISABLED` | **SaaS 멀티테넌트 영역 kill-switch** — `1` 설정 시 admin 영역 즉시 **503** 반환 (`session.py:82,94` — 401 아님). Cycle 79 PR 2 (#255) 신설 — SaaS 영역 운영 사고 시 즉각 차단용. | `0` (기본) / `1` (긴급 중단) |
+| `OPERATIONS_DASHBOARD_DISABLED` | **운영 모니터링 대시보드 kill-switch** — `1` 설정 시 `/admin/operations` 라우트 즉시 **503** 반환 (`admin.py`). Cycle 120 신설 — 운영 KPI 대시보드 장애 시 긴급 차단용. | `0` (기본) / `1` (긴급 중단) |
 
-> **🔴 운영 안전**: 위 5 변수는 운영 사고 발생 시 즉시 사용해야 하므로 Railway Variables 에 미리 배치 권장. `INTERNAL_CRON_API_KEY` 미설정 시 cron job 이 silent 503 으로 실패해 weekly_summary 등이 발송 안 됨 — 운영자 인지 어려움. `SAAS_ADMIN_EMAILS` 미설정 시 admin UI 영역 (`/admin/tenants` 등) 모든 사용자 401 — Cycle 79+ SaaS 영역 활성화 시 의무. kill-switch 신규 추가 시 `src/shared/feature_kill_switch.py::is_disabled(feature)` helper 사용 default (Cycle 78 NEW-P0-2 #253 — 사용처 ≥ 3 도달 시 자동 헬퍼 추출 정책 16 4번 원칙 정합).
+> **🔴 운영 안전**: 위 6 변수는 운영 사고 발생 시 즉시 사용해야 하므로 Railway Variables 에 미리 배치 권장. `INTERNAL_CRON_API_KEY` 미설정 시 cron job 이 silent 503 으로 실패해 weekly_summary 등이 발송 안 됨 — 운영자 인지 어려움. `SAAS_ADMIN_EMAILS` 미설정 시 admin UI 영역 (`/admin/tenants` 등) 모든 사용자 401 — Cycle 79+ SaaS 영역 활성화 시 의무. kill-switch 신규 추가 시 `src/shared/feature_kill_switch.py::is_disabled(feature)` helper 사용 default (Cycle 78 NEW-P0-2 #253 — 사용처 ≥ 3 도달 시 자동 헬퍼 추출 정책 16 4번 원칙 정합).
 
 ## Observability (자동 로깅, env 설정 불필요)
 

--- a/src/ui/routes/admin.py
+++ b/src/ui/routes/admin.py
@@ -9,11 +9,12 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 
 from src.auth.session import CurrentUser, require_admin
+from src.shared.feature_kill_switch import is_disabled
 from src.database import SessionLocal
 from src.services import operations_service, saas_service
 from src.ui._helpers import get_locale, templates
@@ -87,6 +88,10 @@ def admin_operations(
 
     Operations dashboard admin (Cycle 80 PR 2 — area 🅔).
     """
+    # OPERATIONS_DASHBOARD_DISABLED=1 시 운영 대시보드 즉시 503 반환
+    # Return 503 immediately when OPERATIONS_DASHBOARD_DISABLED=1
+    if is_disabled("OPERATIONS_DASHBOARD"):
+        raise HTTPException(status_code=503, detail="Operations dashboard is disabled")
     kpi = operations_service.operations_kpi(db, days=days)
     return templates.TemplateResponse(
         request,

--- a/tests/unit/api/test_admin_endpoints.py
+++ b/tests/unit/api/test_admin_endpoints.py
@@ -153,3 +153,35 @@ def test_admin_operations_blocked_when_kill_switch(monkeypatch):
     assert response.status_code == 503
     response = c.get("/api/admin/operations")
     assert response.status_code == 503
+
+
+# ─── Cycle 111 — OPERATIONS_DASHBOARD_DISABLED kill-switch 회귀 가드 ────────
+
+
+def test_admin_operations_kill_switch_returns_503(client):
+    """OPERATIONS_DASHBOARD_DISABLED=1 시 /admin/operations 가 503 을 반환한다.
+
+    When OPERATIONS_DASHBOARD is disabled via kill-switch, /admin/operations returns 503.
+    """
+    from unittest.mock import patch
+
+    with patch("src.ui.routes.admin.is_disabled", return_value=True):
+        response = client.get("/admin/operations")
+    assert response.status_code == 503
+
+
+def test_admin_operations_active_returns_200(client):
+    """kill-switch 비활성 시 /admin/operations 가 200 을 반환한다.
+
+    When kill-switch is inactive, /admin/operations returns 200 with KPI context.
+    """
+    from unittest.mock import MagicMock, patch
+
+    # MagicMock — 템플릿이 중첩 속성 접근(kpi.cache.hit_rate 등)을 자동 처리
+    # MagicMock — handles nested attribute access (kpi.cache.hit_rate etc.) automatically
+    with patch("src.ui.routes.admin.is_disabled", return_value=False), patch(
+        "src.ui.routes.admin.operations_service.operations_kpi",
+        return_value=MagicMock(),
+    ):
+        response = client.get("/admin/operations")
+    assert response.status_code == 200


### PR DESCRIPTION
## 변경 요약

사이클 119 5+1 회고 Tier B-1 이행 — i18n 번역에 kill-switch 안내가 있지만 실제 admin.py에 구현이 없던 문제를 해결한다.

**변경 파일 3건**:
- `src/ui/routes/admin.py`: `is_disabled("OPERATIONS_DASHBOARD")` 체크 추가 → `HTTPException(503)` 반환
- `tests/unit/api/test_admin_endpoints.py`: kill-switch 회귀 가드 2건 (503 확인 + 200 정상 경로)
- `docs/reference/env-vars.md`: `OPERATIONS_DASHBOARD_DISABLED` 항목 신설 (kill-switch 섹션)

## 구현 패턴

`SAAS_MULTITENANT_DISABLED` 패턴과 동일:
```python
if is_disabled("OPERATIONS_DASHBOARD"):
    raise HTTPException(status_code=503, detail="Operations dashboard is disabled")
```

## 테스트

```
tests/unit/api/test_admin_endpoints.py  10 passed in 0.31s
```

TDD: Red(AttributeError 확인) → Green(503/200 통과) 순서 이행.

Codex mutual: 샌드박스 오류 → Claude 직접 검증 대체 (전 항목 OK).

## 🔍 사용자 검증 필요

- [ ] Railway Variables에 `OPERATIONS_DASHBOARD_DISABLED=1` 설정 후 `/admin/operations` 접근 시 503 반환 확인
- [ ] `OPERATIONS_DASHBOARD_DISABLED` 미설정(기본) 상태에서 `/admin/operations` 정상 동작 확인