### PR TITLE
docs: STATE.md + cycle-history.md 사이클 129 hotfix #656~#658 이력 추가

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,15 +2,15 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-05-28 기준 — **사이클 138 완료**: 대시보드 server-side auto-detect 제거 (#651) 머지 + **사이클 129 Lint L-1 언어 확장 (#654)** 포함): 156+ PR #188~#655 — 누적 정책 본문 18건 + 메모리 17건. 전체 3173 수집 (단위 3022 + 통합 151) / E2E 112 (100 표준 + 12 perf) / pylint **10.00/10**
+## 현재 수치 (2026-05-28 기준 — **사이클 138 완료**: 대시보드 server-side auto-detect 제거 (#651) 머지 + **사이클 129 Lint L-1 언어 확장 (#654)** + **hotfix #656~#658** 포함): 156+ PR #188~#658 — 누적 정책 본문 18건 + 메모리 17건. 전체 3173 수집 (단위 3022 + 통합 151) / E2E 112 (100 표준 + 12 perf) / pylint **10.00/10**
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
 | 전체 테스트 | **3173 수집** *(헤더 = 최신값, 이 셀 = pytest 누적 추적)* | `pytest tests/` — 단위 3022 + 통합 151. 추적 이력: (이전 사이클 73~128 누적 2948) + **사이클 129 #614 AI Issue 등록 +59** (2948→3007). + **사이클 130 #617 +2** (3007→3009). + **사이클 131 Claude Design 재설계 #625~#633 +13** (test_router.py + test_i18n_template_render.py 갱신, 3009→3022 단위). |
 | 통합 테스트 | **151개** | tests/integration/ — 사이클 81 영역 🅑 모바일 Phase 1 MVP +34 + **사이클 84 i18n PR-18 smoke +11** + **PR #400 repo insights +22** + **사이클 99 #441 +3** (repo_report_api auth·list·404) + **사이클 100~101 누적** (test_retry_concurrency_postgres assertion 강화). 기존 test_settings_mobile.py 일부 Windows cp949 인코딩 오류 제외. **= 151 passed** |
 | E2E 테스트 | **112개** | `make test-e2e` (Chromium Playwright) — Phase 3 PR 6 +7 + **사이클 84 i18n PR-16 +14** (3 언어 × 4 페이지 — login/overview/dashboard/settings + Cookie fallback + locale switch). 사이클 94 #372: test_save_success ordering 트랩 차단 (`_reset_repo_config()` 헬퍼) + test_two_column 보류 (`@pytest.mark.skip`). **+ 사이클 106 #500 `@pytest.mark.perf` 12개** (TTFB/FCP/LCP/DCL/Load — 3회 avg/min/max). **+ 사이클 127 #605 `test_nav_handler_survives_hx_boost_renavigation` +1** (hx-boost 3회 재방문 회귀 가드). **+ 사이클 127 #609 사전 실패 8건 해소** (5 TIMEOUT: test_theme.py glass/claude-dark 셀렉터 → pastel/catppuccin 갱신 + 3 ERROR: test_repos_mode.py auth_cookies 픽스처 제거). **= 112 collected (100 표준 + 12 perf)**. `make test-perf` 로 perf 마커만 선택 실행. ⚠️ e2e ↔ tests/integration 동시 실행 금지 — `e2e/pytest.ini` 의도적 asyncio_mode 미설정, 분리 실행 default (`make test-e2e` vs CI command `pytest tests/`) |
-| SonarCloud Quality Gate | **OK** | #399 머지 후 복원 — CPD 14%→<3%, mockup 제외, _NONE_LABEL 상수화 |
-| SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 |
+| SonarCloud Quality Gate | **OK** | #399 이후 유지 — **#658 ReDoS 정규식 수정으로 S5852 hotspot 2건 해소, QG OK 복원** |
+| SonarCloud Security Rating | **A** | Vuln 0, Hotspots 0 (dotnet_format·tsc ReDoS 패턴 #658 수정) |
 | SonarCloud Reliability Rating | **A** | Bugs 0 |
 | SonarCloud Maintainability Rating | **A** | Code Smells 58 (-20 from 78) |
 | SonarCloud BLOCKER / CRITICAL | **0 / 0** | Phase Q.7 완료 — 5건 Cognitive Complexity 전부 해소 |

--- a/docs/cycle-history.md
+++ b/docs/cycle-history.md
@@ -34,7 +34,7 @@
 - [사이클 95~106 (문서 정비 + pylint 10.00 + 성능 측정 E2E, 2026-05-14~18)](#사이클-95106)
 - [사이클 107~109 (테마 차트 수정 + 전체 감사 14건, 2026-05-19)](#사이클-107109)
 - [사이클 110~116 (AI Insight 에러 추적·차트·다국어·감사 묶음, 2026-05-20~22)](#사이클-110116) — 상세: STATE.md 작업 이력 참조
-- [사이클 129 (Lint L-1 언어 확장 — 15개 신규 정적분석기, 2026-05-28)](#사이클-129)
+- [사이클 129 (Lint L-1 언어 확장 — 15개 신규 정적분석기 + hotfix #656~#658, 2026-05-28)](#사이클-129)
 - [사이클 128 (테마 드롭다운 CSS 변수 스코프 + 대비 수정, 2026-05-23)](#사이클-128)
 - [사이클 127 (hx-boost JS 에러 트랩 + 정적 스캐너 + ESLint 인프라 + E2E stale 셀렉터 수정, 2026-05-23)](#사이클-127)
 - [사이클 126 (차트 스파크라인 리디자인 — 테마 accent 그라디언트 fill, 2026-05-23)](#사이클-126)
@@ -383,7 +383,7 @@
 
 ## 사이클 129
 
-- **사이클 129 (2026-05-28 · #654)** — Lint L-1 언어 확장 — Subagent-Driven Development 10-task 실행. **신규 정적분석기 15종**: hadolint(Dockerfile)·ktlint(Kotlin)·tflint(Terraform/HCL)·tsc(TypeScript)·sqlfluff(SQL)·yamllint(YAML)·phpstan(PHP)·swiftlint(Swift)·stylelint(CSS/SCSS)·htmlhint(HTML)·buf_lint(Protobuf)·dart_analyze(Dart)·psscriptanalyzer(PowerShell)·dotnet_format(C#)·clippy(Rust). **핵심 구현**: `src/analyzer/io/static.py` `analyze_file()` — `repo_config` kwarg 추가 (`disabled_tools` 지원, Task 1); 23개 분석기 알파벳 순 import. `src/analyzer/io/tools/` 신규 15개 파일. `railway.toml` buildCommand — P0 도구 괄호식 `(cmd || echo WARNING)` 패턴으로 설치 (ktlint·hadolint·tflint graceful failure). `requirements.txt` — sqlfluff·yamllint 추가 + python-multipart CVE 핀 보존. **보안 수정**: psscriptanalyzer.py path를 f-string이 아닌 `env["PSSA_PATH"]` 환경변수로 전달 (PowerShell command injection 방어). **JSONL 파싱**: buf_lint — 줄 단위 JSON 파싱 (배열 아님). **통합 테스트 수정**: `test_e2e_pipeline_scenarios.py` + `test_webhook_to_gate.py` mock lambda에 `repo_config=None` kwarg 추가 (Task 1 시그니처 변경 대응). `pipeline.py` `_run_static_with_timeout` + `_run_static_analysis` — `repo_config` 파라미터 연쇄 전달. 2단계 리뷰 (스펙 준수 + 코드 품질) 완료. Codex mutual: 정책 18 검증 의뢰. 지원 언어(정적분석) 37개+ → 52개+.
+- **사이클 129 (2026-05-28 · #654~#658)** — Lint L-1 언어 확장 + hotfix 3건. **#654** Subagent-Driven Development 10-task 실행. **신규 정적분석기 15종**: hadolint(Dockerfile)·ktlint(Kotlin)·tflint(Terraform/HCL)·tsc(TypeScript)·sqlfluff(SQL)·yamllint(YAML)·phpstan(PHP)·swiftlint(Swift)·stylelint(CSS/SCSS)·htmlhint(HTML)·buf_lint(Protobuf)·dart_analyze(Dart)·psscriptanalyzer(PowerShell)·dotnet_format(C#)·clippy(Rust). **핵심 구현**: `src/analyzer/io/static.py` `analyze_file()` — `repo_config` kwarg 추가 (`disabled_tools` 지원, Task 1); 23개 분석기 알파벳 순 import. `src/analyzer/io/tools/` 신규 15개 파일. `railway.toml` buildCommand — P0 도구 괄호식 `(cmd || echo WARNING)` 패턴으로 설치 (ktlint·hadolint·tflint graceful failure). `requirements.txt` — sqlfluff·yamllint 추가 + python-multipart CVE 핀 보존. **보안 수정**: psscriptanalyzer.py path를 f-string이 아닌 `env["PSSA_PATH"]` 환경변수로 전달 (PowerShell command injection 방어). **JSONL 파싱**: buf_lint — 줄 단위 JSON 파싱 (배열 아님). **통합 테스트 수정**: `test_e2e_pipeline_scenarios.py` + `test_webhook_to_gate.py` mock lambda에 `repo_config=None` kwarg 추가 (Task 1 시그니처 변경 대응). `pipeline.py` `_run_static_with_timeout` + `_run_static_analysis` — `repo_config` 파라미터 연쇄 전달. 2단계 리뷰 (스펙 준수 + 코드 품질) 완료. Codex mutual: 정책 18 검증 의뢰. 지원 언어(정적분석) 37개+ → 52개+. **#656** pipeline.py 머지 충돌 마커 잔존 제거(SyntaxError) + `_slow`/`_fast` mock 시그니처 `repo_config=None` 추가 — CI 복원. **#657** dotnet_format·tsc `(.+)$`→`([^\n]+)$` ReDoS 1차 수정 (SonarCloud S5852 미해소). **#658** `\s+([^\n]+)$`→`[ \t]+(\S[^\n]*)$` 구분자·캡처 그룹 완전 분리 — S5852 hotspot 2건 해소, SonarCloud Quality Gate OK 복원.
 
 ## 사이클 128
 

--- a/src/analyzer/io/tools/dotnet_format.py
+++ b/src/analyzer/io/tools/dotnet_format.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # dotnet format 진단 출력 패턴: (줄,열): error|warning <code>: 메시지
 # Pattern for dotnet format diagnostic output: (line,col): error|warning <code>: message
 _DOTNET_DIAG_RE = re.compile(
-    r'\((\d+),\d+\):\s+(error|warning)\s+\w+:\s+([^\n]+)$',
+    r'\((\d+),\d+\):\s+(error|warning)\s+\w+:[ \t]+(\S[^\n]*)$',
     re.MULTILINE,
 )
 

--- a/src/analyzer/io/tools/tsc.py
+++ b/src/analyzer/io/tools/tsc.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # tsc 출력 형식: /path/file.ts(LINE,COL): error|warning TSxxxx: message
 # tsc output format: /path/file.ts(LINE,COL): error|warning TSxxxx: message
 _TSC_DIAG_RE = re.compile(
-    r'^[^\n(]+\((\d+),\d+\):\s+(error|warning)\s+TS\d+:\s+([^\n]+)$',
+    r'^[^\n(]+\((\d+),\d+\):\s+(error|warning)\s+TS\d+:[ \t]+(\S[^\n]*)$',
     re.MULTILINE,
 )
 


### PR DESCRIPTION
## 변경 내용

사이클 129 L-1 언어 확장 이후 머지된 hotfix 3건을 문서에 반영합니다.

### STATE.md
- 헤더: PR 범위 `#188~#655` → `#188~#658`, hotfix 언급 추가
- SonarCloud Quality Gate: `#658 ReDoS 정규식 수정으로 S5852 hotspot 2건 해소, QG OK 복원` 비고 갱신
- SonarCloud Security Rating: hotspot 해소 출처 명시

### cycle-history.md
- TOC: 사이클 129 항목에 `+ hotfix #656~#658` 추가
- 사이클 129 본문: #654 뒤에 #656·#657·#658 내용 1줄씩 추가

| PR | 내용 |
|----|------|
| #656 | pipeline.py 충돌 마커 잔존 제거 + mock 시그니처 수정 |
| #657 | ReDoS 정규식 1차 수정 (S5852 미해소) |
| #658 | ReDoS 정규식 완전 분리 — S5852 해소, QG OK 복원 |