### PR TITLE
feat(security): API rate limiting 추가 — slowapi 기반 60req/min IP 제한

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # fastapi>=0.136.3 — starlette CVE-2024-47874 / CVE-2025-54121 패치 버전 번들
 # fastapi>=0.136.3 — bundles starlette with CVE-2024-47874 / CVE-2025-54121 patches
 fastapi>=0.136.3
+slowapi==0.1.9
 uvicorn[standard]==0.48.0
 pydantic-settings==2.14.1
 sqlalchemy==2.0.50

--- a/src/api/repos.py
+++ b/src/api/repos.py
@@ -1,7 +1,8 @@
 """Repository and config REST API endpoints (/api/repos/*)."""
 from typing import Literal
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field, model_validator
+from src.middleware.rate_limiter import limiter, RATE_LIMIT_API
 from src.api.auth import require_api_key
 from src.api.deps import get_repo_or_404
 from src.constants import (
@@ -61,7 +62,8 @@ class RepoConfigUpdate(BaseModel):
 
 
 @router.get("/repos")
-def list_repos():
+@limiter.limit(RATE_LIMIT_API)
+def list_repos(request: Request):  # pylint: disable=unused-argument
     """등록된 전체 리포지토리 목록을 반환한다."""
     with SessionLocal() as db:
         repos = db.query(Repository).order_by(Repository.created_at.desc()).all()
@@ -73,7 +75,8 @@ def list_repos():
 
 
 @router.get("/repos/{repo_name:path}/analyses")
-def list_repo_analyses(repo_name: str, skip: int = 0, limit: int = 20):
+@limiter.limit(RATE_LIMIT_API)
+def list_repo_analyses(request: Request, repo_name: str, skip: int = 0, limit: int = 20):  # pylint: disable=unused-argument
     """리포지토리 분석 이력 목록을 반환한다."""
     with SessionLocal() as db:
         repo = get_repo_or_404(repo_name, db)

--- a/src/api/stats.py
+++ b/src/api/stats.py
@@ -1,15 +1,17 @@
 """Statistics API — analysis detail and per-repo score statistics endpoints."""
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from src.api.auth import require_api_key
 from src.api.deps import get_repo_or_404
 from src.database import SessionLocal
+from src.middleware.rate_limiter import limiter, RATE_LIMIT_API
 from src.models.analysis import Analysis
 
 router = APIRouter(prefix="/api", dependencies=[require_api_key])
 
 
 @router.get("/analyses/{analysis_id}")
-def get_analysis(analysis_id: int):
+@limiter.limit(RATE_LIMIT_API)
+def get_analysis(request: Request, analysis_id: int):  # pylint: disable=unused-argument
     """단일 분석 상세 정보를 반환한다."""
     with SessionLocal() as db:
         analysis = db.query(Analysis).filter(Analysis.id == analysis_id).first()
@@ -25,7 +27,8 @@ def get_analysis(analysis_id: int):
 
 
 @router.get("/repos/{repo_name:path}/stats")
-def get_repo_stats(repo_name: str, limit: int = 30):
+@limiter.limit(RATE_LIMIT_API)
+def get_repo_stats(request: Request, repo_name: str, limit: int = 30):  # pylint: disable=unused-argument
     """리포지토리 점수 통계(평균·트렌드)를 반환한다."""
     with SessionLocal() as db:
         repo = get_repo_or_404(repo_name, db)

--- a/src/main.py
+++ b/src/main.py
@@ -12,8 +12,12 @@ from starlette.middleware.sessions import SessionMiddleware
 from alembic import command
 from alembic.config import Config
 
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+
 from src.config import settings
 from src.constants import GITHUB_API
+from src.middleware.rate_limiter import limiter
 from src.shared.http_client import close_http_client, init_http_client
 from src.webhook.router import router as webhook_router
 from src.api.repos import router as api_repos_router
@@ -149,6 +153,10 @@ app = FastAPI(
     redoc_url=None if _is_prod else "/redoc",
     openapi_url=None if _is_prod else "/openapi.json",
 )
+# slowapi rate limiting 등록 — IP 기반 60req/min (API 엔드포인트 DoS 방어)
+# Register slowapi rate limiting — IP-based 60 req/min (DoS defense for API endpoints)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SecurityHeadersMiddleware)
 # Phase 3 postlude — RLS 운영 활성화 미들웨어. Starlette LIFO 미들웨어 스택:
 # add_middleware 마지막 호출이 outer (request 먼저 처리). 원하는 흐름 = SessionMiddleware → RLSSessionMiddleware → route

--- a/src/middleware/rate_limiter.py
+++ b/src/middleware/rate_limiter.py
@@ -1,0 +1,21 @@
+"""API Rate Limiting 미들웨어 설정.
+API rate limiting middleware configuration using slowapi.
+"""
+import logging
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+logger = logging.getLogger(__name__)
+
+# IP 기반 rate limit — 메모리 스토리지, .env 파일 읽기 비활성화 (Windows cp949 인코딩 충돌 방지)
+# IP-based rate limit — in-memory storage, disable .env reading to avoid Windows cp949 encoding conflicts
+limiter = Limiter(
+    key_func=get_remote_address,
+    storage_uri="memory://",
+    config_filename="",  # .env 파일 자동 탐색 비활성화 / Disable automatic .env file lookup
+)
+
+# 엔드포인트 카테고리별 기본 제한 상수
+# Default rate limit constants per endpoint category
+RATE_LIMIT_API = "60/minute"    # 일반 API (repos 목록, stats 조회)
+RATE_LIMIT_HEAVY = "10/minute"  # 무거운 API (분석 트리거, 대용량 연산)

--- a/tests/unit/api/test_rate_limiter.py
+++ b/tests/unit/api/test_rate_limiter.py
@@ -1,0 +1,80 @@
+"""API Rate Limiting 테스트.
+API rate limiting tests.
+"""
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+
+
+def test_rate_limiter_constants():
+    """rate_limiter 모듈이 예상 상수를 export해야 한다.
+    rate_limiter module must export expected constants.
+    """
+    from src.middleware.rate_limiter import limiter, RATE_LIMIT_API, RATE_LIMIT_HEAVY
+    assert RATE_LIMIT_API == "60/minute"
+    assert RATE_LIMIT_HEAVY == "10/minute"
+    assert limiter is not None
+
+
+def test_rate_limit_exceeded_returns_429():
+    """제한 초과 시 429 Too Many Requests를 반환해야 한다.
+    Must return 429 Too Many Requests when limit is exceeded.
+    """
+    test_limiter = Limiter(key_func=get_remote_address, storage_uri="memory://", config_filename="")
+    app = FastAPI()
+    app.state.limiter = test_limiter
+    app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+    @app.get("/limited")
+    @test_limiter.limit("2/minute")
+    async def _limited(request: Request):  # pylint: disable=unused-argument
+        return {"ok": True}
+
+    client = TestClient(app, raise_server_exceptions=False)
+    headers = {"X-Forwarded-For": "10.10.10.1"}  # NOSONAR python:S1313 — test-only private RFC-1918 address
+
+    # 첫 두 번은 성공해야 함
+    # First two calls must succeed
+    assert client.get("/limited", headers=headers).status_code == 200
+    assert client.get("/limited", headers=headers).status_code == 200
+    # 세 번째는 429여야 함
+    # Third call must return 429
+    resp = client.get("/limited", headers=headers)
+    assert resp.status_code == 429
+
+
+def test_rate_limiter_uses_remote_address_key_func():
+    """Limiter의 key_func이 get_remote_address여야 한다.
+    Limiter must use get_remote_address as key_func.
+    """
+    from src.middleware.rate_limiter import limiter  # pylint: disable=import-outside-toplevel
+
+    # get_remote_address는 slowapi 표준 IP 기반 키 함수
+    # get_remote_address is the standard slowapi IP-based key function
+    assert limiter._key_func is get_remote_address
+
+
+def test_health_endpoint_no_rate_limit():
+    """/health 엔드포인트는 rate limit 없이 반복 호출에도 200을 반환해야 한다.
+    /health must always return 200 regardless of call frequency.
+    """
+    from src.main import app  # pylint: disable=import-outside-toplevel
+
+    client = TestClient(app, raise_server_exceptions=False)
+    for _ in range(15):
+        r = client.get("/health")
+    assert r.status_code == 200
+
+
+def test_app_state_has_limiter():
+    """app.state.limiter가 설정되어 있어야 한다.
+    app.state.limiter must be configured.
+    """
+    from src.main import app  # pylint: disable=import-outside-toplevel
+    from src.middleware.rate_limiter import limiter  # pylint: disable=import-outside-toplevel
+
+    assert hasattr(app.state, "limiter")
+    assert app.state.limiter is limiter


### PR DESCRIPTION
## Summary

- `slowapi==0.1.9` 도입 — IP 기반 rate limiting
- API GET 엔드포인트 4개에 `60/minute` 제한 적용 (repos, analyses, stats)
- `/health`는 rate limit 제외 (liveness probe 보호)
- `config_filename=""` 설정으로 Windows cp949 `.env` 인코딩 충돌 방지
- 5개 단위 테스트 추가 (상수 검증 / 429 동작 / key_func / health 미제한 / app.state)

## 적용 엔드포인트

| 엔드포인트 | 제한 |
|-----------|------|
| `GET /api/repos` | 60/minute |
| `GET /api/repos/{name}/analyses` | 60/minute |
| `GET /api/analyses/{id}` | 60/minute |
| `GET /api/repos/{name}/stats` | 60/minute |

## 검증 (Claude 직접 — Codex 샌드박스 모델 오류 대체)

- [x] 신규 테스트 5/5 통과
- [x] 기존 API 테스트 23/23 통과 (회귀 없음)
- [x] pylint 10.00/10
- [x] `app.state.limiter` 미들웨어 등록 전 배치 확인

## 🔍 사용자 검증 필요

- [ ] Railway 배포 후 실제 API 호출로 `X-RateLimit-*` 헤더 확인
- [ ] 60회 초과 호출 시 429 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)