### PR TITLE
fix(notifier): 알림 채널 엣지 케이스 강화 — Slack 장문 방어 + Email TLS 테스트

### DIFF
--- a/src/notifier/slack.py
+++ b/src/notifier/slack.py
@@ -11,7 +11,7 @@ from src.i18n.loader import get_text
 from src.scorer.calculator import ScoreResult
 from src.analyzer.io.static import StaticAnalysisResult
 from src.analyzer.io.ai_review import AiReviewResult
-from src.notifier._common import format_ref, get_all_issues, truncate_issue_msg
+from src.notifier._common import format_ref, get_all_issues, truncate_issue_msg, truncate_message
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +83,9 @@ def _build_payload(  # pylint: disable=too-many-positional-arguments,too-many-lo
         "fields": fields,
     }
     if footer_text:
-        attachment["text"] = footer_text
+        # Slack attachment.text 3000자 제한 방어 — 장문 AI 요약 + 이슈 목록 누적 시 초과 가능
+        # Guard against Slack attachment.text 3000-char limit for long AI summaries + issue lists
+        attachment["text"] = truncate_message(footer_text, 3000)
 
     return {"text": text, "attachments": [attachment]}
 

--- a/tests/unit/notifier/test_email.py
+++ b/tests/unit/notifier/test_email.py
@@ -271,3 +271,67 @@ def test_build_html_escapes_xss_in_issue_message():
     )
     assert "<script>" not in html
     assert "&lt;script&gt;" in html
+
+
+# ---------------------------------------------------------------------------
+# TLS / SMTP 연결 엣지 케이스 (Phase C 신규)
+# TLS / SMTP connection edge cases (Phase C new)
+# ---------------------------------------------------------------------------
+
+async def test_send_email_called_with_use_tls_true():
+    """aiosmtplib.send()가 use_tls=True로 호출되어야 한다.
+    aiosmtplib.send() must be called with use_tls=True.
+    """
+    with patch("src.notifier.email.aiosmtplib") as mock_smtp:
+        mock_smtp.send = AsyncMock(return_value=None)
+        await send_email_notification(
+            recipients="test@example.com",
+            repo_name="owner/repo",
+            commit_sha="abc1234",
+            score_result=_make_score(),
+            analysis_results=_make_analysis(),
+            smtp_host="smtp.example.com",
+            smtp_port=587,
+            smtp_user="user",
+            smtp_pass="pass",
+        )
+    call_kwargs = mock_smtp.send.await_args.kwargs
+    assert call_kwargs.get("use_tls") is True, "use_tls must be True"
+
+
+async def test_send_email_smtp_tls_error_propagates():
+    """TLS 협상 실패(SMTPNotSupported)는 예외로 전파되어야 한다.
+    SMTPNotSupported must propagate when TLS negotiation fails.
+    """
+    with patch("src.notifier.email.aiosmtplib") as mock_smtp:
+        mock_smtp.send = AsyncMock(
+            side_effect=aiosmtplib.SMTPNotSupported("TLS not available")
+        )
+        with pytest.raises(aiosmtplib.SMTPNotSupported):
+            await send_email_notification(
+                recipients="test@example.com",
+                repo_name="owner/repo",
+                commit_sha="abc1234",
+                score_result=_make_score(),
+                analysis_results=_make_analysis(),
+                smtp_host="smtp.example.com",
+            )
+
+
+async def test_send_email_smtp_server_disconnected_propagates():
+    """서버 연결 끊김(SMTPServerDisconnected)은 예외로 전파되어야 한다.
+    SMTPServerDisconnected must propagate when server connection drops.
+    """
+    with patch("src.notifier.email.aiosmtplib") as mock_smtp:
+        mock_smtp.send = AsyncMock(
+            side_effect=aiosmtplib.SMTPServerDisconnected("Connection lost")
+        )
+        with pytest.raises(aiosmtplib.SMTPServerDisconnected):
+            await send_email_notification(
+                recipients="test@example.com",
+                repo_name="owner/repo",
+                commit_sha="abc1234",
+                score_result=_make_score(),
+                analysis_results=_make_analysis(),
+                smtp_host="smtp.example.com",
+            )

