### PR TITLE
fix(i18n): analysis_detail.html JS 동적 텍스트 i18n (사이클 145 Sprint 1)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -377,6 +377,18 @@
       "modal_title": "📝 Create GitHub Issue",
       "btn_cancel": "Cancel",
       "btn_submit": "Create Issue on GitHub →"
+    },
+    "js_msg": {
+      "suggestion_prefix": "💡 [AI Suggestion] ",
+      "status_resolved": "✅ #{num} Resolved",
+      "status_open": "🔵 #{num} Open",
+      "btn_register": "Register Issue",
+      "body_ai": "## 📌 Analysis Info\nAnalysis ID: {id}\n\n## 💡 AI Suggestion\n{text}\n\n---\n*Generated from SCAManager AI analysis results*",
+      "body_static": "## 📌 Analysis Info\nAnalysis ID: {id}\n\n## 🔴 Issue Details\n- Tool: {tool}\n- Category: {category}\n- Message: {message}\n\n---\n*Generated from SCAManager static analysis results*",
+      "btn_creating": "Creating...",
+      "err_generic": "An error occurred.",
+      "toast_created": "✅ Issue #{num} created",
+      "err_network": "A network error occurred. Please try again."
     }
   },
   "settings": {

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -377,6 +377,18 @@
       "modal_title": "📝 GitHub Issue作成",
       "btn_cancel": "キャンセル",
       "btn_submit": "GitHubにIssue作成 →"
+    },
+    "js_msg": {
+      "suggestion_prefix": "💡 [AI 提案] ",
+      "status_resolved": "✅ #{num} 解決済み",
+      "status_open": "🔵 #{num} 進行中",
+      "btn_register": "Issue 登録",
+      "body_ai": "## 📌 分析情報\n分析ID: {id}\n\n## 💡 AI 提案内容\n{text}\n\n---\n*SCAManager AI 分析結果から生成されました*",
+      "body_static": "## 📌 分析情報\n分析ID: {id}\n\n## 🔴 課題内容\n- ツール: {tool}\n- カテゴリ: {category}\n- メッセージ: {message}\n\n---\n*SCAManager 静的分析結果から生成されました*",
+      "btn_creating": "作成中...",
+      "err_generic": "エラーが発生しました。",
+      "toast_created": "✅ Issue #{num} 作成済み",
+      "err_network": "ネットワークエラーが発生しました。もう一度お試しください。"
     }
   },
   "settings": {

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -377,6 +377,18 @@
       "modal_title": "📝 GitHub Issue 생성",
       "btn_cancel": "취소",
       "btn_submit": "GitHub에 Issue 생성 →"
+    },
+    "js_msg": {
+      "suggestion_prefix": "💡 [AI 제안] ",
+      "status_resolved": "✅ #{num} 해결됨",
+      "status_open": "🔵 #{num} 진행중",
+      "btn_register": "Issue 등록",
+      "body_ai": "## 📌 분석 정보\n분석 ID: {id}\n\n## 💡 AI 제안 내용\n{text}\n\n---\n*SCAManager AI 분석 결과에서 생성됨*",
+      "body_static": "## 📌 분석 정보\n분석 ID: {id}\n\n## 🔴 이슈 내용\n- 도구: {tool}\n- 카테고리: {category}\n- 메시지: {message}\n\n---\n*SCAManager 정적 분석 결과에서 생성됨*",
+      "btn_creating": "생성 중...",
+      "err_generic": "오류가 발생했습니다.",
+      "toast_created": "✅ Issue #{num} 생성됨",
+      "err_network": "네트워크 오류가 발생했습니다. 다시 시도해 주세요."
     }
   },
   "settings": {

--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -781,7 +781,18 @@
   <section class="issue-reg-panel" id="issueRegPanel"
            data-analysis-id="{{ analysis.id }}"
            data-ai-suggestions="{{ (analysis.result or {}).get('ai_suggestions', []) | tojson }}"
-           data-static-issues="{{ (analysis.result or {}).get('issues', []) | tojson }}">
+           data-static-issues="{{ (analysis.result or {}).get('issues', []) | tojson }}"
+           data-i18n-suggestion-prefix="{{ 'analysis_detail.js_msg.suggestion_prefix' | i18n_args(locale | default('ko')) }}"
+           data-i18n-status-resolved="{{ 'analysis_detail.js_msg.status_resolved' | i18n_args(locale | default('ko'), num='__N__') }}"
+           data-i18n-status-open="{{ 'analysis_detail.js_msg.status_open' | i18n_args(locale | default('ko'), num='__N__') }}"
+           data-i18n-btn-register="{{ 'analysis_detail.js_msg.btn_register' | i18n_args(locale | default('ko')) }}"
+           data-i18n-body-ai="{{ 'analysis_detail.js_msg.body_ai' | i18n_args(locale | default('ko'), id='__ID__', text='__TEXT__') }}"
+           data-i18n-body-static="{{ 'analysis_detail.js_msg.body_static' | i18n_args(locale | default('ko'), id='__ID__', tool='__TOOL__', category='__CAT__', message='__MSG__') }}"
+           data-i18n-btn-creating="{{ 'analysis_detail.js_msg.btn_creating' | i18n_args(locale | default('ko')) }}"
+           data-i18n-err-generic="{{ 'analysis_detail.js_msg.err_generic' | i18n_args(locale | default('ko')) }}"
+           data-i18n-toast-created="{{ 'analysis_detail.js_msg.toast_created' | i18n_args(locale | default('ko'), num='__N__') }}"
+           data-i18n-err-network="{{ 'analysis_detail.js_msg.err_network' | i18n_args(locale | default('ko')) }}"
+           data-i18n-btn-submit="{{ 'analysis_detail.issue_panel.btn_submit' | i18n_args(locale | default('ko')) }}">
 
     <h3 class="panel-title">{{ 'analysis_detail.issue_panel.panel_title' | i18n_args(locale | default('ko')) }}</h3>
 
@@ -991,6 +1002,21 @@
   var aiSuggestions = JSON.parse(panel.dataset.aiSuggestions || '[]');
   var staticIssues  = JSON.parse(panel.dataset.staticIssues  || '[]');
 
+  /* ── i18n JS 동적 텍스트 (data-i18n-* + __VAR__ 치환) / i18n JS dynamic text ── */
+  var I18N_JS = {
+    suggestionPrefix: panel.dataset.i18nSuggestionPrefix,
+    statusResolved:   panel.dataset.i18nStatusResolved,
+    statusOpen:       panel.dataset.i18nStatusOpen,
+    btnRegister:      panel.dataset.i18nBtnRegister,
+    bodyAi:           panel.dataset.i18nBodyAi,
+    bodyStatic:       panel.dataset.i18nBodyStatic,
+    btnCreating:      panel.dataset.i18nBtnCreating,
+    errGeneric:       panel.dataset.i18nErrGeneric,
+    toastCreated:     panel.dataset.i18nToastCreated,
+    errNetwork:       panel.dataset.i18nErrNetwork,
+    btnSubmit:        panel.dataset.i18nBtnSubmit,
+  };
+
   /* ── 상태 맵 — issue_key(서버) → registration / State map — issue_key → registration */
   var stateMap = {};
 
@@ -1014,7 +1040,7 @@
       label: text,
       type: 'ai_suggestion',
       suggestionText: text,
-      title: '💡 [AI 제안] ' + text.slice(0, 60),
+      title: I18N_JS.suggestionPrefix + text.slice(0, 60),
     };
   }
 
