### PR TITLE
fix(i18n): repo_detail.html 이슈 등록 UI i18n (사이클 143 Sprint 3)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -266,7 +266,33 @@
     "hook_installed_title": "CLI code review hook is set up!",
     "hook_installed_desc_part1": "Run the following in your local repo, and code review will run automatically on ",
     "hook_installed_desc_code": "git push",
-    "hook_installed_desc_part2": "."
+    "hook_installed_desc_part2": ".",
+    "recent_score": "Recent Score:",
+    "analysis_unit": "analyses",
+    "history_empty": "No analysis history",
+    "history_empty_hint": "The chart will appear after the first analysis is complete following a Push or PR event.",
+    "cost": {
+      "title": "Estimated AI Review Cost This Month",
+      "period": "({month} 1st – last day, server-side Webhook analysis basis)",
+      "tokens": "(input+output {count} tokens)",
+      "no_data": "No data — no token-tracked analyses this month yet.",
+      "disclaimer": "※ Estimated based on Anthropic official pricing. Actual charges may differ. Pre-push hook costs (user API key) are not included.",
+      "model_change": "Change model:",
+      "settings_link": "Settings page"
+    },
+    "issue_mgmt": {
+      "title": "🔁 Recurring Issues — Issue Registration",
+      "tab_static": "🔴 Static Analysis Issues",
+      "tab_ai": "💡 AI Suggestions",
+      "filter_unregistered": "Show unregistered only",
+      "modal_title": "📝 Create GitHub Issue",
+      "form_title": "Title",
+      "form_body": "Body",
+      "form_labels": "Labels (comma separated)",
+      "btn_cancel": "Cancel",
+      "btn_skip": "Skip this item",
+      "btn_create_next": "Create & Next →"
+    }
   },
   "analysis_detail": {
     "title": "Analysis #{id}",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -266,7 +266,33 @@
     "hook_installed_title": "CLI コードレビューフックが設定されました!",
     "hook_installed_desc_part1": "ローカルリポジトリで下記コマンドを実行すると、",
     "hook_installed_desc_code": "git push",
-    "hook_installed_desc_part2": " 時に自動的にコードレビューが実行されます。"
+    "hook_installed_desc_part2": " 時に自動的にコードレビューが実行されます。",
+    "recent_score": "最近スコア:",
+    "analysis_unit": "件",
+    "history_empty": "分析履歴がありません",
+    "history_empty_hint": "PushまたはPRイベント後、最初の分析が完了するとグラフが表示されます。",
+    "cost": {
+      "title": "今月のAIレビュー予想コスト",
+      "period": "({month}月1日〜末日、サーバーサイドWebhook分析基準)",
+      "tokens": "(入力+出力 {count} トークン)",
+      "no_data": "データなし — 今月はトークン追跡分析がまだありません。",
+      "disclaimer": "※ Anthropic公式料金に基づく推定値です。実際の請求額と異なる場合があり、pre-pushフックのコスト（ユーザーAPIキー）は含まれません。",
+      "model_change": "モデル変更:",
+      "settings_link": "設定ページ"
+    },
+    "issue_mgmt": {
+      "title": "🔁 繰り返しイシュー — Issue登録管理",
+      "tab_static": "🔴 静的解析イシュー",
+      "tab_ai": "💡 AI提案事項",
+      "filter_unregistered": "未登録のみ表示",
+      "modal_title": "📝 GitHub Issue作成",
+      "form_title": "タイトル",
+      "form_body": "本文",
+      "form_labels": "ラベル (カンマ区切り)",
+      "btn_cancel": "キャンセル",
+      "btn_skip": "この項目をスキップ",
+      "btn_create_next": "作成して次へ →"
+    }
   },
   "analysis_detail": {
     "title": "分析 #{id}",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -266,7 +266,33 @@
     "hook_installed_title": "CLI 코드리뷰 훅이 설정됐습니다!",
     "hook_installed_desc_part1": "로컬 리포에서 아래 명령어를 실행하면 ",
     "hook_installed_desc_code": "git push",
-    "hook_installed_desc_part2": " 시 자동으로 코드리뷰가 실행됩니다."
+    "hook_installed_desc_part2": " 시 자동으로 코드리뷰가 실행됩니다.",
+    "recent_score": "최근 점수:",
+    "analysis_unit": "건 분석",
+    "history_empty": "분석 이력이 없습니다",
+    "history_empty_hint": "Push 또는 PR 이벤트 후 첫 분석이 완료되면 차트가 표시됩니다",
+    "cost": {
+      "title": "이번 달 AI 리뷰 예상 비용",
+      "period": "({month} 01일 ~ 말일, 서버사이드 Webhook 분석 기준)",
+      "tokens": "(입력+출력 {count} 토큰)",
+      "no_data": "데이터 없음 — 이번 달 토큰 추적 분석이 아직 없습니다.",
+      "disclaimer": "※ Anthropic 공식 요금 기준 추정값입니다. 실제 청구금액과 다를 수 있으며, pre-push 훅 비용(사용자 API 키)은 포함되지 않습니다.",
+      "model_change": "모델 변경:",
+      "settings_link": "설정 페이지"
+    },
+    "issue_mgmt": {
+      "title": "🔁 반복 이슈 — Issue 등록 관리",
+      "tab_static": "🔴 정적 분석 이슈",
+      "tab_ai": "💡 AI 제안사항",
+      "filter_unregistered": "미등록만 보기",
+      "modal_title": "📝 GitHub Issue 생성",
+      "form_title": "제목",
+      "form_body": "본문",
+      "form_labels": "라벨 (쉼표 구분)",
+      "btn_cancel": "취소",
+      "btn_skip": "이 항목 건너뜀",
+      "btn_create_next": "생성 후 다음 →"
+    }
   },
   "analysis_detail": {
     "title": "분석 #{id}",

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -606,20 +606,20 @@
 <section class="issue-reg-panel" id="repoBulkPanel"
          data-repo-id="{{ repo_id }}">
 
-  <h3 class="panel-title">🔁 반복 이슈 — Issue 등록 관리</h3>
+  <h3 class="panel-title">{{ 'repo_detail.issue_mgmt.title' | i18n_args(locale | default('ko')) }}</h3>
 
   <div class="issue-reg-tabs" role="tablist">
     <button class="issue-tab active" data-tab="static" role="tab">
-      🔴 정적 분석 이슈 <span class="issue-tab-count" id="repoStaticCount"></span>
+      {{ 'repo_detail.issue_mgmt.tab_static' | i18n_args(locale | default('ko')) }} <span class="issue-tab-count" id="repoStaticCount"></span>
     </button>
     <button class="issue-tab" data-tab="ai" role="tab">
-      💡 AI 제안사항 <span class="issue-tab-count" id="repoAiCount"></span>
+      {{ 'repo_detail.issue_mgmt.tab_ai' | i18n_args(locale | default('ko')) }} <span class="issue-tab-count" id="repoAiCount"></span>
     </button>
   </div>
 
   <div class="issue-bulk-toolbar">
     <label class="issue-filter-label">
-      <input type="checkbox" id="showUnregisteredOnly"> 미등록만 보기
+      <input type="checkbox" id="showUnregisteredOnly"> {{ 'repo_detail.issue_mgmt.filter_unregistered' | i18n_args(locale | default('ko')) }}
     </label>
     <button class="btn-primary" id="bulkRegisterBtn" disabled>
       선택 항목 일괄 Issue 등록 (0건) →
@@ -638,22 +638,22 @@
 <div class="issue-modal-overlay hidden" id="bulkModalOverlay" role="dialog" aria-modal="true">
   <div class="issue-modal">
     <div class="issue-modal-progress" id="bulkProgress"></div>
-    <h4 class="issue-modal-title">📝 GitHub Issue 생성</h4>
+    <h4 class="issue-modal-title">{{ 'repo_detail.issue_mgmt.modal_title' | i18n_args(locale | default('ko')) }}</h4>
 
-    <label class="issue-modal-label">제목
+    <label class="issue-modal-label">{{ 'repo_detail.issue_mgmt.form_title' | i18n_args(locale | default('ko')) }}
       <input type="text" id="bulkTitle" class="issue-modal-input">
     </label>
-    <label class="issue-modal-label">본문
+    <label class="issue-modal-label">{{ 'repo_detail.issue_mgmt.form_body' | i18n_args(locale | default('ko')) }}
       <textarea id="bulkBody" class="issue-modal-textarea" rows="5"></textarea>
     </label>
-    <label class="issue-modal-label">라벨 (쉼표 구분)
+    <label class="issue-modal-label">{{ 'repo_detail.issue_mgmt.form_labels' | i18n_args(locale | default('ko')) }}
       <input type="text" id="bulkLabels" class="issue-modal-input">
     </label>
 
     <div class="issue-modal-actions">
-      <button type="button" class="btn-secondary" id="bulkCancel">취소</button>
-      <button type="button" class="btn-secondary" id="bulkSkip">이 항목 건너뜀</button>
-      <button type="button" class="btn-primary"   id="bulkSubmit">생성 후 다음 →</button>
+      <button type="button" class="btn-secondary" id="bulkCancel">{{ 'repo_detail.issue_mgmt.btn_cancel' | i18n_args(locale | default('ko')) }}</button>
+      <button type="button" class="btn-secondary" id="bulkSkip">{{ 'repo_detail.issue_mgmt.btn_skip' | i18n_args(locale | default('ko')) }}</button>
+      <button type="button" class="btn-primary"   id="bulkSubmit">{{ 'repo_detail.issue_mgmt.btn_create_next' | i18n_args(locale | default('ko')) }}</button>
     </div>
     <p class="issue-modal-error hidden" id="bulkError"></p>
   </div>

--- a/tests/integration/test_i18n_smoke.py
+++ b/tests/integration/test_i18n_smoke.py
@@ -177,3 +177,24 @@ def test_i18n_metrics_missing_key_increments_fallback_rate():
     assert metrics["lookups_hit"] == 1
     assert metrics["lookups_missing"] == 1
     assert metrics["fallback_rate_pct"] == 50.0
+
+
+# ── repo_detail locale smoke (사이클 143 Sprint 3) ─────────────────────────
+# repo_detail locale smoke (Cycle 143 Sprint 3)
+
+
+@pytest.mark.parametrize("locale", ["en", "ja"])
+def test_repo_detail_redirects_for_unauthenticated(client, locale):
+    """/repos/{owner}/{repo} — 미인증 시 locale 무관하게 302/401/404 반환.
+
+    Unauthenticated access to /repos/ returns 302/401/404 regardless of locale.
+    500이 아님을 확인하여 locale 주입 오류가 없음을 검증한다.
+    Confirms no locale injection error by checking the status code is not 500.
+    """
+    response = client.get(
+        "/repos/testowner/testrepo",
+        cookies={"preferred_language": locale},
+    )
+    assert response.status_code in (302, 401, 404), (
+        f"[{locale}] /repos/ 접근 시 예상치 못한 상태 코드: {response.status_code}"
+    )

--- a/tests/unit/test_i18n_repo_detail.py
+++ b/tests/unit/test_i18n_repo_detail.py
@@ -1,0 +1,119 @@
+"""repo_detail i18n 키 존재 테스트 — Sprint 2+3 (사이클 143).
+
+Tests that repo_detail.* keys exist in all 3 locales.
+Sprint 3 keys will be appended to this same file.
+"""
+from __future__ import annotations
+import json
+import pathlib
+import pytest
+
+_TRANS_DIR = pathlib.Path("src/i18n/translations")
+_LOCALES = ["ko", "en", "ja"]
+
+_SPRINT2_TOP_KEYS = [
+    "recent_score",
+    "analysis_unit",
+    "history_empty",
+    "history_empty_hint",
+]
+_SPRINT2_COST_KEYS = [
+    "title",
+    "period",
+    "tokens",
+    "no_data",
+    "disclaimer",
+    "model_change",
+    "settings_link",
+]
+
+
+def _load(locale: str) -> dict:
+    return json.loads((_TRANS_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT2_TOP_KEYS)
+def test_repo_detail_sprint2_top_key_exists(locale: str, key: str):
+    """repo_detail.<key>가 모든 locale에 존재해야 한다.
+    repo_detail.<key> must exist in all locales.
+    """
+    data = _load(locale)
+    assert "repo_detail" in data, f"[{locale}] repo_detail 없음"
+    assert key in data["repo_detail"], f"[{locale}] repo_detail.{key} 없음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT2_TOP_KEYS)
+def test_repo_detail_sprint2_top_value_non_empty(locale: str, key: str):
+    """repo_detail.<key> 값이 비어있지 않아야 한다.
+    Value must be non-empty.
+    """
+    val = _load(locale).get("repo_detail", {}).get(key)
+    assert isinstance(val, str) and val.strip(), f"[{locale}] repo_detail.{key} 비어있음: {val!r}"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT2_COST_KEYS)
+def test_repo_detail_sprint2_cost_key_exists(locale: str, key: str):
+    """repo_detail.cost.<key>가 모든 locale에 존재해야 한다.
+    repo_detail.cost.<key> must exist in all locales.
+    """
+    data = _load(locale)
+    assert "repo_detail" in data
+    assert "cost" in data["repo_detail"], f"[{locale}] repo_detail.cost 서브키 없음"
+    assert key in data["repo_detail"]["cost"], f"[{locale}] repo_detail.cost.{key} 없음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT2_COST_KEYS)
+def test_repo_detail_sprint2_cost_value_non_empty(locale: str, key: str):
+    """repo_detail.cost.<key> 값이 비어있지 않아야 한다.
+    Value must be non-empty.
+    """
+    val = _load(locale).get("repo_detail", {}).get("cost", {}).get(key)
+    assert isinstance(val, str) and val.strip(), f"[{locale}] repo_detail.cost.{key} 비어있음: {val!r}"
+
+
+# ---------------------------------------------------------------------------
+# Sprint 3 — issue_mgmt 서브 네임스페이스 (사이클 143)
+# ---------------------------------------------------------------------------
+_SPRINT3_ISSUE_MGMT_KEYS = [
+    "title",
+    "tab_static",
+    "tab_ai",
+    "filter_unregistered",
+    "modal_title",
+    "form_title",
+    "form_body",
+    "form_labels",
+    "btn_cancel",
+    "btn_skip",
+    "btn_create_next",
+]
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT3_ISSUE_MGMT_KEYS)
+def test_repo_detail_sprint3_issue_mgmt_key_exists(locale: str, key: str):
+    """repo_detail.issue_mgmt.<key>가 모든 locale에 존재해야 한다.
+    repo_detail.issue_mgmt.<key> must exist in all locales.
+    """
+    data = _load(locale)
+    assert "repo_detail" in data
+    assert "issue_mgmt" in data["repo_detail"], f"[{locale}] repo_detail.issue_mgmt 없음"
+    assert key in data["repo_detail"]["issue_mgmt"], (
+        f"[{locale}] repo_detail.issue_mgmt.{key} 없음"
+    )
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT3_ISSUE_MGMT_KEYS)
+def test_repo_detail_sprint3_issue_mgmt_value_non_empty(locale: str, key: str):
+    """repo_detail.issue_mgmt.<key> 값이 비어있지 않아야 한다.
+    Value must be non-empty.
+    """
+    val = _load(locale).get("repo_detail", {}).get("issue_mgmt", {}).get(key)
+    assert isinstance(val, str) and val.strip(), (
+        f"[{locale}] repo_detail.issue_mgmt.{key} 비어있음: {val!r}"
+    )


