### PR TITLE
fix(dashboard): localStorage redirect 제거 — /dashboard 항상 개요 표시

### DIFF
--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -1273,35 +1273,6 @@
 </script>
 {% endif %}
 
-{# Phase 3 PR 4 — 모드 토글 localStorage persist + 초기 redirect (mode/insight 양 모드 모두 적용) #}
-{# Phase 3 PR 4 — mode toggle localStorage persist + initial redirect (active in both modes) #}
-<script>
-  // 모드 토글 클릭 시 localStorage 저장 — 다음 진입 시 사용자 마지막 선택 보존
-  // Persist mode toggle clicks to localStorage — restore user's last choice on next visit
-  document.querySelectorAll('.dash-mode-toggle a').forEach(function (a) {
-    a.addEventListener('click', function () {
-      try {
-        var m = a.getAttribute('data-mode');
-        if (m) localStorage.setItem('sca-dashboard-mode', m);
-      } catch (e) { /* localStorage 접근 거부 (private mode 등) — silent skip */ }
-    });
-  });
-
-  // URL ?mode= 부재 + localStorage 우선 + 서버 initial_mode 와 다르면 1회 redirect
-  // When URL has no ?mode= and localStorage holds a different value, redirect once (FOUC 최소)
-  (function () {
-    try {
-      var url = new URL(window.location.href);
-      if (url.searchParams.has('mode')) return;  // URL 명시 = 사용자 선택, 손대지 않음
-      var stored = localStorage.getItem('sca-dashboard-mode');
-      if (!stored || (stored !== 'overview' && stored !== 'insight')) return;
-      var page = document.querySelector('.dashboard-page');
-      var initial = (page && page.getAttribute('data-initial-mode')) || 'overview';
-      if (stored !== initial) {
-        url.searchParams.set('mode', stored);
-        window.location.replace(url.toString());
-      }
-    } catch (e) { /* URL/localStorage 접근 오류 — silent skip (page 정상 렌더 보장) */ }
-  })();
-</script>
+{# Phase 3 PR 4 localStorage redirect 제거 — /dashboard 진입 시 항상 개요 표시 #}
+{# Phase 3 PR 4 localStorage redirect removed — /dashboard always opens overview #}
 {% endblock %}


### PR DESCRIPTION
## 버그 원인

`/dashboard` 진입 시 이전 방문 탭을 localStorage에서 읽어 강제 redirect하는 IIFE가 존재했음.

**재현 경로:**
1. 💬 Insight 탭 클릭 → `localStorage['sca-dashboard-mode'] = 'insight'` 저장
2. `/dashboard` 진입 (mode 파라미터 없음)
3. JS: `stored('insight') !== initial('overview')` → `/dashboard?mode=insight`로 `window.location.replace()` 실행
4. 결과: 개요 대신 Insight 탭이 열림

또한 redirect 대상이 `'overview'`/`'insight'` 두 모드만 포함 — 나중에 추가된 `repos`/`security`/`usage` 3종은 누락된 채로 방치된 불완전한 상태였음.

## 변경 내용

- localStorage setItem + redirect IIFE 전체 제거 (31줄 삭제)
- 이후 `/dashboard` 진입 시 항상 서버 기본값(개요) 표시
- 모드 토글 active 클래스는 서버 렌더링(`{% if mode == 'overview' %}class="active"`)으로 이미 정상 동작

## 검증

- `tests/integration/test_dashboard_mobile_priority.py` 5건 ✅
- `tests/unit/services/test_dashboard_feedback_status.py` 6건 ✅
- `grep 'sca-dashboard-mode' dashboard.html` → 0건 (dead reference 없음) ✅
- Codex 샌드박스 오류 재발 → Claude 직접 검토 대체 (세션 선례)

## 🔍 사용자 검증 필요 (정책 11)

| 확인 항목 | 방법 |
|----------|------|
| Insight 탭 방문 후 `/dashboard` 재진입 시 개요 표시 | 브라우저에서 직접 확인 |
| 모드 토글 버튼 active 상태 정상 | dark/light 테마에서 확인 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)