@@ -1062,13 +1088,13 @@
         ? 'issue-badge issue-badge--closed'
         : 'issue-badge issue-badge--open';
       badge.textContent = reg.github_issue_state === 'closed'
-        ? '✅ #' + reg.github_issue_number + ' 해결됨'
-        : '🔵 #' + reg.github_issue_number + ' 진행중';
+        ? I18N_JS.statusResolved.replace('__N__', reg.github_issue_number)
+        : I18N_JS.statusOpen.replace('__N__', reg.github_issue_number);
       li.appendChild(badge);
     } else {
       var btn = document.createElement('button');
       btn.className = 'btn-register';
-      btn.textContent = 'Issue 등록';
+      btn.textContent = I18N_JS.btnRegister;
       btn.addEventListener('click', (function(i) { return function() { openModal(i); }; })(item));
       li.appendChild(btn);
     }
@@ -1106,9 +1132,15 @@
 
   function _defaultBody(item) {
     if (item.type === 'ai_suggestion') {
-      return '## 📌 분석 정보\n분석 ID: ' + analysisId + '\n\n## 💡 AI 제안 내용\n' + item.suggestionText + '\n\n---\n*SCAManager AI 분석 결과에서 생성됨*';
+      return I18N_JS.bodyAi
+        .replace('__ID__', analysisId)
+        .replace('__TEXT__', item.suggestionText);
     }
-    return '## 📌 분석 정보\n분석 ID: ' + analysisId + '\n\n## 🔴 이슈 내용\n- 도구: ' + (item.tool||'') + '\n- 카테고리: ' + (item.category||'') + '\n- 메시지: ' + (item.message||'') + '\n\n---\n*SCAManager 정적 분석 결과에서 생성됨*';
+    return I18N_JS.bodyStatic
+      .replace('__ID__', analysisId)
+      .replace('__TOOL__', item.tool || '')
+      .replace('__CAT__', item.category || '')
+      .replace('__MSG__', item.message || '');
   }
 
   document.getElementById('issueModalCancel').addEventListener('click', closeModal);
