### PR TITLE
fix(i18n): repo_detail.html 일반 텍스트 i18n (사이클 143 Sprint 2)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -266,7 +266,20 @@
     "hook_installed_title": "CLI code review hook is set up!",
     "hook_installed_desc_part1": "Run the following in your local repo, and code review will run automatically on ",
     "hook_installed_desc_code": "git push",
-    "hook_installed_desc_part2": "."
+    "hook_installed_desc_part2": ".",
+    "recent_score": "Recent Score:",
+    "analysis_unit": "analyses",
+    "history_empty": "No analysis history",
+    "history_empty_hint": "The chart will appear after the first analysis is complete following a Push or PR event.",
+    "cost": {
+      "title": "Estimated AI Review Cost This Month",
+      "period": "({month} 1st – last day, server-side Webhook analysis basis)",
+      "tokens": "(input+output {count} tokens)",
+      "no_data": "No data — no token-tracked analyses this month yet.",
+      "disclaimer": "※ Estimated based on Anthropic official pricing. Actual charges may differ. Pre-push hook costs (user API key) are not included.",
+      "model_change": "Change model:",
+      "settings_link": "Settings page"
+    }
   },
   "analysis_detail": {
     "title": "Analysis #{id}",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -266,7 +266,20 @@
     "hook_installed_title": "CLI コードレビューフックが設定されました!",
     "hook_installed_desc_part1": "ローカルリポジトリで下記コマンドを実行すると、",
     "hook_installed_desc_code": "git push",
-    "hook_installed_desc_part2": " 時に自動的にコードレビューが実行されます。"
+    "hook_installed_desc_part2": " 時に自動的にコードレビューが実行されます。",
+    "recent_score": "最近スコア:",
+    "analysis_unit": "件",
+    "history_empty": "分析履歴がありません",
+    "history_empty_hint": "PushまたはPRイベント後、最初の分析が完了するとグラフが表示されます。",
+    "cost": {
+      "title": "今月のAIレビュー予想コスト",
+      "period": "({month}月1日〜末日、サーバーサイドWebhook分析基準)",
+      "tokens": "(入力+出力 {count} トークン)",
+      "no_data": "データなし — 今月はトークン追跡分析がまだありません。",
+      "disclaimer": "※ Anthropic公式料金に基づく推定値です。実際の請求額と異なる場合があり、pre-pushフックのコスト（ユーザーAPIキー）は含まれません。",
+      "model_change": "モデル変更:",
+      "settings_link": "設定ページ"
+    }
   },
   "analysis_detail": {
     "title": "分析 #{id}",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -266,7 +266,20 @@
     "hook_installed_title": "CLI 코드리뷰 훅이 설정됐습니다!",
     "hook_installed_desc_part1": "로컬 리포에서 아래 명령어를 실행하면 ",
     "hook_installed_desc_code": "git push",
-    "hook_installed_desc_part2": " 시 자동으로 코드리뷰가 실행됩니다."
+    "hook_installed_desc_part2": " 시 자동으로 코드리뷰가 실행됩니다.",
+    "recent_score": "최근 점수:",
+    "analysis_unit": "건 분석",
+    "history_empty": "분석 이력이 없습니다",
+    "history_empty_hint": "Push 또는 PR 이벤트 후 첫 분석이 완료되면 차트가 표시됩니다",
+    "cost": {
+      "title": "이번 달 AI 리뷰 예상 비용",
+      "period": "({month} 01일 ~ 말일, 서버사이드 Webhook 분석 기준)",
+      "tokens": "(입력+출력 {count} 토큰)",
+      "no_data": "데이터 없음 — 이번 달 토큰 추적 분석이 아직 없습니다.",
+      "disclaimer": "※ Anthropic 공식 요금 기준 추정값입니다. 실제 청구금액과 다를 수 있으며, pre-push 훅 비용(사용자 API 키)은 포함되지 않습니다.",
+      "model_change": "모델 변경:",
+      "settings_link": "설정 페이지"
+    }
   },
   "analysis_detail": {
     "title": "분석 #{id}",

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -446,9 +446,9 @@
       {%- if _sorted %}
       {%- set _latest = _sorted[0] %}
       <span class="grade grade--{{ (_latest.grade or 'f') | lower }}">{{ _latest.grade or 'F' }}</span>
-      <span style="font-size: var(--fs-sm, 0.875rem); color: var(--text-2, rgba(255,255,255,0.6));">최근 점수: {{ (_latest.score | round(1)) if _latest.score is not none else '—' }}/100</span>
+      <span style="font-size: var(--fs-sm, 0.875rem); color: var(--text-2, rgba(255,255,255,0.6));">{{ 'repo_detail.recent_score' | i18n_args(locale | default('ko')) }} {{ (_latest.score | round(1)) if _latest.score is not none else '—' }}/100</span>
       {%- endif %}
-      <span style="font-size: var(--fs-xs, 0.75rem); color: var(--text-3, rgba(255,255,255,0.4));">{{ analyses | length }}건 분석</span>
+      <span style="font-size: var(--fs-xs, 0.75rem); color: var(--text-3, rgba(255,255,255,0.4));">{{ analyses | length }}{{ 'repo_detail.analysis_unit' | i18n_args(locale | default('ko')) }}</span>
     </div>
   </div>
 </div>
@@ -492,8 +492,8 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
         <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
       </svg>
-      <span class="chart-empty-title" id="chartEmptyText">분석 이력이 없습니다</span>
-      <span class="chart-empty-sub">Push 또는 PR 이벤트 후 첫 분석이 완료되면 차트가 표시됩니다</span>
+      <span class="chart-empty-title" id="chartEmptyText">{{ 'repo_detail.history_empty' | i18n_args(locale | default('ko')) }}</span>
+      <span class="chart-empty-sub">{{ 'repo_detail.history_empty_hint' | i18n_args(locale | default('ko')) }}</span>
     </div>
   </div>
 </div>
@@ -501,22 +501,22 @@
 <!-- 이번 달 AI 리뷰 예상 비용 (Alembic 0032) -->
 <div class="card reveal" style="padding:1rem 1.5rem;margin-bottom:1rem;">
   <div style="display:flex;align-items:center;gap:.6rem;flex-wrap:wrap;">
-    <span style="font-size:13px;font-weight:600;color:var(--text-1);">이번 달 AI 리뷰 예상 비용</span>
-    <span style="font-size:11px;color:var(--text-2);">({{ monthly_cost_month }} 01일 ~ 말일, 서버사이드 Webhook 분석 기준)</span>
+    <span style="font-size:13px;font-weight:600;color:var(--text-1);">{{ 'repo_detail.cost.title' | i18n_args(locale | default('ko')) }}</span>
+    <span style="font-size:11px;color:var(--text-2);">{{ 'repo_detail.cost.period' | i18n_args(locale | default('ko'), month=monthly_cost_month) }}</span>
     {% if monthly_token_count > 0 %}
     <span style="margin-left:auto;font-size:15px;font-weight:700;color:var(--accent);">
       ${{ "%.4f"|format(monthly_cost_usd) }}
     </span>
     <span style="font-size:12px;color:var(--text-2);">
-      (입력+출력 {{ "{:,}".format(monthly_token_count) }} 토큰)
+      {{ 'repo_detail.cost.tokens' | i18n_args(locale | default('ko'), count="{:,}".format(monthly_token_count)) }}
     </span>
     {% else %}
-    <span style="margin-left:auto;font-size:13px;color:var(--text-2);">데이터 없음 — 이번 달 토큰 추적 분석이 아직 없습니다.</span>
+    <span style="margin-left:auto;font-size:13px;color:var(--text-2);">{{ 'repo_detail.cost.no_data' | i18n_args(locale | default('ko')) }}</span>
     {% endif %}
   </div>
   <p style="font-size:11px;color:var(--text-2);margin:.4rem 0 0;">
-    ※ Anthropic 공식 요금 기준 추정값입니다. 실제 청구금액과 다를 수 있으며, pre-push 훅 비용(사용자 API 키)은 포함되지 않습니다.
-    모델 변경: <a href="/repos/{{ repo_name }}/settings" style="color:var(--accent);">설정 페이지</a>
+    {{ 'repo_detail.cost.disclaimer' | i18n_args(locale | default('ko')) }}
+    {{ 'repo_detail.cost.model_change' | i18n_args(locale | default('ko')) }} <a href="/repos/{{ repo_name }}/settings" style="color:var(--accent);">{{ 'repo_detail.cost.settings_link' | i18n_args(locale | default('ko')) }}</a>
   </p>
 </div>
 

--- a/tests/unit/test_i18n_repo_detail.py
+++ b/tests/unit/test_i18n_repo_detail.py
@@ -1,0 +1,75 @@
+"""repo_detail i18n 키 존재 테스트 — Sprint 2+3 (사이클 143).
+
+Tests that repo_detail.* keys exist in all 3 locales.
+Sprint 3 keys will be appended to this same file.
+"""
+from __future__ import annotations
+import json
+import pathlib
+import pytest
+
+_TRANS_DIR = pathlib.Path("src/i18n/translations")
+_LOCALES = ["ko", "en", "ja"]
+
+_SPRINT2_TOP_KEYS = [
+    "recent_score",
+    "analysis_unit",
+    "history_empty",
+    "history_empty_hint",
+]
+_SPRINT2_COST_KEYS = [
+    "title",
+    "period",
+    "tokens",
+    "no_data",
+    "disclaimer",
+    "model_change",
+    "settings_link",
+]
+
+
+def _load(locale: str) -> dict:
+    return json.loads((_TRANS_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT2_TOP_KEYS)
+def test_repo_detail_sprint2_top_key_exists(locale: str, key: str):
+    """repo_detail.<key>가 모든 locale에 존재해야 한다.
+    repo_detail.<key> must exist in all locales.
+    """
+    data = _load(locale)
+    assert "repo_detail" in data, f"[{locale}] repo_detail 없음"
+    assert key in data["repo_detail"], f"[{locale}] repo_detail.{key} 없음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT2_TOP_KEYS)
+def test_repo_detail_sprint2_top_value_non_empty(locale: str, key: str):
+    """repo_detail.<key> 값이 비어있지 않아야 한다.
+    Value must be non-empty.
+    """
+    val = _load(locale).get("repo_detail", {}).get(key)
+    assert isinstance(val, str) and val.strip(), f"[{locale}] repo_detail.{key} 비어있음: {val!r}"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT2_COST_KEYS)
+def test_repo_detail_sprint2_cost_key_exists(locale: str, key: str):
+    """repo_detail.cost.<key>가 모든 locale에 존재해야 한다.
+    repo_detail.cost.<key> must exist in all locales.
+    """
+    data = _load(locale)
+    assert "repo_detail" in data
+    assert "cost" in data["repo_detail"], f"[{locale}] repo_detail.cost 서브키 없음"
+    assert key in data["repo_detail"]["cost"], f"[{locale}] repo_detail.cost.{key} 없음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT2_COST_KEYS)
+def test_repo_detail_sprint2_cost_value_non_empty(locale: str, key: str):
+    """repo_detail.cost.<key> 값이 비어있지 않아야 한다.
+    Value must be non-empty.
+    """
+    val = _load(locale).get("repo_detail", {}).get("cost", {}).get(key)
+    assert isinstance(val, str) and val.strip(), f"[{locale}] repo_detail.cost.{key} 비어있음: {val!r}"


### PR DESCRIPTION
## Summary

Sprint 2 — repo_detail.html 일반 텍스트 영역 하드코딩 한국어 ~10건 i18n 전환.

- `repo_detail.{recent_score,analysis_unit,history_empty,history_empty_hint}` 신규 (ko/en/ja)
- `repo_detail.cost.{title,period,tokens,no_data,disclaimer,model_change,settings_link}` 신규 (ko/en/ja)
- `repo_detail.html` 해당 위치 `i18n_args` 교체 (L449,451,495,496,504,505,511,514,518,519)

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `src/i18n/translations/ko.json` | `repo_detail` 4키 + `cost` 서브키 7키 추가 |
| `src/i18n/translations/en.json` | 동일 11키 영어 번역 |
| `src/i18n/translations/ja.json` | 동일 11키 일어 번역 |
| `src/templates/repo_detail.html` | 하드코딩 한국어 10곳 → `i18n_args` 필터 교체 |
| `tests/unit/test_i18n_repo_detail.py` | 66케이스 신규 (키 존재 + 값 비어있지 않음) |

## 테스트 결과

- `test_i18n_repo_detail.py` **66 PASSED** ✅
- `test_i18n_smoke.py` **11 PASSED** ✅ (기존 유지)

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] EN locale에서 `/repos/{owner}/{repo}` 진입 시 최근 점수 라벨, 빈 이력 메시지, AI 비용 섹션이 영어로 표시되는지 확인
- [ ] JA locale에서 동일 섹션 일본어 표시 확인

## 🔍 Claude 시각 검증 불가 (정책 11)

UI 텍스트 교체 PR — 아래 8조합 시각 정합성은 사용자 확인 의무:

| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | ☐ | ☐ |
| light | ☐ | ☐ |
| pastel | ☐ | ☐ |
| catppuccin | ☐ | ☐ |

## 🔍 Codex 검증 의뢰 (push 전 → push 후 사후 의뢰, 정책 18)

- [ ] Codex OK / Claude 직접 검증 대체 OK

🤖 Generated with Claude Code