### PR TITLE
fix(i18n): analysis_detail.html Issue 패널 i18n (사이클 144 Sprint 1)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -367,6 +367,14 @@
       "title": "Title",
       "body": "Body",
       "labels": "Labels (comma separated)"
+    },
+    "issue_panel": {
+      "panel_title": "📋 GitHub Issue Registration",
+      "tab_ai": "💡 AI Suggestions",
+      "tab_static": "🔴 Static Analysis Issues",
+      "modal_title": "📝 Create GitHub Issue",
+      "btn_cancel": "Cancel",
+      "btn_submit": "Create Issue on GitHub →"
     }
   },
   "settings": {

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -367,6 +367,14 @@
       "title": "タイトル",
       "body": "本文",
       "labels": "ラベル (カンマ区切り)"
+    },
+    "issue_panel": {
+      "panel_title": "📋 GitHub Issue登録",
+      "tab_ai": "💡 AI提案事項",
+      "tab_static": "🔴 静的解析イシュー",
+      "modal_title": "📝 GitHub Issue作成",
+      "btn_cancel": "キャンセル",
+      "btn_submit": "GitHubにIssue作成 →"
     }
   },
   "settings": {

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -367,6 +367,14 @@
       "title": "제목",
       "body": "본문",
       "labels": "라벨 (쉼표 구분)"
+    },
+    "issue_panel": {
+      "panel_title": "📋 GitHub Issue 등록",
+      "tab_ai": "💡 AI 제안사항",
+      "tab_static": "🔴 정적 분석 이슈",
+      "modal_title": "📝 GitHub Issue 생성",
+      "btn_cancel": "취소",
+      "btn_submit": "GitHub에 Issue 생성 →"
     }
   },
   "settings": {

--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -783,15 +783,15 @@
            data-ai-suggestions="{{ (analysis.result or {}).get('ai_suggestions', []) | tojson }}"
            data-static-issues="{{ (analysis.result or {}).get('issues', []) | tojson }}">
 
-    <h3 class="panel-title">📋 GitHub Issue 등록</h3>
+    <h3 class="panel-title">{{ 'analysis_detail.issue_panel.panel_title' | i18n_args(locale | default('ko')) }}</h3>
 
     <!-- 탭 / Tabs -->
     <div class="issue-reg-tabs" role="tablist">
       <button class="issue-tab active" data-tab="ai" role="tab">
-        💡 AI 제안사항 <span class="issue-tab-count" id="aiCount"></span>
+        {{ 'analysis_detail.issue_panel.tab_ai' | i18n_args(locale | default('ko')) }} <span class="issue-tab-count" id="aiCount"></span>
       </button>
       <button class="issue-tab" data-tab="static" role="tab">
-        🔴 정적 분석 이슈 <span class="issue-tab-count" id="staticCount"></span>
+        {{ 'analysis_detail.issue_panel.tab_static' | i18n_args(locale | default('ko')) }} <span class="issue-tab-count" id="staticCount"></span>
       </button>
     </div>
 
@@ -809,7 +809,7 @@
   <!-- 편집 모달 / Edit modal -->
   <div class="issue-modal-overlay hidden" id="issueModalOverlay" role="dialog" aria-modal="true">
     <div class="issue-modal">
-      <h4 class="issue-modal-title">📝 GitHub Issue 생성</h4>
+      <h4 class="issue-modal-title">{{ 'analysis_detail.issue_panel.modal_title' | i18n_args(locale | default('ko')) }}</h4>
 
       <label class="issue-modal-label">{{ 'analysis_detail.issue_form.title' | i18n_args(locale | default('ko')) }}
         <input type="text" id="issueTitle" class="issue-modal-input">
@@ -825,9 +825,9 @@
       </label>
 
       <div class="issue-modal-actions">
-        <button type="button" class="btn-secondary" id="issueModalCancel">취소</button>
+        <button type="button" class="btn-secondary" id="issueModalCancel">{{ 'analysis_detail.issue_panel.btn_cancel' | i18n_args(locale | default('ko')) }}</button>
         <button type="button" class="btn-primary" id="issueModalSubmit">
-          GitHub에 Issue 생성 →
+          {{ 'analysis_detail.issue_panel.btn_submit' | i18n_args(locale | default('ko')) }}
         </button>
       </div>
       <p class="issue-modal-error hidden" id="issueModalError"></p>

--- a/tests/unit/test_i18n_analysis_detail.py
+++ b/tests/unit/test_i18n_analysis_detail.py
@@ -41,3 +41,42 @@ def test_analysis_detail_issue_form_value_non_empty(locale: str, key: str):
     assert isinstance(val, str) and val.strip(), (
         f"[{locale}] analysis_detail.issue_form.{key} 값이 비어있음: {val!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# 사이클 144 Sprint 1 — issue_panel 서브 네임스페이스
+# ---------------------------------------------------------------------------
+_ISSUE_PANEL_KEYS = [
+    "panel_title",
+    "tab_ai",
+    "tab_static",
+    "modal_title",
+    "btn_cancel",
+    "btn_submit",
+]
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _ISSUE_PANEL_KEYS)
+def test_analysis_detail_issue_panel_key_exists(locale: str, key: str):
+    """analysis_detail.issue_panel.<key>가 모든 locale에 존재해야 한다.
+    analysis_detail.issue_panel.<key> must exist in all locales.
+    """
+    data = _load(locale)
+    assert "analysis_detail" in data
+    assert "issue_panel" in data["analysis_detail"], f"[{locale}] issue_panel 없음"
+    assert key in data["analysis_detail"]["issue_panel"], (
+        f"[{locale}] analysis_detail.issue_panel.{key} 없음"
+    )
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _ISSUE_PANEL_KEYS)
+def test_analysis_detail_issue_panel_value_non_empty(locale: str, key: str):
+    """analysis_detail.issue_panel.<key> 값이 비어있지 않아야 한다.
+    Value must be non-empty.
+    """
+    val = _load(locale).get("analysis_detail", {}).get("issue_panel", {}).get(key)
+    assert isinstance(val, str) and val.strip(), (
+        f"[{locale}] analysis_detail.issue_panel.{key} 비어있음: {val!r}"
+    )


### PR DESCRIPTION
## Summary
사이클 143 회고 P1-2 이행 — analysis_detail.html Issue 등록 패널 정적 한국어 6건 i18n.

## 변경 내용
- analysis_detail.issue_panel.{panel_title,tab_ai,tab_static,modal_title,btn_cancel,btn_submit} 신규 (ko/en/ja)
- analysis_detail.html L786,791,794,812,828,830 i18n_args 교체
- repo_detail.issue_mgmt와 별도 네임스페이스 (페이지별 독립 원칙)

## 미처리 (의도적 보류)
- analysis_detail JS 동적 텍스트 (L1150/1168 btn.textContent 'GitHub에 Issue 생성 →', 생성 중.../오류 메시지 등) — 별도 사이클

## 테스트
- test_i18n_analysis_detail.py 54케이스 (기존 18 + 신규 36) PASS
- test_i18n_smoke.py 13케이스 PASS

## 사용자 검증 필요 (정책 11)
| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |

- [ ] CI 통과 확인
- [ ] EN/JA locale에서 /analyses/{id} Issue 패널 탭/모달/버튼 번역 확인

## Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증 의뢰 완료 — push 전 Codex OK 회신 대기 중

🤖 Generated with [Claude Code](https://claude.com/claude-code)
