### PR TITLE
fix(e2e): stale theme selectors + remove auth_cookies fixture

### DIFF
--- a/e2e/test_repos_mode.py
+++ b/e2e/test_repos_mode.py
@@ -6,14 +6,14 @@ from playwright.sync_api import Page, expect
 
 
 @pytest.mark.e2e
-def test_repos_tab_visible(page: Page, base_url: str, auth_cookies):
+def test_repos_tab_visible(page: Page, base_url: str):
     """repos 탭 링크가 Dashboard에 표시된다."""
     page.goto(f"{base_url}/dashboard")
     expect(page.get_by_role("link", name="Repos")).to_be_visible()
 
 
 @pytest.mark.e2e
-def test_repos_mode_summary_visible(page: Page, base_url: str, auth_cookies):
+def test_repos_mode_summary_visible(page: Page, base_url: str):
     """repos 모드 진입 시 KPI 카드와 드롭다운이 렌더링된다."""
     page.goto(f"{base_url}/dashboard?mode=repos")
     expect(page.locator(".repos-kpi-grid")).to_be_visible()
@@ -21,7 +21,7 @@ def test_repos_mode_summary_visible(page: Page, base_url: str, auth_cookies):
 
 
 @pytest.mark.e2e
-def test_repos_mode_empty_state(page: Page, base_url: str, auth_cookies):
+def test_repos_mode_empty_state(page: Page, base_url: str):
     """Repo 미선택 시 레포트 섹션이 없어야 한다."""
     page.goto(f"{base_url}/dashboard?mode=repos")
     expect(page.locator(".repos-report")).not_to_be_visible()

--- a/e2e/test_theme.py
+++ b/e2e/test_theme.py
@@ -24,12 +24,12 @@ def test_switch_to_light_theme(page, base_url):
     assert page.get_attribute("body", "data-theme") == "light"
 
 
-def test_switch_to_glass_theme(page, base_url):
-    """글래스모피즘 테마로 전환되어야 한다."""
+def test_switch_to_pastel_theme(page, base_url):
+    """파스텔 테마로 전환되어야 한다."""
     page.goto(base_url)
     page.click("#themeToggle")
-    page.click('[data-theme="glass"]')
-    assert page.get_attribute("body", "data-theme") == "glass"
+    page.click('[data-theme="pastel"]')
+    assert page.get_attribute("body", "data-theme") == "pastel"
 
 
 def test_theme_persists_after_reload(page, base_url):
@@ -45,9 +45,9 @@ def test_theme_saved_to_localstorage(page, base_url):
     """선택한 테마가 localStorage에 저장되어야 한다."""
     page.goto(base_url)
     page.click("#themeToggle")
-    page.click('[data-theme="glass"]')
+    page.click('[data-theme="pastel"]')
     value = page.evaluate("localStorage.getItem('sca-theme')")
-    assert value == "glass"
+    assert value == "pastel"
 
 
 def test_active_class_on_selected_theme(page, base_url):
@@ -73,19 +73,19 @@ def test_dropdown_closes_on_outside_click(page, base_url):
     assert not page.is_visible(".theme-switcher.open")
 
 
-def test_claude_dark_theme_switch(page, base_url):
-    """PR-D5 회귀 가드 — claude-dark 테마 옵션 (Phase 1B 도입) 클릭 + 적용 검증.
+def test_catppuccin_theme_switch(page, base_url):
+    """PR-D5 회귀 가드 — catppuccin 테마 옵션 클릭 + 적용 검증.
 
