### PR TITLE
fix(analyzer): ReDoS 정규식 구분자/캡처 그룹 완전 분리 — S5852 해소

### DIFF
--- a/src/analyzer/io/tools/dotnet_format.py
+++ b/src/analyzer/io/tools/dotnet_format.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # dotnet format 진단 출력 패턴: (줄,열): error|warning <code>: 메시지
 # Pattern for dotnet format diagnostic output: (line,col): error|warning <code>: message
 _DOTNET_DIAG_RE = re.compile(
-    r'\((\d+),\d+\):\s+(error|warning)\s+\w+:\s+([^\n]+)$',
+    r'\((\d+),\d+\):\s+(error|warning)\s+\w+:[ \t]+(\S[^\n]*)$',
     re.MULTILINE,
 )
 

--- a/src/analyzer/io/tools/tsc.py
+++ b/src/analyzer/io/tools/tsc.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # tsc 출력 형식: /path/file.ts(LINE,COL): error|warning TSxxxx: message
 # tsc output format: /path/file.ts(LINE,COL): error|warning TSxxxx: message
 _TSC_DIAG_RE = re.compile(
-    r'^[^\n(]+\((\d+),\d+\):\s+(error|warning)\s+TS\d+:\s+([^\n]+)$',
+    r'^[^\n(]+\((\d+),\d+\):\s+(error|warning)\s+TS\d+:[ \t]+(\S[^\n]*)$',
     re.MULTILINE,
 )
 


### PR DESCRIPTION
## 변경 내용

PR #657의 `[^\n]+` 수정 후에도 SonarCloud `python:S5852`가 지속된 근본 원인 해소.

### 근본 원인

`\s+([^\n]+)$` 패턴에서 `\s`(공백·탭)와 `[^\n]`(공백 포함) 두 그룹이 **겹침** — 엔진이 공백을 어느 그룹에 할당할지 O(n)으로 탐색. SonarCloud S5852가 이를 탐지.

### 수정 내용

| 파일 | 변경 전 | 변경 후 |
|------|---------|---------|
| `dotnet_format.py:24` | `\s+([^\n]+)$` | `[ \t]+(\S[^\n]*)$` |
| `tsc.py:24` | `\s+([^\n]+)$` | `[ \t]+(\S[^\n]*)$` |

- `[ \t]+` : 수평 공백(구분자)만 — `\n` 제외
- `\S[^\n]*` : **비공백으로 시작** → 두 그룹이 완전히 분리(disjoint) → 백트래킹 0

**동작 변화 없음** — tsc/dotnet 진단 메시지는 항상 비공백 문자로 시작.

## 테스트

- `test_dotnet_format.py` 10개 PASSED
- `test_tsc.py` 7개 PASSED

## 🔍 사용자 검증 필요

- [ ] PR 머지 후 SonarCloud Hotspot 2건이 "Fixed" 탭으로 이동하는지 확인 (~5분 재스캔)
- [ ] Quality Gate OK 전환 확인