### PR TITLE
fix(ui): 모바일 테이블 헤더-값 정렬 불일치 수정 (repo_detail / analysis_detail / repo_insights)

### DIFF
--- a/src/static/css/repo_insights.css
+++ b/src/static/css/repo_insights.css
@@ -223,7 +223,7 @@
   padding: 10px 18px;
   font-size: 13px;
   color: var(--text-1);
-  vertical-align: middle;
+  vertical-align: top;
 }
 
 .ri-issues-table td.ri-num {
@@ -439,6 +439,15 @@
   .ri-day-btn {
     min-height: 44px;
     padding: 0 14px;
+  }
+}
+
+/* 모바일 ≤640px: 이슈 테이블 '도구' 컬럼(3번째) 숨김 — 배지에 이미 표시됨 */
+/* Mobile ≤640px: hide the tool column (3rd) — already shown in badge */
+@media (max-width: 640px) {
+  .ri-issues-table th:nth-child(3),
+  .ri-issues-table td:nth-child(3) {
+    display: none;
   }
 }
 

--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -235,6 +235,9 @@
     .ad-breakdown table { font-size: 12px; }
   }
   @media (max-width: 480px) {
+    /* th:first-child = <th scope="row"> 레이블 셀, td:first-child = fallback */
+    /* th:first-child = <th scope="row"> label cell, td:first-child = fallback */
+    .ad-breakdown th:first-child,
     .ad-breakdown td:first-child { width: 80px; font-size: 11px !important; }
     .ad-breakdown td:nth-child(2) { width: 50px; font-size: 12px !important; }
   }
@@ -493,6 +496,7 @@
       <div class="card__title">{{ 'analysis_detail.breakdown.section_title' | i18n_args(locale | default('ko')) }}</div>
     </div>
     <div class="card__body">
+      <div class="table-wrap">
       <table>
         <thead class="sr-only">
           <tr>
@@ -517,6 +521,7 @@
         {% endfor %}
         </tbody>
       </table>
+      </div>
     </div>
   </div>
   {% endif %}

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -422,6 +422,10 @@
     .filter-search { min-width: unset; }
     .custom-date-wrap { flex-direction: column; align-items: stretch; }
     .date-input { width: 100%; }
+    /* 좁은 모바일: '커밋'(2번째)+'출처'(6번째) 컬럼 숨김 → 4컬럼으로 축소 */
+    /* Narrow mobile: hide commit (col2) + source (col6) → collapse to 4 cols */
+    .tbl th:nth-child(2), .tbl td:nth-child(2),
+    .tbl th:nth-child(6), .tbl td:nth-child(6) { display: none; }
   }
   @media (max-width: 768px) {
     .repo-wrap { padding: var(--space-5, 1.25rem) var(--space-4, 1rem) var(--space-6, 1.5rem); }

--- a/src/templates/repo_insights.html
+++ b/src/templates/repo_insights.html
@@ -138,6 +138,7 @@
         <h2 class="ri-card-title card__title">🔄 반복 이슈 랭킹</h2>
       </div>
       {% if recurring_issues %}
+      <div class="table-wrap">
       <table class="ri-issues-table" aria-label="반복 이슈 목록">
         <thead>
           <tr>
@@ -170,6 +171,7 @@
           {% endfor %}
         </tbody>
       </table>
+      </div>
       {% else %}
       <div class="ri-empty">반복 이슈 없음</div>
       {% endif %}


### PR DESCRIPTION
## 🔍 사용자 검증 필요 (정책 11)

> **Claude 시각 검증 불가** — 아래 조합은 사용자 직접 확인 필요

| 테마 | 모바일 (≤480px) | 태블릿 (768px) |
|------|---------------|--------------|
| dark | [ ] repo_detail 4컬럼 정렬 | [ ] |
| light | [ ] repo_insights 상단정렬 | [ ] |
| pastel | [ ] analysis_detail 점수 브레이크다운 | [ ] |
| catppuccin | [ ] | [ ] |

---

## Summary

- **repo_insights.css**: `vertical-align: middle → top` — 멀티라인 이슈 메시지 행에서 `#`/`도구` 값이 행 중앙에 부유하던 문제 수정
- **repo_insights.css**: `@media (max-width: 640px)` 도구 컬럼(3번째) 숨김 — 배지에 이미 표시됨
- **repo_insights.html**: `ri-issues-table`을 `.table-wrap`으로 감쌈 (`overflow-x: auto` 적용)
- **analysis_detail.html**: 점수 브레이크다운 `table`을 `.table-wrap`으로 감쌈
- **analysis_detail.html**: `@media (max-width: 480px)` 규칙에 `th:first-child` 추가 — `<th scope="row">`가 `td:first-child` 선택자에 매칭되지 않던 버그 수정
- **repo_detail.html**: `@media (max-width: 480px)` 에서 커밋(col2)/출처(col6) 숨김 → 6컬럼 → 4컬럼 (날짜·PR·점수·등급)

## Playwright 검증

- 390px(iPhone 12 Pro) 뷰포트에서 before/after 스크린샷 비교 확인
- Section 1: 4컬럼 (날짜·PR·점수·등급) 정렬 정상 ✅
- Section 2: `vertical-align: top` 으로 `#`/`도구` 값 상단 고정 ✅
- Section 3: "커밋 메시지" 1줄 렌더링, 진행바 정렬 정상 ✅

## Test plan

- [ ] `make test` CI 통과 확인 (HTML/CSS 변경으로 Python 테스트 영향 없음)
- [ ] 모바일 (390px): repo_detail 4컬럼 확인 — 커밋·출처 숨김 정상
- [ ] 모바일 (390px): repo_insights 이슈 테이블 — 값이 행 상단에 위치
- [ ] 모바일 (390px): analysis_detail 점수 브레이크다운 — 레이블 1줄 렌더링
- [ ] 데스크탑 (1200px): 3페이지 모두 기존 레이아웃 유지 (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)