### PR TITLE
fix(tests): CodeQL py/unused-import 경고 수정 — 미사용 Category/Severity/pytest 제거

### DIFF
--- a/tests/unit/analyzer/test_static_disabled.py
+++ b/tests/unit/analyzer/test_static_disabled.py
@@ -1,7 +1,6 @@
 """disabled_tools 인프라 테스트 — repo_config.disabled_tools에 등록된 도구는 스킵된다.
 Infrastructure tests for disabled_tools — analyzers listed in repo_config.disabled_tools are skipped.
 """
-import pytest
 from src.analyzer.io.static import analyze_file
 
 

--- a/tests/unit/analyzer/tools/test_clippy.py
+++ b/tests/unit/analyzer/tools/test_clippy.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import pytest
 from unittest.mock import patch, MagicMock
-from src.analyzer.pure.registry import AnalyzeContext, Severity, Category, REGISTRY
+from src.analyzer.pure.registry import AnalyzeContext, Severity, REGISTRY
 
 
 def _make_ctx(language: str, filename: str, content: str = "fn main() {}") -> AnalyzeContext:

--- a/tests/unit/analyzer/tools/test_hadolint.py
+++ b/tests/unit/analyzer/tools/test_hadolint.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import pytest
 from unittest.mock import patch, MagicMock
-from src.analyzer.pure.registry import AnalyzeContext, Severity, Category, REGISTRY
+from src.analyzer.pure.registry import AnalyzeContext, Severity, REGISTRY
 
 
 def _make_ctx(language: str, filename: str) -> AnalyzeContext:

--- a/tests/unit/analyzer/tools/test_ktlint.py
+++ b/tests/unit/analyzer/tools/test_ktlint.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import pytest
 from unittest.mock import patch, MagicMock
-from src.analyzer.pure.registry import AnalyzeContext, Severity, Category, REGISTRY
+from src.analyzer.pure.registry import AnalyzeContext, REGISTRY
 
 
 def _make_ctx(language: str, filename: str) -> AnalyzeContext:

--- a/tests/unit/analyzer/tools/test_sqlfluff.py
+++ b/tests/unit/analyzer/tools/test_sqlfluff.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import pytest
 from unittest.mock import patch, MagicMock
-from src.analyzer.pure.registry import AnalyzeContext, Severity, Category, REGISTRY
+from src.analyzer.pure.registry import AnalyzeContext, REGISTRY
 
 
 def _make_ctx(language: str, filename: str) -> AnalyzeContext:

--- a/tests/unit/analyzer/tools/test_tflint.py
+++ b/tests/unit/analyzer/tools/test_tflint.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import pytest
 from unittest.mock import patch, MagicMock
-from src.analyzer.pure.registry import AnalyzeContext, Severity, Category, REGISTRY
+from src.analyzer.pure.registry import AnalyzeContext, Severity, REGISTRY
 
 
 def _make_ctx(language: str, filename: str) -> AnalyzeContext:

--- a/tests/unit/analyzer/tools/test_tsc.py
+++ b/tests/unit/analyzer/tools/test_tsc.py
@@ -2,7 +2,7 @@
 import subprocess
 import pytest
 from unittest.mock import patch, MagicMock
-from src.analyzer.pure.registry import AnalyzeContext, Severity, Category, REGISTRY
+from src.analyzer.pure.registry import AnalyzeContext, Severity, REGISTRY
 
 
 def _make_ctx(language: str, filename: str) -> AnalyzeContext:

--- a/tests/unit/analyzer/tools/test_yamllint.py
+++ b/tests/unit/analyzer/tools/test_yamllint.py
@@ -5,7 +5,7 @@ import json
 import subprocess
 import pytest
 from unittest.mock import patch, MagicMock
-from src.analyzer.pure.registry import AnalyzeContext, Severity, Category, REGISTRY
+from src.analyzer.pure.registry import AnalyzeContext, Severity, REGISTRY
 
 
 def _make_ctx(language: str, filename: str) -> AnalyzeContext:


### PR DESCRIPTION
## Summary

- 8개 테스트 파일에서 미사용 import 제거 (CodeQL `py/unused-import` 8건 해소)
- `Category`: `test_clippy`, `test_hadolint`, `test_tflint`, `test_tsc`, `test_yamllint` — Severity는 사용 중, Category만 제거
- `Category` + `Severity` 둘 다: `test_ktlint`, `test_sqlfluff` — 두 심볼 모두 미사용
- `pytest`: `test_static_disabled` — pytest.mark/raises/fixture 사용 없음

## Code Scanning 처리 현황

| 유형 | 건수 | 처리 |
|------|------|------|
| 실제 미사용 import (이 PR) | 8건 | fix |
| `static.py` side-effect import (false-positive) | 21건 | dismiss (PR 머지 후) |
| `py/import-and-import-from` reload 패턴 (false-positive) | 5건 | dismiss (PR 머지 후) |

## Test Results

```
58 passed in 9.55s
```

## Codex 검증 (정책 18)

- Codex 샌드박스 Windows spawn 오류 → Claude 직접 검증 대체
- 8개 파일 전체 `grep` 실측: 제거 심볼 사용 0건 확인
- 58개 테스트 통과 확인 → **OK**

## 🔍 사용자 검증 필요

- [ ] PR 머지 후 GitHub Security 탭 Code Scanning alerts 감소 확인 (8건 → 자동 해소 예정)
- [ ] dismiss 처리할 false-positive 26건 (static.py 21건 + import-and-import-from 5건) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)