--- a/tests/unit/notifier/test_slack.py
+++ b/tests/unit/notifier/test_slack.py
@@ -109,3 +109,22 @@ async def test_send_slack_notification_skips_when_no_url():
             analysis_results=_make_analysis(),
         )
     mock_build.assert_not_called()
+
+
+def test_build_payload_long_footer_text_is_truncated():
+    """attachment.text가 3000자를 초과하면 절단되어야 한다.
+    attachment.text must be truncated when it exceeds 3000 characters.
+    """
+    long_summary = "A" * 3500
+    ai = AiReviewResult(
+        commit_score=17, ai_score=15, test_score=10,
+        summary=long_summary, suggestions=[],
+    )
+    payload = _build_payload(
+        "owner/repo", "abc1234",
+        _make_score(), _make_analysis(),
+        pr_number=None, ai_review=ai,
+    )
+    footer = payload["attachments"][0].get("text", "")
+    assert len(footer) <= 3000, f"footer too long: {len(footer)} chars"
+    assert len(footer) > 0  # 내용은 있어야 함 / content must exist

--- a/tests/unit/notifier/test_telegram.py
+++ b/tests/unit/notifier/test_telegram.py
@@ -277,3 +277,25 @@ async def test_telegram_post_message_raises_on_second_429():
 
     # 정확히 2회 시도 후 포기
     assert mock_client.post.call_count == 2
+
+
+async def test_telegram_post_message_zero_retry_after_uses_minimum():
+    """retry_after=0 응답 시 최소 대기 1초가 적용되어야 한다.
+    Minimum wait of 1 second must apply when retry_after is 0.
+    """
+    with patch("src.notifier.telegram.get_http_client") as mock_get, \
+         patch("src.notifier.telegram.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+        mock_client = MagicMock()
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client.post = AsyncMock(side_effect=[_make_429_response(0), _make_200_response()])
+        mock_get.return_value = mock_client
+
+        await telegram_post_message(
+            bot_token="123:ABC", chat_id="-100", payload={"text": "x"},
+        )
+
+    sleep_arg = mock_sleep.await_args.args[0]
+    # max(0, 1) = 1 → cap 적용으로 최소 1초 보장
+    # max(0, 1) = 1 → cap ensures minimum 1 second
+    assert sleep_arg >= 1, f"sleep must be >= 1s, got {sleep_arg}"


### PR DESCRIPTION
## Summary

- **Slack**: `attachment.text` 3000자 초과 시 `truncate_message(3000)` 절단 (장문 AI 요약 + 이슈 누적 방어)
- **Email**: `use_tls=True` 확인 + `SMTPNotSupported` + `SMTPServerDisconnected` 전파 테스트 3건
- **Telegram**: `retry_after=0` 응답 시 최소 1초 대기 보장 확인 테스트 1건

## 신규 테스트 (5건)

| 채널 | 테스트명 | 검증 내용 |
|------|---------|---------|
| Slack | `test_build_payload_long_footer_text_is_truncated` | 3500자 요약 → 3000자 이하 절단 |
| Email | `test_send_email_called_with_use_tls_true` | `use_tls=True` kwarg 확인 |
| Email | `test_send_email_smtp_tls_error_propagates` | `SMTPNotSupported` 전파 |
| Email | `test_send_email_smtp_server_disconnected_propagates` | `SMTPServerDisconnected` 전파 |
| Telegram | `test_telegram_post_message_zero_retry_after_uses_minimum` | 0초 → 최소 1초 cap 보장 |

## 검증 (Claude 직접)

- [x] 전체 알림 테스트 235/235 통과
- [x] pylint 10.00/10 (slack.py)

## 🔍 사용자 검증 필요

- [ ] 장문 AI 요약 포함 실제 Slack 알림에서 메시지 렌더링 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)