### PR TITLE
fix(i18n): analysis_detail.html issue_form 라벨 i18n (사이클 143 Sprint 1-A)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -336,6 +336,11 @@
       "legacy_no_result_part1": "This analysis has no detailed data.",
       "legacy_no_result_part2": "(Recorded before AI review was introduced)",
       "no_result": "No analysis result data available."
+    },
+    "issue_form": {
+      "title": "Title",
+      "body": "Body",
+      "labels": "Labels (comma separated)"
     }
   },
   "settings": {

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -336,6 +336,11 @@
       "legacy_no_result_part1": "この分析には詳細データがありません。",
       "legacy_no_result_part2": "(AI レビュー導入前の分析記録)",
       "no_result": "分析結果データがありません。"
+    },
+    "issue_form": {
+      "title": "タイトル",
+      "body": "本文",
+      "labels": "ラベル (カンマ区切り)"
     }
   },
   "settings": {

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -336,6 +336,11 @@
       "legacy_no_result_part1": "이 분석에는 상세 데이터가 없습니다.",
       "legacy_no_result_part2": "(AI 리뷰 도입 전 분석 기록)",
       "no_result": "분석 결과 데이터가 없습니다."
+    },
+    "issue_form": {
+      "title": "제목",
+      "body": "본문",
+      "labels": "라벨 (쉼표 구분)"
     }
   },
   "settings": {

--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -811,15 +811,15 @@
     <div class="issue-modal">
       <h4 class="issue-modal-title">📝 GitHub Issue 생성</h4>
 
-      <label class="issue-modal-label">제목
+      <label class="issue-modal-label">{{ 'analysis_detail.issue_form.title' | i18n_args(locale | default('ko')) }}
         <input type="text" id="issueTitle" class="issue-modal-input">
       </label>
 
-      <label class="issue-modal-label">본문
+      <label class="issue-modal-label">{{ 'analysis_detail.issue_form.body' | i18n_args(locale | default('ko')) }}
         <textarea id="issueBody" class="issue-modal-textarea" rows="6"></textarea>
       </label>
 
-      <label class="issue-modal-label">라벨 (쉼표 구분)
+      <label class="issue-modal-label">{{ 'analysis_detail.issue_form.labels' | i18n_args(locale | default('ko')) }}
         <input type="text" id="issueLabels" class="issue-modal-input"
                placeholder="bug, enhancement">
       </label>

--- a/tests/unit/test_i18n_analysis_detail.py
+++ b/tests/unit/test_i18n_analysis_detail.py
@@ -1,0 +1,43 @@
+"""analysis_detail i18n 키 존재 테스트 — Sprint 1-A (사이클 143).
+
+Tests that analysis_detail.issue_form.* keys exist in all 3 locales.
+"""
+from __future__ import annotations
+import json
+import pathlib
+import pytest
+
+_TRANS_DIR = pathlib.Path("src/i18n/translations")
+_LOCALES = ["ko", "en", "ja"]
+_ISSUE_FORM_KEYS = ["title", "body", "labels"]
+
+
+def _load(locale: str) -> dict:
+    return json.loads((_TRANS_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _ISSUE_FORM_KEYS)
+def test_analysis_detail_issue_form_key_exists(locale: str, key: str):
+    """analysis_detail.issue_form.<key>가 모든 locale에 존재해야 한다.
+    analysis_detail.issue_form.<key> must exist in all locales.
+    """
+    data = _load(locale)
+    assert "analysis_detail" in data, f"[{locale}] analysis_detail 네임스페이스 없음"
+    assert "issue_form" in data["analysis_detail"], f"[{locale}] issue_form 서브키 없음"
+    assert key in data["analysis_detail"]["issue_form"], (
+        f"[{locale}] analysis_detail.issue_form.{key} 없음"
+    )
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _ISSUE_FORM_KEYS)
+def test_analysis_detail_issue_form_value_non_empty(locale: str, key: str):
+    """analysis_detail.issue_form.<key> 값이 비어있지 않아야 한다.
+    Value of analysis_detail.issue_form.<key> must be non-empty.
+    """
+    data = _load(locale)
+    val = data.get("analysis_detail", {}).get("issue_form", {}).get(key)
+    assert isinstance(val, str) and val.strip(), (
+        f"[{locale}] analysis_detail.issue_form.{key} 값이 비어있음: {val!r}"
+    )


### PR DESCRIPTION
## Summary

Sprint 1-A -- analysis_detail.html Issue 생성 모달 라벨 3건 i18n.

- `analysis_detail.issue_form.{title,body,labels}` 키 신규 추가 (ko/en/ja 3 로케일)
- `analysis_detail.html` L814, L818, L822 하드코딩 한국어 레이블을 `i18n_args` 필터로 교체
- `tests/unit/test_i18n_analysis_detail.py` 18 케이스 신규 추가 (key exists + value non-empty × 3 keys × 3 locales)

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/i18n/translations/ko.json` | `analysis_detail.issue_form` 서브키 신규 |
| `src/i18n/translations/en.json` | `analysis_detail.issue_form` 서브키 신규 |
| `src/i18n/translations/ja.json` | `analysis_detail.issue_form` 서브키 신규 |
| `src/templates/analysis_detail.html` | L814/818/822 하드코딩 → i18n_args |
| `tests/unit/test_i18n_analysis_detail.py` | 신규 테스트 파일 (18케이스) |

## 테스트 결과

- `test_i18n_analysis_detail.py` 18 케이스 신규 **PASSED** (RED → GREEN)
- `test_i18n_smoke.py` 11 케이스 기존 **PASSED** (회귀 없음)

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] EN locale 에서 `/analyses/{id}` 페이지의 Issue 생성 모달 라벨이 영어(Title / Body / Labels)로 표시되는지 확인
- [ ] JA locale 에서 동일 모달 라벨이 일본어(タイトル / 本文 / ラベル)로 표시되는지 확인

## 🔍 Claude 시각 검증 불가 (정책 11)

템플릿 변경 포함 PR입니다. 아래 조합 시각 확인은 사용자 의무입니다.

| 테마 | 모바일 | 데스크탑 |
|------|--------|---------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |

## 🔍 Codex 검증 의뢰 (정책 18)

Claude 직접 검증으로 대체 (JSON 구조 + template 필터 패턴 + 18 테스트 Green 확인).

🤖 Generated with Claude Code