### PR TITLE
fix(i18n): dashboard.html repos 모드 한국어 하드코딩 → i18n 전환 (Tier B P1-4)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -152,7 +152,26 @@
     "recurring_issues_count": "{count} recurring issues",
     "trend_improve": "↑ Improved",
     "trend_decline": "↓ Declined",
-    "trend_stable": "→ Stable"
+    "trend_stable": "→ Stable",
+    "repos": {
+      "kpi_avg_score": "Avg Score",
+      "kpi_connected_repos": "Connected Repos",
+      "kpi_warning": "Warning",
+      "grade_distribution": "Grade Distribution",
+      "grade_bar_tooltip": "{grade} Grade {count} repos",
+      "select_repo_aria": "Select Repo",
+      "chart_avg_score_label": "Avg Score",
+      "cat_security_error": "Security Error",
+      "cat_security_warning": "Security Warning",
+      "cat_quality_error": "Quality Error",
+      "cat_quality_warning": "Quality Warning",
+      "recurring_count": "{count} occurrences"
+    },
+    "kpi_foot_avg": "Recent {days}-day avg",
+    "kpi_unit_count": "analyses",
+    "score_trend_subtitle": "Score Trend",
+    "repo_insights_title": "🗂 Per-Repo Insights",
+    "recent_days": "Recent {days} days"
   },
   "overview": {
     "greeting": "Hello, {name}",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -152,7 +152,26 @@
     "recurring_issues_count": "繰り返しイシュー{count}件",
     "trend_improve": "↑ 改善",
     "trend_decline": "↓ 低下",
-    "trend_stable": "→ 維持"
+    "trend_stable": "→ 維持",
+    "repos": {
+      "kpi_avg_score": "平均スコア",
+      "kpi_connected_repos": "接続リポ",
+      "kpi_warning": "警告",
+      "grade_distribution": "グレード分布",
+      "grade_bar_tooltip": "{grade}グレード {count}件",
+      "select_repo_aria": "リポを選択",
+      "chart_avg_score_label": "平均スコア",
+      "cat_security_error": "セキュリティエラー",
+      "cat_security_warning": "セキュリティ警告",
+      "cat_quality_error": "品質エラー",
+      "cat_quality_warning": "品質警告",
+      "recurring_count": "{count}回繰り返し"
+    },
+    "kpi_foot_avg": "直近{days}日平均",
+    "kpi_unit_count": "件",
+    "score_trend_subtitle": "スコアトレンド",
+    "repo_insights_title": "🗂 リポ別インサイト",
+    "recent_days": "直近{days}日"
   },
   "overview": {
     "greeting": "こんにちは、{name}さん",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -152,7 +152,26 @@
     "recurring_issues_count": "반복이슈 {count}종",
     "trend_improve": "↑ 개선",
     "trend_decline": "↓ 하락",
-    "trend_stable": "→ 유지"
+    "trend_stable": "→ 유지",
+    "repos": {
+      "kpi_avg_score": "평균 점수",
+      "kpi_connected_repos": "연결 Repo",
+      "kpi_warning": "경고",
+      "grade_distribution": "등급 분포",
+      "grade_bar_tooltip": "{grade}등급 {count}개",
+      "select_repo_aria": "Repo 선택",
+      "chart_avg_score_label": "평균 점수",
+      "cat_security_error": "보안 에러",
+      "cat_security_warning": "보안 경고",
+      "cat_quality_error": "품질 에러",
+      "cat_quality_warning": "품질 경고",
+      "recurring_count": "{count}회 반복"
+    },
+    "kpi_foot_avg": "최근 {days}일 평균",
+    "kpi_unit_count": "건",
+    "score_trend_subtitle": "점수 추세",
+    "repo_insights_title": "🗂 리포별 인사이트",
+    "recent_days": "최근 {days}일"
   },
   "overview": {
     "greeting": "안녕하세요, {name}님",

--- a/src/templates/dashboard.html
+++ b/src/templates/dashboard.html
@@ -430,17 +430,17 @@
   {# Top summary (B+C): KPI cards + grade distribution bar + warning banners #}
   <div class="kpi-row repos-kpi-grid">
     <div class="kpi">
-      <div class="kpi__label"><span>평균 점수</span></div>
+      <div class="kpi__label"><span>{{ 'dashboard.repos.kpi_avg_score' | i18n_args(locale | default('ko')) }}</span></div>
       <div class="kpi__value">
         <span class="t-num">{% if summary.summary.avg_score is not none %}{{ summary.summary.avg_score }}{% else %}—{% endif %}</span>
       </div>
     </div>
     <div class="kpi">
-      <div class="kpi__label"><span>연결 Repo</span></div>
+      <div class="kpi__label"><span>{{ 'dashboard.repos.kpi_connected_repos' | i18n_args(locale | default('ko')) }}</span></div>
       <div class="kpi__value"><span class="t-num">{{ summary.summary.total_repos }}</span></div>
     </div>
     <div class="kpi">
-      <div class="kpi__label"><span>경고</span></div>
+      <div class="kpi__label"><span>{{ 'dashboard.repos.kpi_warning' | i18n_args(locale | default('ko')) }}</span></div>
       <div class="kpi__value">
         <span class="t-num" style="color: {% if summary.summary.warning_count > 0 %}var(--danger){% else %}var(--success){% endif %}">
           {{ summary.summary.warning_count }}
@@ -455,12 +455,12 @@
   {% set total = summary.summary.total_repos %}
   {% if total > 0 %}
   <div class="repos-grade-bar-wrap">
-    <div class="repos-grade-bar-label">등급 분포</div>
+    <div class="repos-grade-bar-label">{{ 'dashboard.repos.grade_distribution' | i18n_args(locale | default('ko')) }}</div>
     <div class="repos-grade-bar">
       {% for grade, color in [('A','var(--grade-a)'),('B','var(--grade-b)'),('C','var(--grade-c)'),('D','var(--grade-d)'),('F','var(--grade-f)')] %}
         {% set count = dist.get(grade, 0) %}
         {% if count > 0 %}
-        <div class="repos-grade-seg" title="{{ grade }}등급 {{ count }}개"
+        <div class="repos-grade-seg" title="{{ 'dashboard.repos.grade_bar_tooltip' | i18n_args(locale | default('ko'), grade=grade, count=count) }}"
              style="width:{{ (count / total * 100) | round(1) }}%; background:{{ color }}">
         </div>
         {% endif %}
@@ -507,7 +507,7 @@
     <input type="hidden" name="mode" value="repos">
     <input type="hidden" name="days" value="{{ days }}">
     <select name="repo" class="repos-selector"
-            onchange="this.form.submit()" aria-label="Repo 선택">
+            onchange="this.form.submit()" aria-label="{{ 'dashboard.repos.select_repo_aria' | i18n_args(locale | default('ko')) }}">
       <option value="">{{ 'dashboard.select_repo_placeholder' | i18n_args(locale | default('ko')) }}</option>
       {% for r in summary.repos %}
       <option value="{{ r.full_name }}"
@@ -566,7 +566,7 @@
           data: {
             labels: trendData.map(function(d) { return d.date; }),
             datasets: [{
-              label: '평균 점수',
+              label: '{{ "dashboard.repos.chart_avg_score_label" | i18n_args(locale | default("ko")) | e }}',
               data: trendData.map(function(d) { return d.avg_score; }),
               borderColor: accent,
               backgroundColor: grad,
@@ -629,19 +629,19 @@
       <div class="repos-category-grid">
         <div class="repos-cat-card repos-cat-security-error">
           <div class="repos-cat-value">{{ bd.security_error }}</div>
-          <div class="repos-cat-label">보안 에러</div>
+          <div class="repos-cat-label">{{ 'dashboard.repos.cat_security_error' | i18n_args(locale | default('ko')) }}</div>
         </div>
         <div class="repos-cat-card repos-cat-security-warn">
           <div class="repos-cat-value">{{ bd.security_warning }}</div>
-          <div class="repos-cat-label">보안 경고</div>
+          <div class="repos-cat-label">{{ 'dashboard.repos.cat_security_warning' | i18n_args(locale | default('ko')) }}</div>
         </div>
         <div class="repos-cat-card repos-cat-quality-error">
           <div class="repos-cat-value">{{ bd.code_quality_error }}</div>
-          <div class="repos-cat-label">품질 에러</div>
+          <div class="repos-cat-label">{{ 'dashboard.repos.cat_quality_error' | i18n_args(locale | default('ko')) }}</div>
         </div>
         <div class="repos-cat-card repos-cat-quality-warn">
           <div class="repos-cat-value">{{ bd.code_quality_warning }}</div>
-          <div class="repos-cat-label">품질 경고</div>
+          <div class="repos-cat-label">{{ 'dashboard.repos.cat_quality_warning' | i18n_args(locale | default('ko')) }}</div>
         </div>
       </div>
     </section>
@@ -650,7 +650,7 @@
     {# ③ AI review summary (recurring issue patterns) #}
     {% if repo_report.ai_suggestions %}
     <section class="repos-section">
-      <h3>AI 리뷰 요약</h3>
+      <h3>{{ 'dashboard.ai_review_summary' | i18n_args(locale | default('ko')) }}</h3>
       <ul class="repos-suggestions">
         {% for s in repo_report.ai_suggestions[:5] %}
         <li class="repos-suggestion-item">
@@ -666,7 +666,7 @@
     {# ⑤ Recommendations based on recurring issues #}
     {% if repo_report.recurring_issues %}
     <section class="repos-section">
-      <h3>개선 권장 사항</h3>
+      <h3>{{ 'dashboard.recommendations' | i18n_args(locale | default('ko')) }}</h3>
       <ul class="repos-recommendations">
         {% for issue in repo_report.recurring_issues[:5] %}
         <li class="repos-rec-item">
@@ -674,7 +674,7 @@
             {{ (issue.severity or 'WARNING') | upper }}
           </span>
           <span class="repos-rec-msg">{{ issue.message }}</span>
-          <span class="repos-rec-count">{{ issue.count }}회 반복</span>
+          <span class="repos-rec-count">{{ 'dashboard.repos.recurring_count' | i18n_args(locale | default('ko'), count=issue.count) }}</span>
         </li>
         {% endfor %}
       </ul>
@@ -926,7 +926,7 @@
       {% else %}
         <div class="kpi__delta kpi__delta--flat">— {{ 'dashboard.delta.no_comparison' | i18n_args(locale | default('ko')) }}</div>
       {% endif %}
-      <div class="kpi__foot">최근 {{ days }}일 평균</div>
+      <div class="kpi__foot">{{ 'dashboard.kpi_foot_avg' | i18n_args(locale | default('ko'), days=days) }}</div>
     </div>
 
     {# ② 분석 건수 / Analysis count #}
@@ -934,7 +934,7 @@
       <div class="kpi__label"><span>{{ 'dashboard.kpi.analysis_count' | i18n_args(locale | default('ko')) }}</span></div>
       <div class="kpi__value">
         <span class="t-num" data-count="{{ kpi.analysis_count.value }}">{{ kpi.analysis_count.value }}</span>
-        <span class="kpi__unit">건</span>
+        <span class="kpi__unit">{{ 'dashboard.kpi_unit_count' | i18n_args(locale | default('ko')) }}</span>
       </div>
       {% if kpi.analysis_count.delta > 0 %}
         <div class="kpi__delta kpi__delta--up">▲ +{{ kpi.analysis_count.delta }} {{ 'dashboard.delta.vs_period' | i18n_args(locale | default('ko'), days=days) }}</div>
@@ -1028,7 +1028,7 @@
   <div class="card dash-grid--full" style="margin-bottom: var(--space-5, 1.25rem);">
     <div class="card__head">
       <div>
-        <div style="font-size: var(--fs-xs, 0.75rem); color: var(--text-2, rgba(255,255,255,0.6)); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; margin-bottom: 4px;">점수 추세</div>
+        <div style="font-size: var(--fs-xs, 0.75rem); color: var(--text-2, rgba(255,255,255,0.6)); text-transform: uppercase; letter-spacing: 0.06em; font-weight: 600; margin-bottom: 4px;">{{ 'dashboard.score_trend_subtitle' | i18n_args(locale | default('ko')) }}</div>
         <div class="card__title">{{ 'dashboard.trend' | i18n_args(locale | default('ko'), days=days) }}</div>
       </div>
     </div>
@@ -1116,8 +1116,8 @@
   {% if repo_cards %}
   <div style="margin-top: 24px;">
     <div style="display:flex; align-items:center; justify-content:space-between; margin-bottom:16px; flex-wrap:wrap; gap:8px;">
-      <h2 class="dash-section-title">🗂 리포별 인사이트</h2>
-      <span style="font-size:12px; color:var(--text-2);">최근 {{ days }}일</span>
+      <h2 class="dash-section-title">{{ 'dashboard.repo_insights_title' | i18n_args(locale | default('ko')) }}</h2>
+      <span style="font-size:12px; color:var(--text-2);">{{ 'dashboard.recent_days' | i18n_args(locale | default('ko'), days=days) }}</span>
     </div>
     <div style="display:grid; grid-template-columns:repeat(auto-fill, minmax(240px, 1fr)); gap:16px;">
       {% for card in repo_cards %}

--- a/tests/unit/test_i18n_dashboard_repos.py
+++ b/tests/unit/test_i18n_dashboard_repos.py
@@ -1,0 +1,225 @@
+"""dashboard.html repos 모드 신규 i18n 키 존재 검증 테스트 (Red 단계).
+
+RED phase tests: verify that newly planned i18n keys for the dashboard repos
+mode exist in all three locale files (ko/en/ja).  These tests must FAIL until
+the keys are added to the JSON translation files.
+"""
+
+import json
+import pathlib
+
+import pytest
+
+# src 모듈 import 전 환경변수 주입 — conftest 보다 먼저 실행되는 단위 테스트 파일 안전장치
+# Inject env vars before any src import — safety net for unit test files loaded before conftest
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-key")
+os.environ.setdefault("GITHUB_CLIENT_ID", "test-github-client-id")
+os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-github-client-secret")
+os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+
+# 프로젝트 루트 기준 절대 경로 — CI / 로컬 모두 동일하게 동작
+# Absolute path anchored at project root — works on both CI and local
+_PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_TRANSLATIONS_DIR = _PROJECT_ROOT / "src" / "i18n" / "translations"
+
+# ──────────────────────────────────────────────────────────────
+# 검증할 신규 키 목록
+# List of new keys to be validated
+# ──────────────────────────────────────────────────────────────
+
+# dashboard.repos 서브 네임스페이스 아래에 추가될 키 (12개)
+# Keys to be added under the dashboard.repos sub-namespace (12 keys)
+_REPOS_SUB_KEYS: list[str] = [
+    "kpi_avg_score",
+    "kpi_connected_repos",
+    "kpi_warning",
+    "grade_distribution",
+    "grade_bar_tooltip",
+    "select_repo_aria",
+    "chart_avg_score_label",
+    "cat_security_error",
+    "cat_security_warning",
+    "cat_quality_error",
+    "cat_quality_warning",
+    "recurring_count",
+]
+
+# dashboard 최상위에 추가될 키 (5개)
+# Keys to be added at the dashboard top level (5 keys)
+_DASHBOARD_TOP_KEYS: list[str] = [
+    "kpi_foot_avg",
+    "kpi_unit_count",
+    "score_trend_subtitle",
+    "repo_insights_title",
+    "recent_days",
+]
+
+# 지원 locale 목록
+# Supported locale list
+_LOCALES: list[str] = ["ko", "en", "ja"]
+
+
+# ──────────────────────────────────────────────────────────────
+# 헬퍼
+# Helpers
+# ──────────────────────────────────────────────────────────────
+
+def _load_translation(locale: str) -> dict:
+    """지정 locale 의 JSON 번역 파일을 dict 로 반환한다.
+
+    Load and return the JSON translation file for the given locale as a dict.
+    """
+    path = _TRANSLATIONS_DIR / f"{locale}.json"
+    assert path.exists(), (
+        f"번역 파일이 없습니다: {path}\n"
+        f"Translation file not found: {path}"
+    )
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ──────────────────────────────────────────────────────────────
+# 테스트 1 — dashboard.repos 서브 네임스페이스 키 존재 확인
+# Test 1 — Verify dashboard.repos sub-namespace keys exist
+# ──────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _REPOS_SUB_KEYS)
+def test_dashboard_repos_keys_exist_in_all_locales(locale: str, key: str) -> None:
+    """ko/en/ja 번역 파일 모두에 dashboard.repos.<key> 가 존재해야 한다.
+
+    Each planned key under dashboard.repos must exist in all three locale files.
+    This test is RED until the keys are added to the JSON files.
+    """
+    data = _load_translation(locale)
+
+    # dashboard 네임스페이스 접근
+    # Access dashboard namespace
+    assert "dashboard" in data, (
+        f"[{locale}] 'dashboard' 네임스페이스가 없습니다.\n"
+        f"[{locale}] 'dashboard' namespace is missing."
+    )
+
+    # repos 서브 네임스페이스 접근
+    # Access repos sub-namespace
+    assert "repos" in data["dashboard"], (
+        f"[{locale}] 'dashboard.repos' 서브 네임스페이스가 없습니다.\n"
+        f"[{locale}] 'dashboard.repos' sub-namespace is missing."
+    )
+
+    # 개별 키 존재 확인
+    # Check individual key existence
+    assert key in data["dashboard"]["repos"], (
+        f"[{locale}] 'dashboard.repos.{key}' 키가 없습니다.\n"
+        f"[{locale}] Key 'dashboard.repos.{key}' is missing."
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# 테스트 2 — dashboard 최상위 신규 키 존재 확인
+# Test 2 — Verify new dashboard top-level keys exist
+# ──────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _DASHBOARD_TOP_KEYS)
+def test_dashboard_top_level_keys_exist_in_all_locales(locale: str, key: str) -> None:
+    """ko/en/ja 번역 파일 모두에 dashboard.<key> 최상위 키가 존재해야 한다.
+
+    Each planned top-level key under dashboard must exist in all three locale files.
+    This test is RED until the keys are added to the JSON files.
+    """
+    data = _load_translation(locale)
+
+    assert "dashboard" in data, (
+        f"[{locale}] 'dashboard' 네임스페이스가 없습니다.\n"
+        f"[{locale}] 'dashboard' namespace is missing."
+    )
+
+    assert key in data["dashboard"], (
+        f"[{locale}] 'dashboard.{key}' 최상위 키가 없습니다.\n"
+        f"[{locale}] Top-level key 'dashboard.{key}' is missing."
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# 테스트 3 — dashboard.repos 키 값이 빈 문자열이 아님 확인
+# Test 3 — Verify dashboard.repos key values are non-empty
+# ──────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _REPOS_SUB_KEYS)
+def test_dashboard_repos_keys_are_non_empty(locale: str, key: str) -> None:
+    """ko/en/ja 모두에서 dashboard.repos.<key> 값이 빈 문자열이 아니어야 한다.
+
+    The value of each dashboard.repos key must be a non-empty string in all
+    three locales.  An empty string signals a placeholder that was never filled.
+    This test is RED until the keys are added with non-empty translations.
+    """
+    data = _load_translation(locale)
+
+    # repos 서브 네임스페이스와 키 자체의 존재는 테스트 1이 이미 담당하므로
+    # 여기서는 존재를 가정하고 값의 내용만 검증한다.
+    # Existence of the repos sub-namespace and each key is covered by test 1;
+    # here we only assert the value is a non-empty string.
+    repos = data.get("dashboard", {}).get("repos", {})
+    value = repos.get(key)
+
+    assert isinstance(value, str) and value.strip() != "", (
+        f"[{locale}] 'dashboard.repos.{key}' 값이 비어 있거나 문자열이 아닙니다 (현재 값: {value!r}).\n"
+        f"[{locale}] 'dashboard.repos.{key}' value is empty or not a string (current: {value!r})."
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# 테스트 4 — dashboard 최상위 신규 키 값이 빈 문자열이 아님 확인
+# Test 4 — Verify new dashboard top-level key values are non-empty
+# ──────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _DASHBOARD_TOP_KEYS)
+def test_dashboard_top_level_keys_are_non_empty(locale: str, key: str) -> None:
+    """ko/en/ja 모두에서 dashboard.<key> 최상위 값이 빈 문자열이 아니어야 한다.
+
+    The value of each new dashboard top-level key must be a non-empty string
+    in all three locales.
+    This test is RED until the keys are added with non-empty translations.
+    """
+    data = _load_translation(locale)
+
+    dashboard = data.get("dashboard", {})
+    value = dashboard.get(key)
+
+    assert isinstance(value, str) and value.strip() != "", (
+        f"[{locale}] 'dashboard.{key}' 값이 비어 있거나 문자열이 아닙니다 (현재 값: {value!r}).\n"
+        f"[{locale}] 'dashboard.{key}' value is empty or not a string (current: {value!r})."
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# 테스트 5 — repos 서브 네임스페이스에 정확히 예정된 키만 존재하는지 확인
+# Test 5 — Verify repos sub-namespace contains exactly the planned keys (no extras)
+# ──────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("locale", _LOCALES)
+def test_dashboard_repos_has_all_expected_keys(locale: str) -> None:
+    """ko/en/ja 의 dashboard.repos 가 예정된 12개 키를 모두 포함해야 한다.
+
+    The dashboard.repos sub-namespace must contain all 12 planned keys in every
+    locale.  This test catches the case where only some keys are added partially.
+    This test is RED until all 12 keys are present.
+    """
+    data = _load_translation(locale)
+
+    repos = data.get("dashboard", {}).get("repos", {})
+    missing = [k for k in _REPOS_SUB_KEYS if k not in repos]
+
+    assert not missing, (
+        f"[{locale}] dashboard.repos 에 누락된 키 {len(missing)}개: {missing}\n"
+        f"[{locale}] {len(missing)} key(s) missing from dashboard.repos: {missing}"
+    )


### PR DESCRIPTION
## Summary

사이클 142 회고 Tier B P1-4 — dashboard.html 내 repos 모드 블록 및 overview 일부 하드코딩 한국어 19개 항목 i18n 처리.

## 변경 내용

### 신규 i18n 키 (ko/en/ja 동시 추가)

**dashboard.repos 서브 네임스페이스 12개**:
- kpi_avg_score / kpi_connected_repos / kpi_warning (KPI 라벨)
- grade_distribution / grade_bar_tooltip (등급 분포 바)
- select_repo_aria (드롭다운 aria-label)
- chart_avg_score_label (JS Chart.js 데이터셋 라벨)
- cat_security_error / cat_security_warning / cat_quality_error / cat_quality_warning (이슈 카테고리)
- recurring_count (반복 횟수)

**dashboard 최상위 5개**: kpi_foot_avg / kpi_unit_count / score_trend_subtitle / repo_insights_title / recent_days

**기존 키 활용**: ai_review_summary·recommendations (존재하나 repos 모드 미사용 → 연결)

### 미처리 범위 (다음 사이클 예정)
repo_detail.html·analysis_detail.html의 광범위한 한국어 (별도 Phase)

## 테스트

TDD (Red → Green):
- `tests/unit/test_i18n_dashboard_repos.py` 105케이스 신규 (3언어 × 17키 × 존재+비공백)
- `tests/integration/test_i18n_smoke.py` 11케이스 기존 유지
- 합계 116/116 passed ✅

## 🔍 사용자 검증 필요 (정책 11)

UI 변경 — Claude 시각 검증 불가. 아래 8조합 확인 부탁드립니다:

| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |

특히 확인 필요:
- [ ] EN/JA locale로 전환 후 dashboard `?mode=repos` 진입 시 KPI 라벨, 카테고리 라벨이 번역된 텍스트로 표시되는지
- [ ] 리포별 인사이트 섹션 제목 / 최근 N일 텍스트 번역 확인 (overview 모드)
- [ ] 점수 추세 카드 서브라벨 번역 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)