-    이전 e2e 는 dark/light/glass 만 검증 → claude-dark 누락. PR #150 신규 4번째 옵션.
-    Previous e2e covered dark/light/glass only; claude-dark (PR #150) was missing.
+    이전 e2e 는 dark/light/glass 만 검증 → catppuccin 누락. 2026-05-11 UI 리디자인 후 4번째 옵션.
+    Previous e2e covered dark/light/glass only; catppuccin (2026-05-11 redesign) was missing.
     """
     page.goto(base_url)
     page.click("#themeToggle")
     page.wait_for_selector(".theme-switcher.open", timeout=2000)
-    # claude-dark 옵션 존재 + 클릭 가능
-    # claude-dark option must exist + be clickable
-    page.click('.theme-option[data-theme="claude-dark"]')
-    assert page.get_attribute("body", "data-theme") == "claude-dark"
+    # catppuccin 옵션 존재 + 클릭 가능
+    # catppuccin option must exist + be clickable
+    page.click('.theme-option[data-theme="catppuccin"]')
+    assert page.get_attribute("body", "data-theme") == "catppuccin"
     # 드롭다운 자동 닫힘
     # Dropdown auto-closes
     assert not page.is_visible(".theme-switcher.open")

--- a/e2e/test_theme_mobile_guards.py
+++ b/e2e/test_theme_mobile_guards.py
@@ -1,45 +1,47 @@
-"""E2E 회귀 가드 — claude-dark 토큰 누락 + WCAG 2.5.5 모바일 클릭 영역.
+"""E2E 회귀 가드 — catppuccin 토큰 누락 + WCAG 2.5.5 모바일 클릭 영역.
 
 7-에이전트 정합성 검증 (2026-05-02) P1 #5 후속.
 도입 배경:
-  - cleanup PR #169 — claude-dark 테마가 settings 페이지 토큰 8종 (`--save-btn-bg`,
+  - cleanup PR #169 — catppuccin(구 claude-dark) 테마가 settings 페이지 토큰 8종 (`--save-btn-bg`,
     `--grad-gate/merge/notify/hook`, `--title-gradient`, `--btn-gate-active-*`,
     `--hint-*`, `--hook-btn-*`) 미정의로 카드 헤더가 흰색/투명 깨졌던 사고.
   - UI 감사 Step A — WCAG 2.5.5 Target Size — 모바일 (≤768px) 인터랙티브 요소
     `.btn`/`.btn--sm`/`.nav-hamburger`/`.nav-logout-btn` min-height ≥40~44px 의무.
+  - 2026-05-11 UI 리디자인: claude-dark → catppuccin, glass → pastel 로 테마 명칭 변경.
 
 본 테스트는 두 영역의 회귀를 e2e 레벨에서 차단한다.
 """
-# E2E regression guards — claude-dark token regression + WCAG 2.5.5 mobile click area.
+# E2E regression guards — catppuccin token regression + WCAG 2.5.5 mobile click area.
 
 import pytest
 
 
-# ── A. claude-dark 토큰 회귀 가드 (cleanup PR #169 사고 차단) ────────────────
+# ── A. catppuccin 토큰 회귀 가드 (cleanup PR #169 사고 차단) ─────────────────
 
 
-def _set_claude_dark(page) -> None:
-    """헬퍼 — claude-dark 테마로 전환 후 적용 확인.
+def _set_catppuccin(page) -> None:
+    """헬퍼 — catppuccin 테마로 전환 후 적용 확인.
 
-    드롭다운 → claude-dark 옵션 클릭 → body[data-theme=claude-dark] 단언.
+    드롭다운 → catppuccin 옵션 클릭 → body[data-theme=catppuccin] 단언.
+    (2026-05-11 UI 리디자인 전 이름: claude-dark)
     """
-    # Helper — switch to claude-dark theme and assert it applied.
+    # Helper — switch to catppuccin theme and assert it applied (formerly claude-dark).
     page.click("#themeToggle")
     page.wait_for_selector(".theme-switcher.open", timeout=2000)
-    page.click('.theme-option[data-theme="claude-dark"]')
-    assert page.get_attribute("body", "data-theme") == "claude-dark"
+    page.click('.theme-option[data-theme="catppuccin"]')
+    assert page.get_attribute("body", "data-theme") == "catppuccin"
 
 
-def test_claude_dark_settings_tokens_defined(seeded_page, base_url):
-    """claude-dark 테마에서 settings 페이지의 8 토큰 모두 정의되어 있어야 한다.
+def test_catppuccin_settings_tokens_defined(seeded_page, base_url):
+    """catppuccin 테마에서 settings 페이지의 8 토큰 모두 정의되어 있어야 한다.
 
-    회귀 사례: cleanup PR #169 이전 settings 페이지가 claude-dark 토큰 미정의로
+    회귀 사례: cleanup PR #169 이전 settings 페이지가 catppuccin(구 claude-dark) 토큰 미정의로
     `var(--save-btn-bg)` 등이 invalid → 카드 헤더 흰색 / 저장 버튼 투명 깨짐.
     """
-    # Regression guard: cleanup PR #169 — claude-dark settings tokens were missing,
+    # Regression guard: cleanup PR #169 — catppuccin settings tokens were missing,
     # causing card headers / save button to render blank.
     seeded_page.goto(f"{base_url}/repos/owner/testrepo/settings")
-    _set_claude_dark(seeded_page)
+    _set_catppuccin(seeded_page)
 
     # 8 토큰 모두 :root 에 정의되어 있어야 함 (빈 문자열이면 미정의 = invalid var())
     # All 8 tokens must be defined on :root (empty value = undefined = invalid).
@@ -53,49 +55,49 @@ def test_claude_dark_settings_tokens_defined(seeded_page, base_url):
         "--hint-bg",
         "--hook-btn-bg",
     ]
-    # claude-dark 토큰은 body[data-theme="claude-dark"] 스코프 → document.body 에서 조회
-    # claude-dark tokens scoped to body[data-theme=claude-dark] — query document.body.
+    # catppuccin 토큰은 body[data-theme="catppuccin"] 스코프 → document.body 에서 조회
+    # catppuccin tokens scoped to body[data-theme=catppuccin] — query document.body.
     for token in required:
         value = seeded_page.evaluate(
             f"getComputedStyle(document.body).getPropertyValue('{token}').trim()"
         )
