### PR TITLE
fix(alembic): 0035 revision 중복 해소 — repo_config_disabled_tools를 0036으로 renumber

### DIFF
--- a/alembic/versions/0036_repo_config_disabled_tools.py
+++ b/alembic/versions/0036_repo_config_disabled_tools.py
@@ -1,15 +1,15 @@
 """repo_config: disabled_tools JSON 컬럼 추가
 Add disabled_tools JSON column to repo_config for per-repo tool exclusion.
 
-Revision ID: 0035
-Revises: 0034
+Revision ID: 0036
+Revises: 0035
 Create Date: 2026-05-28
 """
 import sqlalchemy as sa
 from alembic import op
 
-revision = '0035'
-down_revision = '0034'
+revision = '0036'
+down_revision = '0035'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary

- `0035_repo_config_disabled_tools.py`와 `0035_issue_registrations.py`가 동일 `revision='0035'` + `down_revision='0034'` 충돌
- `0036_repo_config_disabled_tools.py`로 renumber (`down_revision='0035'` 유지)
- alembic history 단선 체인 복원 확인: `0035 → 0036 (head)`
- ORM `RepoConfig.disabled_tools` 컬럼과 정합성 확인

## 검증

- [x] `alembic history` 단선 체인 (0035 → 0036 head)
- [x] ORM `repo_config.py:56` `disabled_tools = Column(JSON, ...)` 일치
- [x] migration 단위 테스트 29 passed
- [x] Claude 직접 검증 OK (Codex 샌드박스 모델 오류로 대체)

## 🔍 사용자 검증 필요

- [ ] Railway 운영 DB: `make migrate` 후 `disabled_tools` 컬럼 정상 추가 확인
- [ ] 다음 신규 마이그레이션 생성 시 `0037_` 사용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)