### PR TITLE
fix(security): session DB 예외 처리 + overflow 경계 테스트 + 회고 P1/P2 이행 (#125)

### DIFF
--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -32,20 +32,25 @@ def get_current_user(request: Request) -> CurrentUser | None:
     user_id = request.session.get("user_id")
     if not user_id:
         return None
-    with SessionLocal() as db:
-        user = user_repo.find_by_id(db, user_id)
-        if not user:
-            return None
-        return CurrentUser(
-            id=user.id,
-            github_login=user.github_login,
-            email=user.email,
-            display_name=user.display_name,
-            plaintext_token=user.plaintext_token or "",
-            # telegram_user_id가 있으면 연동 완료 상태
-            # is_telegram_connected is True when telegram_user_id is set.
-            is_telegram_connected=user.is_telegram_connected,
-        )
+    try:
+        with SessionLocal() as db:
+            user = user_repo.find_by_id(db, user_id)
+            if not user:
+                return None
+            return CurrentUser(
+                id=user.id,
+                github_login=user.github_login,
+                email=user.email,
+                display_name=user.display_name,
+                plaintext_token=user.plaintext_token or "",
+                # telegram_user_id가 있으면 연동 완료 상태
+                # is_telegram_connected is True when telegram_user_id is set.
+                is_telegram_connected=user.is_telegram_connected,
+            )
+    except Exception:
+        # 세션 변조 값(오버플로우 정수 등)이 DB 오류를 유발해도 안전하게 None 반환
+        # Safely return None when session-injected values (e.g. overflow int) cause DB errors
+        return None
 
 
 def require_login(request: Request) -> CurrentUser:

--- a/src/constants.py
+++ b/src/constants.py
@@ -124,8 +124,8 @@ SKIP_CI_MARKERS: tuple[str, ...] = ("[skip ci]", "[skip-sca]", "[ci skip]")
 # 커밋 메시지에 이 문자열이 포함되면 분석 skip
 # If any of these strings appear in a commit message, analysis is skipped
 
-# ── 점수 breakdown dict 키 (단일 출처 — calculator · notifier · gate 공유) ─────
-# ── Score breakdown dict keys (single source — shared by calculator/notifier/gate) ──
+# ── 점수 breakdown dict 키 (단일 출처 — 현재 calculator 전용, notifier·gate 확장 예정) ─────
+# ── Score breakdown dict keys (single source — currently calculator only; notifier/gate extension planned) ──
 BREAKDOWN_KEY_CODE_QUALITY = "code_quality"
 BREAKDOWN_KEY_SECURITY = "security"
 BREAKDOWN_KEY_COMMIT_MESSAGE = "commit_message"

--- a/tests/unit/auth/test_github.py
+++ b/tests/unit/auth/test_github.py
@@ -743,6 +743,12 @@ def test_oauth_state_consumed_after_use_reuse_fails():
 
     이 동작은 state 재사용 공격(replay attack)을 차단한다.
     This behaviour prevents OAuth state replay attacks.
+
+    주의: 신규 코드 경로 추가 아님 — test_callback_mismatching_state_error_redirects_to_oauth_error와
+    동일 코드 경로를 실행하며, "state 위조"와 "state 재사용" 공격 벡터를 각각 문서화하는 목적.
+    Note: not a new code path — shares the same execution path as
+    test_callback_mismatching_state_error_redirects_to_oauth_error.
+    Both tests document distinct attack vectors: state forgery vs. state replay/reuse.
     """
     try:
         from authlib.integrations.base_client.errors import MismatchingStateError

--- a/tests/unit/auth/test_session_security.py
+++ b/tests/unit/auth/test_session_security.py
@@ -5,14 +5,18 @@ src/auth/session.py 의 비정상 user_id 값 처리 및 존재하지 않는 사
 Verifies handling of malformed user_id values and redirect for nonexistent users.
 """
 import os
-os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
-os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
-os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
-os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
-os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
-os.environ.setdefault("GITHUB_CLIENT_ID", "test-cid")
-os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-csecret")
-os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+# conftest.py 직접 대입 패턴 의무 (testing.md) — setdefault는 기존 환경변수를 덮지 않아
+# 운영 토큰 유입 위험이 있음 (사이클 65 fix 교훈).
+# Direct assignment required per testing.md — setdefault does not override existing env vars,
+# risking production token bleed-in (cycle 65 fix lesson).
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+os.environ["GITHUB_WEBHOOK_SECRET"] = "test_secret"
+os.environ["GITHUB_TOKEN"] = "ghp_test"
+os.environ["TELEGRAM_BOT_TOKEN"] = "123:ABC"
+os.environ["TELEGRAM_CHAT_ID"] = "-100123"
+os.environ["GITHUB_CLIENT_ID"] = "test-cid"
+os.environ["GITHUB_CLIENT_SECRET"] = "test-csecret"
+os.environ["SESSION_SECRET"] = "test-session-secret-32-chars-long!"
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -105,9 +109,32 @@ def test_get_current_user_with_large_int_user_id_returns_none():
 
     이유: 공격자가 대형 정수를 주입해 다른 사용자 세션을 탈취하려는 시도를 차단함.
     Reason: documents that even boundary-value integer injection returns None safely.
+    신규 코드 경로 추가 아님 — 경계값 명세 + 공격 벡터 문서화 목적.
+    Not a new code path — documents the boundary value and attack vector.
     """
     mock_db = _mock_db_not_found()
     with patch("src.auth.session.SessionLocal") as mock_sl:
         mock_sl.return_value.__enter__.return_value = mock_db
         result = get_current_user(_req({"user_id": 2**31 - 1}))
+    assert result is None
+
+
+def test_get_current_user_with_overflow_user_id_returns_none():
+    """세션 user_id가 INT_MAX+1 (2^31, PG INTEGER 오버플로우 경계)이면 안전하게 None을 반환해야 한다.
+    When session user_id is INT_MAX+1 (2^31, PostgreSQL INTEGER overflow boundary),
+    get_current_user must return None safely — not propagate a DataError as a 500 response.
+
+    이유: 공격자가 PG INTEGER 범위 초과 값을 주입 시 DataError → 500 노출 위험을 차단.
+    Reason: guards against attackers injecting values beyond PG INTEGER range,
+    which would otherwise cause a DataError to propagate as an unhandled 500 response.
+    """
+    mock_db = MagicMock()
+    # PG DataError 시뮬레이션 — 오버플로우 값이 DB 조회 시 예외를 발생시키는 상황
+    # Simulate PG DataError — overflow value triggers an exception during DB lookup
+    mock_db.query.return_value.filter.return_value.first.side_effect = Exception(
+        "integer out of range"
+    )
+    with patch("src.auth.session.SessionLocal") as mock_sl:
+        mock_sl.return_value.__enter__.return_value = mock_db
+        result = get_current_user(_req({"user_id": 2**31}))
     assert result is None


### PR DESCRIPTION
## 개요

사이클 125 회고 5+1 다중 에이전트에서 식별된 P1/P2 개선 항목 전수 이행.

## 변경 내용

### P1-1: `src/auth/session.py` — DB 조회 예외 처리 추가
`get_current_user()` DB 조회 블록을 `try/except Exception: return None` 으로 감싸 세션 변조 값 (INT_MAX+1 등 PG INTEGER 오버플로우) 이 DataError를 유발해도 500 응답 대신 안전하게 None을 반환.

### P1-2: `tests/unit/auth/test_session_security.py`
- `os.environ.setdefault` → 직접 대입 (`os.environ["KEY"] = "value"`) — `testing.md` 규칙 + 사이클 65 fix 교훈 적용
- `test_get_current_user_with_overflow_user_id_returns_none` 추가: `user_id=2^31` 주입 + DB DataError 시 None 반환 확인 (P1-1 페어)

### P1-3: `src/constants.py` — 주석 범위 수정
`BREAKDOWN_KEY_*` 주석 "calculator·notifier·gate 공유" → "현재 calculator 전용, notifier·gate 확장 예정" (선언/현실 불일치 해소)

### P2: `tests/unit/auth/test_github.py` — docstring 명시
`test_oauth_state_consumed_after_use_reuse_fails` 에 "신규 코드 경로 추가 아님, state 재사용 공격 벡터 문서화 목적" 명시 (기존 테스트와의 중복 혼란 방지)

## 테스트 결과

```
tests/unit/auth/ — 57 passed
tests/unit/auth/test_session_security.py — 6 passed (신규 1건 포함)
```

## 상호 검증 (정책 18)

Codex CLI 런타임 오류 → 사용자 승인 하에 Claude 직접 검증 대체 (정책 18 예외 적용):
- 정상 경로 (`CurrentUser` 반환) + 예외 경로 (`None` 반환) 모두 기존 테스트로 커버 확인
- setdefault → 직접 대입: conftest.py 패턴 일치 확인
- constants.py 주석: 동작 영향 없는 문자열 변경 확인

## 🔍 사용자 검증 필요

- [ ] `GET /` (비로그인) → `/auth/github` 302 리다이렉트 정상 동작 확인 (session.py 변경 영향)
- [ ] 로그인 → 대시보드 진입 정상 동작 확인 (get_current_user happy-path 무결성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)