### PR TITLE
fix(ui): nav-logo color #fff → var(--text-1) (라이트/파스텔 SCAManager 텍스트 불가시 수정)

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -92,7 +92,7 @@
       align-items: center;
       gap: var(--space-2);
       text-decoration: none;
-      color: #fff;
+      color: var(--text-1);
       margin-right: var(--space-2);
       flex-shrink: 0;
     }


### PR DESCRIPTION
## 버그 원인

`.nav-logo { color: #fff; }` 하드코딩 + 라이트/파스텔 테마 nav 배경 조합:

| 테마 | `--bg-nav` | 기존 `#fff` 텍스트 결과 |
|------|-----------|----------------------|
| dark | `rgba(8, 8, 16, 0.72)` | ✅ 가시 (어두운 배경) |
| **light** | `rgba(255, 255, 255, 0.82)` | ❌ 불가시 (흰색 on 흰색) |
| **pastel** | `rgba(250, 246, 238, 0.82)` | ⚠️ 저대비 (흰색 on 크림) |
| catppuccin | `rgba(24, 24, 37, 0.82)` | ✅ 가시 (어두운 배경) |

## 수정

`color: #fff` → `color: var(--text-1)` — 각 테마 `--text-1` 값:
- dark: `#f3f3fa` (거의 흰색, 기존과 동일)
- light: `#131325` (어두운 네이비, 흰 배경에 가시)
- pastel: `#2d2738` (어두운 보라, 크림 배경에 가시)
- catppuccin: `#cdd6f4` (연한 청보라, 어두운 배경에 가시)

## 🔍 사용자 검증 필요 (정책 11 — 4테마 시각 검증)

| 테마 | "SCAManager" 텍스트 가시 여부 |
|------|------------------------------|
| 다크 오로라 | [ ] 확인 |
| 라이트 | [ ] 확인 (버그 수정 대상) |
| 파스텔 | [ ] 확인 (버그 수정 대상) |
| 개발자 다크 | [ ] 확인 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)