### PR TITLE
fix(phase-c): API 보강 — Rate limiting 확장·async fix·CORS·body limit

### DIFF
--- a/src/api/hook.py
+++ b/src/api/hook.py
@@ -6,7 +6,8 @@ import hmac
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Header, HTTPException, Query
+from fastapi import APIRouter, Header, HTTPException, Query, Request
+from src.middleware.rate_limiter import limiter, RATE_LIMIT_API
 from pydantic import BaseModel
 
 from src.database import SessionLocal
@@ -29,7 +30,9 @@ router = APIRouter(prefix="/api/hook")
 # ---------------------------------------------------------------------------
 
 @router.get("/verify")
+@limiter.limit(RATE_LIMIT_API)
 def verify_hook(
+    request: Request,  # pylint: disable=unused-argument
     repo: str,
     token: str | None = Query(default=None),
     authorization: str | None = Header(default=None),
@@ -79,7 +82,8 @@ class HookResultRequest(BaseModel):
 
 
 @router.post("/result")
-def save_hook_result(body: HookResultRequest):
+@limiter.limit(RATE_LIMIT_API)
+def save_hook_result(request: Request, body: HookResultRequest):  # pylint: disable=unused-argument
     """pre-push 훅이 코드리뷰 결과를 전송하는 엔드포인트.
 
     토큰 검증 후 Analysis 레코드를 저장하고 점수를 반환한다.

--- a/src/api/issue_registration.py
+++ b/src/api/issue_registration.py
@@ -1,8 +1,10 @@
 """issue_registration API — GitHub Issue 등록 + 상태 조회 엔드포인트.
 issue_registration API — endpoints for registering GitHub Issues and querying state.
 """
+import asyncio
 import httpx
 from fastapi import APIRouter, HTTPException, Request
+from src.middleware.rate_limiter import limiter, RATE_LIMIT_API, RATE_LIMIT_HEAVY
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -70,6 +72,7 @@ def _make_issue_key(req: RegisterRequest) -> str:
 
 
 @router.post("/register", status_code=201)
+@limiter.limit(RATE_LIMIT_HEAVY)
 async def register(request: Request, req: RegisterRequest):
     """AI 분석 이슈를 GitHub Issue로 등록한다.
     Register an AI analysis issue as a GitHub Issue.
@@ -80,8 +83,15 @@ async def register(request: Request, req: RegisterRequest):
 
     issue_key = _make_issue_key(req)
 
+    # A2: 소유권 검증은 sync DB 쿼리 — asyncio.to_thread로 이벤트 루프 차단 방지
+    # A2: Ownership check is sync DB query — offload to thread to avoid blocking event loop
+    def _check_ownership():
+        with SessionLocal() as _db:
+            return _get_analysis_and_repo(_db, req.analysis_id, current_user_id=current_user.id)
+
+    _, repo = await asyncio.to_thread(_check_ownership)
+
     with SessionLocal() as db:
-        _, repo = _get_analysis_and_repo(db, req.analysis_id, current_user_id=current_user.id)
         try:
             result = await register_issue(
                 db,
@@ -117,6 +127,7 @@ async def register(request: Request, req: RegisterRequest):
 
 
 @router.get("/status")
+@limiter.limit(RATE_LIMIT_API)
 async def get_status(request: Request, analysis_id: int):
     """analysis_detail용 등록 이력 + GitHub 상태 동기화 결과를 반환한다.
     Return registration history and synced GitHub state for analysis_detail.
@@ -125,8 +136,13 @@ async def get_status(request: Request, analysis_id: int):
     if not current_user:
         raise HTTPException(status_code=401, detail="Login required")
 
+    def _check():
+        with SessionLocal() as _db:
+            return _get_analysis_and_repo(_db, analysis_id, current_user_id=current_user.id)
+
+    _, repo = await asyncio.to_thread(_check)
+
     with SessionLocal() as db:
-        _, repo = _get_analysis_and_repo(db, analysis_id, current_user_id=current_user.id)
         statuses = await get_analysis_issue_status(
             db,
             analysis_id=analysis_id,
@@ -152,6 +168,7 @@ def _get_repo_or_404(db: Session, repo_id: int, *, current_user_id: int) -> Repo
 
 
 @router.get("/repo-summary")
+@limiter.limit(RATE_LIMIT_API)
 async def repo_summary(request: Request, repo_id: int):
     """repo_detail용 등록 이력 + GitHub 상태를 반환한다.
     Return registration history and GitHub state for repo_detail.
@@ -160,8 +177,13 @@ async def repo_summary(request: Request, repo_id: int):
     if not current_user:
         raise HTTPException(status_code=401, detail="Login required")
 
+    def _check():
+        with SessionLocal() as _db:
+            return _get_repo_or_404(_db, repo_id, current_user_id=current_user.id)
+
+    repo = await asyncio.to_thread(_check)
+
     with SessionLocal() as db:
-        repo = _get_repo_or_404(db, repo_id, current_user_id=current_user.id)
         registrations = await get_repo_issue_summary(
             db,
             repo_id=repo_id,

--- a/src/api/repo_report.py
+++ b/src/api/repo_report.py
@@ -2,8 +2,10 @@
 Per-repository analysis report JSON API endpoints.
 """
 from datetime import datetime, timezone
+from typing import Annotated
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
+from src.middleware.rate_limiter import limiter, RATE_LIMIT_API
 
 from src.api.auth import require_api_key
 from src.api.deps import get_repo_or_404
@@ -25,8 +27,10 @@ _WARNING_GRADES = {"D", "F"}
 
 
 @router.get("/repos/report")
+@limiter.limit(RATE_LIMIT_API)
 def list_repos_report(
-    days: int = Query(default=30, ge=1, le=365),
+    request: Request,  # pylint: disable=unused-argument
+    days: Annotated[int, Query(ge=1, le=365)] = 30,
 ) -> dict:
     """연결된 전체 Repo 요약 반환 (KPI + 등급 + 경고 여부).
 
@@ -87,9 +91,11 @@ def list_repos_report(
 
 
 @router.get("/repos/{repo_name:path}/report")
+@limiter.limit(RATE_LIMIT_API)
 def get_repo_report(
+    request: Request,  # pylint: disable=unused-argument
     repo_name: str,
-    days: int = Query(default=30, ge=1, le=365),
+    days: Annotated[int, Query(ge=1, le=365)] = 30,
 ) -> dict:
     """개별 Repo 상세 분석 레포트 반환.
 

--- a/src/api/repos.py
+++ b/src/api/repos.py
@@ -1,8 +1,8 @@
 """Repository and config REST API endpoints (/api/repos/*)."""
-from typing import Literal
-from fastapi import APIRouter, Request
+from typing import Annotated, Literal
+from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel, Field, model_validator
-from src.middleware.rate_limiter import limiter, RATE_LIMIT_API
+from src.middleware.rate_limiter import limiter, RATE_LIMIT_API, RATE_LIMIT_HEAVY
 from src.api.auth import require_api_key
 from src.api.deps import get_repo_or_404
 from src.constants import (
@@ -76,7 +76,12 @@ def list_repos(request: Request):  # pylint: disable=unused-argument
 
 @router.get("/repos/{repo_name:path}/analyses")
 @limiter.limit(RATE_LIMIT_API)
-def list_repo_analyses(request: Request, repo_name: str, skip: int = 0, limit: int = 20):  # pylint: disable=unused-argument
+def list_repo_analyses(
+    request: Request,
+    repo_name: str,
+    skip: Annotated[int, Query(ge=0)] = 0,
+    limit: Annotated[int, Query(ge=1, le=200)] = 20,
+):  # pylint: disable=unused-argument
     """리포지토리 분석 이력 목록을 반환한다."""
     with SessionLocal() as db:
         repo = get_repo_or_404(repo_name, db)
@@ -95,7 +100,8 @@ def list_repo_analyses(request: Request, repo_name: str, skip: int = 0, limit: i
 
 
 @router.put("/repos/{repo_name:path}/config")
-def update_repo_config(repo_name: str, body: RepoConfigUpdate):
+@limiter.limit(RATE_LIMIT_HEAVY)
+def update_repo_config(request: Request, repo_name: str, body: RepoConfigUpdate):  # pylint: disable=unused-argument
     """리포지토리 Gate·알림 설정을 업데이트한다."""
     with SessionLocal() as db:
         record = upsert_repo_config(db, RepoConfigData(
@@ -106,7 +112,8 @@ def update_repo_config(repo_name: str, body: RepoConfigUpdate):
 
 
 @router.delete("/repos/{repo_name:path}")
-def delete_repo_api(repo_name: str):
+@limiter.limit(RATE_LIMIT_HEAVY)
+def delete_repo_api(request: Request, repo_name: str):  # pylint: disable=unused-argument
     """리포지토리와 모든 연관 데이터(Analysis, GateDecision, RepoConfig)를 삭제한다.
 
     API 모드는 사용자 OAuth 토큰이 없으므로 GitHub Webhook은 자동 삭제하지 않는다.

--- a/src/api/stats.py
+++ b/src/api/stats.py
@@ -1,5 +1,6 @@
 """Statistics API — analysis detail and per-repo score statistics endpoints."""
-from fastapi import APIRouter, HTTPException, Request
+from typing import Annotated
+from fastapi import APIRouter, HTTPException, Query, Request
 from src.api.auth import require_api_key
 from src.api.deps import get_repo_or_404
 from src.database import SessionLocal
@@ -28,7 +29,11 @@ def get_analysis(request: Request, analysis_id: int):  # pylint: disable=unused-
 
 @router.get("/repos/{repo_name:path}/stats")
 @limiter.limit(RATE_LIMIT_API)
-def get_repo_stats(request: Request, repo_name: str, limit: int = 30):  # pylint: disable=unused-argument
+def get_repo_stats(
+    request: Request,
+    repo_name: str,
+    limit: Annotated[int, Query(ge=1, le=200)] = 30,
+):  # pylint: disable=unused-argument
     """리포지토리 점수 통계(평균·트렌드)를 반환한다."""
     with SessionLocal() as db:
         repo = get_repo_or_404(repo_name, db)

--- a/src/main.py
+++ b/src/main.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
@@ -33,6 +34,19 @@ from src.ui.router import router as ui_router
 from src.auth.github import router as auth_router
 
 logger = logging.getLogger(__name__)
+
+
+class LimitBodySizeMiddleware(BaseHTTPMiddleware):  # pylint: disable=too-few-public-methods
+    """요청 본문 크기를 제한한다 (DoS 방어).
+    Limits request body size to prevent DoS via oversized payloads."""
+
+    _MAX_BODY = 10 * 1024 * 1024  # 10 MB
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        content_length = request.headers.get("content-length")
+        if content_length and int(content_length) > self._MAX_BODY:
+            return Response("Request body too large", status_code=413)
+        return await call_next(request)
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):  # pylint: disable=too-few-public-methods
@@ -181,6 +195,18 @@ app = FastAPI(
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SecurityHeadersMiddleware)
+app.add_middleware(LimitBodySizeMiddleware)
+# A4: CORS — APP_BASE_URL 기반 명시적 출처 허용 (allow_origins=["*"] 금지)
+# A4: CORS — explicit origin from APP_BASE_URL, never allow_origins=["*"]
+if settings.app_base_url:
+    _origin = settings.app_base_url.rstrip("/")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[_origin],
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "DELETE"],
+        allow_headers=["*"],
+    )
 # Phase 3 postlude — RLS 운영 활성화 미들웨어. Starlette LIFO 미들웨어 스택:
 # add_middleware 마지막 호출이 outer (request 먼저 처리). 원하는 흐름 = SessionMiddleware → RLSSessionMiddleware → route
 # 따라서 RLS 먼저 등록 (inner), SessionMiddleware 나중 등록 (outer — RLS 보다 먼저 호출).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,19 @@ def _clear_user_repos_cache():
     _add_repo_module._user_repos_cache.clear()
 
 
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """Rate limiter 인메모리 카운터를 테스트마다 초기화한다 — 테스트 간 rate limit 누적 방지.
+    Reset in-memory rate limiter counters between tests to prevent cross-test leakage.
+    """
+    from src.middleware.rate_limiter import limiter  # pylint: disable=import-outside-toplevel
+    yield
+    try:
+        limiter._storage.reset()  # limits.MemoryStorage.reset() — 모든 카운터 초기화
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+
 @pytest.fixture
 def client():
     return TestClient(app)


### PR DESCRIPTION
## Summary

5+1 감사 Phase C — API/아키텍처 보강 6건.

## 변경 내용

### A1 — Rate limiting 확장 (10개 엔드포인트)
| 파일 | 엔드포인트 | 적용 제한 |
|------|-----------|---------|
| `repos.py` | `PUT /repos/{repo}/config`, `DELETE /repos/{repo}` | HEAVY (10/min) |
| `hook.py` | `GET /hook/verify`, `POST /hook/result` | API (60/min) |
| `repo_report.py` | `GET /repos/report`, `GET /repos/{repo}/report` | API (60/min) |
| `issue_registration.py` | `POST /issues/register` | HEAVY / `GET /status`, `GET /repo-summary` | API |

`users.py`의 `issue_telegram_otp`, `update_preferred_language`는 `@limiter.limit` + `Depends(require_login)` 조합이 FastAPI 422를 유발 → 미적용 (해당 엔드포인트는 `require_login`으로 인증 보호됨).

### A2 — issue_registration.py async 이벤트 루프 차단 해소
`async def register/get_status/repo_summary` 내 sync DB 소유권 검증을 `asyncio.to_thread`로 분리 — `users.py:60`의 기존 패턴과 통일.

### A4 — CORS 미들웨어 추가 (`main.py`)
`APP_BASE_URL` 기반 명시적 `allow_origins` 설정. `allow_origins=["*"]` 금지.

### P2 — 요청 본문 크기 제한 (`main.py`)
`LimitBodySizeMiddleware`: `Content-Length > 10MB` → 413 반환 (DoS 방어).

### P2 — Query 파라미터 상한선 + Annotated 패턴 (`repos.py`, `stats.py`, `repo_report.py`)
- `limit`: 1~200, `skip`: ≥0, `days`: 1~365
- `Annotated[int, Query(ge=, le=)]` 패턴 (S8410 해소)

## 테스트
- `conftest.py` autouse 픽스처: 테스트 간 rate limiter 카운터 초기화 (429 cross-test 오염 방지)
- **3220 passed, 1 skipped** ✅

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인
- [ ] PUT /api/repos/{repo}/config 10회 이상 빠르게 요청 시 429 반환 확인 (rate limit 동작)
- [ ] CORS Origin 헤더가 `APP_BASE_URL` 기반으로 설정되는지 브라우저 Network 탭 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)