@@ -1120,7 +1152,7 @@
     if (!_currentItem) return;
     var btn = document.getElementById('issueModalSubmit');
     btn.disabled = true;
-    btn.textContent = '생성 중...';
+    btn.textContent = I18N_JS.btnCreating;
 
     var payload = {
       analysis_id: analysisId,
@@ -1144,10 +1176,10 @@
     .then(function(res) {
       if (!res.ok) {
         var errEl = document.getElementById('issueModalError');
-        errEl.textContent = res.data.detail || '오류가 발생했습니다.';
+        errEl.textContent = res.data.detail || I18N_JS.errGeneric;
         errEl.classList.remove('hidden');
         btn.disabled = false;
-        btn.textContent = 'GitHub에 Issue 생성 →';
+        btn.textContent = I18N_JS.btnSubmit;
         return;
       }
       /* 성공 — 상태 맵 갱신 후 목록 다시 렌더링 / Success — update state map and re-render list */
@@ -1158,14 +1190,14 @@
       };
       closeModal();
       renderAll();
-      showToast('✅ Issue #' + res.data.github_issue_number + ' 생성됨');
+      showToast(I18N_JS.toastCreated.replace('__N__', res.data.github_issue_number));
     })
     .catch(function() {
       var errEl = document.getElementById('issueModalError');
-      errEl.textContent = '네트워크 오류가 발생했습니다. 다시 시도해 주세요.';
+      errEl.textContent = I18N_JS.errNetwork;
       errEl.classList.remove('hidden');
       btn.disabled = false;
-      btn.textContent = 'GitHub에 Issue 생성 →';
+      btn.textContent = I18N_JS.btnSubmit;
     });
   });
 

