### PR TITLE
fix(i18n): repo_detail.html 일괄 등록 버튼 정적+JS i18n (사이클 144 Sprint 2)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -291,7 +291,9 @@
       "form_labels": "Labels (comma separated)",
       "btn_cancel": "Cancel",
       "btn_skip": "Skip this item",
-      "btn_create_next": "Create & Next →"
+      "btn_create_next": "Create & Next →",
+      "bulk_register": "Register Selected Issues in Bulk ({count}) →",
+      "bulk_complete": "✅ {count} issues registered"
     }
   },
   "analysis_detail": {

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -291,7 +291,9 @@
       "form_labels": "ラベル (カンマ区切り)",
       "btn_cancel": "キャンセル",
       "btn_skip": "この項目をスキップ",
-      "btn_create_next": "作成して次へ →"
+      "btn_create_next": "作成して次へ →",
+      "bulk_register": "選択項目を一括Issue登録 ({count}件) →",
+      "bulk_complete": "✅ {count}件のIssue登録完了"
     }
   },
   "analysis_detail": {

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -291,7 +291,9 @@
       "form_labels": "라벨 (쉼표 구분)",
       "btn_cancel": "취소",
       "btn_skip": "이 항목 건너뜀",
-      "btn_create_next": "생성 후 다음 →"
+      "btn_create_next": "생성 후 다음 →",
+      "bulk_register": "선택 항목 일괄 Issue 등록 ({count}건) →",
+      "bulk_complete": "✅ {count}건 Issue 등록 완료"
     }
   },
   "analysis_detail": {

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -604,7 +604,9 @@
 
 {# ─── 반복 이슈 일괄 등록 패널 (Phase 2 신규) ─── #}
 <section class="issue-reg-panel" id="repoBulkPanel"
-         data-repo-id="{{ repo_id }}">
+         data-repo-id="{{ repo_id }}"
+         data-i18n-bulk-register="{{ 'repo_detail.issue_mgmt.bulk_register' | i18n_args(locale | default('ko'), count='__N__') }}"
+         data-i18n-bulk-complete="{{ 'repo_detail.issue_mgmt.bulk_complete' | i18n_args(locale | default('ko'), count='__N__') }}">
 
   <h3 class="panel-title">{{ 'repo_detail.issue_mgmt.title' | i18n_args(locale | default('ko')) }}</h3>
 
@@ -622,7 +624,7 @@
       <input type="checkbox" id="showUnregisteredOnly"> {{ 'repo_detail.issue_mgmt.filter_unregistered' | i18n_args(locale | default('ko')) }}
     </label>
     <button class="btn-primary" id="bulkRegisterBtn" disabled>
-      선택 항목 일괄 Issue 등록 (0건) →
+      {{ 'repo_detail.issue_mgmt.bulk_register' | i18n_args(locale | default('ko'), count=0) }}
     </button>
   </div>
 
@@ -846,6 +848,14 @@ const I18N = {
   sourcePush: _i18nCard.dataset.i18nSourcePush,
   sourceCli: _i18nCard.dataset.i18nSourceCli,
 };
+
+// 사이클 144 Sprint 2 — 일괄 등록 버튼/토스트 i18n (#repoBulkPanel data-i18n-*)
+// Cycle 144 Sprint 2 — bulk register button/toast i18n (#repoBulkPanel data-i18n-*)
+const _i18nBulkPanel = document.getElementById('repoBulkPanel');
+const I18N_BULK = _i18nBulkPanel ? {
+  bulkRegister: _i18nBulkPanel.dataset.i18nBulkRegister,
+  bulkComplete: _i18nBulkPanel.dataset.i18nBulkComplete,
+} : { bulkRegister: '', bulkComplete: '' };
 
 // ── 상태 ─────────────────────────────────────────────
 const state = {
@@ -1237,7 +1247,7 @@ function _initRepoBulk() {
     var checked = document.querySelectorAll('.issue-list input[type=checkbox]:checked');
     var btn = document.getElementById('bulkRegisterBtn');
     btn.disabled = checked.length === 0;
-    btn.textContent = '선택 항목 일괄 Issue 등록 (' + checked.length + '건) →';
+    btn.textContent = I18N_BULK.bulkRegister.replace('__N__', checked.length);
   }
 
   /* ── 탭 전환 ── */
@@ -1338,7 +1348,7 @@ function _initRepoBulk() {
         closeBulkModal();
         renderAll();
         var toast = document.getElementById('repoIssueToast');
-        toast.textContent = '✅ ' + total + '건 Issue 등록 완료';
+        toast.textContent = I18N_BULK.bulkComplete.replace('__N__', total);
         toast.classList.remove('hidden');
         setTimeout(function() { toast.classList.add('hidden'); }, 5000);
       }

--- a/tests/unit/test_i18n_repo_detail.py
+++ b/tests/unit/test_i18n_repo_detail.py
@@ -117,3 +117,34 @@ def test_repo_detail_sprint3_issue_mgmt_value_non_empty(locale: str, key: str):
     assert isinstance(val, str) and val.strip(), (
         f"[{locale}] repo_detail.issue_mgmt.{key} 비어있음: {val!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# 사이클 144 Sprint 2 — issue_mgmt 동적 카운트 키 (data-i18n 패턴)
+# Cycle 144 Sprint 2 — issue_mgmt dynamic count keys (data-i18n pattern)
+# ---------------------------------------------------------------------------
+_SPRINT2_144_BULK_KEYS = ["bulk_register", "bulk_complete"]
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT2_144_BULK_KEYS)
+def test_repo_detail_bulk_key_exists(locale: str, key: str):
+    """repo_detail.issue_mgmt.<bulk_key>가 모든 locale에 존재해야 한다.
+    repo_detail.issue_mgmt.<bulk_key> must exist in all locales.
+    """
+    data = _load(locale)
+    assert "issue_mgmt" in data["repo_detail"]
+    assert key in data["repo_detail"]["issue_mgmt"], (
+        f"[{locale}] repo_detail.issue_mgmt.{key} 없음"
+    )
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _SPRINT2_144_BULK_KEYS)
+def test_repo_detail_bulk_value_has_count_placeholder(locale: str, key: str):
+    """repo_detail.issue_mgmt.<bulk_key> 값에 {count} 플레이스홀더가 있어야 한다.
+    Value must contain the {count} placeholder for dynamic count injection.
+    """
+    val = _load(locale).get("repo_detail", {}).get("issue_mgmt", {}).get(key)
+    assert isinstance(val, str) and val.strip(), f"[{locale}] {key} 비어있음"
+    assert "{count}" in val, f"[{locale}] {key}에 {{count}} 플레이스홀더 없음: {val!r}"


### PR DESCRIPTION
## Summary
사이클 143 회고 P1-3 이행 — repo_detail.html 일괄 등록 버튼 정적(L625) + JS 동적(L1240,L1341) i18n.

## 변경 내용
- repo_detail.issue_mgmt.{bulk_register,bulk_complete} 신규 ({count} 플레이스홀더, ko/en/ja)
- 정적 버튼: count=0 직접 렌더
- JS 동적: 기존 Phase 2 PR-7 data-i18n-* + __N__ 치환 패턴 재사용 (XSS-safe)
  - #repoBulkPanel에 data-i18n-bulk-* 속성 추가
  - I18N_BULK 객체 + .replace('__N__', count)

## 테스트
- test_i18n_repo_detail.py 144케이스 (기존 132 + 신규 12) 통과
- test_i18n_smoke.py 13케이스 통과
- i18n_args_filter 치환 검증: count='__N__' -> __N__ 렌더, count=0/5 -> 숫자 렌더, 리터럴 {count} 누출 없음

## 🔍 사용자 검증 필요 (정책 11)
| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |

- [ ] CI 통과 확인
- [ ] EN/JA locale에서 /repos/{owner}/{repo} 이슈 체크박스 선택 시 버튼 카운트 텍스트 번역 확인
- [ ] 일괄 등록 완료 시 토스트 번역 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증 의뢰 완료 — push 전 Codex OK 회신 대기 중 (컨트롤러가 별도 수행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
