### PR TITLE
test(i18n): 사이클 143/144 렌더 정합 가드 (사이클 144 Sprint 3)

### DIFF
--- a/tests/unit/templates/test_detail_i18n_render.py
+++ b/tests/unit/templates/test_detail_i18n_render.py
@@ -309,3 +309,61 @@ def test_analysis_detail_locale_none_defaults_to_ko():
     out = _render("analysis_detail.html", **_analysis_ctx())
     assert "← 이력" in out  # back ko default
     assert "분석 #42" in out
+
+
+# ---------------------------------------------------------------------------
+# 사이클 143/144 i18n 렌더 정합 가드 (회고 P1-4)
+# 키 존재가 아닌 실제 렌더 결과에 번역 텍스트가 나타나는지 검증 —
+# 템플릿이 오타 키 호출 시 raw 키 노출을 검출.
+# Render-parity guard: verifies translated text appears in rendered output,
+# catching template typo-key calls that key-existence tests miss.
+# ---------------------------------------------------------------------------
+
+
+def test_repo_detail_cycle143_korean_strings_render():
+    """repo_detail.html ko — 사이클 143 신규 번역 텍스트 렌더 검증."""
+    out = _render("repo_detail.html", locale="ko", **_repo_ctx())
+    assert "최근 점수:" in out  # recent_score
+    assert "이번 달 AI 리뷰 예상 비용" in out  # cost.title
+    assert "한 달 전체" in out  # cost.period ({month} 보간 후 Tier A 수정값)
+    assert "반복 이슈" in out  # issue_mgmt.title (🔁 반복 이슈 — Issue 등록 관리)
+
+
+def test_repo_detail_cycle143_english_strings_render():
+    """repo_detail.html en — 사이클 143 신규 번역 텍스트 렌더 검증."""
+    out = _render("repo_detail.html", locale="en", **_repo_ctx())
+    assert "Recent Score:" in out  # recent_score
+    assert "Estimated AI Review Cost This Month" in out  # cost.title
+
+
+def test_repo_detail_history_empty_renders_when_no_analyses():
+    """repo_detail.html — analyses 비어있을 때 history_empty 빈 상태 렌더."""
+    out = _render("repo_detail.html", locale="ko", **_repo_ctx(analyses=[]))
+    assert "분석 이력이 없습니다" in out  # history_empty
+
+
+def test_repo_detail_cycle144_bulk_register_renders():
+    """repo_detail.html ko — 사이클 144 일괄 등록 버튼 정적 렌더 (count=0)."""
+    out = _render("repo_detail.html", locale="ko", **_repo_ctx())
+    # 템플릿이 count=0 으로 i18n_args 호출 → {count}건 보간 검증
+    assert "선택 항목 일괄 Issue 등록 (0건)" in out  # issue_mgmt.bulk_register
+
+
+def test_analysis_detail_cycle144_issue_panel_korean_renders():
+    """analysis_detail.html ko — 사이클 144 Issue 패널 번역 텍스트 렌더."""
+    out = _render("analysis_detail.html", locale="ko", **_analysis_ctx())
+    assert "GitHub Issue 등록" in out  # issue_panel.panel_title (📋 GitHub Issue 등록)
+    assert "GitHub Issue 생성" in out  # issue_panel.modal_title (📝 GitHub Issue 생성)
+
+
+def test_analysis_detail_cycle144_issue_panel_english_renders():
+    """analysis_detail.html en — 사이클 144 Issue 패널 번역 텍스트 렌더."""
+    out = _render("analysis_detail.html", locale="en", **_analysis_ctx())
+    assert "GitHub Issue Registration" in out  # issue_panel.panel_title
+    assert "Create GitHub Issue" in out  # issue_panel.modal_title
+
+
+def test_analysis_detail_cycle143_issue_form_renders():
+    """analysis_detail.html ko — 사이클 143 issue_form 라벨 렌더."""
+    out = _render("analysis_detail.html", locale="ko", **_analysis_ctx())
+    assert "제목" in out  # issue_form.title


### PR DESCRIPTION
## Summary
사이클 143 회고 P1-4 이행 — i18n 렌더 정합 가드 추가.

## 배경
기존 i18n 테스트는 JSON 키 존재만 검증 → 템플릿이 오타 키 (`modal_titel` 등) 호출 시 raw 키가 화면에 노출되나 테스트는 통과하는 사각. 실제 렌더 결과에 번역 텍스트 출현을 검증하는 가드 추가.

## 변경 내용
`test_detail_i18n_render.py` 파일 끝에 사이클 143/144 신규 키 렌더 검증 7건 추가:
- **repo_detail**: recent_score, cost.title, cost.period (`{month}` 보간), issue_mgmt.title, history_empty (analyses=[] 빈 상태), bulk_register (count=0 정적 렌더)
- **analysis_detail**: issue_panel.panel_title, issue_panel.modal_title, issue_form.title
- ko/en 양 언어 검증

## 실제 JSON 값 확인 결과 (가이드 vs 실측)
모든 키 정상 렌더 — i18n 누락 P0 없음. 보간 키 실측:
- `cost.period` ko = `({month} 한 달 전체, 서버사이드 Webhook 분석 기준)` → month=2026-05 보간 후 '한 달 전체' 출현 확인
- `bulk_register` ko = `선택 항목 일괄 Issue 등록 ({count}건) →` → 템플릿이 count=0 호출 → '선택 항목 일괄 Issue 등록 (0건)' 출현 확인
- `issue_mgmt.title` = `🔁 반복 이슈 — Issue 등록 관리` / `panel_title` = `📋 GitHub Issue 등록` / `modal_title` = `📝 GitHub Issue 생성` (이모지 prefix 포함, 부분 문자열 assert)

## 테스트
- test_detail_i18n_render.py 전체 23 passed (16 기존 + 7 신규), 회귀 0 ✅
- 실패한 assert 0건 — 가이드 텍스트 그대로 통과 (조정 불필요)

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증은 컨트롤러 별도 진행 (본 작업 위임 범위 = push + PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)