### PR TITLE
feat(ui): admin pages redesign — tbl class, badge BEM (PR-P7)

### DIFF
--- a/src/static/css/admin.css
+++ b/src/static/css/admin.css
@@ -100,6 +100,37 @@
   font-size: 11px;
 }
 
+/* ── BEM 배지 별칭 (badge + badge--*) / BEM badge aliases ── */
+/* badge-success/danger 구형 클래스와 공존 / coexists with legacy badge-* classes */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 10px;
+  border-radius: 20px;
+  font-size: 12px;
+  font-weight: 600;
+  animation: var(--anim-badge-pop);
+}
+
+.badge--success {
+  background: color-mix(in srgb, var(--success) 15%, transparent);
+  color: var(--success);
+  border: 1px solid color-mix(in srgb, var(--success) 30%, transparent);
+}
+
+.badge--danger {
+  background: color-mix(in srgb, var(--danger) 15%, transparent);
+  color: var(--danger);
+  border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
+}
+
+.badge--warn {
+  background: color-mix(in srgb, var(--warning) 15%, transparent);
+  color: var(--warning);
+  border: 1px solid color-mix(in srgb, var(--warning) 30%, transparent);
+}
+
 /* ── 테이블 컨테이너 / Table container ───────────────────── */
 .admin-table-wrap {
   overflow-x: auto;

--- a/src/static/css/admin.css
+++ b/src/static/css/admin.css
@@ -67,6 +67,9 @@
 }
 
 /* ── 상태 배지 (공통) / Status badges (shared) ───────────── */
+/* .badge base + legacy selectors share one layout block
+   .badge 기반 + 레거시 셀렉터가 하나의 레이아웃 블록 공유 */
+.badge,
 .badge-success,
 .badge-danger,
 .status-applied,
@@ -81,6 +84,7 @@
   animation: var(--anim-badge-pop);
 }
 
+.badge--success,
 .badge-success,
 .status-applied {
   background: color-mix(in srgb, var(--success) 15%, transparent);
@@ -88,38 +92,9 @@
   border: 1px solid color-mix(in srgb, var(--success) 30%, transparent);
 }
 
+.badge--danger,
 .badge-danger,
 .status-missing {
-  background: color-mix(in srgb, var(--danger) 15%, transparent);
-  color: var(--danger);
-  border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
-}
-
-.status-applied,
-.status-missing {
-  font-size: 11px;
-}
-
-/* ── BEM 배지 별칭 (badge + badge--*) / BEM badge aliases ── */
-/* badge-success/danger 구형 클래스와 공존 / coexists with legacy badge-* classes */
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 2px 10px;
-  border-radius: 20px;
-  font-size: 12px;
-  font-weight: 600;
-  animation: var(--anim-badge-pop);
-}
-
-.badge--success {
-  background: color-mix(in srgb, var(--success) 15%, transparent);
-  color: var(--success);
-  border: 1px solid color-mix(in srgb, var(--success) 30%, transparent);
-}
-
-.badge--danger {
   background: color-mix(in srgb, var(--danger) 15%, transparent);
   color: var(--danger);
   border: 1px solid color-mix(in srgb, var(--danger) 30%, transparent);
@@ -129,6 +104,18 @@
   background: color-mix(in srgb, var(--warning) 15%, transparent);
   color: var(--warning);
   border: 1px solid color-mix(in srgb, var(--warning) 30%, transparent);
+}
+
+.status-applied,
+.status-missing {
+  font-size: 11px;
+}
+
+/* .tbl は components.css がマージされると定義される前方互換フック
+   .tbl is a forward-compat hook — defined in components.css once Task 2 merges */
+.tbl {
+  width: 100%;
+  border-collapse: collapse;
 }
 
 /* ── 테이블 컨테이너 / Table container ───────────────────── */

--- a/src/templates/admin_rls_audit.html
+++ b/src/templates/admin_rls_audit.html
@@ -18,17 +18,17 @@
   <div class="admin-summary-bar">
     <strong>{{ 'admin.rls_audit.total_label' | i18n_args(locale | default('ko')) }}</strong>: {{ summary.total }}
     <span class="sep">·</span>
-    <span class="badge-success">{{ 'admin.rls_audit.applied_label' | i18n_args(locale | default('ko'), count=summary.applied) }}</span>
+    <span class="badge badge--success">{{ 'admin.rls_audit.applied_label' | i18n_args(locale | default('ko'), count=summary.applied) }}</span>
     {% if summary.missing > 0 %}
     <span class="sep">·</span>
-    <span class="badge-danger">{{ 'admin.rls_audit.missing_label' | i18n_args(locale | default('ko'), count=summary.missing) }}</span>
+    <span class="badge badge--danger">{{ 'admin.rls_audit.missing_label' | i18n_args(locale | default('ko'), count=summary.missing) }}</span>
     {% endif %}
     <span class="sep">·</span>
     <a href="/admin/tenants" class="admin-link">{{ 'admin.rls_audit.tenants_link' | i18n_args(locale | default('ko')) }}</a>
   </div>
 
   <div class="admin-table-wrap">
-    <table class="admin-table">
+    <table class="admin-table tbl">
       <thead>
         <tr>
           <th>{{ 'admin.rls_audit.th.table' | i18n_args(locale | default('ko')) }}</th>
@@ -45,9 +45,9 @@
           <td class="mono">{{ m.since }}</td>
           <td>
             {% if m.status == "applied" %}
-            <span class="status-applied">{{ 'admin.rls_audit.status_applied' | i18n_args(locale | default('ko')) }}</span>
+            <span class="badge badge--success">{{ 'admin.rls_audit.status_applied' | i18n_args(locale | default('ko')) }}</span>
             {% else %}
-            <span class="status-missing">{{ 'admin.rls_audit.status_missing' | i18n_args(locale | default('ko')) }}</span>
+            <span class="badge badge--danger">{{ 'admin.rls_audit.status_missing' | i18n_args(locale | default('ko')) }}</span>
             {% endif %}
           </td>
         </tr>

--- a/src/templates/admin_tenants.html
+++ b/src/templates/admin_tenants.html
@@ -44,7 +44,7 @@
 
   {% if tenants %}
   <div class="admin-table-wrap">
-    <table class="admin-table">
+    <table class="admin-table tbl">
       <thead>
         <tr>
           <th>{{ 'admin.tenants.th.id' | i18n_args(locale | default('ko')) }}</th>


### PR DESCRIPTION
## Summary
- admin_rls_audit.html: <table class="admin-table tbl">, badge-success/danger → badge badge--success/danger
- admin_tenants.html: <table class="admin-table tbl">
- admin_operations.html: 테이블 없음 — 변경 없음
- admin.css: 레거시 .badge-success/.badge-danger + BEM .badge.badge--success 중복 베이스 블록 통합
- .tbl 전방 호환 stub 추가 (components.css 머지 후 스타일 자동 적용)

## 🔍 사용자 검증 필요 (정책 11)
- [ ] dark: 관리자 테이블 hover 효과, 상태 배지 색상 (success=녹색, danger=빨간색)
- [ ] 관리자 계정으로 /admin/operations, /admin/rls-audit, /admin/tenants 순차 확인
- [ ] 배지 클래스 전환 후 JS 오류 없는지 (브라우저 콘솔)

🤖 Generated with Claude Code