### PR TITLE
docs: STATE.md + cycle-history.md 사이클 131 Claude Design 재설계 이력 추가

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,11 +2,11 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-05-24 기준 — **사이클 130 완료**: pylint 10.00/10 복원 + IssueRegistration 타입 힌트 + codecov/patch 수정 (#617 머지)): 151+ PR #188~#617 — 누적 정책 본문 18건 + 메모리 17건. 전체 3185+ 수집 (단위 3009 + 통합 151) / E2E 112 (100 표준 + 12 perf) / pylint **10.00/10**
+## 현재 수치 (2026-05-25 기준 — **사이클 131 완료**: Claude Design UI 전체 재설계 9 PR (#625~#633) 머지): 151+ PR #188~#633 — 누적 정책 본문 18건 + 메모리 17건. 전체 3173 수집 (단위 3022 + 통합 151) / E2E 112 (100 표준 + 12 perf) / pylint **10.00/10**
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 전체 테스트 | **3185+ 수집** *(헤더 = 최신값, 이 셀 = pytest 누적 추적)* | `pytest tests/` — 단위 3009 + 통합 151. 추적 이력: (이전 사이클 73~128 누적 2948) + **사이클 129 #614 AI Issue 등록 +59** (모델 4 + 리포 8 + github_client 4 + 서비스 15 + API 17 + SonarCloud CPD fix-up, 2948→3007). + **사이클 130 #617 except Exception 경로 +2** (get_current_user DB 오류 + github_repos_list API 오류, 3007→3009). |
+| 전체 테스트 | **3173 수집** *(헤더 = 최신값, 이 셀 = pytest 누적 추적)* | `pytest tests/` — 단위 3022 + 통합 151. 추적 이력: (이전 사이클 73~128 누적 2948) + **사이클 129 #614 AI Issue 등록 +59** (2948→3007). + **사이클 130 #617 +2** (3007→3009). + **사이클 131 Claude Design 재설계 #625~#633 +13** (test_router.py + test_i18n_template_render.py 갱신, 3009→3022 단위). |
 | 통합 테스트 | **151개** | tests/integration/ — 사이클 81 영역 🅑 모바일 Phase 1 MVP +34 + **사이클 84 i18n PR-18 smoke +11** + **PR #400 repo insights +22** + **사이클 99 #441 +3** (repo_report_api auth·list·404) + **사이클 100~101 누적** (test_retry_concurrency_postgres assertion 강화). 기존 test_settings_mobile.py 일부 Windows cp949 인코딩 오류 제외. **= 151 passed** |
 | E2E 테스트 | **112개** | `make test-e2e` (Chromium Playwright) — Phase 3 PR 6 +7 + **사이클 84 i18n PR-16 +14** (3 언어 × 4 페이지 — login/overview/dashboard/settings + Cookie fallback + locale switch). 사이클 94 #372: test_save_success ordering 트랩 차단 (`_reset_repo_config()` 헬퍼) + test_two_column 보류 (`@pytest.mark.skip`). **+ 사이클 106 #500 `@pytest.mark.perf` 12개** (TTFB/FCP/LCP/DCL/Load — 3회 avg/min/max). **+ 사이클 127 #605 `test_nav_handler_survives_hx_boost_renavigation` +1** (hx-boost 3회 재방문 회귀 가드). **+ 사이클 127 #609 사전 실패 8건 해소** (5 TIMEOUT: test_theme.py glass/claude-dark 셀렉터 → pastel/catppuccin 갱신 + 3 ERROR: test_repos_mode.py auth_cookies 픽스처 제거). **= 112 collected (100 표준 + 12 perf)**. `make test-perf` 로 perf 마커만 선택 실행. ⚠️ e2e ↔ tests/integration 동시 실행 금지 — `e2e/pytest.ini` 의도적 asyncio_mode 미설정, 분리 실행 default (`make test-e2e` vs CI command `pytest tests/`) |
 | SonarCloud Quality Gate | **OK** | #399 머지 후 복원 — CPD 14%→<3%, mockup 제외, _NONE_LABEL 상수화 |

--- a/docs/cycle-history.md
+++ b/docs/cycle-history.md
@@ -5,6 +5,7 @@
 
 ## 목차
 
+- [사이클 131 (Claude Design UI 전체 재설계 9 PR — 토큰 시스템·컴포넌트·WCAG, 2026-05-25)](#사이클-131)
 - [사이클 130 (pylint 10.00/10 복원 + IssueRegistration 타입 힌트 + codecov/patch 수정, 2026-05-24)](#사이클-130)
 - [사이클 129 (AI Issue 등록 기능 Phase 1+2, 2026-05-24)](#사이클-129)
 - [Phase F~Phase 12 (그룹 시대)](#phase-f-phase-12)
@@ -38,6 +39,45 @@
 - [사이클 119 (5+1 문서 감사 22건 정확도 수정 Option C, 2026-05-22)](#사이클-119)
 - [사이클 118 (회고 P0/P1 전수 이행 — architecture.md/STATE.md/landing.html, 2026-05-22)](#사이클-118)
 - [사이클 117 (/login 제거 + 오류 배너 + P2 login.html 삭제, 2026-05-22)](#사이클-117)
+
+## 사이클 131
+
+**날짜**: 2026-05-25 | **PR**: #625~#633 (9건) | **상태**: ✅ 머지 완료
+
+**작업 내용**: Claude Design UI 전체 재설계 — 디자인 토큰 시스템, 컴포넌트 분리, WCAG 모바일 수정
+
+| PR | 브랜치 | 내용 |
+|----|--------|------|
+| #625 | `feat/design-tokens-t1` | T1 토큰 구조 재편 — `tokens.css` `[data-theme]` 블록 4테마, `themes.css` 7줄 스텁 전환 |
+| #626 | `feat/base-html-shell-v3` | T2 base.html — `.atmosphere` div, `components.css`/`pages.css`/`effects.js`/`tweaks.js` 신규, grade BEM 클래스 |
+| #627 | `feat/dashboard-redesign` | 대시보드 KPI 카드 재설계 — score-bar, freq-rows, `.kpi`+`.dash-kpi` 이중 클래스 |
+| #628 | `feat/analysis-detail-redesign` | analysis_detail 재설계 |
+| #629 | `feat/repo-detail-redesign` | repo_detail 재설계 |
+| #630 | `feat/overview-add-repo-redesign` | overview + add_repo 재설계 — score-bar clamp, step-cards, WCAG btn-primary/back-btn 48/44px |
+| #631 | `feat/settings-redesign` | settings 재설계 — 6카드, toggle-switch, save-bar, WCAG gate-mode-btn/mode-toggle-btn 44px |
+| #632 | `feat/landing-redesign` | landing 재설계 — standalone `.atmosphere`, grade BEM 5종, prefers-reduced-motion |
+| #633 | `feat/admin-redesign` | admin 재설계 — `.tbl` stub, `badge--success/danger` BEM, `<table class="admin-table tbl">` |
+
+**핵심 변경**:
+- `tokens.css` `[data-theme="dark/light/pastel/catppuccin"]` 블록 신설 — grade-bg/bd 토큰 포함
+- `components.css` (1041줄) + `pages.css` (761줄) 신규 파일 분리
+- `effects.js` + `tweaks.js` 신규 JS 파일 (atmosphere 애니메이션)
+- 모든 `.grade-X` → `.grade.grade--x` BEM 통일
+- WCAG 2.5.5 모바일 44/48px 회귀 가드 수정 (정책 WCAG 규칙 준수)
+
+**충돌 해소 (3회 force-push rebase)**:
+1. T2 themes.css — T1이 stub 전환했으므로 `--ours` 수락 (grade-bg/bd는 tokens.css에 이미 존재)
+2. T2 components.css add/add — landing PR (#632) 머지 후 swatch 중복 제거본을 `--ours` 수락
+3. overview+add_repo — 중간 PR 머지 후 rolling conflict 해소
+
+**CI 수정 사항**:
+- `.kpi:nth-child()` → `.dash-kpi:nth-child()` (대시보드 order 선택자 — 회귀 가드 `.dash-kpi` 클래스 필수)
+- `add_repo.html` `.btn-primary { min-height: 48px; }` + `.back-btn { min-height: 44px; }` 복원 (WCAG 회귀)
+- `settings.html` `.gate-mode-btn { min-height: 44px; }` 단독 규칙 분리 (정확한 문자열 매치 테스트)
+
+**테스트**: 단위 3009 → 3022 (+13, test_router.py + test_i18n_template_render.py 갱신)
+
+---
 
 ## 사이클 130
 


### PR DESCRIPTION
## Summary

- `docs/STATE.md` 헤더 수치 갱신: 사이클 131 완료, 테스트 3173 (단위 3022 + 통합 151)
- `docs/cycle-history.md` 목차 + 사이클 131 섹션 추가: 9 PR (#625~#633) Claude Design UI 전체 재설계 이력

## 변경 내용

### docs/STATE.md
- 현재 수치 헤더: 사이클 131 완료 (Claude Design UI 전체 재설계 9 PR)
- 전체 테스트: 3173 수집 (단위 3022 + 통합 151)
- 사이클 131 추적 이력 1줄 추가: `test_router.py + test_i18n_template_render.py 갱신, 3009→3022`

### docs/cycle-history.md
- 목차 최상단: 사이클 131 링크 추가
- 사이클 131 섹션 신설:
  - PR 9건 (#625~#633) 표 — 브랜치·내용 요약
  - 핵심 변경: tokens.css `[data-theme]` 블록, components.css/pages.css 신규 분리, BEM grade 통일
  - 충돌 해소 3회 force-push rebase 기록
  - CI 수정 사항: dash-kpi, WCAG btn-primary/back-btn, gate-mode-btn 규칙 분리

## 🔍 사용자 검증 필요

- [ ] `docs/STATE.md` 테스트 수치 3173이 현재 CI 결과와 일치하는지 확인
- [ ] `docs/cycle-history.md` 사이클 131 내용이 실제 작업 내역과 정확히 맞는지 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)