### PR TITLE
fix(i18n): base.html 테마 드롭다운 i18n (사이클 146 Sprint 1)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -18,7 +18,17 @@
     "no_data": "No data available",
     "menu_aria": "Open menu",
     "theme_aria": "Change theme",
-    "lang_aria": "Change language"
+    "lang_aria": "Change language",
+    "theme": {
+      "dark_label": "Dark Aurora",
+      "light_label": "Light",
+      "pastel_label": "Pastel",
+      "catppuccin_label": "Developer Dark",
+      "dark_short": "Dark",
+      "light_short": "Light",
+      "pastel_short": "Pastel",
+      "catppuccin_short": "Developer"
+    }
   },
   "header": {
     "welcome": "Welcome, {name}",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -18,7 +18,17 @@
     "no_data": "データなし",
     "menu_aria": "メニューを開く",
     "theme_aria": "テーマを変更",
-    "lang_aria": "言語を変更"
+    "lang_aria": "言語を変更",
+    "theme": {
+      "dark_label": "ダークオーロラ",
+      "light_label": "ライト",
+      "pastel_label": "パステル",
+      "catppuccin_label": "デベロッパーダーク",
+      "dark_short": "ダーク",
+      "light_short": "ライト",
+      "pastel_short": "パステル",
+      "catppuccin_short": "デベロッパー"
+    }
   },
   "header": {
     "welcome": "ようこそ、{name}さん",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -18,7 +18,17 @@
     "no_data": "데이터 없음",
     "menu_aria": "메뉴 열기",
     "theme_aria": "테마 변경",
-    "lang_aria": "언어 변경"
+    "lang_aria": "언어 변경",
+    "theme": {
+      "dark_label": "다크 오로라",
+      "light_label": "라이트",
+      "pastel_label": "파스텔",
+      "catppuccin_label": "개발자 다크",
+      "dark_short": "다크",
+      "light_short": "라이트",
+      "pastel_short": "파스텔",
+      "catppuccin_short": "개발자"
+    }
   },
   "header": {
     "welcome": "환영합니다, {name}님",

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -650,17 +650,21 @@
       <div class="nav-avatar" aria-hidden="true">{{ (current_user.display_name or current_user.github_login or 'U')[0] | upper }}</div>
     </div>
     {% endif %}
-    <div class="theme-switcher" id="themeSwitcher">
+    <div class="theme-switcher" id="themeSwitcher"
+         data-i18n-theme-dark-short="{{ 'common.theme.dark_short' | i18n_args(locale | default('ko')) }}"
+         data-i18n-theme-light-short="{{ 'common.theme.light_short' | i18n_args(locale | default('ko')) }}"
+         data-i18n-theme-pastel-short="{{ 'common.theme.pastel_short' | i18n_args(locale | default('ko')) }}"
+         data-i18n-theme-catppuccin-short="{{ 'common.theme.catppuccin_short' | i18n_args(locale | default('ko')) }}">
       <button class="theme-btn" id="themeToggle" aria-label="{{ 'common.theme_aria' | i18n_args(locale | default('ko')) }}" aria-haspopup="true" aria-expanded="false">
         <span id="themeIcon">🌙</span>
-        <span id="themeName">다크</span>
+        <span id="themeName">{{ 'common.theme.dark_short' | i18n_args(locale | default('ko')) }}</span>
         <span class="chevron">▾</span>
       </button>
       <div class="theme-dropdown" id="themeDropdown" role="menu">
-        <div class="theme-option" data-theme-target="dark"       role="menuitem" tabindex="0">🌌 다크 오로라</div>
-        <div class="theme-option" data-theme-target="light"      role="menuitem" tabindex="0">☀️ 라이트</div>
-        <div class="theme-option" data-theme-target="pastel"     role="menuitem" tabindex="0">🌸 파스텔</div>
-        <div class="theme-option" data-theme-target="catppuccin" role="menuitem" tabindex="0">🐾 개발자 다크</div>
+        <div class="theme-option" data-theme-target="dark"       role="menuitem" tabindex="0">🌌 {{ 'common.theme.dark_label' | i18n_args(locale | default('ko')) }}</div>
+        <div class="theme-option" data-theme-target="light"      role="menuitem" tabindex="0">☀️ {{ 'common.theme.light_label' | i18n_args(locale | default('ko')) }}</div>
+        <div class="theme-option" data-theme-target="pastel"     role="menuitem" tabindex="0">🌸 {{ 'common.theme.pastel_label' | i18n_args(locale | default('ko')) }}</div>
+        <div class="theme-option" data-theme-target="catppuccin" role="menuitem" tabindex="0">🐾 {{ 'common.theme.catppuccin_label' | i18n_args(locale | default('ko')) }}</div>
       </div>
     </div>
     {# Phase 2 PR-4 (사이클 84) — 다국어 i18n 헤더 dropdown (테마 토글 패턴 차용) #}
@@ -697,11 +701,17 @@
     // 🔴 var 사용 필수 — const는 hx-boost body swap 후 스크립트 재실행 시 재선언 SyntaxError 유발
     // 🔴 Must use var — const causes SyntaxError on re-execution after hx-boost body swap
     var THEME_MIGRATE = { 'glass': 'pastel', 'claude-dark': 'catppuccin' };
+    // 테마 짧은 이름은 themeSwitcher 컨테이너의 data-i18n 속성에서 읽음 (locale별 i18n)
+    // Theme short names are read from themeSwitcher container's data-i18n attributes (locale-aware i18n)
+    // 🔴 var 사용 필수 — hx-boost body swap 후 재실행 시 매번 dataset 재읽기 (stale 방지)
+    // 🔴 Must use var — re-reads dataset each time on hx-boost body swap re-execution (stale guard)
+    var _themeSw = document.getElementById('themeSwitcher');
+    var _themeDs = (_themeSw && _themeSw.dataset) || {};
     var THEMES = {
-      dark:        { icon: '🌌', name: '다크' },
-      light:       { icon: '☀️', name: '라이트' },
-      pastel:      { icon: '🌸', name: '파스텔' },
-      catppuccin:  { icon: '🐾', name: '개발자' }
+      dark:        { icon: '🌌', name: _themeDs.i18nThemeDarkShort || '다크' },
+      light:       { icon: '☀️', name: _themeDs.i18nThemeLightShort || '라이트' },
+      pastel:      { icon: '🌸', name: _themeDs.i18nThemePastelShort || '파스텔' },
+      catppuccin:  { icon: '🐾', name: _themeDs.i18nThemeCatppuccinShort || '개발자' }
     };
 
     function applyTheme(theme) {

--- a/tests/unit/test_i18n_common_theme.py
+++ b/tests/unit/test_i18n_common_theme.py
@@ -1,0 +1,36 @@
+"""common.theme.* i18n 키 존재 테스트 — 사이클 146 Sprint 1.
+
+Tests that common.theme.* keys exist in all 3 locales.
+"""
+from __future__ import annotations
+import json
+import pathlib
+import pytest
+
+_TRANS_DIR = pathlib.Path("src/i18n/translations")
+_LOCALES = ["ko", "en", "ja"]
+_THEME_KEYS = [
+    "dark_label", "light_label", "pastel_label", "catppuccin_label",
+    "dark_short", "light_short", "pastel_short", "catppuccin_short",
+]
+
+
+def _load(locale: str) -> dict:
+    return json.loads((_TRANS_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _THEME_KEYS)
+def test_common_theme_key_exists(locale: str, key: str):
+    """common.theme.<key>가 모든 locale에 존재해야 한다."""
+    data = _load(locale)
+    assert "theme" in data["common"], f"[{locale}] common.theme 없음"
+    assert key in data["common"]["theme"], f"[{locale}] common.theme.{key} 없음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _THEME_KEYS)
+def test_common_theme_value_non_empty(locale: str, key: str):
+    """common.theme.<key> 값이 비어있지 않아야 한다."""
+    val = _load(locale).get("common", {}).get("theme", {}).get(key)
+    assert isinstance(val, str) and val.strip(), f"[{locale}] common.theme.{key} 비어있음"


### PR DESCRIPTION
## Summary
base.html 헤더 테마 드롭다운 한국어 i18n. 전 페이지 노출 고가시성 영역.

## 변경 내용
- common.theme.* 신규 8키 (label 4 + short 4, ko/en/ja)
- 테마 옵션(L660-663) 라벨 i18n (아이콘 🌌☀️🌸🐾 유지)
- THEMES JS 객체 name을 themeSwitcher 컨테이너 data-i18n 속성에서 읽도록 전환 (기존 id 재사용, 신규 id 부여 없음)
- themeName 초기값 i18n (`dark_short`)
- THEMES JS는 `var _themeSw`/`_themeDs`로 매 스크립트 재실행 시 dataset 재읽기 (hx-boost stale 방지) + `|| 한국어` fallback

## i18n 제외 (의도적)
- 언어 옵션 endonym (English/한국어/日本語) — 각 언어 자기 표기, i18n 표준상 비번역. langSwitcher 블록 전체 미변경

## 테스트
- test_i18n_common_theme.py 48케이스 신규 ✅ (Red 48 → Green 48)
- tests/unit/templates/ 92 passed (base.html 상속 렌더 회귀 없음) ✅
- i18n 관련 unit 483 passed ✅

## 🔍 사용자 검증 필요 (정책 11)
| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |
- [ ] CI 통과 확인
- [ ] EN/JA locale에서 헤더 테마 드롭다운 라벨 + 현재 테마명 번역 확인
- [ ] 테마 전환 시 themeName 갱신 정상 (JS data-i18n 읽기)
- [ ] 언어 선택기 endonym (English/한국어/日本語) 변동 없음 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증 — 컨트롤러 별도 진행 (본 작업 범위 외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)