### PR TITLE
fix(ui): theme-option data-theme → data-theme-target (테마 옵션 텍스트 불가시 버그)

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -657,10 +657,10 @@
         <span class="chevron">▾</span>
       </button>
       <div class="theme-dropdown" id="themeDropdown" role="menu">
-        <div class="theme-option" data-theme="dark"       role="menuitem" tabindex="0">🌌 다크 오로라</div>
-        <div class="theme-option" data-theme="light"      role="menuitem" tabindex="0">☀️ 라이트</div>
-        <div class="theme-option" data-theme="pastel"     role="menuitem" tabindex="0">🌸 파스텔</div>
-        <div class="theme-option" data-theme="catppuccin" role="menuitem" tabindex="0">🐾 개발자 다크</div>
+        <div class="theme-option" data-theme-target="dark"       role="menuitem" tabindex="0">🌌 다크 오로라</div>
+        <div class="theme-option" data-theme-target="light"      role="menuitem" tabindex="0">☀️ 라이트</div>
+        <div class="theme-option" data-theme-target="pastel"     role="menuitem" tabindex="0">🌸 파스텔</div>
+        <div class="theme-option" data-theme-target="catppuccin" role="menuitem" tabindex="0">🐾 개발자 다크</div>
       </div>
     </div>
     {# Phase 2 PR-4 (사이클 84) — 다국어 i18n 헤더 dropdown (테마 토글 패턴 차용) #}
@@ -712,7 +712,7 @@
       document.getElementById('themeIcon').textContent = THEMES[theme].icon;
       document.getElementById('themeName').textContent = THEMES[theme].name;
       document.querySelectorAll('.theme-option').forEach(el => {
-        el.classList.toggle('active', el.dataset.theme === theme);
+        el.classList.toggle('active', el.dataset.themeTarget === theme);
       });
       document.dispatchEvent(new CustomEvent('themechange', { detail: theme }));
     }
@@ -737,7 +737,7 @@
       if (iconEl) iconEl.textContent = THEMES[theme].icon;
       if (nameEl) nameEl.textContent = THEMES[theme].name;
       document.querySelectorAll('.theme-option').forEach(function(el) {
-        el.classList.toggle('active', el.dataset.theme === theme);
+        el.classList.toggle('active', el.dataset.themeTarget === theme);
       });
     }
 
@@ -791,14 +791,14 @@
         }, { signal: sig });
         document.querySelectorAll('.theme-option').forEach(function(el) {
           el.addEventListener('click', function() {
-            applyTheme(el.dataset.theme);
+            applyTheme(el.dataset.themeTarget);
             switcher.classList.remove('open');
             toggleBtn.setAttribute('aria-expanded', 'false');
           }, { signal: sig });
           el.addEventListener('keydown', function(e) {
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
-              applyTheme(el.dataset.theme);
+              applyTheme(el.dataset.themeTarget);
               switcher.classList.remove('open');
               toggleBtn.setAttribute('aria-expanded', 'false');
               toggleBtn.focus();


### PR DESCRIPTION
## 버그 원인

T1 PR (#625)에서 `tokens.css`가 `body[data-theme="dark"]` → `[data-theme="dark"]` (element-agnostic 선택자)로 변경됨.

`.theme-option` 드롭다운 항목에 `data-theme="dark"` 속성이 있었으므로 해당 요소에 다크 테마 CSS 변수들이 그대로 적용:
- 파스텔 테마에서 `[data-theme="dark"]` 옵션 → `--text-1: #f3f3fa` (흰색) → 밝은 배경에 불가시
- catppuccin 테마에서 `[data-theme="pastel"]` 옵션 → `--text-1: #2d2738` (어두운 색) → 어두운 배경에 저대비

## 수정 내용

`data-theme` → `data-theme-target` 속성명 변경으로 CSS `[data-theme]` 선택자 충돌 차단.

| 변경 | 파일 | 내용 |
|------|------|------|
| HTML 4곳 | `base.html:660-663` | `.theme-option` 속성 `data-theme` → `data-theme-target` |
| JS 4곳 | `base.html:715,740,794,801` | `el.dataset.theme` → `el.dataset.themeTarget` |

## 🔍 사용자 검증 필요

**정책 11 — 4테마 × 2환경 8조합 시각 검증:**

| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| 다크 오로라 | [ ] 드롭다운 모든 옵션 텍스트 가시 | [ ] |
| 라이트 | [ ] 드롭다운 모든 옵션 텍스트 가시 | [ ] |
| 파스텔 | [ ] "다크 오로라" 옵션 텍스트 가시 (기존 버그) | [ ] |
| 개발자 다크 | [ ] "파스텔" 옵션 텍스트 가시 (기존 버그) | [ ] |

- [ ] 테마 전환 클릭 시 올바른 테마로 변경되는지 확인 (기능 정상)
- [ ] active 체크마크(✓)가 현재 선택된 테마에 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)