### PR TITLE
fix(tests): conftest.py CLAUDE_REVIEW/INSIGHT_MODEL 기본값 명시 — .env 빈값 override 방지

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,10 @@ os.environ["ANTHROPIC_API_KEY"] = "sk-test-key"
 os.environ["GITHUB_CLIENT_ID"] = "test-github-client-id"
 os.environ["GITHUB_CLIENT_SECRET"] = "test-github-client-secret"
 os.environ["SESSION_SECRET"] = "test-session-secret-32-chars-long!"
+# Claude 모델 기본값 명시 — .env.example 이 빈값으로 설정되어 Python default 를 override 하는 버그 방지
+# Explicitly set Claude model defaults — .env.example sets empty values that would override Python defaults
+os.environ["CLAUDE_REVIEW_MODEL"] = "claude-sonnet-4-6"
+os.environ["CLAUDE_INSIGHT_MODEL"] = "claude-haiku-4-5"
 
 from src.main import app
 from src.ui.routes import add_repo as _add_repo_module


### PR DESCRIPTION
## Summary

`.env.example` L82/L86에 `CLAUDE_REVIEW_MODEL=` / `CLAUDE_INSIGHT_MODEL=`가 빈값으로 정의되어 있어, pydantic-settings가 Python default(`claude-sonnet-4-6` / `claude-haiku-4-5`)를 무시하고 빈 문자열로 설정하는 문제 수정.

## Root Cause

```
pydantic-settings 우선순위: env vars > .env file > Python default
.env 파일에 CLAUDE_INSIGHT_MODEL= (빈값) → Python default "claude-haiku-4-5" 무시
→ test_dashboard_insight_haiku 3건: assert "haiku" in '' → 실패
```

## Fix

`conftest.py`에 기존 사이클 65 패턴(직접 대입)으로 두 모델 env var 추가 — `from src.main import app` 이전에 설정하여 Settings 싱글톤 인스턴스화 시 반영.

## 검증

- [x] 기존 실패 3건 → 3 passed
- [x] 전체 서비스 테스트 265/265 통과

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인 (GitHub Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)