### PR DESCRIPTION
## Summary

Sprint 3 — repo_detail.html 이슈 등록 관리 UI 하드코딩 한국어 11건 i18n 전환.

- `repo_detail.issue_mgmt` 서브키 11종 신규 (ko/en/ja): `title` / `tab_static` / `tab_ai` / `filter_unregistered` / `modal_title` / `form_title` / `form_body` / `form_labels` / `btn_cancel` / `btn_skip` / `btn_create_next`
- `repo_detail.html` 이슈 등록 패널·탭·모달 11곳 `i18n_args` 교체
- `test_i18n_repo_detail.py` Sprint 3 케이스 추가 (66건 신규 → 총 132 PASSED)
- `test_i18n_smoke.py` `/repos/` locale smoke 2건 추가 (총 13 PASSED)

> Note: Sprint 2 키 (`recent_score` / `analysis_unit` / `history_empty` / `history_empty_hint` / `cost`)도 본 브랜치에 포함 — main에 Sprint 2 미머지 상태에서 독립 작업.

## 테스트

- `tests/unit/test_i18n_repo_detail.py` → **132 passed** (Sprint 2: 66 + Sprint 3: 66)
- `tests/integration/test_i18n_smoke.py` → **13 passed** (+2)

## 🔍 사용자 검증 필요 (정책 11)

UI 변경 포함 — 8 조합 시각 검증 필요:

| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |

- [ ] CI 통과 확인
- [ ] EN locale 쿠키 설정 후 `/repos/{owner}/{repo}` 이슈 등록 패널 진입 시 탭(Static Analysis Issues / AI Suggestions) / 필터(Show unregistered only) / 모달 버튼(Cancel / Skip this item / Create & Next →) 라벨이 영어로 표시되는지 확인
- [ ] JA locale 쿠키 설정 후 동일 UI가 일본어로 표시되는지 확인

## 🔍 Codex 검증 의뢰 (정책 18)

- [ ] Codex OK / Claude 직접 검증 대체 OK (로컬 테스트 132+13 PASSED 확인 완료)

🤖 Generated with [Claude Code](https://claude.com/claude-code)