### PR TITLE
test(security): Email issue.message XSS 회귀 가드 + Optional→X|None 현대화 (사이클 123 B+C)

### DIFF
--- a/src/middleware/locale.py
+++ b/src/middleware/locale.py
@@ -30,8 +30,6 @@ Kill-switch: When `is_disabled("I18N")`, skip detection + force scope locale = "
 (emergency disable — pairs with Cycle 78 NEW-P0-2 pattern).
 """
 import logging
-from typing import Optional
-
 from src.config import settings
 from src.shared.feature_kill_switch import is_disabled
 
@@ -101,7 +99,7 @@ class LocaleMiddleware:  # pylint: disable=too-few-public-methods
         return settings.locale_fallback
 
     @staticmethod
-    def _parse_cookie_locale(headers: list) -> Optional[str]:
+    def _parse_cookie_locale(headers: list) -> str | None:
         """Cookie 헤더에서 `preferred_language` 추출.
 
         Extract `preferred_language` from Cookie header.
@@ -160,7 +158,7 @@ class LocaleMiddleware:  # pylint: disable=too-few-public-methods
         return items
 
     @classmethod
-    def _parse_accept_language(cls, headers: list) -> Optional[str]:
+    def _parse_accept_language(cls, headers: list) -> str | None:
         """Accept-Language 헤더 RFC 7231 q-weight 파싱 후 최우선 locale 반환.
 
         Parse Accept-Language header per RFC 7231 q-weights, return top locale.

--- a/src/notifier/_language.py
+++ b/src/notifier/_language.py
@@ -26,7 +26,7 @@ DI 패턴 (dependency injection): db 와 user_repo 는 Optional — 단위 테�
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from sqlalchemy.orm import Session
 
@@ -36,11 +36,11 @@ logger = logging.getLogger(__name__)
 
 
 def resolve_notification_language(
-    db: Optional[Session] = None,
+    db: Session | None = None,
     *,
-    _repo_full_name: Optional[str] = None,
+    _repo_full_name: str | None = None,
     config: Any = None,
-    telegram_user_id: Optional[str] = None,
+    telegram_user_id: str | None = None,
 ) -> str:
     """알림 채널 사용자 언어 결정 — 3-layer fallback.
 

--- a/tests/unit/notifier/test_email.py
+++ b/tests/unit/notifier/test_email.py
@@ -255,3 +255,19 @@ async def test_send_email_passes_explicit_timeout_to_aiosmtplib():
     assert "timeout" in call_kwargs, "aiosmtplib.send 호출에 timeout 인자 필수"
     assert isinstance(call_kwargs["timeout"], (int, float))
     assert 0 < call_kwargs["timeout"] <= 30  # 보수적 상한
+
+
+def test_build_html_escapes_xss_in_issue_message():
+    """issue.message에 XSS 페이로드가 있어도 HTML body에 raw 태그가 출력되지 않는다.
+    When issue.message contains an XSS payload, raw tags must not appear in the HTML body.
+    """
+    xss_issue = AnalysisIssue(
+        tool="pylint",
+        severity="warning",
+        message="<script>alert('xss')</script>",
+    )
+    html = _build_html_body(
+        "owner/repo", "abc1234", _make_score(), _make_analysis(issues=[xss_issue]), None
+    )
+    assert "<script>" not in html
+    assert "&lt;script&gt;" in html


### PR DESCRIPTION
## Summary

- **B — P3 보안 심층 테스트 (Email parity)**:  
  `tests/unit/notifier/test_email.py` — `test_build_html_escapes_xss_in_issue_message` 추가.  
  Telegram은 4건(repo_name/ai_summary/suggestions/issue.message)이지만 Email은 repo_name+ai_summary 2건만 존재했던 parity 갭 해소.

- **C — SonarCloud S6540 Code Smells 감소 (Phase 1)**:  
  `src/middleware/locale.py` — `Optional[str]` → `str | None` 2곳 + `from typing import Optional` 제거.  
  `src/notifier/_language.py` — `Optional[Session/str]` → `Session|None/str|None` 3곳 + `Optional` import 제거.  
  런타임 영향 없음 (Python 3.14, `from __future__ import annotations` 환경 모두 안전).

## Test Results

- `tests/unit/notifier/test_email.py` — 17/17 통과 (신규 1개 포함)
- `tests/unit/notifier/` + `tests/unit/auth/test_session_security.py` — 234/234 통과

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] SonarCloud 재분석 후 `Optional` 관련 S6540 alert 감소 확인 (Security/Code Smells 탭)

🤖 Generated with [Claude Code](https://claude.com/claude-code)