### PR TITLE
fix(tests): CodeQL py/import-and-import-from #489/#490 해소 — import 스타일 통일

### DIFF
--- a/tests/unit/webhook/test_telegram_provider.py
+++ b/tests/unit/webhook/test_telegram_provider.py
@@ -494,7 +494,7 @@ def test_unknown_payload_returns_ok():
 def test_sender_receiver_hmac_token_parity():
     """발신측 _gate_callback_token() 이 만든 토큰을 수신측이 검증 통과해야 한다."""
     from src.gate.telegram_gate import _gate_callback_token  # pylint: disable=import-outside-toplevel
-    from src.webhook.providers.telegram import _parse_gate_callback  # pylint: disable=import-outside-toplevel
+    import src.webhook.providers.telegram as _tg  # pylint: disable=import-outside-toplevel
 
     bot_token = "123:ABC"  # conftest 환경변수와 일치
     analysis_id = 99
@@ -504,7 +504,7 @@ def test_sender_receiver_hmac_token_parity():
     with patch("src.webhook.providers.telegram.settings") as mock_settings:
         mock_settings.telegram_bot_token = bot_token
         callback_data = f"gate:approve:{analysis_id}:{sender_token}"
-        parsed = _parse_gate_callback(callback_data)
+        parsed = _tg._parse_gate_callback(callback_data)
 
     assert parsed is not None, (
         "PARITY 위반: 발신측 토큰이 수신측 검증을 통과해야 함 — "
@@ -527,8 +527,8 @@ def test_receiver_rejects_legacy_str_id_token():
 
     with patch("src.webhook.providers.telegram.settings") as mock_settings:
         mock_settings.telegram_bot_token = bot_token
-        from src.webhook.providers.telegram import _parse_gate_callback  # pylint: disable=import-outside-toplevel
-        parsed = _parse_gate_callback(f"gate:approve:42:{legacy_token}")
+        import src.webhook.providers.telegram as _tg  # pylint: disable=import-outside-toplevel
+        parsed = _tg._parse_gate_callback(f"gate:approve:42:{legacy_token}")
 
     assert parsed is None, "구 패턴 토큰은 거부되어야 함 (Critical C10 가드)"
 
@@ -541,8 +541,8 @@ def test_cmd_scope_token_does_not_validate_as_gate():
 
     with patch("src.webhook.providers.telegram.settings") as mock_settings:
         mock_settings.telegram_bot_token = bot_token
-        from src.webhook.providers.telegram import _parse_gate_callback  # pylint: disable=import-outside-toplevel
-        parsed = _parse_gate_callback(f"gate:approve:42:{cmd_token}")
+        import src.webhook.providers.telegram as _tg  # pylint: disable=import-outside-toplevel
+        parsed = _tg._parse_gate_callback(f"gate:approve:42:{cmd_token}")
 
     assert parsed is None, "cmd 도메인 토큰을 gate 로 재사용 시도 차단 필요"
 


### PR DESCRIPTION
## Summary

Code Scanning alert #489/#490 (`py/import-and-import-from`) 해소.

`tests/unit/webhook/test_telegram_provider.py` 내 동일 모듈(`src.webhook.providers.telegram`)을 `import ... as _tg`와 `from ... import _parse_gate_callback` 두 가지 스타일로 혼용하던 문제 수정.

## 변경 내용

3개 테스트 함수의 `from src.webhook.providers.telegram import _parse_gate_callback` →
`import src.webhook.providers.telegram as _tg` + `_tg._parse_gate_callback()` 통일:

- `test_sender_receiver_hmac_token_parity`
- `test_receiver_rejects_legacy_str_id_token`
- `test_cmd_scope_token_does_not_validate_as_gate`

기존 `import ... as _tg` 패턴(lines 48, 86 — monkeypatch용)과 스타일 통일.
동작 변경 없음 — 동일 함수를 다른 경로로 접근하는 것뿐.

## 검증

- 수정된 3개 테스트 모두 PASSED ✅
- import 스타일 단일화 확인: `grep -n "from src.webhook.providers.telegram import" tests/unit/webhook/test_telegram_provider.py` → 0건

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] CodeQL 재실행 후 alert #489/#490 닫힘 확인 (CodeQL은 주 1회 실행 — CI 통과 후 자동 해소 예상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)