### PR TITLE
test: 사이클 121 P2 — GET timeout 회귀 가드 + Cycle 120 코멘트 수정

### DIFF
--- a/tests/unit/api/test_admin_endpoints.py
+++ b/tests/unit/api/test_admin_endpoints.py
@@ -155,7 +155,7 @@ def test_admin_operations_blocked_when_kill_switch(monkeypatch):
     assert response.status_code == 503
 
 
-# ─── Cycle 111 — OPERATIONS_DASHBOARD_DISABLED kill-switch 회귀 가드 ────────
+# ─── Cycle 120 — OPERATIONS_DASHBOARD_DISABLED kill-switch 회귀 가드 ────────
 
 
 def test_admin_operations_kill_switch_returns_503(client):

--- a/tests/unit/github_client/test_repos.py
+++ b/tests/unit/github_client/test_repos.py
@@ -202,3 +202,25 @@ async def test_auth_header_included_in_requests():
     for put_call in client.put.call_args_list:
         headers = put_call.kwargs.get("headers") or {}
         assert headers.get("Authorization") == f"Bearer {TOKEN}"
+
+
+# ---------------------------------------------------------------------------
+# 시나리오 7: GET timeout — httpx.HTTPError 시 False 반환 (Cycle 121 P2)
+# Scenario 7: GET network timeout raises httpx.HTTPError → returns False.
+# ---------------------------------------------------------------------------
+
+
+async def test_get_timeout_returns_false():
+    """GET 요청 중 네트워크 timeout 발생 시 False 를 반환한다.
+    When GET raises httpx.HTTPError (e.g. timeout), commit_scamanager_files returns False.
+    """
+    client = AsyncMock()
+    client.get = AsyncMock(side_effect=httpx.TimeoutException("timeout"))
+    patcher = _patch_client(client)
+    try:
+        result = await commit_scamanager_files(TOKEN, REPO, SERVER, HOOK_TOKEN)
+    finally:
+        patcher.stop()
+
+    assert result is False
+    client.put.assert_not_called()


### PR DESCRIPTION
## Summary

- `test_repos.py` 신규 테스트: `commit_scamanager_files` GET timeout (`httpx.TimeoutException`) 시 `False` 반환 + `PUT` 미호출 검증 — 사이클 121 회고 cross-verify 식별 P2 잔여 갭 해소
- `test_admin_endpoints.py` 섹션 헤더 오기입 "Cycle 111" → "Cycle 120" 수정 (사이클 121 자성 사항)

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `tests/unit/github_client/test_repos.py` | `test_get_timeout_returns_false` 추가 (7/7 pass) |
| `tests/unit/api/test_admin_endpoints.py` | 섹션 헤더 "Cycle 111" → "Cycle 120" |

## Claude 직접 검증 (정책 18 — Codex 대체)

- `httpx.TimeoutException` → `httpx.HTTPError` 서브클래스 확인 ✅
- `commit_scamanager_files:312` `except httpx.HTTPError` 블록이 정확히 포착 ✅
- 7/7 tests pass in `test_repos.py` ✅

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] `test_get_timeout_returns_false` — `False` + `put.assert_not_called()` 로직 의도 일치 여부