### PR TITLE
fix(cycle-143-retro): Tier A — PR 템플릿 정책 18 정렬 + cost.period 문구 수정

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -46,8 +46,13 @@
 | catppuccin | [ ] | [ ] |
 -->
 
+## ⚠️ 자율 판단 보고 (정책 3, 해당 시)
+
+<!-- Claude가 위임받은 작업 중 자율 판단한 항목 명시 (없으면 이 섹션 삭제) -->
+
 ## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
 
-- [ ] Codex OK / Claude 직접 검증 대체 OK
+- [ ] Codex 검증 의뢰 완료 — push 전 Codex OK 회신 대기 중
+- [ ] (예외) Codex 샌드박스 오류 시 Claude 직접 검증 대체 — 사유 명시
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -273,7 +273,7 @@
     "history_empty_hint": "The chart will appear after the first analysis is complete following a Push or PR event.",
     "cost": {
       "title": "Estimated AI Review Cost This Month",
-      "period": "({month} 1st – last day, server-side Webhook analysis basis)",
+      "period": "(Full month of {month}, server-side Webhook analysis basis)",
       "tokens": "(input+output {count} tokens)",
       "no_data": "No data — no token-tracked analyses this month yet.",
       "disclaimer": "※ Estimated based on Anthropic official pricing. Actual charges may differ. Pre-push hook costs (user API key) are not included.",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -273,7 +273,7 @@
     "history_empty_hint": "PushまたはPRイベント後、最初の分析が完了するとグラフが表示されます。",
     "cost": {
       "title": "今月のAIレビュー予想コスト",
-      "period": "({month}月1日〜末日、サーバーサイドWebhook分析基準)",
+      "period": "({month} の月間全体、サーバーサイドWebhook分析基準)",
       "tokens": "(入力+出力 {count} トークン)",
       "no_data": "データなし — 今月はトークン追跡分析がまだありません。",
       "disclaimer": "※ Anthropic公式料金に基づく推定値です。実際の請求額と異なる場合があり、pre-pushフックのコスト（ユーザーAPIキー）は含まれません。",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -273,7 +273,7 @@
     "history_empty_hint": "Push 또는 PR 이벤트 후 첫 분석이 완료되면 차트가 표시됩니다",
     "cost": {
       "title": "이번 달 AI 리뷰 예상 비용",
-      "period": "({month} 01일 ~ 말일, 서버사이드 Webhook 분석 기준)",
+      "period": "({month} 한 달 전체, 서버사이드 Webhook 분석 기준)",
       "tokens": "(입력+출력 {count} 토큰)",
       "no_data": "데이터 없음 — 이번 달 토큰 추적 분석이 아직 없습니다.",
       "disclaimer": "※ Anthropic 공식 요금 기준 추정값입니다. 실제 청구금액과 다를 수 있으며, pre-push 훅 비용(사용자 API 키)은 포함되지 않습니다.",


### PR DESCRIPTION
## Summary

사이클 143 5+1 회고 Tier A 이행 — 프로세스 문서 + i18n 번역 수정 2건.

## 변경 내용

### P1-A: .github/PULL_REQUEST_TEMPLATE.md (정책 18 정렬)
- 정책 18 체크박스를 `.claude/policies/active.md` canonical 문구로 정렬
  - 기존: `Codex OK / Claude 직접 검증 대체 OK` (무조건 대체 허용으로 읽힘)
  - 변경: `Codex 검증 의뢰 완료 — push 전 Codex OK 회신 대기 중` + 샌드박스 오류 시 예외 조건부 라인
- 정책 3 자율 판단 보고 섹션 추가 (회고 cross-verify 누락 지적)

### P1-1: repo_detail.cost.period (ko/en/ja)
- `{month}` 플레이스홀더가 받는 실제 값은 `monthly_cost_month = now.strftime("%Y-%m")` = `2026-05` (YYYY-MM)
- 기존 "01일~말일" / "月1日" 표현이 YYYY-MM 입력 시 비문 유발 (특히 ja `2026-05月1日`)
- "{month} 한 달 전체" 형태로 3언어 재작성

렌더 결과 (month=2026-05):
- ko: `(2026-05 한 달 전체, 서버사이드 Webhook 분석 기준)`
- en: `(Full month of 2026-05, server-side Webhook analysis basis)`
- ja: `(2026-05 の月間全体、サーバーサイドWebhook分析基準)`

## 테스트
- test_i18n_repo_detail.py 132 passed ✅

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인
- [ ] EN/JA locale에서 /repos/{owner}/{repo} AI 비용 섹션 기간 문구 자연스러운지 확인

## ⚠️ 자율 판단 보고 (정책 3)
- P1-1 수정 방향: 백엔드(detail.py) 변경 대신 번역 문구 재작성 선택 — monthly_cost_month 단일 사용처(repo_detail.cost.period)이고 백엔드 변경은 다른 표시 영향 리스크 있어 번역만 수정

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [x] Codex 검증 의뢰 완료 — 4개 항목 전부 PASS

🤖 Generated with Claude Code