### PR TITLE
fix(i18n): repo_detail.html JS 동적 텍스트 i18n (사이클 145 Sprint 2)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -294,6 +294,22 @@
       "btn_create_next": "Create & Next →",
       "bulk_register": "Register Selected Issues in Bulk ({count}) →",
       "bulk_complete": "✅ {count} issues registered"
+    },
+    "js_msg": {
+      "chart_avg": "Avg",
+      "chart_max": "Max",
+      "chart_min": "Min",
+      "tooltip_score": "Score {score}",
+      "grade_suffix": " · Grade {grade}",
+      "label_ai": "AI Suggestion",
+      "label_static": "Static Analysis",
+      "status_resolved": "✅ #{num} Resolved",
+      "status_open": "🔵 #{num} Open",
+      "bulk_submit_final": "Create Issue on GitHub",
+      "btn_creating": "Creating...",
+      "err_generic": "An error occurred",
+      "btn_retry": "Retry",
+      "err_network": "Network error"
     }
   },
   "analysis_detail": {

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -294,6 +294,22 @@
       "btn_create_next": "作成して次へ →",
       "bulk_register": "選択項目を一括Issue登録 ({count}件) →",
       "bulk_complete": "✅ {count}件のIssue登録完了"
+    },
+    "js_msg": {
+      "chart_avg": "平均",
+      "chart_max": "最高",
+      "chart_min": "最低",
+      "tooltip_score": "スコア {score}",
+      "grade_suffix": " · {grade}グレード",
+      "label_ai": "AI提案",
+      "label_static": "静的解析",
+      "status_resolved": "✅ #{num} 解決済み",
+      "status_open": "🔵 #{num} 進行中",
+      "bulk_submit_final": "GitHubにIssueを作成",
+      "btn_creating": "作成中...",
+      "err_generic": "エラーが発生しました",
+      "btn_retry": "再試行",
+      "err_network": "ネットワークエラー"
     }
   },
   "analysis_detail": {

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -294,6 +294,22 @@
       "btn_create_next": "생성 후 다음 →",
       "bulk_register": "선택 항목 일괄 Issue 등록 ({count}건) →",
       "bulk_complete": "✅ {count}건 Issue 등록 완료"
+    },
+    "js_msg": {
+      "chart_avg": "평균",
+      "chart_max": "최고",
+      "chart_min": "최저",
+      "tooltip_score": "점수 {score}",
+      "grade_suffix": " · {grade}등급",
+      "label_ai": "AI 제안",
+      "label_static": "정적 분석",
+      "status_resolved": "✅ #{num} 해결됨",
+      "status_open": "🔵 #{num} 진행중",
+      "bulk_submit_final": "GitHub에 Issue 생성",
+      "btn_creating": "생성 중...",
+      "err_generic": "오류 발생",
+      "btn_retry": "다시 시도",
+      "err_network": "네트워크 오류"
     }
   },
   "analysis_detail": {

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -529,7 +529,12 @@
      data-i18n-page-range="{{ 'repo_detail.page_range' | i18n_args(locale | default('ko'), start='__S__', end='__E__', total='__T__') }}"
      data-i18n-source-pr="{{ 'repo_detail.source_filter.pr' | i18n_args(locale | default('ko')) }}"
      data-i18n-source-push="{{ 'repo_detail.source_filter.push' | i18n_args(locale | default('ko')) }}"
-     data-i18n-source-cli="{{ 'repo_detail.source_filter.cli' | i18n_args(locale | default('ko')) }}">
+     data-i18n-source-cli="{{ 'repo_detail.source_filter.cli' | i18n_args(locale | default('ko')) }}"
+     data-i18n-chart-avg="{{ 'repo_detail.js_msg.chart_avg' | i18n_args(locale | default('ko')) }}"
+     data-i18n-chart-max="{{ 'repo_detail.js_msg.chart_max' | i18n_args(locale | default('ko')) }}"
+     data-i18n-chart-min="{{ 'repo_detail.js_msg.chart_min' | i18n_args(locale | default('ko')) }}"
+     data-i18n-tooltip-score="{{ 'repo_detail.js_msg.tooltip_score' | i18n_args(locale | default('ko'), score='__S__') }}"
+     data-i18n-grade-suffix="{{ 'repo_detail.js_msg.grade_suffix' | i18n_args(locale | default('ko'), grade='__G__') }}">
   <div class="card__head history-header">
     <h3 class="card__title">{{ 'repo_detail.history_title' | i18n_args(locale | default('ko')) }}</h3>
     <span class="history-count" id="historyCount">{{ 'repo_detail.history_count_recent' | i18n_args(locale | default('ko'), count=(analyses | length)) }}</span>
@@ -606,7 +611,17 @@
 <section class="issue-reg-panel" id="repoBulkPanel"
          data-repo-id="{{ repo_id }}"
          data-i18n-bulk-register="{{ 'repo_detail.issue_mgmt.bulk_register' | i18n_args(locale | default('ko'), count='__N__') }}"
-         data-i18n-bulk-complete="{{ 'repo_detail.issue_mgmt.bulk_complete' | i18n_args(locale | default('ko'), count='__N__') }}">
+         data-i18n-bulk-complete="{{ 'repo_detail.issue_mgmt.bulk_complete' | i18n_args(locale | default('ko'), count='__N__') }}"
+         data-i18n-label-ai="{{ 'repo_detail.js_msg.label_ai' | i18n_args(locale | default('ko')) }}"
+         data-i18n-label-static="{{ 'repo_detail.js_msg.label_static' | i18n_args(locale | default('ko')) }}"
+         data-i18n-status-resolved="{{ 'repo_detail.js_msg.status_resolved' | i18n_args(locale | default('ko'), num='__N__') }}"
+         data-i18n-status-open="{{ 'repo_detail.js_msg.status_open' | i18n_args(locale | default('ko'), num='__N__') }}"
+         data-i18n-bulk-submit-final="{{ 'repo_detail.js_msg.bulk_submit_final' | i18n_args(locale | default('ko')) }}"
+         data-i18n-btn-create-next="{{ 'repo_detail.issue_mgmt.btn_create_next' | i18n_args(locale | default('ko')) }}"
+         data-i18n-btn-creating="{{ 'repo_detail.js_msg.btn_creating' | i18n_args(locale | default('ko')) }}"
+         data-i18n-err-generic="{{ 'repo_detail.js_msg.err_generic' | i18n_args(locale | default('ko')) }}"
+         data-i18n-btn-retry="{{ 'repo_detail.js_msg.btn_retry' | i18n_args(locale | default('ko')) }}"
+         data-i18n-err-network="{{ 'repo_detail.js_msg.err_network' | i18n_args(locale | default('ko')) }}">
 
   <h3 class="panel-title">{{ 'repo_detail.issue_mgmt.title' | i18n_args(locale | default('ko')) }}</h3>
 
@@ -733,9 +748,9 @@
       var mn  = Math.min.apply(null, scores);
       var mx  = Math.max.apply(null, scores);
       statsEl.innerHTML =
-        '<div class="chart-stat"><span class="chart-stat-val">' + avg + '</span><span class="chart-stat-lbl">평균</span></div>' +
-        '<div class="chart-stat"><span class="chart-stat-val" style="color:' + success + '">' + mx + '</span><span class="chart-stat-lbl">최고</span></div>' +
-        '<div class="chart-stat"><span class="chart-stat-val" style="color:' + danger  + '">' + mn + '</span><span class="chart-stat-lbl">최저</span></div>';
+        '<div class="chart-stat"><span class="chart-stat-val">' + avg + '</span><span class="chart-stat-lbl">' + I18N.chartAvg + '</span></div>' +
+        '<div class="chart-stat"><span class="chart-stat-val" style="color:' + success + '">' + mx + '</span><span class="chart-stat-lbl">' + I18N.chartMax + '</span></div>' +
+        '<div class="chart-stat"><span class="chart-stat-val" style="color:' + danger  + '">' + mn + '</span><span class="chart-stat-lbl">' + I18N.chartMin + '</span></div>';
     }
 
     /* 스파크라인 그라디언트 fill — accent 기반, 위에서 아래로 투명
@@ -795,7 +810,7 @@
             callbacks: {
               label: function(item) {
                 var a = _chartData[item.dataIndex];
-                return '점수 ' + item.raw + (a && a.grade ? ' · ' + a.grade + '등급' : '');
+                return I18N.tooltipScore.replace('__S__', item.raw) + (a && a.grade ? I18N.gradeSuffix.replace('__G__', a.grade) : '');
               }
             }
           }
@@ -847,6 +862,13 @@ const I18N = {
   sourcePr: _i18nCard.dataset.i18nSourcePr,
   sourcePush: _i18nCard.dataset.i18nSourcePush,
   sourceCli: _i18nCard.dataset.i18nSourceCli,
+  // 사이클 145 Sprint 2 — 차트 통계/tooltip i18n
+  // Cycle 145 Sprint 2 — chart stats/tooltip i18n
+  chartAvg: _i18nCard.dataset.i18nChartAvg,
+  chartMax: _i18nCard.dataset.i18nChartMax,
+  chartMin: _i18nCard.dataset.i18nChartMin,
+  tooltipScore: _i18nCard.dataset.i18nTooltipScore,
+  gradeSuffix: _i18nCard.dataset.i18nGradeSuffix,
 };
 
 // 사이클 144 Sprint 2 — 일괄 등록 버튼/토스트 i18n (#repoBulkPanel data-i18n-*)
@@ -855,6 +877,18 @@ const _i18nBulkPanel = document.getElementById('repoBulkPanel');
 const I18N_BULK = _i18nBulkPanel ? {
   bulkRegister: _i18nBulkPanel.dataset.i18nBulkRegister,
   bulkComplete: _i18nBulkPanel.dataset.i18nBulkComplete,
+  // 사이클 145 Sprint 2 — Issue 모달 라벨/상태/버튼/오류 i18n
+  // Cycle 145 Sprint 2 — Issue modal label/status/button/error i18n
+  labelAi: _i18nBulkPanel.dataset.i18nLabelAi,
+  labelStatic: _i18nBulkPanel.dataset.i18nLabelStatic,
+  statusResolved: _i18nBulkPanel.dataset.i18nStatusResolved,
+  statusOpen: _i18nBulkPanel.dataset.i18nStatusOpen,
+  bulkSubmitFinal: _i18nBulkPanel.dataset.i18nBulkSubmitFinal,
+  btnCreateNext: _i18nBulkPanel.dataset.i18nBtnCreateNext,
+  btnCreating: _i18nBulkPanel.dataset.i18nBtnCreating,
+  errGeneric: _i18nBulkPanel.dataset.i18nErrGeneric,
+  btnRetry: _i18nBulkPanel.dataset.i18nBtnRetry,
+  errNetwork: _i18nBulkPanel.dataset.i18nErrNetwork,
 } : { bulkRegister: '', bulkComplete: '' };
 
 // ── 상태 ─────────────────────────────────────────────
@@ -1183,7 +1217,7 @@ function _initRepoBulk() {
           _allItems.push({
             key:   reg.issue_key,
             type:  reg.issue_type,
-            label: '#' + reg.github_issue_number + ' — ' + (reg.issue_type === 'ai_suggestion' ? 'AI 제안' : '정적 분석'),
+            label: '#' + reg.github_issue_number + ' — ' + (reg.issue_type === 'ai_suggestion' ? I18N_BULK.labelAi : I18N_BULK.labelStatic),
           });
         });
         renderAll();
@@ -1236,8 +1270,8 @@ function _initRepoBulk() {
         ? 'issue-badge issue-badge--closed'
         : 'issue-badge issue-badge--open';
       badge.textContent = reg.github_issue_state === 'closed'
-        ? '✅ #' + reg.github_issue_number + ' 해결됨'
-        : '🔵 #' + reg.github_issue_number + ' 진행중';
+        ? I18N_BULK.statusResolved.replace('__N__', reg.github_issue_number)
+        : I18N_BULK.statusOpen.replace('__N__', reg.github_issue_number);
       li.appendChild(badge);
     }
     return li;
@@ -1283,7 +1317,7 @@ function _initRepoBulk() {
     document.getElementById('bulkError').classList.add('hidden');
     document.getElementById('bulkSubmit').disabled = false;
     document.getElementById('bulkSubmit').textContent =
-      _queueIdx < _queue.length - 1 ? '생성 후 다음 →' : 'GitHub에 Issue 생성';
+      _queueIdx < _queue.length - 1 ? I18N_BULK.btnCreateNext : I18N_BULK.bulkSubmitFinal;
     document.getElementById('bulkModalOverlay').classList.remove('hidden');
   }
 
@@ -1305,7 +1339,7 @@ function _initRepoBulk() {
     var item = _queue[_queueIdx];
     var btn  = document.getElementById('bulkSubmit');
     btn.disabled = true;
-    btn.textContent = '생성 중...';
+    btn.textContent = I18N_BULK.btnCreating;
 
     var payload = {
       analysis_id: item.analysis_id,
@@ -1329,10 +1363,10 @@ function _initRepoBulk() {
     .then(function(res) {
       if (!res.ok) {
         var errEl = document.getElementById('bulkError');
-        errEl.textContent = res.data.detail || '오류 발생';
+        errEl.textContent = res.data.detail || I18N_BULK.errGeneric;
         errEl.classList.remove('hidden');
         btn.disabled = false;
-        btn.textContent = '다시 시도';
+        btn.textContent = I18N_BULK.btnRetry;
         return;
       }
       stateMap[item.key] = {
@@ -1354,10 +1388,10 @@ function _initRepoBulk() {
       }
     })
     .catch(function() {
-      document.getElementById('bulkError').textContent = '네트워크 오류';
+      document.getElementById('bulkError').textContent = I18N_BULK.errNetwork;
       document.getElementById('bulkError').classList.remove('hidden');
       btn.disabled = false;
-      btn.textContent = '다시 시도';
+      btn.textContent = I18N_BULK.btnRetry;
     });
   });
 

--- a/tests/unit/test_i18n_repo_detail.py
+++ b/tests/unit/test_i18n_repo_detail.py
@@ -148,3 +148,43 @@ def test_repo_detail_bulk_value_has_count_placeholder(locale: str, key: str):
     val = _load(locale).get("repo_detail", {}).get("issue_mgmt", {}).get(key)
     assert isinstance(val, str) and val.strip(), f"[{locale}] {key} 비어있음"
     assert "{count}" in val, f"[{locale}] {key}에 {{count}} 플레이스홀더 없음: {val!r}"
+
+
+# ---------------------------------------------------------------------------
+# 사이클 145 Sprint 2 — js_msg 동적 텍스트 키
+# Cycle 145 Sprint 2 — js_msg dynamic text keys
+# ---------------------------------------------------------------------------
+_JS_MSG_KEYS_145 = [
+    "chart_avg", "chart_max", "chart_min",
+    "tooltip_score", "grade_suffix",
+    "label_ai", "label_static",
+    "status_resolved", "status_open",
+    "bulk_submit_final", "btn_creating", "err_generic", "btn_retry", "err_network",
+]
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _JS_MSG_KEYS_145)
+def test_repo_detail_js_msg_key_exists(locale: str, key: str):
+    """repo_detail.js_msg.<key>가 모든 locale에 존재해야 한다."""
+    data = _load(locale)
+    assert "js_msg" in data["repo_detail"], f"[{locale}] js_msg 없음"
+    assert key in data["repo_detail"]["js_msg"], f"[{locale}] js_msg.{key} 없음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _JS_MSG_KEYS_145)
+def test_repo_detail_js_msg_non_empty(locale: str, key: str):
+    """repo_detail.js_msg.<key> 값이 비어있지 않아야 한다."""
+    val = _load(locale).get("repo_detail", {}).get("js_msg", {}).get(key)
+    assert isinstance(val, str) and val.strip(), f"[{locale}] js_msg.{key} 비어있음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+def test_repo_detail_js_msg_placeholders(locale: str):
+    """플레이스홀더 키 검증."""
+    js = _load(locale)["repo_detail"]["js_msg"]
+    assert "{num}" in js["status_resolved"]
+    assert "{num}" in js["status_open"]
+    assert "{score}" in js["tooltip_score"]
+    assert "{grade}" in js["grade_suffix"]


### PR DESCRIPTION
## Summary
repo_detail.html JS 동적 한국어 i18n — 차트 통계/tooltip/상태/버튼/오류.

## 변경 내용
- repo_detail.js_msg.* 신규 (14키, ko/en/ja)
- 차트 통계(평균/최고/최저)·tooltip → .history-card I18N 객체 (5키)
- Issue 모달(라벨/상태/버튼/오류) → #repoBulkPanel I18N_BULK 객체 (10키)
- btn_create_next 기존 키 재사용 (data-i18n-btn-create-next)
- 기존 data-i18n-* + __VAR__ 패턴 (XSS-safe): {score}→__S__, {grade}→__G__, {num}→__N__ 서버 렌더 후 JS .replace() 런타임 치환

## 교체 라인 (11건)
- L751-753 차트 통계 라벨 → I18N.chartAvg/chartMax/chartMin
- L813 tooltip → I18N.tooltipScore + gradeSuffix
- L1220 라벨 → I18N_BULK.labelAi/labelStatic
- L1273-1274 상태 배지 → statusResolved/statusOpen
- L1320 제출 버튼 → btnCreateNext/bulkSubmitFinal
- L1342 → btnCreating, L1366/1391 → errGeneric/errNetwork, L1369/1394 → btnRetry

## 테스트
- test_i18n_repo_detail.py js_msg 케이스 87건 신규 → 231 passed
- test_detail_i18n_render.py 회귀 없음 (23 passed)

## 🔍 사용자 검증 필요 (정책 11)
| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |
- [ ] CI 통과 확인
- [ ] EN/JA locale에서 /repos/{owner}/{repo} 차트 통계 라벨·tooltip·일괄 등록 모달 번역 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증 의뢰 완료 — 컨트롤러 별도 진행

🤖 Generated with Claude Code