### PR TITLE
test(ui)+fix(ui): top-level const/let 정적 스캐너 + 템플릿 hx-boost 안전 수정 (PR B+C)

### DIFF
--- a/src/templates/add_repo.html
+++ b/src/templates/add_repo.html
@@ -208,13 +208,14 @@
 
 {% block scripts %}
 <script>
-  const select = document.getElementById('repo_full_name');
-  const submitBtn = document.getElementById('submitBtn');
-  const hint = document.getElementById('repoHint');
+  // 🔴 Must use var — const causes SyntaxError on hx-boost body swap re-execution
+  var select = document.getElementById('repo_full_name');
+  var submitBtn = document.getElementById('submitBtn');
+  var hint = document.getElementById('repoHint');
   // Phase 2 PR-5 — 다국어 동적 텍스트 (서버 Jinja injection 페어)
   // Phase 2 PR-5 — i18n dynamic text (paired with server-side Jinja injection)
-  const i18nCard = document.querySelector('.add-repo-card');
-  const I18N = {
+  var i18nCard = document.querySelector('.add-repo-card');
+  var I18N = {
     placeholder: i18nCard.dataset.i18nPlaceholder,
     noReposOption: i18nCard.dataset.i18nNoReposOption,
     noReposHint: i18nCard.dataset.i18nNoReposHint,
@@ -226,7 +227,7 @@
 
   // 페이지 이탈 시 fetch abort 제어 — hx-boost 뒤로가기 freezing 방지
   // AbortController to cancel in-flight fetch on page leave — prevents stale DOM updates after hx-boost navigation
-  let _repoCtrl = new AbortController();
+  var _repoCtrl = new AbortController();
   window.addEventListener('pagehide', () => _repoCtrl.abort());
 
   async function loadRepos() {
@@ -279,8 +280,8 @@
 
   // 에러 쿼리 파라미터 → 토스트 팝업
   // Error query parameter → toast popup
-  const params = new URLSearchParams(window.location.search);
-  const errorMsg = params.get('error');
+  var params = new URLSearchParams(window.location.search);
+  var errorMsg = params.get('error');
   if (errorMsg) {
     const toast = document.getElementById('errorToast');
     toast.textContent = errorMsg;

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1223,7 +1223,8 @@
 <script>
   // 추세 데이터 (서버 주입) — autoescape 안전
   // Trend data (server-injected) — autoescape safe
-  const trendData = {{ trend | tojson }};
+  // 🔴 Must use var — const causes SyntaxError on hx-boost body swap re-execution
+  var trendData = {{ trend | tojson }};
 
   /* --d-accent 등 .dashboard-page scoped 토큰은 documentElement에서 읽으면 빈 값 반환
      (CSS 변수는 하위→상위 방향 상속 불가). .dashboard-page 요소 기준으로 읽어야 올바른 값 반환.
@@ -1235,7 +1236,8 @@
     return v || fallback;
   }
 
-  let dashChart = null;
+  // 🔴 Must use var — let causes SyntaxError on hx-boost body swap re-execution
+  var dashChart = null;
   function buildDashChart(animate) {
     const ctx = document.getElementById('dashTrendChart');
     if (!ctx) return;

--- a/tests/unit/ui/test_template_js_const.py
+++ b/tests/unit/ui/test_template_js_const.py
@@ -8,6 +8,7 @@ Top-level const/let re-declaration → SyntaxError → all handlers silenced (PR
 """
 
 import re
+from html.parser import HTMLParser
 from pathlib import Path
 
 _TEMPLATES_DIR = Path(__file__).parent.parent.parent.parent / "src" / "templates"
@@ -17,12 +18,38 @@ def _extract_inline_scripts(html: str) -> list[str]:
     """<script src=...> 외부 스크립트를 제외하고 인라인 <script> 블록 내용만 반환한다.
     Returns inline <script> block contents, excluding <script src=...> external scripts.
     """
-    blocks = []
-    for m in re.finditer(r"<script([^>]*)>(.*?)</script>", html, re.DOTALL | re.IGNORECASE):
-        attrs, content = m.group(1), m.group(2)
-        if "src=" not in attrs:
-            blocks.append(content)
-    return blocks
+    class _InlineScriptExtractor(HTMLParser):
+        def __init__(self) -> None:
+            super().__init__()
+            self.blocks: list[str] = []
+            self._in_script = False
+            self._current: list[str] = []
+            self._script_has_src = False
+
+        def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+            if tag.lower() != "script":
+                return
+            self._in_script = True
+            self._current = []
+            self._script_has_src = any((name or "").lower() == "src" for name, _ in attrs)
+
+        def handle_endtag(self, tag: str) -> None:
+            if tag.lower() != "script" or not self._in_script:
+                return
+            if not self._script_has_src:
+                self.blocks.append("".join(self._current))
+            self._in_script = False
+            self._current = []
+            self._script_has_src = False
+
+        def handle_data(self, data: str) -> None:
+            if self._in_script:
+                self._current.append(data)
+
+    parser = _InlineScriptExtractor()
+    parser.feed(html)
+    parser.close()
+    return parser.blocks
 
 
 def _find_toplevel_const_let(js: str) -> list[tuple[int, str]]:

--- a/tests/unit/ui/test_template_js_const.py
+++ b/tests/unit/ui/test_template_js_const.py
@@ -1,0 +1,142 @@
+"""src/templates/*.html <script> 블록에서 top-level const/let 선언 정적 스캔.
+Static scanner for top-level const/let declarations in <script> blocks.
+
+hx-boost body swap 시 <script> 블록은 동일 JS 컨텍스트에서 재실행됨.
+top-level const/let 재선언 → SyntaxError → 핸들러 전체 무력화 (PR #604 회귀 학습).
+On hx-boost body swap, <script> blocks re-execute in the same JS context.
+Top-level const/let re-declaration → SyntaxError → all handlers silenced (PR #604).
+"""
+
+import re
+from pathlib import Path
+
+_TEMPLATES_DIR = Path(__file__).parent.parent.parent.parent / "src" / "templates"
+
+
+def _extract_inline_scripts(html: str) -> list[str]:
+    """<script src=...> 외부 스크립트를 제외하고 인라인 <script> 블록 내용만 반환한다.
+    Returns inline <script> block contents, excluding <script src=...> external scripts.
+    """
+    blocks = []
+    for m in re.finditer(r"<script([^>]*)>(.*?)</script>", html, re.DOTALL | re.IGNORECASE):
+        attrs, content = m.group(1), m.group(2)
+        if "src=" not in attrs:
+            blocks.append(content)
+    return blocks
+
+
+def _find_toplevel_const_let(js: str) -> list[tuple[int, str]]:
+    """JS 텍스트에서 brace depth 0 의 top-level const/let 선언 위치를 반환한다.
+    Returns (line_number, keyword) for top-level const/let at brace depth 0.
+
+    중괄호 깊이 추적 방식 — 주석·문자열 내부는 건너뜀.
+    Tracks brace depth, skipping content inside comments and string literals.
+    """
+    violations: list[tuple[int, str]] = []
+    depth = 0
+    i = 0
+    line = 1
+    n = len(js)
+    in_line_comment = False
+    in_block_comment = False
+    in_string = False
+    string_char = ""
+
+    while i < n:
+        ch = js[i]
+
+        # 개행: 줄번호 증가 + 라인 주석 종료
+        # Newline: increment line counter and end line comment
+        if ch == "\n":
+            line += 1
+            in_line_comment = False
+            i += 1
+            continue
+
+        if in_line_comment:
+            i += 1
+            continue
+
+        if in_block_comment:
+            if js[i : i + 2] == "*/":
+                in_block_comment = False
+                i += 2
+            else:
+                i += 1
+            continue
+
+        if in_string:
+            if ch == "\\" and i + 1 < n:
+                i += 2  # 이스케이프 문자 건너뜀 / skip escaped char
+            elif ch == string_char:
+                in_string = False
+                i += 1
+            else:
+                i += 1
+            continue
+
+        # 주석 시작 감지 / detect comment start
+        if js[i : i + 2] == "//":
+            in_line_comment = True
+            i += 2
+            continue
+        if js[i : i + 2] == "/*":
+            in_block_comment = True
+            i += 2
+            continue
+
+        # 문자열 시작 감지 (백틱 템플릿 리터럴 포함) / detect string start (incl. template literals)
+        if ch in ('"', "'", "`"):
+            in_string = True
+            string_char = ch
+            i += 1
+            continue
+
+        # 중괄호 깊이 추적 / track brace depth
+        if ch == "{":
+            depth += 1
+            i += 1
+            continue
+        if ch == "}":
+            depth -= 1
+            i += 1
+            continue
+
+        # depth 0 에서만 top-level 선언 검사 / check only at depth 0
+        if depth == 0:
+            for kw in ("const ", "let "):
+                if js[i : i + len(kw)] == kw:
+                    # 직전 문자가 식별자 문자이면 키워드가 아님 (예: notconst)
+                    # Skip if preceded by an identifier character (e.g. "notconst")
+                    if i == 0 or not (js[i - 1].isalnum() or js[i - 1] == "_"):
+                        violations.append((line, kw.strip()))
+                    break
+
+        i += 1
+
+    return violations
+
+
+def test_no_toplevel_const_let_in_templates():
+    """모든 템플릿 <script> 블록에 top-level const/let 선언이 없어야 한다.
+    No template <script> block should contain a top-level const/let declaration.
+
+    위반 시 hx-boost 재방문에서 SyntaxError 발생 → 핸들러 전체 무력화.
+    Violation causes SyntaxError on hx-boost re-visit → all handlers silenced.
+    """
+    all_violations: list[str] = []
+
+    for html_file in sorted(_TEMPLATES_DIR.glob("*.html")):
+        html = html_file.read_text(encoding="utf-8")
+        scripts = _extract_inline_scripts(html)
+        for block_idx, script in enumerate(scripts):
+            hits = _find_toplevel_const_let(script)
+            for line_in_block, kw in hits:
+                all_violations.append(
+                    f"{html_file.name} script#{block_idx + 1} line {line_in_block}: `{kw}`"
+                )
+
+    assert not all_violations, (
+        "top-level const/let 선언 발견 — hx-boost SyntaxError 위험 (PR #604 회귀):\n"
+        + "\n".join(f"  {v}" for v in all_violations)
+    )

--- a/tests/unit/ui/test_template_js_const.py
+++ b/tests/unit/ui/test_template_js_const.py
@@ -7,7 +7,6 @@ On hx-boost body swap, <script> blocks re-execute in the same JS context.
 Top-level const/let re-declaration → SyntaxError → all handlers silenced (PR #604).
 """
 
-import re
 from html.parser import HTMLParser
 from pathlib import Path
 


### PR DESCRIPTION
## Summary

TDD Red→Green 2-커밋으로 구성:
1. **[Red] PR B** — `tests/unit/ui/test_template_js_const.py`: `src/templates/*.html` `<script>` 블록에서 top-level `const`/`let` 선언 정적 스캔 테스트
2. **[Green] PR C** — `add_repo.html` + `dashboard.html`: top-level `const`/`let` → `var` 교체

## 배경

사이클 127 PR #604: `base.html`의 top-level `const` 재선언 → hx-boost body swap 시 SyntaxError → `_initNavHandlers` 전체 무력화. PR A(`e2e/conftest.py` pageerror 트랩)가 `add_repo.html`의 동일 버그를 새로 감지. PR B는 이 버그 클래스를 영구 차단하는 정적 가드.

## 스캐너 동작 원리

```python
# brace depth 추적 — depth 0에서 const/let 선언 = hx-boost 위험
# 주석·문자열 내부 건너뜀, 함수/블록 내부(depth>0) 제외
_find_toplevel_const_let(js_block) → list[(line_num, keyword)]
```

## 수정 내용 (PR C)

| 파일 | 위반 (depth 0) | 수정 |
|------|--------------|------|
| `add_repo.html` | `const` × 7 + `let` × 1 | → `var` |
| `dashboard.html` | `const` × 1 + `let` × 1 | → `var` |

함수/블록 내부 `const`/`let`은 depth > 0이므로 변경하지 않음.

## 테스트 결과

- `test_template_js_const.py::test_no_toplevel_const_let_in_templates` — PASSED (0 violations)
- `tests/unit/ui/` 177 passed

## 🔍 사용자 검증 필요

- [ ] `/repos/add` 페이지에서 레포 목록 로드 및 제출 버튼 동작 확인
- [ ] `/dashboard` 페이지에서 추세 차트 정상 렌더링 확인 (4개 테마)

## Policy 18 (mutual 검증)

Codex sandbox PowerShell spawn 오류로 상호 검증 불가 — 이전 PR A와 동일 환경 이슈. 단위 테스트 177 passed로 로컬 검증 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)