### PR TITLE
chore: GitHub PR 단일 템플릿 업데이트 — 정책 18/11 체크리스트 (사이클 143 Sprint 1-B)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,14 @@
-## 변경 요약
-<!-- 무엇을, 왜 변경했는지 1~3줄로 -->
+## Summary
 
+<!-- 변경 내용을 1-3줄로 요약 -->
+
+## 변경 내용
+
+<!-- 구체적인 변경 사항 -->
+
+## 테스트
+
+<!-- 테스트 방법 및 결과 -->
 
 ## 체크리스트
 
@@ -9,8 +17,8 @@
 - [ ] `make lint` 통과 (pylint 10.00 · bandit HIGH 0)
 
 ### 신규 파일 추가 시 (없으면 이 섹션 전체 삭제)
-- [ ] `CLAUDE.md` `src/` 트리 블록에 신규 파일 항목 추가
-- [ ] `CLAUDE.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
+- [ ] `docs/architecture.md` `src/` 트리 블록에 신규 파일 항목 추가
+- [ ] `docs/architecture.md` `templates/` · `repositories/` · `services/` 카운트·목록 갱신 (해당 시)
 - [ ] `docs/STATE.md` 그룹 이력에 신규 파일 표 추가
 
 ### ORM 컬럼 추가 시 (없으면 이 섹션 전체 삭제)
@@ -22,3 +30,24 @@
 ### 수치 변경 시 (없으면 이 섹션 전체 삭제)
 - [ ] `docs/STATE.md` 헤더 수치 갱신
 - [ ] `README.md` + `README.ko.md` 배지 갱신
+
+## 🔍 사용자 검증 필요
+
+- [ ] CI 통과 확인
+- [ ] (UI 변경 시) 4테마(dark/light/pastel/catppuccin) × 2뷰포트(데스크탑/모바일) 8조합 시각 확인
+
+<!-- UI/CSS/HTML 변경 PR은 아래 8조합 체크리스트를 작성해 주세요 (정책 11) -->
+<!--
+| 테마 | 데스크탑 | 모바일 |
+|------|---------|--------|
+| dark | [ ] | [ ] |
+| light | [ ] | [ ] |
+| pastel | [ ] | [ ] |
+| catppuccin | [ ] | [ ] |
+-->
+
+## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
+
+- [ ] Codex OK / Claude 직접 검증 대체 OK
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Summary

Sprint 1-B — `.github/PULL_REQUEST_TEMPLATE.md` 업데이트.
기존 체크리스트에 정책 18(Codex 검증 의뢰)과 정책 11(UI 8조합 체크리스트) 섹션 추가.

## 변경 내용

- Summary / 변경 내용 / 테스트 섹션 추가 (구조 개선)
- 정책 18: `🔍 Codex 검증 의뢰 (push 전)` 체크리스트 추가
- 정책 11: UI/CSS/HTML 변경 시 8조합(4테마 × 2뷰포트) 체크리스트 주석 추가
- 기존 기본/ORM/수치 체크리스트 섹션 보존
- `docs/architecture.md` 인용으로 CLAUDE.md src/ 트리 참조 수정 (사이클 85 분리 반영)

## 테스트

없음 (문서 파일)

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] 새 PR 생성 시 GitHub UI에서 템플릿 자동 적용 확인 (이 PR 이후 테스트 가능)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [ ] Codex OK / Claude 직접 검증 대체 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)