### PR TITLE
feat(ui): overview + add_repo redesign — repo-card, score-bar, step-cards (PR-P4)

### DIFF
--- a/src/templates/add_repo.html
+++ b/src/templates/add_repo.html
@@ -2,158 +2,130 @@
 {% block title %}{{ 'add_repo.title_prefix' | i18n_args(locale | default('ko')) }} — SCAManager{% endblock %}
 {% block content %}
 <style>
+  /* ── add_repo v3 redesign ──────────────────────────────────────────── */
+
   /* 페이지 제목 그라디언트 텍스트
      Page title gradient text */
   .add-repo-page-title {
     font-size: clamp(1.4rem, 3vw, 1.8rem);
-    font-weight: 700;
-    background: linear-gradient(135deg, var(--text-1), var(--accent));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-    line-height: 1.3;
+    font-weight: 760;
+    background: var(--accent-grad, linear-gradient(135deg, #7c7aff, #b289ff));
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+    margin: 0; line-height: 1.3;
   }
 
-  /* 폼 카드 글래스모피즘 스타일
-     Form card glassmorphism style */
-  .add-repo-card {
+  /* 열 너비 제한 (일러스트 + 카드 동일 열)
+     Column width constraint (illustration + card same column) */
+  .addrepo-col {
     max-width: 560px;
-    margin: 2rem auto;
-    background: var(--bg-card);
-    backdrop-filter: blur(12px) saturate(150%);
-    -webkit-backdrop-filter: blur(12px) saturate(150%);
-    border: 1px solid var(--border-subtle);
-    border-radius: 16px;
-    box-shadow: var(--shadow-md);
-    padding: 32px;
+    margin: 0 auto;
   }
 
   /* 토스트 에러 팝업
      Toast error popup */
   .toast {
-    position: fixed;
-    top: 1.5rem;
-    left: 50%;
-    transform: translateX(-50%);
-    background: var(--danger);
-    color: var(--btn-on-accent);
-    padding: .75rem 1.5rem;
-    border-radius: var(--radius-btn, 8px);
-    font-size: 14px;
-    font-weight: 600;
-    box-shadow: 0 4px 16px color-mix(in srgb, var(--danger) 40%, transparent);
-    z-index: 9999;
-    opacity: 0;
-    transition: opacity .3s;
-    pointer-events: none;
+    position: fixed; top: 1.5rem; left: 50%; transform: translateX(-50%);
+    background: var(--danger, #f87171); color: var(--btn-on-accent, #fff);
+    padding: .75rem 1.5rem; border-radius: var(--radius-btn, 8px);
+    font-size: 14px; font-weight: 600;
+    box-shadow: 0 4px 16px color-mix(in srgb, var(--danger, #f87171) 40%, transparent);
+    z-index: 9999; opacity: 0; transition: opacity .3s; pointer-events: none;
   }
   .toast.show { opacity: 1; }
 
-  /* 폼 그룹 간격
-     Form group spacing */
+  /* 단계 카드 공통
+     Step card common */
+  .step-card {
+    background: var(--bg-card, var(--bg-2, rgba(255,255,255,0.05)));
+    border: 1px solid var(--border-subtle, rgba(255,255,255,0.08));
+    border-radius: var(--radius-lg, 12px);
+    padding: var(--space-5, 1.25rem);
+    margin-bottom: var(--space-4, 1rem);
+  }
+  .step-card__header {
+    display: flex; align-items: center; gap: var(--space-3, 0.75rem);
+    margin-bottom: var(--space-4, 1rem);
+  }
+  .step-card__num {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--accent-grad, linear-gradient(135deg, #7c7aff, #b289ff));
+    font-size: var(--fs-xs, 0.75rem); font-weight: 700; color: #fff; flex-shrink: 0;
+  }
+  .step-card__title { font-size: var(--fs-md, 1rem); font-weight: 640; color: var(--text-1, #fff); }
+
+  /* 폼 그룹
+     Form group */
   .form-group { margin-bottom: 1.25rem; }
 
-  /* 폼 라벨 스타일
-     Form label style */
+  /* 폼 라벨
+     Form label */
   .form-label {
-    display: block;
-    font-size: 13px;
-    font-weight: 500;
-    color: var(--text-2);
-    margin-bottom: 6px;
+    display: block; font-size: 13px; font-weight: 500;
+    color: var(--text-2, rgba(255,255,255,0.6)); margin-bottom: 6px;
   }
 
   /* select 입력 스타일 — focus glow 포함
      Select input style — with focus glow */
   .form-select {
-    width: 100%;
-    padding: 10px 14px;
-    padding-right: 36px;
-    background: var(--bg-elevated);
-    border: 1px solid var(--border-subtle);
-    border-radius: 10px;
-    color: var(--text-1);
-    font-size: 14px;
+    width: 100%; padding: 10px 14px; padding-right: 36px;
+    background: var(--bg-elevated, var(--bg-2, rgba(255,255,255,0.06)));
+    border: 1px solid var(--border-subtle, rgba(255,255,255,0.12));
+    border-radius: 10px; color: var(--text-1, #fff); font-size: 14px;
     transition: border-color 0.2s, box-shadow 0.2s;
-    appearance: none;
-    cursor: pointer;
+    appearance: none; cursor: pointer;
     /* appearance:none 으로 제거된 기본 화살표를 SVG chevron 으로 보강
        SVG chevron to replace the native arrow removed by appearance:none */
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='none' stroke='%2373737c' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' d='M1 1l5 5 5-5'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-position: right 14px center;
+    background-repeat: no-repeat; background-position: right 14px center;
     box-sizing: border-box;
   }
   .form-select:focus {
-    outline: none;
-    border-color: var(--accent);
-    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 15%, transparent);
+    outline: none; border-color: var(--accent, #7c7aff);
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #7c7aff) 15%, transparent);
   }
 
   /* 힌트 텍스트 — 인포 박스 스타일
      Hint text — info box style */
   .repo-hint {
-    margin-top: 10px;
-    padding: 10px 14px;
-    background: var(--bg-elevated);
-    border-left: 3px solid var(--accent);
+    margin-top: 10px; padding: 10px 14px;
+    background: var(--bg-elevated, var(--bg-2, rgba(255,255,255,0.06)));
+    border-left: 3px solid var(--accent, #7c7aff);
     border-radius: 0 8px 8px 0;
-    color: var(--text-2);
-    font-size: 13px;
-    line-height: 1.5;
+    color: var(--text-2, rgba(255,255,255,0.6)); font-size: 13px; line-height: 1.5;
   }
 
   /* 제출 버튼 — 액센트 그라디언트, hover 리프트, active 스케일
      Submit button — accent gradient, hover lift, active scale */
   .btn-submit {
-    background: linear-gradient(135deg, var(--accent), var(--accent-2, var(--accent)));
-    color: var(--btn-on-accent);
-    border: none;
-    border-radius: 12px;
-    padding: 12px 28px;
-    font-size: 15px;
-    font-weight: 600;
-    cursor: pointer;
-    width: 100%;
+    background: var(--accent-grad, linear-gradient(135deg, #7c7aff, #b289ff));
+    color: var(--btn-on-accent, #fff);
+    border: none; border-radius: 12px;
+    padding: 12px 28px; font-size: 15px; font-weight: 600;
+    cursor: pointer; width: 100%;
     transition: transform 0.1s, box-shadow 0.2s, opacity 0.2s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
+    display: flex; align-items: center; justify-content: center; gap: 8px;
   }
   .btn-submit:hover:not(:disabled) {
     transform: translateY(-1px);
-    box-shadow: 0 6px 20px color-mix(in srgb, var(--accent) 30%, transparent);
+    box-shadow: 0 6px 20px color-mix(in srgb, var(--accent, #7c7aff) 30%, transparent);
   }
   .btn-submit:active:not(:disabled) { transform: scale(0.97); }
-  .btn-submit:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
+  .btn-submit:disabled { opacity: 0.5; cursor: not-allowed; }
 
   /* 모바일 분기 — iOS Safari 자동 줌인 방지 (font-size < 16px 시 zoom 트리거)
      Mobile breakpoint — prevent iOS Safari zoom on focus (triggers below 16px) */
   @media (max-width: 768px) {
-    .add-repo-card {
-      margin: 1rem auto;
-      padding: 24px 20px;
-    }
-    .form-select { min-height: 44px; font-size: 16px; padding: .75rem 1rem; padding-right: 36px; box-sizing: border-box; }
+    .addrepo-col { margin: 1rem auto; }
+    .step-card { padding: 1rem; }
+    /* iOS Safari 자동 줌 방지 — font-size ≥ 16px 필수
+       iOS Safari auto-zoom prevention — font-size ≥ 16px required */
+    .form-select { min-height: 44px; font-size: 16px; padding: .75rem 1rem; padding-right: 36px; }
     .btn-submit { min-height: 48px; }
-    .btn-primary { min-height: 48px; }
-    .back-btn { min-height: 44px; padding: .5rem .85rem; }
     .form-group { margin-bottom: 1rem; }
   }
   @media (max-width: 480px) {
-    .add-repo-card { padding: 20px 16px; }
-  }
-
-  /* 이미지와 카드를 동일한 560px 열로 묶어 정렬 통일
-     Constrain illustration and card to the same 560px column */
-  .add-repo-col {
-    max-width: 560px;
-    margin: 0 auto;
+    .step-card { padding: 0.875rem 0.875rem; }
   }
 </style>
 
@@ -167,44 +139,52 @@
   </div>
 </div>
 
-{# 이미지와 카드를 동일한 560px 열로 묶어 정렬 통일 (illustration--tutorial max-width:100% 와 카드 padding 차이로 인한 시각 불일치 해소)
-   Wrap illustration and card in the same 560px column to fix visual misalignment caused by illustration--tutorial max-width:100% vs card padding #}
-<div class="add-repo-col">
+{# 이미지와 카드를 동일한 560px 열로 묶어 정렬 통일
+   Wrap illustration and card in the same 560px column for alignment consistency #}
+<div class="addrepo-col">
 
-{# Cycle 94 Step 2-B — repository 분석 파이프라인 일러스트 (1792x1024 가로형)
-   Cycle 94 Step 2-B — repository analysis pipeline illustration (1792x1024 landscape) #}
-<img src="/static/illustrations/add_repo_hero.png"
-     class="illustration illustration--tutorial"
-     alt=""
-     role="presentation"
-     loading="eager"
-     decoding="sync">
+  {# Cycle 94 Step 2-B — repository 분석 파이프라인 일러스트 (1792x1024 가로형)
+     Cycle 94 Step 2-B — repository analysis pipeline illustration (1792x1024 landscape) #}
+  <img src="/static/illustrations/add_repo_hero.png"
+       class="illustration illustration--tutorial"
+       alt=""
+       role="presentation"
+       loading="eager"
+       decoding="sync">
 
-{# Phase 2 PR-5 — 다국어 적용. JS 동적 텍스트는 data-i18n-* 속성으로 서버측 주입
-   (LocaleMiddleware ↔ Jinja {{ locale }} 페어 — XSS 차단 + race condition 0). #}
-<div class="card add-repo-card reveal"
-     data-i18n-placeholder="{{ 'add_repo.placeholder_option' | i18n_args(locale | default('ko')) }}"
-     data-i18n-no-repos-option="{{ 'add_repo.no_repos_option' | i18n_args(locale | default('ko')) }}"
-     data-i18n-no-repos-hint="{{ 'add_repo.no_repos_hint' | i18n_args(locale | default('ko')) }}"
-     data-i18n-loaded-template="{{ 'add_repo.loaded_hint' | i18n_args(locale | default('ko'), count='__N__') }}"
-     data-i18n-load-failed="{{ 'add_repo.load_failed_option' | i18n_args(locale | default('ko')) }}"
-     data-i18n-error-prefix="{{ 'add_repo.error_prefix' | i18n_args(locale | default('ko')) }}"
-     data-i18n-api-error-prefix="{{ 'add_repo.api_error_prefix' | i18n_args(locale | default('ko')) }}">
-  <form method="post" action="/repos/add" id="addRepoForm">
-    <div class="form-group">
-      <label class="form-label" for="repo_full_name">{{ 'add_repo.label_select' | i18n_args(locale | default('ko')) }}</label>
-      <select class="form-select" name="repo_full_name" id="repo_full_name" required>
-        <option value="">{{ 'add_repo.loading_option' | i18n_args(locale | default('ko')) }}</option>
-      </select>
-      <p class="repo-hint" id="repoHint">{{ 'add_repo.hint_default' | i18n_args(locale | default('ko')) }}</p>
+  {# Phase 2 PR-5 — 다국어 적용. JS 동적 텍스트는 data-i18n-* 속성으로 서버측 주입
+     Phase 2 PR-5 — i18n applied. JS dynamic text injected server-side via data-i18n-* attributes. #}
+  <form method="post" action="/repos/add" id="addRepoForm"
+        data-i18n-placeholder="{{ 'add_repo.placeholder_option' | i18n_args(locale | default('ko')) }}"
+        data-i18n-no-repos-option="{{ 'add_repo.no_repos_option' | i18n_args(locale | default('ko')) }}"
+        data-i18n-no-repos-hint="{{ 'add_repo.no_repos_hint' | i18n_args(locale | default('ko')) }}"
+        data-i18n-loaded-template="{{ 'add_repo.loaded_hint' | i18n_args(locale | default('ko'), count='__N__') }}"
+        data-i18n-load-failed="{{ 'add_repo.load_failed_option' | i18n_args(locale | default('ko')) }}"
+        data-i18n-error-prefix="{{ 'add_repo.error_prefix' | i18n_args(locale | default('ko')) }}"
+        data-i18n-api-error-prefix="{{ 'add_repo.api_error_prefix' | i18n_args(locale | default('ko')) }}">
+
+    {# Step 1: GitHub 리포지터리 선택
+       Step 1: Select GitHub repository #}
+    <div class="step-card">
+      <div class="step-card__header">
+        <span class="step-card__num">1</span>
+        <div class="step-card__title">{{ 'add_repo.label_select' | i18n_args(locale | default('ko')) }}</div>
+      </div>
+      <div class="form-group" style="margin-bottom: 0;">
+        <label class="form-label" for="repo_full_name">{{ 'add_repo.label_select' | i18n_args(locale | default('ko')) }}</label>
+        <select class="form-select" name="repo_full_name" id="repo_full_name" required>
+          <option value="">{{ 'add_repo.loading_option' | i18n_args(locale | default('ko')) }}</option>
+        </select>
+        <p class="repo-hint" id="repoHint">{{ 'add_repo.hint_default' | i18n_args(locale | default('ko')) }}</p>
+      </div>
     </div>
+
     <button type="submit" class="btn-submit" id="submitBtn" disabled>
       {{ 'add_repo.submit' | i18n_args(locale | default('ko')) }}
     </button>
   </form>
-</div>
 
-</div>{# /add-repo-col #}
+</div>{# /addrepo-col #}
 
 {% block scripts %}
 <script>
@@ -214,15 +194,15 @@
   var hint = document.getElementById('repoHint');
   // Phase 2 PR-5 — 다국어 동적 텍스트 (서버 Jinja injection 페어)
   // Phase 2 PR-5 — i18n dynamic text (paired with server-side Jinja injection)
-  var i18nCard = document.querySelector('.add-repo-card');
+  var i18nForm = document.getElementById('addRepoForm');
   var I18N = {
-    placeholder: i18nCard.dataset.i18nPlaceholder,
-    noReposOption: i18nCard.dataset.i18nNoReposOption,
-    noReposHint: i18nCard.dataset.i18nNoReposHint,
-    loadedTemplate: i18nCard.dataset.i18nLoadedTemplate,
-    loadFailed: i18nCard.dataset.i18nLoadFailed,
-    errorPrefix: i18nCard.dataset.i18nErrorPrefix,
-    apiErrorPrefix: i18nCard.dataset.i18nApiErrorPrefix,
+    placeholder: i18nForm.dataset.i18nPlaceholder,
+    noReposOption: i18nForm.dataset.i18nNoReposOption,
+    noReposHint: i18nForm.dataset.i18nNoReposHint,
+    loadedTemplate: i18nForm.dataset.i18nLoadedTemplate,
+    loadFailed: i18nForm.dataset.i18nLoadFailed,
+    errorPrefix: i18nForm.dataset.i18nErrorPrefix,
+    apiErrorPrefix: i18nForm.dataset.i18nApiErrorPrefix,
   };
 
   // 페이지 이탈 시 fetch abort 제어 — hx-boost 뒤로가기 freezing 방지

--- a/src/templates/add_repo.html
+++ b/src/templates/add_repo.html
@@ -122,6 +122,8 @@
        iOS Safari auto-zoom prevention — font-size ≥ 16px required */
     .form-select { min-height: 44px; font-size: 16px; padding: .75rem 1rem; padding-right: 36px; }
     .btn-submit { min-height: 48px; }
+    .btn-primary { min-height: 48px; }
+    .back-btn { min-height: 44px; padding: .5rem .85rem; }
     .form-group { margin-bottom: 1rem; }
   }
   @media (max-width: 480px) {

--- a/src/templates/add_repo.html
+++ b/src/templates/add_repo.html
@@ -150,7 +150,7 @@
        alt=""
        role="presentation"
        loading="eager"
-       decoding="sync">
+       decoding="async">
 
   {# Phase 2 PR-5 — 다국어 적용. JS 동적 텍스트는 data-i18n-* 속성으로 서버측 주입
      Phase 2 PR-5 — i18n applied. JS dynamic text injected server-side via data-i18n-* attributes. #}

--- a/src/templates/overview.html
+++ b/src/templates/overview.html
@@ -188,7 +188,7 @@
       </div>
       {% if item.avg_score %}
       <div class="score-bar score-bar--{{ (item.avg_grade or 'f') | lower }}"
-           style="--sb-pct: {{ item.avg_score | round | int }}%;">
+           style="--sb-pct: {{ [[item.avg_score | round | int, 0] | max, 100] | min }}%;">
       </div>
       <div class="repo-card__score-row">
         <span class="repo-card__score">{{ item.avg_score }}<span style="color: var(--text-3, rgba(255,255,255,0.4)); font-size:11px;">/100</span></span>

--- a/src/templates/overview.html
+++ b/src/templates/overview.html
@@ -2,209 +2,133 @@
 {% block title %}{{ 'header.overview' | i18n_args(locale | default('ko')) }} — SCAManager{% endblock %}
 {% block content %}
 <style>
-  /* ── Overview page premium redesign ────────────────────────────────── */
+  /* ── Overview page v3 redesign ─────────────────────────────────────── */
 
-  /* 헤더 레이아웃
-     Header layout */
-  .overview-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: var(--space-7);
-    gap: var(--space-4);
+  /* 페이지 전체 래퍼
+     Page-level wrapper */
+  .overview-wrap {
+    max-width: 1200px; margin: 0 auto;
+    padding: var(--space-7, 2rem) var(--space-6, 1.5rem) var(--space-8, 3rem);
   }
 
-  /* 환영 인사 서브텍스트
-     Greeting sub-text */
-  .overview-greeting {
-    margin: 0 0 var(--space-2);
-    font-size: var(--fs-sm);
-    color: var(--text-2, var(--text-muted));
+  /* 페이지 헤더
+     Page header */
+  .ov-head {
+    display: flex; align-items: center; justify-content: space-between;
+    margin-bottom: var(--space-7, 2rem); gap: var(--space-4, 1rem); flex-wrap: wrap;
+  }
+  .ov-head-greeting {
+    margin: 0 0 var(--space-2, 0.5rem);
+    font-size: var(--fs-sm, 0.875rem);
+    color: var(--text-2, rgba(255,255,255,0.6));
     font-weight: 400;
   }
-
-  /* 그라디언트 페이지 타이틀
-     Gradient page title */
-  .overview-title {
+  .ov-head-title {
+    font-size: var(--fs-display-sm, 2rem); font-weight: 760;
+    letter-spacing: -0.025em; line-height: 1.2;
+    background: var(--accent-grad, linear-gradient(135deg, #7c7aff, #b289ff));
+    -webkit-background-clip: text; background-clip: text; color: transparent;
     margin: 0;
-    font-size: 1.5rem;
-    font-weight: 700;
-    letter-spacing: -.02em;
-    background: linear-gradient(135deg, var(--text-1, var(--text-primary)), var(--accent));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
   }
-
-  /* 헤더 우측 액션 영역
-     Header right-side actions */
-  .overview-actions { display: flex; align-items: center; gap: var(--space-3); }
 
   /* 리포 개수 뱃지
      Repo count badge */
   .repo-count {
-    font-size: var(--fs-xs);
-    color: var(--text-2, var(--text-muted));
-    background: var(--bg-elevated, var(--bg-input));
-    border: 1px solid var(--border-subtle, var(--border));
+    font-size: var(--fs-xs, 0.75rem);
+    color: var(--text-2, rgba(255,255,255,0.6));
+    background: var(--bg-elevated, var(--bg-2, rgba(255,255,255,0.05)));
+    border: 1px solid var(--border-subtle, rgba(255,255,255,0.08));
     padding: 4px 12px;
-    border-radius: var(--radius-pill);
+    border-radius: var(--radius-pill, 999px);
   }
 
-  /* 기본 버튼 — 그라디언트 스타일
-     Primary button — gradient style */
-  .btn-primary {
-    background: linear-gradient(135deg, var(--accent), var(--accent-2, var(--accent))) !important;
-    color: var(--btn-on-accent, #fff) !important;
-    border: none !important;
-    border-radius: 10px !important;
-    font-weight: 600;
-    transition: transform 0.1s, box-shadow 0.2s;
-    cursor: pointer;
+  /* 리포 그리드
+     Repo grid */
+  .repo-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: var(--space-4, 1rem);
   }
-  .btn-primary:hover {
+
+  /* 리포 카드
+     Repo card */
+  .repo-card {
+    display: flex; flex-direction: column; gap: var(--space-3, 0.75rem);
+    background: var(--bg-card, var(--bg-2, rgba(255,255,255,0.05)));
+    border: 1px solid var(--border-subtle, rgba(255,255,255,0.08));
+    border-radius: var(--radius-lg, 12px);
+    padding: var(--space-5, 1.25rem);
+    text-decoration: none;
+    transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+  }
+  .repo-card:hover {
     transform: translateY(-1px);
-    box-shadow: 0 6px 20px rgba(var(--accent-rgb, 99,102,241), 0.3) !important;
+    box-shadow: var(--shadow-md, 0 4px 16px rgba(0,0,0,0.2));
+    border-color: var(--border-strong, rgba(255,255,255,0.2));
     text-decoration: none;
   }
-  .btn-primary:active { transform: scale(0.97); }
-
-  /* ── 리포 테이블 카드 ──────────────────────────────────────────────── */
-
-  /* 테이블 래퍼 — 카드 스타일 강화
-     Table wrapper — enhanced card style */
-  .overview-table-card {
-    background: var(--bg-card, var(--bg-surface));
-    backdrop-filter: blur(12px) saturate(150%);
-    border: 1px solid var(--border-subtle, var(--border));
-    border-radius: 16px;
-    box-shadow: var(--shadow-sm);
-    overflow: hidden;
-    margin-bottom: 0;
+  .repo-card__row { display: flex; align-items: center; justify-content: space-between; gap: var(--space-3, 0.75rem); }
+  .repo-card__name {
+    font-size: var(--fs-md, 1rem); font-weight: 640; color: var(--text-1, #fff);
+    letter-spacing: -0.01em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   }
-
-  /* 테이블 가로 스크롤 래퍼
-     Table horizontal scroll wrapper */
-  .table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
-
-  /* 테이블 기본 스타일
-     Table base styles */
-  .overview-table-card table { width: 100%; border-collapse: collapse; }
-
-  /* 테이블 헤더 — 고급형 스타일
-     Table header — premium style */
-  .overview-table-card thead th {
-    background: var(--bg-elevated, var(--bg-nav));
-    color: var(--text-2, var(--text-muted));
-    font-size: 12px;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-    padding: 12px 16px;
-    font-weight: 600;
-    border-bottom: 1px solid var(--border-subtle, var(--border));
-    white-space: nowrap;
+  .repo-card__meta { font-size: var(--fs-xs, 0.75rem); color: var(--text-3, rgba(255,255,255,0.4)); }
+  .repo-card__score-row {
+    display: flex; align-items: center; justify-content: space-between;
+    font-size: var(--fs-xs, 0.75rem);
   }
+  .repo-card__score { font-family: var(--claude-font-mono, monospace); color: var(--text-1, #fff); font-size: var(--fs-sm, 0.875rem); }
 
-  /* 리포 행 — 호버 액센트 바 효과
-     Repo row — hover accent bar effect
-     🔴 tr::before 방식은 Chromium이 phantom table-column으로 취급 → thead/tbody 컬럼 오정렬.
-     🔴 tr::before causes Chromium to insert phantom first column → thead/tbody column desync.
-     → first-child td의 inset box-shadow 방식으로 교체 (position:relative 불필요).
-     → Replaced with inset box-shadow on first td (no position:relative needed). */
-  .repo-row {
-    transition: background 0.15s;
+  /* 점수 바 (인라인)
+     Score bar (inline) */
+  .score-bar {
+    height: 4px;
+    background: var(--table-row-hover, rgba(255,255,255,0.08));
+    border-radius: 999px; overflow: hidden;
   }
-  .repo-row td {
-    padding: 13px 16px;
-    border-bottom: 1px solid var(--border-subtle, var(--border));
-    white-space: nowrap;
-    vertical-align: middle;
+  .score-bar::after {
+    content: ''; display: block; height: 100%; width: var(--sb-pct, 0%);
+    background: var(--accent-grad, linear-gradient(90deg, #7c7aff, #b289ff));
+    border-radius: 999px;
   }
-  .repo-row:last-child td { border-bottom: none; }
+  .score-bar--a::after { background: var(--success, #34d399); }
+  .score-bar--b::after { background: #60a5fa; }
+  .score-bar--c::after { background: var(--warning, #fbbf24); }
+  .score-bar--d::after { background: #fb923c; }
+  .score-bar--f::after { background: var(--danger, #f87171); }
 
-  /* 왼쪽 액센트 바 — inset box-shadow (호버 시 노출)
-     Left accent bar — inset box-shadow (shown on hover) */
-  .repo-row td:first-child {
-    box-shadow: inset 3px 0 0 transparent;
-    transition: box-shadow 0.15s;
-  }
-  .repo-row:hover td:first-child {
-    box-shadow: inset 3px 0 0 var(--accent);
-  }
-  .repo-row:hover { background: var(--table-row-hover, transparent); }
-
-  /* 리포 링크
-     Repo link */
-  .repo-link {
-    font-weight: 600;
-    font-size: var(--fs-sm);
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    color: var(--text-1, var(--text-primary));
-    text-decoration: none;
-  }
-  .repo-link::before {
-    content: '';
-    display: inline-block;
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: var(--success);
-    flex-shrink: 0;
-  }
-  .repo-link:hover { color: var(--accent); text-decoration: none; }
-
-  /* 분석 수 텍스트
-     Analysis count text */
-  .analysis-count { font-size: var(--fs-xs); color: var(--text-2, var(--text-muted)); }
-
-  /* 점수 셀 — badge-pop 애니메이션 적용
-     Score cell — badge-pop animation applied */
-  .score-cell {
-    font-weight: 700;
-    font-size: var(--fs-base);
-    animation: var(--anim-badge-pop);
-  }
-  .score-cell.score-high { color: var(--grade-a); }
-  .score-cell.score-mid  { color: var(--grade-c); }
-  .score-cell.score-low  { color: var(--grade-f); }
-
-  /* 등급 뱃지 — badge-pop 애니메이션 적용
-     Grade badge — badge-pop animation applied */
+  /* 등급 뱃지
+     Grade badge */
   .grade {
+    display: inline-flex; align-items: center; justify-content: center;
+    font-weight: 700; font-size: 0.75rem; line-height: 1;
+    padding: 2px 7px; border-radius: 6px; border: 1px solid transparent;
+    text-transform: uppercase; letter-spacing: 0.05em; flex-shrink: 0;
     animation: var(--anim-badge-pop);
   }
+  .grade-A { background: rgba(52,211,153,0.12); color: #34d399; border-color: rgba(52,211,153,0.32); }
+  .grade-B { background: rgba(96,165,250,0.12); color: #60a5fa; border-color: rgba(96,165,250,0.32); }
+  .grade-C { background: rgba(251,191,36,.12);  color: #fbbf24; border-color: rgba(251,191,36,0.32); }
+  .grade-D { background: rgba(251,146,60,.12);  color: #fb923c; border-color: rgba(251,146,60,0.32); }
+  .grade-F { background: rgba(248,113,113,.12); color: #f87171; border-color: rgba(248,113,113,0.32); }
 
-  /* Step B (B4): settings-link nowrap + 모바일에서 클릭 영역 ≥40px (WCAG 2.5.5)
-     Step B (B4): settings-link nowrap + ≥40px touch on mobile (WCAG 2.5.5) */
-  .settings-link {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    font-size: var(--fs-xs);
-    color: var(--text-2, var(--text-muted));
-    text-decoration: none;
-    padding: 4px 10px;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--border-subtle, var(--border));
-    transition: all var(--transition);
-    white-space: nowrap;
+  /* 빈 상태
+     Empty state */
+  .ov-empty-state {
+    text-align: center;
+    padding: 4rem 2rem;
   }
-  .settings-link:hover { color: var(--accent); border-color: var(--accent); text-decoration: none; }
+  .ov-empty-icon { font-size: 2.5rem; margin-bottom: var(--space-4, 1rem); opacity: 0.4; }
+  .ov-empty-state p { color: var(--text-2, rgba(255,255,255,0.6)); margin: 0; font-size: var(--fs-sm, 0.875rem); line-height: 1.7; }
 
-  /* ── 캘리브레이션 카드 ───────────────────────────────────────────── */
-
-  /* 캘리브레이션 카드 스타일
-     Calibration card styles */
+  /* 캘리브레이션 카드
+     Calibration card */
   .calibration-card {
-    margin-top: 1.5rem;
-    padding: 1.2rem 1.4rem;
+    margin-top: 1.5rem; padding: 1.2rem 1.4rem;
     background: var(--bg-card, var(--bg-surface));
     backdrop-filter: blur(12px) saturate(150%);
     border: 1px solid var(--border-subtle, var(--border));
-    border-radius: 16px;
-    box-shadow: var(--shadow-sm);
+    border-radius: 16px; box-shadow: var(--shadow-sm);
   }
   .calibration-header { margin-bottom: 0.8rem; }
   .calibration-header h3 { margin: 0 0 0.3rem; font-size: 16px; }
@@ -212,262 +136,210 @@
   .calibration-table { width: 100%; border-collapse: collapse; margin-top: 0.5rem; }
   .calibration-table th,
   .calibration-table td {
-    padding: 0.5rem 0.75rem;
-    text-align: left;
+    padding: 0.5rem 0.75rem; text-align: left;
     border-bottom: 1px solid var(--border-subtle, var(--border));
   }
   .calibration-table th {
     background: var(--bg-elevated, var(--bg-nav));
-    font-size: 12px;
-    color: var(--text-2, var(--text-muted));
-    font-weight: 600;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
+    font-size: 12px; color: var(--text-2, var(--text-muted));
+    font-weight: 600; letter-spacing: 0.05em; text-transform: uppercase;
   }
   .cal-bar { width: 160px; height: 8px; background: var(--bg-elevated, var(--bg-hover)); border-radius: 4px; overflow: hidden; }
-
-  /* Step D: cal-bar-fill 시맨틱 토큰화 — claude-dark 에서 sage 톤 자동 적용
-     Step D: semantic tokenization — auto sage in claude-dark theme */
   .cal-bar-fill { height: 100%; background: linear-gradient(90deg, var(--success), var(--success)); opacity: .85; transition: width 0.3s ease; }
 
-  /* ── 반응형 ─────────────────────────────────────────────────────── */
+  /* 반응형
+     Responsive */
   @media (max-width: 768px) {
-    .overview-header { flex-direction: column; align-items: flex-start; margin-bottom: var(--space-5); }
-
-    /* B4: 테이블 헤더/셀 세로 wrap ("평/균/점/수") 방지 + 가로 스크롤
-       B4: prevent vertical wrap on narrow th/td + horizontal scroll */
-    .table-wrap th, .table-wrap td { white-space: nowrap; }
-    .repo-link { white-space: nowrap; }
-
-    /* B4: 설정 링크 클릭 영역 강화 (모바일 손가락 권장 ≥40px)
-       B4: enlarge settings-link tap target on mobile (≥40px) */
-    .settings-link { padding: 8px 12px; min-height: 44px; box-sizing: border-box; }
+    .overview-wrap { padding: var(--space-5, 1.25rem) var(--space-4, 1rem) var(--space-6, 1.5rem); }
+    .ov-head { flex-direction: column; align-items: flex-start; margin-bottom: var(--space-5, 1.25rem); }
+    .repo-grid { grid-template-columns: 1fr; }
   }
 </style>
 
-<div class="overview-header">
-  <div>
-    {# Phase 1B (UI 개편) — 친근한 환영 인사 (current_user 있을 때만) / Phase 2 PR-5 — 다국어 적용 #}
-    {# Phase 1B (UI redesign) — friendly greeting (only when current_user exists) / Phase 2 PR-5 — i18n applied #}
-    {% if current_user %}
-    <p class="overview-greeting">{{ 'overview.greeting' | i18n_args(locale | default('ko'), name=(current_user.display_name or current_user.github_login)) }} 👋</p>
-    {% endif %}
-    <h2 class="overview-title">{% if repos %}{{ 'overview.title' | i18n_args(locale | default('ko')) }}{% else %}{{ 'overview.title_empty' | i18n_args(locale | default('ko')) }}{% endif %}</h2>
+<div class="overview-wrap">
+  <div class="ov-head">
+    <div>
+      {# 친근한 환영 인사 (current_user 있을 때만) / 다국어 적용
+         Friendly greeting (only when current_user exists) / i18n applied #}
+      {% if current_user %}
+      <p class="ov-head-greeting">{{ 'overview.greeting' | i18n_args(locale | default('ko'), name=(current_user.display_name or current_user.github_login)) }} 👋</p>
+      {% endif %}
+      <h2 class="ov-head-title">{% if repos %}{{ 'overview.title' | i18n_args(locale | default('ko')) }}{% else %}{{ 'overview.title_empty' | i18n_args(locale | default('ko')) }}{% endif %}</h2>
+    </div>
+    <div style="display: flex; align-items: center; gap: var(--space-3, 0.75rem);">
+      {% if repos %}
+      <span class="repo-count">{{ 'overview.repo_count' | i18n_args(locale | default('ko'), count=repos | length) }}</span>
+      {% endif %}
+      <a href="/repos/add" class="btn btn-primary btn--sm">{{ 'overview.add_repo' | i18n_args(locale | default('ko')) }}</a>
+    </div>
   </div>
-  <div class="overview-actions">
-    {% if repos %}
-    <span class="repo-count">{{ 'overview.repo_count' | i18n_args(locale | default('ko'), count=repos | length) }}</span>
-    {% endif %}
-    <a href="/repos/add" class="btn btn-primary btn--sm">{{ 'overview.add_repo' | i18n_args(locale | default('ko')) }}</a>
-  </div>
-</div>
 
-{% if repos %}
-<div class="overview-table-card">
-  <div class="table-wrap">
-    <table>
+  {% if repos %}
+  <div class="repo-grid">
+    {% for item in repos %}
+    <a class="repo-card reveal" href="/repos/{{ item.full_name }}">
+      <div class="repo-card__row">
+        <span class="repo-card__name">{{ item.full_name }}</span>
+        {% if item.avg_grade %}
+        {# (value or 'f') | lower — None 함정 방지 (ui.md 규칙)
+           (value or 'f') | lower — guard against None (ui.md rule) #}
+        <span class="grade grade-{{ item.avg_grade }}">{{ item.avg_grade }}</span>
+        {% endif %}
+      </div>
+      {% if item.avg_score %}
+      <div class="score-bar score-bar--{{ (item.avg_grade or 'F') | lower }}"
+           style="--sb-pct: {{ item.avg_score | round | int }}%;">
+      </div>
+      <div class="repo-card__score-row">
+        <span class="repo-card__score">{{ item.avg_score }}<span style="color: var(--text-3, rgba(255,255,255,0.4)); font-size:11px;">/100</span></span>
+        <span class="repo-card__meta">{{ 'overview.analysis_count_unit' | i18n_args(locale | default('ko'), count=item.analysis_count) }}</span>
+      </div>
+      {% else %}
+      <span class="repo-card__meta" style="color: var(--text-2, rgba(255,255,255,0.6));">{{ 'overview.analysis_count_unit' | i18n_args(locale | default('ko'), count=item.analysis_count) }}</span>
+      {% endif %}
+    </a>
+    {% endfor %}
+  </div>
+  {% else %}
+  {# Phase E.5 — Onboarding 3단계 튜토리얼 (리포 0개일 때만 노출)
+     Phase E.5 — Onboarding 3-step tutorial (shown only when no repos) #}
+  <style>
+    /* 튜토리얼 카드 공통 (리포 없을 때만 로드)
+       Tutorial card common (loaded only when no repos) */
+    .get-started-tutorial {
+      padding: 1.4rem 1.6rem;
+      background: var(--bg-card, var(--bg-surface));
+      backdrop-filter: blur(12px) saturate(150%);
+      border: 1px solid var(--border-subtle, var(--border));
+      border-radius: 16px;
+      box-shadow: var(--shadow-sm);
+    }
+    .gst-header { margin-bottom: 1.2rem; }
+    .gst-title { margin: 0 0 0.3rem; font-size: 20px; }
+    .gst-subtitle { margin: 0; color: var(--text-2, var(--text-muted)); font-size: 14px; }
+
+    /* Step E (E5): 데스크탑 ≥1024px 에서 3-col grid
+       Step E (E5): 3-col grid on desktop ≥1024px */
+    .gst-steps { display: flex; flex-direction: column; gap: 0.9rem; }
+    @media (min-width: 1024px) {
+      .gst-steps { display: grid; grid-template-columns: repeat(3, 1fr); align-items: stretch; }
+    }
+
+    /* 튜토리얼 단계 카드
+       Tutorial step card */
+    .gst-step {
+      display: flex; gap: 1rem; align-items: flex-start;
+      padding: 1rem 1.1rem;
+      background: var(--bg-elevated, var(--bg-hover));
+      border-radius: 10px;
+      border: 1px solid var(--border-subtle, var(--border));
+      transition: transform 0.2s, box-shadow 0.2s;
+    }
+    .gst-step:hover { transform: translateY(-2px); box-shadow: var(--shadow-md); }
+    .gst-step-num {
+      flex-shrink: 0; width: 36px; height: 36px; border-radius: 50%;
+      background: linear-gradient(135deg, var(--accent), var(--accent-2, var(--accent)));
+      color: var(--btn-on-accent, white);
+      display: flex; align-items: center; justify-content: center;
+      font-weight: 700; font-size: 16px;
+    }
+    .gst-step-body { flex: 1; }
+    .gst-step-title { font-size: 15px; font-weight: 700; color: var(--text-1, var(--text-primary)); margin-bottom: 0.25rem; }
+    .gst-step-desc { font-size: 13px; color: var(--text-2, var(--text-muted)); line-height: 1.5; }
+    .gst-step-desc code { background: var(--bg-card); padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 12px; }
+    .gst-cta { margin-top: 0.5rem; }
+    .gst-footer {
+      margin-top: 1rem; padding: 0.7rem 0.9rem;
+      background: rgba(var(--accent-rgb, 99,102,241), 0.08);
+      border-radius: 6px; border-left: 3px solid var(--accent);
+    }
+    .gst-footer-hint { font-size: 12px; color: var(--text-1, var(--text-primary)); }
+    .gst-footer-hint code { background: var(--bg-card); padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 12px; }
+  </style>
+  <div class="get-started-tutorial">
+    {# Cycle 94 Step 2-B — 3-step onboarding illustration #}
+    <img src="/static/illustrations/overview_onboarding.png"
+         class="illustration illustration--tutorial"
+         alt=""
+         role="presentation"
+         loading="eager"
+         decoding="async">
+    <div class="gst-header">
+      <h2 class="gst-title">🚀 {{ 'overview.tutorial.title' | i18n_args(locale | default('ko')) }}</h2>
+      <p class="gst-subtitle">{{ 'overview.tutorial.subtitle' | i18n_args(locale | default('ko')) }}</p>
+    </div>
+    <div class="gst-steps">
+      <div class="gst-step">
+        <div class="gst-step-num">1</div>
+        <div class="gst-step-body">
+          <div class="gst-step-title">{{ 'overview.tutorial.step1_title' | i18n_args(locale | default('ko')) }}</div>
+          <div class="gst-step-desc">{{ 'overview.tutorial.step1_desc' | i18n_args(locale | default('ko')) }}</div>
+          <a href="/repos/add" class="btn btn-primary btn--sm gst-cta">{{ 'overview.tutorial.step1_cta' | i18n_args(locale | default('ko')) }}</a>
+        </div>
+      </div>
+      <div class="gst-step">
+        <div class="gst-step-num">2</div>
+        <div class="gst-step-body">
+          <div class="gst-step-title">{{ 'overview.tutorial.step2_title' | i18n_args(locale | default('ko')) }}</div>
+          <div class="gst-step-desc">
+            {{ 'overview.tutorial.step2_desc_part1' | i18n_args(locale | default('ko')) }}<strong>{{ 'overview.tutorial.step2_desc_preset' | i18n_args(locale | default('ko')) }}</strong>{{ 'overview.tutorial.step2_desc_part2' | i18n_args(locale | default('ko')) }}
+          </div>
+        </div>
+      </div>
+      <div class="gst-step">
+        <div class="gst-step-num">3</div>
+        <div class="gst-step-body">
+          <div class="gst-step-title">{{ 'overview.tutorial.step3_title' | i18n_args(locale | default('ko')) }}</div>
+          <div class="gst-step-desc">{{ 'overview.tutorial.step3_desc' | i18n_args(locale | default('ko')) }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="gst-footer">
+      <div class="gst-footer-hint">
+        💡 <strong>{{ 'overview.tutorial.tip_label' | i18n_args(locale | default('ko')) }}</strong>{{ 'overview.tutorial.tip_desc_part1' | i18n_args(locale | default('ko')) }}<code>ANTHROPIC_API_KEY</code>{{ 'overview.tutorial.tip_desc_part2' | i18n_args(locale | default('ko')) }}
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
+  {# Phase E.3-d — AI 점수 정합도 지표 (피드백 1건 이상 있을 때만 노출)
+     Phase E.3-d — AI calibration (shown only when feedback count > 0) #}
+  {% set cal_total = calibration.values() | map(attribute='count') | sum %}
+  {% if calibration and cal_total > 0 %}
+  <div class="calibration-card reveal">
+    <div class="calibration-header">
+      <h3>📊 {{ 'overview.calibration.title' | i18n_args(locale | default('ko')) }}</h3>
+      <span class="calibration-hint">{{ 'overview.calibration.hint' | i18n_args(locale | default('ko')) }}</span>
+    </div>
+    <table class="calibration-table">
       <thead>
         <tr>
-          <th>{{ 'overview.table.repository' | i18n_args(locale | default('ko')) }}</th>
-          <th>{{ 'overview.table.analysis' | i18n_args(locale | default('ko')) }}</th>
-          <th>{{ 'overview.table.avg_score' | i18n_args(locale | default('ko')) }}</th>
-          <th>{{ 'overview.table.grade' | i18n_args(locale | default('ko')) }}</th>
-          <th></th>
+          <th>{{ 'overview.calibration.range' | i18n_args(locale | default('ko')) }}</th>
+          <th>{{ 'overview.calibration.feedback_count' | i18n_args(locale | default('ko')) }}</th>
+          <th>{{ 'overview.calibration.up_ratio' | i18n_args(locale | default('ko')) }}</th>
+          <th>{{ 'overview.calibration.visualization' | i18n_args(locale | default('ko')) }}</th>
         </tr>
       </thead>
       <tbody>
-      {% for item in repos %}
-      <tr class="repo-row reveal">
-        <td>
-          <a class="repo-link" href="/repos/{{ item.full_name }}">{{ item.full_name }}</a>
-        </td>
-        <td><span class="analysis-count">{{ 'overview.analysis_count_unit' | i18n_args(locale | default('ko'), count=item.analysis_count) }}</span></td>
-        <td>
-          {% if item.avg_score %}
-          <span class="score-cell {% if item.avg_score >= 75 %}score-high{% elif item.avg_score >= 50 %}score-mid{% else %}score-low{% endif %}">
-            {{ item.avg_score }}
-          </span>
-          {% else %}
-          <span style="color:var(--text-2, var(--text-muted))">—</span>
-          {% endif %}
-        </td>
-        <td>
-          {% if item.avg_grade %}
-          <span class="grade grade-{{ item.avg_grade }}">{{ item.avg_grade }}</span>
-          {% endif %}
-        </td>
-        <td><a class="settings-link" href="/repos/{{ item.full_name }}/settings">⚙️ {{ 'overview.settings_link' | i18n_args(locale | default('ko')) }}</a></td>
-      </tr>
+      {% for range_name, data in calibration.items() %}
+        {% if data.count > 0 %}
+        <tr>
+          <td><strong>{{ range_name }}</strong></td>
+          <td>{{ data.count }}</td>
+          <td>{{ "%.1f"|format(data.up_ratio * 100) }}%</td>
+          <td>
+            <div class="cal-bar">
+              <div class="cal-bar-fill" style="width: {{ (data.up_ratio * 100) | round(1) }}%"></div>
+            </div>
+          </td>
+        </tr>
+        {% endif %}
       {% endfor %}
       </tbody>
     </table>
   </div>
-</div>
-{% else %}
-{# Phase E.5 — Onboarding 3단계 튜토리얼 (리포 0개일 때만 노출) #}
-<style>
-  /* 빈 상태 컨테이너 (리포 없을 때만 로드)
-     Empty-state container (loaded only when no repos) */
-  .empty-state {
-    text-align: center;
-    padding: 4rem 2rem;
-  }
-  .empty-icon { font-size: 2.5rem; margin-bottom: var(--space-4); opacity: 0.4; }
-  .empty-state p { color: var(--text-2, var(--text-muted)); margin: 0; font-size: var(--fs-sm); line-height: 1.7; }
+  {% endif %}
 
-  /* 튜토리얼 카드 공통 (리포 없을 때만 로드)
-     Tutorial card common (loaded only when no repos) */
-  .get-started-tutorial {
-    padding: 1.4rem 1.6rem;
-    background: var(--bg-card, var(--bg-surface));
-    backdrop-filter: blur(12px) saturate(150%);
-    border: 1px solid var(--border-subtle, var(--border));
-    border-radius: 16px;
-    box-shadow: var(--shadow-sm);
-  }
-  .gst-header { margin-bottom: 1.2rem; }
-  .gst-title { margin: 0 0 0.3rem; font-size: 20px; }
-  .gst-subtitle { margin: 0; color: var(--text-2, var(--text-muted)); font-size: 14px; }
-
-  /* Step E (E5): 데스크탑 ≥1024px 에서 3-col grid (튜토리얼 카드 가로 펼침)
-     모바일은 1-col 유지 (col 너비 부족).
-     Step E (E5): 3-col grid on desktop ≥1024px; 1-col stack on mobile */
-  .gst-steps { display: flex; flex-direction: column; gap: 0.9rem; }
-  @media (min-width: 1024px) {
-    .gst-steps { display: grid; grid-template-columns: repeat(3, 1fr); align-items: stretch; }
-  }
-
-  /* 튜토리얼 단계 카드
-     Tutorial step card */
-  .gst-step {
-    display: flex;
-    gap: 1rem;
-    align-items: flex-start;
-    padding: 1rem 1.1rem;
-    background: var(--bg-elevated, var(--bg-hover));
-    border-radius: 10px;
-    border: 1px solid var(--border-subtle, var(--border));
-    transition: transform 0.2s, box-shadow 0.2s;
-  }
-  .gst-step:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-md);
-  }
-  .gst-step-num {
-    flex-shrink: 0;
-    width: 36px;
-    height: 36px;
-    border-radius: 50%;
-    background: linear-gradient(135deg, var(--accent), var(--accent-2, var(--accent)));
-    color: var(--btn-on-accent, white);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: 700;
-    font-size: 16px;
-  }
-  .gst-step-body { flex: 1; }
-  .gst-step-title { font-size: 15px; font-weight: 700; color: var(--text-1, var(--text-primary)); margin-bottom: 0.25rem; }
-  .gst-step-desc { font-size: 13px; color: var(--text-2, var(--text-muted)); line-height: 1.5; }
-  .gst-step-desc code { background: var(--bg-card); padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 12px; }
-  .gst-cta { margin-top: 0.5rem; }
-
-  /* 팁 푸터
-     Tip footer */
-  .gst-footer {
-    margin-top: 1rem;
-    padding: 0.7rem 0.9rem;
-    background: rgba(var(--accent-rgb, 99,102,241), 0.08);
-    border-radius: 6px;
-    border-left: 3px solid var(--accent);
-  }
-  .gst-footer-hint { font-size: 12px; color: var(--text-1, var(--text-primary)); }
-  .gst-footer-hint code { background: var(--bg-card); padding: 0.1rem 0.35rem; border-radius: 3px; font-size: 12px; }
-</style>
-<div class="get-started-tutorial">
-  {# Cycle 94 Step 2-B — 3-step onboarding 일러스트 (1792x1024 가로형)
-     Cycle 94 Step 2-B — 3-step onboarding illustration (1792x1024 landscape) #}
-  <img src="/static/illustrations/overview_onboarding.png"
-       class="illustration illustration--tutorial"
-       alt=""
-       role="presentation"
-       loading="eager"
-       decoding="async">
-  <div class="gst-header">
-    <h2 class="gst-title">🚀 {{ 'overview.tutorial.title' | i18n_args(locale | default('ko')) }}</h2>
-    <p class="gst-subtitle">{{ 'overview.tutorial.subtitle' | i18n_args(locale | default('ko')) }}</p>
-  </div>
-  <div class="gst-steps">
-    <div class="gst-step">
-      <div class="gst-step-num">1</div>
-      <div class="gst-step-body">
-        <div class="gst-step-title">{{ 'overview.tutorial.step1_title' | i18n_args(locale | default('ko')) }}</div>
-        <div class="gst-step-desc">{{ 'overview.tutorial.step1_desc' | i18n_args(locale | default('ko')) }}</div>
-        <a href="/repos/add" class="btn btn-primary btn--sm gst-cta">{{ 'overview.tutorial.step1_cta' | i18n_args(locale | default('ko')) }}</a>
-      </div>
-    </div>
-    <div class="gst-step">
-      <div class="gst-step-num">2</div>
-      <div class="gst-step-body">
-        <div class="gst-step-title">{{ 'overview.tutorial.step2_title' | i18n_args(locale | default('ko')) }}</div>
-        <div class="gst-step-desc">
-          {{ 'overview.tutorial.step2_desc_part1' | i18n_args(locale | default('ko')) }}<strong>{{ 'overview.tutorial.step2_desc_preset' | i18n_args(locale | default('ko')) }}</strong>{{ 'overview.tutorial.step2_desc_part2' | i18n_args(locale | default('ko')) }}
-        </div>
-      </div>
-    </div>
-    <div class="gst-step">
-      <div class="gst-step-num">3</div>
-      <div class="gst-step-body">
-        <div class="gst-step-title">{{ 'overview.tutorial.step3_title' | i18n_args(locale | default('ko')) }}</div>
-        <div class="gst-step-desc">
-          {{ 'overview.tutorial.step3_desc' | i18n_args(locale | default('ko')) }}
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="gst-footer">
-    <div class="gst-footer-hint">
-      💡 <strong>{{ 'overview.tutorial.tip_label' | i18n_args(locale | default('ko')) }}</strong>{{ 'overview.tutorial.tip_desc_part1' | i18n_args(locale | default('ko')) }}<code>ANTHROPIC_API_KEY</code>{{ 'overview.tutorial.tip_desc_part2' | i18n_args(locale | default('ko')) }}
-    </div>
-  </div>
-</div>
-{% endif %}
-
-{# Phase E.3-d — AI 점수 정합도 지표 (피드백 1건 이상 있을 때만 노출) #}
-{% set cal_total = calibration.values() | map(attribute='count') | sum %}
-{% if calibration and cal_total > 0 %}
-<div class="calibration-card reveal">
-  <div class="calibration-header">
-    <h3>📊 {{ 'overview.calibration.title' | i18n_args(locale | default('ko')) }}</h3>
-    <span class="calibration-hint">{{ 'overview.calibration.hint' | i18n_args(locale | default('ko')) }}</span>
-  </div>
-  <table class="calibration-table">
-    <thead>
-      <tr>
-        <th>{{ 'overview.calibration.range' | i18n_args(locale | default('ko')) }}</th>
-        <th>{{ 'overview.calibration.feedback_count' | i18n_args(locale | default('ko')) }}</th>
-        <th>{{ 'overview.calibration.up_ratio' | i18n_args(locale | default('ko')) }}</th>
-        <th>{{ 'overview.calibration.visualization' | i18n_args(locale | default('ko')) }}</th>
-      </tr>
-    </thead>
-    <tbody>
-    {% for range_name, data in calibration.items() %}
-      {% if data.count > 0 %}
-      <tr>
-        <td><strong>{{ range_name }}</strong></td>
-        <td>{{ data.count }}</td>
-        <td>{{ "%.1f"|format(data.up_ratio * 100) }}%</td>
-        <td>
-          <div class="cal-bar">
-            <div class="cal-bar-fill" style="width: {{ (data.up_ratio * 100) | round(1) }}%"></div>
-          </div>
-        </td>
-      </tr>
-      {% endif %}
-    {% endfor %}
-    </tbody>
-  </table>
-</div>
-{% endif %}
+</div>{# /overview-wrap #}
 
 {% endblock %}

--- a/src/templates/overview.html
+++ b/src/templates/overview.html
@@ -106,11 +106,11 @@
     text-transform: uppercase; letter-spacing: 0.05em; flex-shrink: 0;
     animation: var(--anim-badge-pop);
   }
-  .grade-A { background: rgba(52,211,153,0.12); color: #34d399; border-color: rgba(52,211,153,0.32); }
-  .grade-B { background: rgba(96,165,250,0.12); color: #60a5fa; border-color: rgba(96,165,250,0.32); }
-  .grade-C { background: rgba(251,191,36,.12);  color: #fbbf24; border-color: rgba(251,191,36,0.32); }
-  .grade-D { background: rgba(251,146,60,.12);  color: #fb923c; border-color: rgba(251,146,60,0.32); }
-  .grade-F { background: rgba(248,113,113,.12); color: #f87171; border-color: rgba(248,113,113,0.32); }
+  .grade--a { background: rgba(52,211,153,0.12); color: #34d399; border-color: rgba(52,211,153,0.32); }
+  .grade--b { background: rgba(96,165,250,0.12); color: #60a5fa; border-color: rgba(96,165,250,0.32); }
+  .grade--c { background: rgba(251,191,36,.12);  color: #fbbf24; border-color: rgba(251,191,36,0.32); }
+  .grade--d { background: rgba(251,146,60,.12);  color: #fb923c; border-color: rgba(251,146,60,0.32); }
+  .grade--f { background: rgba(248,113,113,.12); color: #f87171; border-color: rgba(248,113,113,0.32); }
 
   /* 빈 상태
      Empty state */
@@ -183,11 +183,11 @@
         {% if item.avg_grade %}
         {# (value or 'f') | lower — None 함정 방지 (ui.md 규칙)
            (value or 'f') | lower — guard against None (ui.md rule) #}
-        <span class="grade grade-{{ item.avg_grade }}">{{ item.avg_grade }}</span>
+        <span class="grade grade--{{ (item.avg_grade or 'f') | lower }}">{{ item.avg_grade or 'F' }}</span>
         {% endif %}
       </div>
       {% if item.avg_score %}
-      <div class="score-bar score-bar--{{ (item.avg_grade or 'F') | lower }}"
+      <div class="score-bar score-bar--{{ (item.avg_grade or 'f') | lower }}"
            style="--sb-pct: {{ item.avg_score | round | int }}%;">
       </div>
       <div class="repo-card__score-row">

--- a/tests/unit/templates/test_i18n_template_render.py
+++ b/tests/unit/templates/test_i18n_template_render.py
@@ -77,7 +77,7 @@ class _FakeUser:
 
 
 def test_overview_html_with_repos_renders_korean():
-    """overview.html (리포 ≥ 1) — 한국어 greeting + table header + repo_count."""
+    """overview.html (리포 ≥ 1) — 한국어 greeting + card 구조 + repo_count."""
     repos = [{"full_name": "owner/repo", "analysis_count": 5, "avg_score": 80, "avg_grade": "B"}]
     out = _render(
         "overview.html",
@@ -89,15 +89,13 @@ def test_overview_html_with_repos_renders_korean():
     assert "안녕하세요, Alice님" in out  # greeting
     assert "오늘의 분석" in out  # title (with repos)
     assert "1개 리포" in out  # repo_count
-    assert "리포지토리</th>" in out  # table.repository
-    assert "분석</th>" in out  # table.analysis
-    assert "평균 점수</th>" in out  # table.avg_score
-    assert "등급</th>" in out  # table.grade
+    assert "owner/repo" in out  # repo card name
+    assert "grade-B" in out  # grade badge CSS class
     assert "5회</span>" in out  # analysis_count_unit
 
 
 def test_overview_html_with_repos_renders_english():
-    """overview.html (리포 ≥ 1) — 영문 greeting + table header + repo_count."""
+    """overview.html (리포 ≥ 1) — 영문 greeting + card 구조 + repo_count."""
     repos = [{"full_name": "owner/repo", "analysis_count": 5, "avg_score": 80, "avg_grade": "B"}]
     out = _render(
         "overview.html",
@@ -109,13 +107,13 @@ def test_overview_html_with_repos_renders_english():
     assert "Hello, Alice" in out
     assert "Today&#39;s Analyses" in out  # apostrophe escaped
     assert "1 repos" in out
-    assert "Repository</th>" in out
-    assert "Average Score</th>" in out
+    assert "owner/repo" in out  # repo card name
+    assert "grade-B" in out  # grade badge CSS class
     assert "5 runs</span>" in out
 
 
 def test_overview_html_with_repos_renders_japanese():
-    """overview.html (리포 ≥ 1) — 일본어 greeting + table header + repo_count."""
+    """overview.html (리포 ≥ 1) — 일본어 greeting + card 구조 + repo_count."""
     repos = [{"full_name": "owner/repo", "analysis_count": 5, "avg_score": 80, "avg_grade": "B"}]
     out = _render(
         "overview.html",
@@ -127,8 +125,8 @@ def test_overview_html_with_repos_renders_japanese():
     assert "こんにちは、Aliceさん" in out
     assert "本日の分析" in out
     assert "1個のリポ" in out
-    assert "リポジトリ</th>" in out
-    assert "平均スコア</th>" in out
+    assert "owner/repo" in out  # repo card name
+    assert "grade-B" in out  # grade badge CSS class
     assert "5回</span>" in out
 
 

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -1674,10 +1674,9 @@ def test_overview_does_not_show_latest_score_column():
 
 
 def test_overview_grade_derived_from_avg_score():
-    """avg_map에 {1: 92.0} 반환 시 등급 뱃지 'grade-A'가 HTML에 포함되어야 한다.
-    변경 예정: 등급 컬럼을 최신 grade가 아닌 평균 점수 기반 calculate_grade(avg_score)로 변경.
-    평균 92점 → GRADE_THRESHOLDS A≥90 → 'grade-A' CSS 클래스.
-    구현 전에는 avg 기반 grade 렌더링이 없으므로 이 테스트는 실패(Red).
+    """avg_map에 {1: 92.0} 반환 시 등급 뱃지 'grade--a'가 HTML에 포함되어야 한다.
+    등급 컬럼은 최신 grade가 아닌 평균 점수 기반 calculate_grade(avg_score)로 산출.
+    평균 92점 → GRADE_THRESHOLDS A≥90 → 'grade--a' BEM CSS 클래스.
     """
     mock_db = MagicMock()
     mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1, created_at="2026-01-01")
@@ -1695,9 +1694,9 @@ def test_overview_grade_derived_from_avg_score():
     with patch("src.ui.routes.overview.SessionLocal", return_value=_ctx(mock_db)):
         r = client.get("/")
     assert r.status_code == 200
-    # 평균 92점 → grade A → 템플릿에서 <span class="grade grade-A"> 뱃지 스팬으로 렌더
-    # 현재 구현(latest_grade 기반)에서는 latest_map이 비어 있어 이 스팬이 없음 → Red
-    assert '<span class="grade grade-A">' in r.text
+    # 평균 92점 → grade A → 템플릿에서 <span class="grade grade--a"> 뱃지 스팬으로 렌더 (BEM 패턴)
+    # Average 92 → grade A → template renders <span class="grade grade--a"> badge (BEM pattern)
+    assert '<span class="grade grade--a">' in r.text
 
 
 # ── Settings 페이지 재설계 스모크 테스트 (2026-04-21) ──────────────────────────

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -73,19 +73,25 @@ def test_overview_returns_html():
 
 
 def test_overview_with_repos_shows_avg_score():
-    """리포 목록에 평균 점수(avg_score) 컬럼이 표시되어야 한다 (i18n: en/ko)."""
+    """리포 목록에 평균 점수(avg_score)가 카드 형태로 표시되어야 한다.
+    v3 card redesign — table 헤더 제거, 카드 내 점수 표시로 변경.
+    """
     mock_db = MagicMock()
     mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1, created_at="2026-01-01")
     mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [mock_repo]
-    # count_map, avg_map → dict([]) = {}, latest_map → {}
-    mock_db.query.return_value.filter.return_value.group_by.return_value.all.return_value = []
+    # count_map → [(1, 1)], avg_map → [(1, 75.0)]
+    # v3 card redesign — avg_score rendered in repo-card, not table column
+    mock_db.query.return_value.filter.return_value.group_by.return_value.all.side_effect = [
+        [(1, 1)],     # count_map
+        [(1, 75.0)],  # avg_map
+    ]
     mock_db.query.return_value.filter.return_value.all.return_value = []
     with patch("src.ui.routes.overview.SessionLocal", return_value=_ctx(mock_db)):
         r = client.get("/")
     assert r.status_code == 200
-    # Phase 2 PR-5 (사이클 84) — i18n 적용 후 default locale (en) 기준
-    # Phase 2 PR-5 (Cycle 84) — after i18n, default locale (en) baseline
-    assert "Average Score" in r.text or "평균 점수" in r.text
+    # v3 카드 — 점수는 repo-card__score span 으로 렌더 (테이블 헤더 없음)
+    # v3 card — score rendered in repo-card__score span (no table header)
+    assert "repo-card__score" in r.text or "/100" in r.text
 
 
 def test_repo_detail_returns_html():


### PR DESCRIPTION
## Summary
- overview: .repo-card hover-lift 그리드 + .score-bar (--sb-pct 인라인) + .grade--a/b/c/d/f BEM
- overview: grade 배지 (item.avg_grade or 'f') | lower 패턴 (None 트랩 방지)
- overview: score-bar clamp [0,100] 적용
- add_repo: .step-card 번호 레이아웃 + decoding="async" 수정
- 테스트: test_overview_grade_derived_from_avg_score grade-A → grade--a 업데이트

## 🔍 사용자 검증 필요 (정책 11)
- [ ] dark/light: 리포 카드 hover lift + accent bar 효과
- [ ] grade 배지 색상 (A=녹색, F=빨간색)
- [ ] score-bar 너비 정확도 (100점 = 100%, 0점 = 0%)
- [ ] mobile: 카드 그리드 1컬럼 + 44px 탭 타깃

🤖 Generated with Claude Code