-        assert value, f"claude-dark 테마에 {token} 미정의 (settings 페이지 깨짐 위험)"
+        assert value, f"catppuccin 테마에 {token} 미정의 (settings 페이지 깨짐 위험)"
 
 
-def test_claude_dark_dashboard_renders_without_token_failure(page, base_url):
-    """claude-dark 테마 적용 후 dashboard 페이지가 정상 렌더되고 body 배경이 투명이 아니어야 한다.
+def test_catppuccin_dashboard_renders_without_token_failure(page, base_url):
+    """catppuccin 테마 적용 후 dashboard 페이지가 정상 렌더되고 body 배경이 투명이 아니어야 한다.
 
     회귀 사례: --bg-app 등 핵심 토큰 미정의 시 body 배경이 transparent → 시각 깨짐.
     """
     # Regression guard: missing --bg-app etc. would render body bg transparent.
     page.goto(f"{base_url}/dashboard")
-    _set_claude_dark(page)
+    _set_catppuccin(page)
 
     # body 배경이 transparent / rgba(0,0,0,0) 가 아니어야 함
     # body bg must not be transparent / rgba(0,0,0,0).
     bg = page.evaluate("getComputedStyle(document.body).backgroundColor")
     assert bg not in ("rgba(0, 0, 0, 0)", "transparent"), (
-        f"claude-dark dashboard body 배경 투명 — 토큰 누락 의심: {bg}"
+        f"catppuccin dashboard body 배경 투명 — 토큰 누락 의심: {bg}"
     )
 
 
-def test_claude_dark_grade_aliases_defined(page, base_url):
-    """claude-dark 테마에서 등급 색 alias (--grade-a/b/c/d/f) 가 모두 정의되어 있어야 한다.
+def test_catppuccin_grade_aliases_defined(page, base_url):
+    """catppuccin 테마에서 등급 색 alias (--grade-a/b/c/d/f) 가 모두 정의되어 있어야 한다.
 
     회귀 사례: 등급 색 미정의 시 overview 카드의 등급 뱃지가 색상 없이 렌더.
     """
     # Regression guard: missing --grade-* aliases would render overview grade badges colorless.
     page.goto(base_url)
-    _set_claude_dark(page)
+    _set_catppuccin(page)
 
-    # 등급 alias 도 body[data-theme="claude-dark"] 스코프
-    # Grade aliases scoped to body[data-theme=claude-dark] too.
+    # 등급 alias 도 body[data-theme="catppuccin"] 스코프
+    # Grade aliases scoped to body[data-theme=catppuccin] too.
     for grade in ["a", "b", "c", "d", "f"]:
         token = f"--grade-{grade}"
         value = page.evaluate(
             f"getComputedStyle(document.body).getPropertyValue('{token}').trim()"
         )
-        assert value, f"claude-dark 테마에 {token} 미정의"
+        assert value, f"catppuccin 테마에 {token} 미정의"
 
 
 # ── B. WCAG 2.5.5 모바일 클릭 영역 회귀 가드 (UI 감사 Step A) ─────────────────


### PR DESCRIPTION
## Summary

- **`test_repos_mode.py`** (3 tests ERROR): removed `auth_cookies` fixture parameter — it was never defined; `conftest.py` `get_current_user` override already handles E2E auth for all tests
- **`test_theme.py`** (2 tests TIMEOUT): updated stale selectors from 2026-05-11 UI redesign:
  - `glass` → `pastel` (`test_switch_to_pastel_theme`, `test_theme_saved_to_localstorage`)
  - `claude-dark` → `catppuccin` (`test_catppuccin_theme_switch`)
- **`test_theme_mobile_guards.py`** (3 tests TIMEOUT): renamed `_set_claude_dark()` → `_set_catppuccin()`, updated all 3 test names, selectors, assertions, and comments

Root cause: 2026-05-11 UI redesign renamed `glass→pastel` and `claude-dark→catppuccin` in `base.html` but E2E tests were not updated accordingly.

## Changes

| File | Before | After |
|------|--------|-------|
| `test_repos_mode.py` | `auth_cookies` fixture (undefined) | removed — conftest override handles auth |
| `test_theme.py` | `[data-theme="glass"]` | `[data-theme="pastel"]` |
| `test_theme.py` | `[data-theme="claude-dark"]` | `[data-theme="catppuccin"]` |
| `test_theme_mobile_guards.py` | `_set_claude_dark()` | `_set_catppuccin()` |

## 🔍 사용자 검증 필요

- [ ] E2E 테스트 CI 통과 확인 (8개 테스트: 5 TIMEOUT → PASS, 3 ERROR → PASS)
- [ ] 로컬에서 테마 드롭다운에 `pastel` / `catppuccin` 옵션이 실제로 존재하는지 확인 (`[data-theme="pastel"]`, `[data-theme="catppuccin"]`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)