### PR TITLE
fix(phase-a): P0 테스트 수치 수정 + 즉각 로직 버그 3건 — 5+1 감사 결과 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 [![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=xzawed_SCAManager&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=xzawed_SCAManager)
 
-[![Tests](https://img.shields.io/badge/Tests-3173%2B_total_(3022_unit_+_151_integration)-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
+[![Tests](https://img.shields.io/badge/Tests-3364%2B_total_(3213_unit_+_151_integration)-brightgreen?style=flat-square&logo=pytest&logoColor=white)](tests/)
 [![E2E](https://img.shields.io/badge/E2E-112_passing-brightgreen?style=flat-square&logo=playwright&logoColor=white)](e2e/)
 [![pylint](https://img.shields.io/badge/pylint-10.00%2F10-brightgreen?style=flat-square&logo=python&logoColor=white)](src/)
 [![bandit](https://img.shields.io/badge/bandit-HIGH_0-brightgreen?style=flat-square&logo=security&logoColor=white)](src/)

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,11 +2,11 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-05-30 기준 — **사이클 141 완료**: Rate Limiting 테스트 보강 (#669) + GateAction 구현 직접 이전 (#670) + CodeQL 4건 해소 (#671) 머지): 156+ PR #188~#671 — 누적 정책 본문 18건 + 메모리 17건. 전체 3212 수집 (단위 3061 + 통합 151) / E2E 112 (100 표준 + 12 perf) / pylint **10.00/10**
+## 현재 수치 (2026-05-31 기준 — **사이클 142 진행 중**: 5+1 에이전트 감사 Phase A — P0 수치 수정 + 즉각 버그 3건): 156+ PR #188~#674+ — 누적 정책 본문 18건 + 메모리 17건. 전체 3364 수집 (단위 3213 + 통합 151) / E2E 112 (100 표준 + 12 perf) / pylint **10.00/10**
 
 | 지표 | 값 | 비고 |
 |------|-----|------|
-| 전체 테스트 | **3212 수집** *(헤더 = 최신값, 이 셀 = pytest 누적 추적)* | `pytest tests/` — 단위 3061 + 통합 151. 추적 이력: (이전 사이클 73~128 누적 2948) + **사이클 129 #614 AI Issue 등록 +59** (2948→3007). + **사이클 130 #617 +2** (3007→3009). + **사이클 131 Claude Design 재설계 #625~#633 +13** (3009→3022 단위). + **사이클 139 #660~#664 +13** (rate_limiter 5 + notifier 5 + dashboard 3, 3022→3035 단위). + **사이클 140 #666~#667 +17** (GateAction 17개, 3035→3052 단위). + **사이클 141 #669 +9** (Rate Limiting 보강 9개, 3052→3061 단위). |
+| 전체 테스트 | **3364 수집** *(헤더 = 최신값, 이 셀 = pytest 누적 추적)* | `pytest tests/` — 단위 3213 + 통합 151. 추적 이력: (이전 사이클 73~128 누적 2948) + **사이클 129 #614 AI Issue 등록 +59** (2948→3007). + **사이클 130 #617 +2** (3007→3009). + **사이클 131 Claude Design 재설계 #625~#633 +13** (3009→3022 단위). + **사이클 139 #660~#664 +13** (rate_limiter 5 + notifier 5 + dashboard 3, 3022→3035 단위). + **사이클 140 #666~#667 +17** (GateAction 17개, 3035→3052 단위). + **사이클 141 #669 +9** (Rate Limiting 보강 9개, 3052→3061 단위). + **사이클 142 P0 수정 — 실측 기반 재집계** (3061→3213 단위, 이전 과소집계 152건 보정). |
 | 통합 테스트 | **151개** | tests/integration/ — 사이클 81 영역 🅑 모바일 Phase 1 MVP +34 + **사이클 84 i18n PR-18 smoke +11** + **PR #400 repo insights +22** + **사이클 99 #441 +3** (repo_report_api auth·list·404) + **사이클 100~101 누적** (test_retry_concurrency_postgres assertion 강화). 기존 test_settings_mobile.py 일부 Windows cp949 인코딩 오류 제외. **= 151 passed** |
 | E2E 테스트 | **112개** | `make test-e2e` (Chromium Playwright) — Phase 3 PR 6 +7 + **사이클 84 i18n PR-16 +14** (3 언어 × 4 페이지 — login/overview/dashboard/settings + Cookie fallback + locale switch). 사이클 94 #372: test_save_success ordering 트랩 차단 (`_reset_repo_config()` 헬퍼) + test_two_column 보류 (`@pytest.mark.skip`). **+ 사이클 106 #500 `@pytest.mark.perf` 12개** (TTFB/FCP/LCP/DCL/Load — 3회 avg/min/max). **+ 사이클 127 #605 `test_nav_handler_survives_hx_boost_renavigation` +1** (hx-boost 3회 재방문 회귀 가드). **+ 사이클 127 #609 사전 실패 8건 해소** (5 TIMEOUT: test_theme.py glass/claude-dark 셀렉터 → pastel/catppuccin 갱신 + 3 ERROR: test_repos_mode.py auth_cookies 픽스처 제거). **= 112 collected (100 표준 + 12 perf)**. `make test-perf` 로 perf 마커만 선택 실행. ⚠️ e2e ↔ tests/integration 동시 실행 금지 — `e2e/pytest.ini` 의도적 asyncio_mode 미설정, 분리 실행 default (`make test-e2e` vs CI command `pytest tests/`) |
 | SonarCloud Quality Gate | **OK** | #399 이후 유지 — **#658 ReDoS 정규식 수정으로 S5852 hotspot 2건 해소, QG OK 복원** |
@@ -42,7 +42,7 @@
 | `src/notifier/merge_failure_issue.py` | `create_merge_failure_issue()` — auto-merge 실패 GitHub Issue (Phase F.3, dedup 24h) |
 | `src/models/merge_attempt.py` | MergeAttempt ORM — score/threshold 스냅샷 + failure_reason 태그 (Phase F.1, append-only) |
 | `src/shared/merge_metrics.py` | parse_reason_tag + log_merge_attempt — DB INSERT + 구조화 로그 (Phase F.1) |
-| `src/repositories/` | DB 접근 계층 10종 — repository_repo (`find_by_full_name` + Phase H 신규 `find_by_full_name_with_owner` opt-in joinedload), analysis_repo, analysis_feedback_repo, merge_attempt_repo, gate_decision_repo, repo_config_repo, user_repo, merge_retry_repo, insight_narrative_cache_repo (0033: `record_error` / `record_error_repo` 에러 빈도 추적), security_alert_log_repo |
+| `src/repositories/` | DB 접근 계층 11종 — repository_repo (`find_by_full_name` + Phase H 신규 `find_by_full_name_with_owner` opt-in joinedload), analysis_repo, analysis_feedback_repo, merge_attempt_repo, gate_decision_repo, repo_config_repo, user_repo, merge_retry_repo, insight_narrative_cache_repo (0033: `record_error` / `record_error_repo` 에러 빈도 추적), security_alert_log_repo, issue_registration_repo |
 | `src/worker/pipeline.py` | 분석 파이프라인 + build_analysis_result_dict |
 | `src/models/merge_retry.py` | MergeRetryQueue ORM — 재시도 큐 (append-only claim 패턴) |
 | `src/repositories/merge_retry_repo.py` | enqueue_or_bump · claim_batch · mark_succeeded/terminal/expired — 원자적 SKIP LOCKED 클레임 |

--- a/src/webhook/providers/telegram.py
+++ b/src/webhook/providers/telegram.py
@@ -88,6 +88,14 @@ async def handle_gate_callback(
                 if repo.owner and repo.owner.plaintext_token
                 else settings.github_token
             )
+            if analysis.pr_number is None:
+                # push 이벤트로 생성된 Analysis는 pr_number=None — GitHub Review 불가
+                # Analysis created from push event has no pr_number — GitHub Review unavailable
+                logger.warning(
+                    "handle_gate_callback: analysis %d has no pr_number, skipping gate action",
+                    analysis_id,
+                )
+                return
             body = f"{'✅ 승인' if decision == 'approve' else '❌ 반려'} by @{decided_by}"
             await post_github_review(
                 github_token, repo.full_name,

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -9,7 +9,6 @@ from sqlalchemy.orm import Session
 
 from src.database import SessionLocal
 from src.config import settings
-from src.constants import PIPELINE_ANALYSIS_TIMEOUT
 from src.shared.log_safety import sanitize_for_log
 from src.shared.stage_metrics import stage_timer
 from src.github_client.diff import get_pr_files, get_push_files, ChangedFile
@@ -279,6 +278,11 @@ async def _regate_pr_if_needed(
     owner_token: str = settings.github_token
     if repo.owner and repo.owner.plaintext_token:
         owner_token = repo.owner.plaintext_token
+    if existing.result is None:
+        # result=None 이면 run_gate_check 내부에서 AttributeError 발생 — 조기 종료
+        # Skip if result is None to avoid AttributeError inside run_gate_check
+        logger.warning("_regate_pr_if_needed: analysis %d has no result, skipping gate", existing.id)
+        return
     try:
         await run_gate_check(
             repo_name=repo_name,
@@ -318,6 +322,11 @@ async def _race_recover_existing(
         repo_config = None
 
     if params.pr_number is None or existing.pr_number is not None:
+        return repo_config
+    if existing.result is None:
+        # result=None 이면 run_gate_check 내부에서 AttributeError 발생 — 조기 종료
+        # Skip if result is None to avoid AttributeError inside run_gate_check
+        logger.warning("_race_recover_existing: analysis %d has no result, skipping gate", existing.id)
         return repo_config
 
     try:
@@ -438,7 +447,7 @@ async def _send_notifications(notify_tasks: list, task_names: list[str]) -> None
     """알림 채널들을 병렬 실행하고 실패를 로그로 기록한다."""
     results = await asyncio.gather(*notify_tasks, return_exceptions=True)
     for idx, exc in enumerate(results):
-        if isinstance(exc, Exception):
+        if isinstance(exc, BaseException):
             name = task_names[idx] if idx < len(task_names) else "unknown"
             logger.error("Notification [%s] failed: %s", name, exc,
                          exc_info=(type(exc), exc, exc.__traceback__))

--- a/tests/unit/webhook/test_telegram_provider.py
+++ b/tests/unit/webhook/test_telegram_provider.py
@@ -513,3 +513,27 @@ def test_cmd_scope_token_does_not_validate_as_gate():
         parsed = _parse_gate_callback(f"gate:approve:42:{cmd_token}")
 
     assert parsed is None, "cmd 도메인 토큰을 gate 로 재사용 시도 차단 필요"
+
+
+# --- handle_gate_callback pr_number=None 가드 (B1) ---
+
+async def test_handle_gate_callback_skips_when_pr_number_is_none():
+    """pr_number=None인 Analysis(push 이벤트)가 연결된 경우 gate action을 건너뛰어야 한다.
+    Gate action must be skipped when the linked Analysis has pr_number=None (push event).
+    """
+    from src.webhook.router import handle_gate_callback  # pylint: disable=import-outside-toplevel
+    # push Analysis — pr_number 없음
+    mock_analysis = MagicMock(id=55, repo_id=1, pr_number=None, result={"score": 80})
+    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [
+        mock_analysis, mock_repo
+    ]
+    with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
+        with patch("src.webhook.providers.telegram.post_github_review",
+                   new_callable=AsyncMock) as mock_review:
+            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
+                await handle_gate_callback(analysis_id=55, decision="approve", decided_by="john")
+    # pr_number=None → post_github_review·save_gate_decision 모두 호출되지 않아야 한다
+    mock_review.assert_not_called()
+    mock_save.assert_not_called()

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -1022,3 +1022,87 @@ async def test_run_static_with_timeout_returns_results_when_fast():
         result = await _run_static_with_timeout([])
 
     assert result == fake_result
+
+
+# ---------------------------------------------------------------------------
+# _send_notifications — BaseException 처리 (B2)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_send_notifications_handles_cancelled_error():
+    """asyncio.CancelledError(BaseException 서브클래스)가 로그 출력 후 묵살되어야 한다.
+    CancelledError must be logged and not re-raised (BaseException fix).
+    """
+    import asyncio
+    from src.worker.pipeline import _send_notifications  # pylint: disable=import-outside-toplevel
+
+    cancelled = asyncio.CancelledError("cancelled")
+    with patch("src.worker.pipeline.logger") as mock_logger:
+        # CancelledError를 반환하는 gather 결과 시뮬레이션
+        with patch("src.worker.pipeline.asyncio.gather",
+                   new=AsyncMock(return_value=[cancelled])):
+            # 예외가 전파되지 않아야 한다 — BaseException 경로 커버
+            await _send_notifications([AsyncMock()], ["test_channel"])
+    mock_logger.error.assert_called_once()
+    assert "test_channel" in mock_logger.error.call_args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# _regate_pr_if_needed — result=None 가드 (B3)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_regate_pr_skips_when_result_is_none():
+    """existing.result=None이면 run_gate_check를 호출하지 않고 조기 종료해야 한다.
+    Must return early without calling run_gate_check when existing.result is None.
+    """
+    from src.worker.pipeline import _regate_pr_if_needed  # pylint: disable=import-outside-toplevel
+
+    mock_db = MagicMock()
+    # pr_number=None → guard 통과, sha lookup 필요
+    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_repo.owner = MagicMock(plaintext_token="tok")
+    # pr_number=None이어야 `existing.pr_number == pr_number(5)` 조건 통과
+    mock_existing = MagicMock(id=10, pr_number=None, result=None)
+
+    with patch("src.worker.pipeline.repository_repo") as mock_repo_repo:
+        mock_repo_repo.find_by_full_name.return_value = mock_repo
+        with patch("src.worker.pipeline.analysis_repo") as mock_analysis_repo:
+            mock_analysis_repo.find_by_sha.return_value = mock_existing
+            with patch("src.worker.pipeline.run_gate_check", new_callable=AsyncMock) as mock_gate:
+                await _regate_pr_if_needed(mock_db, "owner/repo", "abc123", 5)
+
+    mock_gate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_race_recover_existing_skips_when_result_is_none():
+    """existing.result=None이면 run_gate_check를 호출하지 않고 repo_config를 반환해야 한다.
+    Must return repo_config without calling run_gate_check when existing.result is None.
+    """
+    from src.worker.pipeline import _race_recover_existing  # pylint: disable=import-outside-toplevel
+    from src.worker.pipeline import _AnalysisSaveParams  # pylint: disable=import-outside-toplevel
+
+    mock_db = MagicMock()
+    # pr_number가 있어야 'params.pr_number is None' early-return을 통과
+    # existing.pr_number=None이어야 'existing.pr_number is not None' early-return을 통과
+    mock_existing = MagicMock(id=20, pr_number=None, result=None)
+    mock_repo_config = MagicMock()
+
+    params = _AnalysisSaveParams(
+        repo_name="owner/repo",
+        commit_sha="abc123",
+        commit_message="feat: test",
+        pr_number=7,
+        owner_token="tok",
+        analysis_results=[],
+        ai_review=MagicMock(),
+        score_result=MagicMock(),
+    )
+
+    with patch("src.worker.pipeline.get_repo_config", return_value=mock_repo_config):
+        with patch("src.worker.pipeline.run_gate_check", new_callable=AsyncMock) as mock_gate:
+            result = await _race_recover_existing(mock_db, params, mock_existing)
+
+    mock_gate.assert_not_called()
+    assert result is mock_repo_config


### PR DESCRIPTION
## Summary

5+1 다중 에이전트 감사(사이클 142) Phase A — 가장 위험도 높은 P0 수치 오류 + 즉각 로직 버그 3건 수정.

## 변경 내용

### P0 — 수치 수정
| 파일 | 변경 |
|------|------|
| `docs/STATE.md` | 단위 테스트 3061 → **3213** (실측, 이전 152건 과소집계), 전체 3212 → **3364**, repositories 10종 → **11종** |
| `README.md` | 테스트 배지 3173/3022 → **3364/3213** 동기화 |

### B1 — `src/webhook/providers/telegram.py`
`handle_gate_callback`: `analysis.pr_number is None` 가드 추가.  
push 이벤트로 생성된 Analysis(pr_number=None)가 gate callback에 연결될 경우 `post_github_review`에 None 전달 → HTTPError 방지.

### B2 — `src/worker/pipeline.py`
`_send_notifications`: `isinstance(exc, Exception)` → `isinstance(exc, BaseException)`.  
Python 3.8+에서 `asyncio.CancelledError`는 `BaseException` 서브클래스 → 기존 코드가 묵살. `engine.py:90`과 동일 패턴으로 통일.

### B3 — `src/worker/pipeline.py`
`_regate_pr_if_needed` + `_race_recover_existing`: `existing.result is None` 가드 추가.  
`Analysis.result`는 `nullable=True` 컬럼. None이면 `run_gate_check` 내부 `result.get('score', 0)` 에서 AttributeError 발생.

### Dead import — `src/worker/pipeline.py`
`from src.constants import PIPELINE_ANALYSIS_TIMEOUT` 제거.  
line 32에서 즉시 60으로 재정의하는 dead import였음 (constants.py 값 = 300).

## 테스트
- `tests/unit/webhook/test_telegram_provider.py` — 87 passed ✅
- `tests/unit/worker/` — 80 passed ✅

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인
- [ ] push Analysis에서 Telegram gate callback 트리거 시 로그에 warning 출력 확인 (`analysis X has no pr_number`)
- [ ] PR Analysis에서 정상 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)