--- a/tests/unit/test_i18n_analysis_detail.py
+++ b/tests/unit/test_i18n_analysis_detail.py
@@ -80,3 +80,54 @@ def test_analysis_detail_issue_panel_value_non_empty(locale: str, key: str):
     assert isinstance(val, str) and val.strip(), (
         f"[{locale}] analysis_detail.issue_panel.{key} 비어있음: {val!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# 사이클 145 Sprint 1 — js_msg 동적 텍스트 키
+# Cycle 145 Sprint 1 — js_msg dynamic text keys
+# ---------------------------------------------------------------------------
+_JS_MSG_KEYS = [
+    "suggestion_prefix",
+    "status_resolved",
+    "status_open",
+    "btn_register",
+    "body_ai",
+    "body_static",
+    "btn_creating",
+    "err_generic",
+    "toast_created",
+    "err_network",
+]
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _JS_MSG_KEYS)
+def test_analysis_detail_js_msg_key_exists(locale: str, key: str):
+    """analysis_detail.js_msg.<key>가 모든 locale에 존재해야 한다."""
+    data = _load(locale)
+    assert "js_msg" in data["analysis_detail"], f"[{locale}] js_msg 없음"
+    assert key in data["analysis_detail"]["js_msg"], f"[{locale}] js_msg.{key} 없음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _JS_MSG_KEYS)
+def test_analysis_detail_js_msg_non_empty(locale: str, key: str):
+    """analysis_detail.js_msg.<key> 값이 비어있지 않아야 한다."""
+    val = _load(locale).get("analysis_detail", {}).get("js_msg", {}).get(key)
+    assert isinstance(val, str) and val.strip(), f"[{locale}] js_msg.{key} 비어있음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+def test_analysis_detail_js_msg_count_placeholders(locale: str):
+    """카운트 키는 {num} 플레이스홀더를 가져야 한다."""
+    js = _load(locale)["analysis_detail"]["js_msg"]
+    for key in ["status_resolved", "status_open", "toast_created"]:
+        assert "{num}" in js[key], f"[{locale}] {key}에 {{num}} 없음: {js[key]!r}"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+def test_analysis_detail_js_msg_body_placeholders(locale: str):
+    """본문 빌더 키는 {id} 플레이스홀더를 가져야 한다."""
+    js = _load(locale)["analysis_detail"]["js_msg"]
+    assert "{id}" in js["body_ai"], f"[{locale}] body_ai에 {{id}} 없음"
+    assert "{id}" in js["body_static"], f"[{locale}] body_static에 {{id}} 없음"


### PR DESCRIPTION
## Summary
analysis_detail.html JS 동적 한국어 i18n — 상태/버튼/오류/Issue 본문 빌더.

## 변경 내용
- `analysis_detail.js_msg.*` 신규 (10키, ko/en/ja) — `{num}`/`{id}`/`{text}`/`{tool}`/`{category}`/`{message}` 플레이스홀더
- 기존 `data-i18n-*` + `__VAR__` 치환 패턴 재사용 (Phase 2 PR-7) — XSS-safe, 서버 Jinja injection
- `#issueRegPanel` section 에 data-i18n 속성 11개 추가, JS `I18N_JS` 객체로 읽어 `.replace('__N__', ...)` 치환
- Issue 본문 빌더(`body_ai`/`body_static`) locale 번역 — 생성되는 GitHub Issue 본문도 다국어 (마크다운 구조 보존)
- L1150/1168 GitHub Issue 생성 버튼은 기존 `issue_panel.btn_submit` 재사용 (신규 키 미생성)

## 교체 사용처 (12개)
suggestion_prefix · status_resolved · status_open · btn_register · body_ai · body_static · btn_creating · err_generic · btn_submit(x2) · toast_created · err_network

## 미처리 (보류)
- L1055 (구 L1029) `🔴 [' + category + '] ' + tool + ': ' + message.slice(0,50)` — 변수 3개 + 슬라이스 구조 분해 복잡, 별도 사이클로 보류

## 테스트
- `test_i18n_analysis_detail.py` js_msg 케이스 신규 66건 ✅ (전체 120 passed)
- `test_detail_i18n_render.py` 렌더 가드 회귀 없음 ✅ (23 passed)
- 멀티라인 본문 빌더 검증: i18n_args 통과 후 data 속성에 개행 7개 + 모든 플레이스홀더 보존 확인 (ko/en/ja)

## 🔍 사용자 검증 필요 (정책 11)
| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |
- [ ] CI 통과 확인
- [ ] EN/JA locale 에서 `/analyses/{id}` Issue 생성 흐름 (등록 버튼/상태 뱃지/오류/생성된 Issue 본문) 번역 확인
- [ ] 생성된 GitHub Issue 본문이 locale 별 마크다운으로 정상 렌더되는지 (개행 보존)

> Claude 시각 검증 불가: template/JS 정적 코드만 검증 가능. 4-테마 × 모바일/데스크탑 8조합 시각 정합성은 사용자 의무.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증 의뢰 — 컨트롤러 별도 진행 (본 작업은 컨트롤러 디스패치 작업으로, push+PR 까지 수행)

🤖 Generated with [Claude Code](https://claude.com/claude-code)