### PR TITLE
fix(i18n): settings.html 저장 토스트 + 모델 hint i18n (사이클 147 Sprint 1)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -445,7 +445,10 @@
     "mode_semi_auto": "📱 Semi-auto",
     "preset_applied_suffix": "preset applied — please click the Save button",
     "hide_value": "Hide value",
-    "show_value": "Show value"
+    "show_value": "Show value",
+    "save_toast_ok": "✅ Settings saved.",
+    "save_toast_err": "❌ Save failed. The approve threshold is lower than the reject threshold.",
+    "model_hint": "Select an AI review model per repo. Haiku → fast & cheap ($0.80/1M) · Sonnet → balanced ($3/1M) · Opus → high quality ($15/1M). Leave empty to use the server global default (claude-sonnet-4-6). ※ Prices are based on Anthropic official rates (actual billing may differ)."
   },
   "settings_page": {
     "title_prefix": "Settings",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -445,7 +445,10 @@
     "mode_semi_auto": "📱 半自動",
     "preset_applied_suffix": "プリセット適用済み — 保存ボタンを押してください",
     "hide_value": "値を隠す",
-    "show_value": "値を表示"
+    "show_value": "値を表示",
+    "save_toast_ok": "✅ 設定が保存されました。",
+    "save_toast_err": "❌ 保存に失敗しました。承認基準点が却下基準点より低いです。",
+    "model_hint": "リポジトリ別のAIレビューモデルを選択します。Haiku → 高速・低コスト ($0.80/1M) · Sonnet → バランス ($3/1M) · Opus → 高品質 ($15/1M)。空欄の場合はサーバー全体のデフォルト(claude-sonnet-4-6)を使用します。※ 価格はAnthropic公式基準です(実際の請求と異なる場合があります)。"
   },
   "settings_page": {
     "title_prefix": "設定",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -445,7 +445,10 @@
     "mode_semi_auto": "📱 반자동",
     "preset_applied_suffix": "프리셋 적용됨 — 저장 버튼을 눌러주세요",
     "hide_value": "값 숨기기",
-    "show_value": "값 보이기"
+    "show_value": "값 보이기",
+    "save_toast_ok": "✅ 설정이 저장되었습니다.",
+    "save_toast_err": "❌ 저장에 실패했습니다. 승인 기준점이 반려 기준점보다 낮습니다.",
+    "model_hint": "리포별 AI 리뷰 모델을 선택합니다. Haiku → 빠름·저렴 ($0.80/1M) · Sonnet → 균형 ($3/1M) · Opus → 고품질 ($15/1M). 비어두면 서버 전역 기본값(claude-sonnet-4-6)을 따릅니다. ※ 가격은 Anthropic 공식 기준 (실제 청구와 다를 수 있습니다)."
   },
   "settings_page": {
     "title_prefix": "설정",

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -630,7 +630,7 @@
               <div class="t-title">{{ 'settings_page.pr_rules.pr_comment_title' | i18n_args(locale | default('ko')) }}</div>
               <div class="t-desc">{{ 'settings_page.pr_rules.pr_comment_desc' | i18n_args(locale | default('ko')) }}</div>
             </div>
-            <label class="toggle-switch">
+            <label class="toggle-switch" aria-label="{{ 'settings_page.pr_rules.pr_comment_title' | i18n_args(locale | default('ko')) }}">
               <input type="checkbox" name="pr_review_comment" value="on"
                      {% if config.pr_review_comment %}checked{% endif %}>
               <span class="toggle-track"></span>
@@ -644,7 +644,7 @@
               <div class="t-title">{{ 'settings_page.pr_rules.auto_merge_title' | i18n_args(locale | default('ko')) }}</div>
               <div class="t-desc">{{ 'settings_page.pr_rules.auto_merge_desc' | i18n_args(locale | default('ko')) | safe }}</div>
             </div>
-            <label class="toggle-switch">
+            <label class="toggle-switch" aria-label="{{ 'settings_page.pr_rules.auto_merge_title' | i18n_args(locale | default('ko')) }}">
               <input type="checkbox" id="autoMergeChk" name="auto_merge" value="on"
                      {% if config.auto_merge %}checked{% endif %}
                      onchange="toggleMergeThreshold(this.checked)">
@@ -741,7 +741,7 @@
                   <div class="t-title">{{ 'settings_page.pr_rules.merge_issue_title' | i18n_args(locale | default('ko')) }}</div>
                   <div class="t-desc">{{ 'settings_page.pr_rules.merge_issue_desc' | i18n_args(locale | default('ko')) | safe }}</div>
                 </div>
-                <label class="toggle-switch">
+                <label class="toggle-switch" aria-label="{{ 'settings_page.pr_rules.merge_issue_title' | i18n_args(locale | default('ko')) }}">
                   <input type="checkbox" name="auto_merge_issue_on_failure" value="on"
                          {% if config.auto_merge_issue_on_failure %}checked{% endif %}>
                   <span class="toggle-track"></span>
@@ -772,7 +772,7 @@
               <div class="t-title">{{ 'settings_page.post_event.commit_comment_title' | i18n_args(locale | default('ko')) }}</div>
               <div class="t-desc">{{ 'settings_page.post_event.commit_comment_desc' | i18n_args(locale | default('ko')) | safe }}</div>
             </div>
-            <label class="toggle-switch">
+            <label class="toggle-switch" aria-label="{{ 'settings_page.post_event.commit_comment_title' | i18n_args(locale | default('ko')) }}">
               <input type="checkbox" name="commit_comment" value="on"
                      {% if config.commit_comment %}checked{% endif %}>
               <span class="toggle-track"></span>
@@ -785,7 +785,7 @@
               <div class="t-title">{{ 'settings_page.post_event.create_issue_title' | i18n_args(locale | default('ko')) }}</div>
               <div class="t-desc">{{ 'settings_page.post_event.create_issue_desc' | i18n_args(locale | default('ko')) | safe }}</div>
             </div>
-            <label class="toggle-switch">
+            <label class="toggle-switch" aria-label="{{ 'settings_page.post_event.create_issue_title' | i18n_args(locale | default('ko')) }}">
               <input type="checkbox" name="create_issue" value="on"
                      {% if config.create_issue %}checked{% endif %}>
               <span class="toggle-track"></span>
@@ -799,7 +799,7 @@
               <div class="t-title">{{ 'settings_page.post_event.railway_alerts_title' | i18n_args(locale | default('ko')) }}</div>
               <div class="t-desc">{{ 'settings_page.post_event.railway_alerts_desc' | i18n_args(locale | default('ko')) | safe }}</div>
             </div>
-            <label class="toggle-switch">
+            <label class="toggle-switch" aria-label="{{ 'settings_page.post_event.railway_alerts_title' | i18n_args(locale | default('ko')) }}">
               <input type="checkbox" name="railway_deploy_alerts" id="railway_deploy_alerts" value="on"
                      {% if config.railway_deploy_alerts %}checked{% endif %}>
               <span class="toggle-track"></span>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -410,11 +410,11 @@
   <!-- 저장 결과 토스트 / Save result toast -->
   {% if saved %}
   <div class="save-toast save-toast-ok" id="saveToast">
-    ✅ 설정이 저장되었습니다.
+    {{ 'settings.save_toast_ok' | i18n_args(locale | default('ko')) }}
   </div>
   {% elif save_error %}
   <div class="save-toast save-toast-err" id="saveToast">
-    ❌ 저장에 실패했습니다. 승인 기준점이 반려 기준점보다 낮습니다.
+    {{ 'settings.save_toast_err' | i18n_args(locale | default('ko')) }}
   </div>
   {% endif %}
 
@@ -1084,10 +1084,7 @@
           {% endfor %}
         </select>
         <span class="field-hint">
-          리포별 AI 리뷰 모델을 선택합니다.
-          Haiku → 빠름·저렴 ($0.80/1M) · Sonnet → 균형 ($3/1M) · Opus → 고품질 ($15/1M).
-          비어두면 서버 전역 기본값(claude-sonnet-4-6)을 따릅니다.
-          ※ 가격은 Anthropic 공식 기준 (실제 청구와 다를 수 있습니다).
+          {{ 'settings.model_hint' | i18n_args(locale | default('ko')) }}
         </span>
       </div>
     </div>

--- a/tests/unit/test_i18n_settings.py
+++ b/tests/unit/test_i18n_settings.py
@@ -19,6 +19,7 @@ _KEYS = [
     "field_approve_threshold", "field_reject_threshold", "field_merge_threshold",
     "mode_auto", "mode_semi_auto",
     "preset_applied_suffix", "hide_value", "show_value",
+    "save_toast_ok", "save_toast_err", "model_hint",
 ]
 
 


### PR DESCRIPTION
## Summary

사이클 146 회고 cross-verify P1-1~3 이행 — settings.html survey 누락분 i18n 완결.

## 변경 내용
- settings.{save_toast_ok, save_toast_err, model_hint} 신규 (ko/en/ja)
- L413/L417 저장 토스트 (`{% if saved %}`/`{% elif save_error %}` 서버 렌더)
- L1087-1090 AI 모델 카드 field-hint (가격/설명)
- settings.html 잔존 한국어 0건

## 회고 자성 반영
sprint 3(#704) survey가 Jinja 조건 블록 내부 서버 렌더 토스트를 놓침. 이번에 Jinja 블록 포함 전수 재스캔.

## 테스트
- test_i18n_settings.py 138케이스 (기존 + save_toast/model_hint 18) ✅

## 🔍 사용자 검증 필요 (정책 11)
| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |
- [ ] CI 통과 확인
- [ ] EN/JA locale에서 설정 저장 시 토스트 + 모델 카드 hint 번역 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [x] Claude 직접 검증 (settings 잔존 0건 + 138 passed 실측)

🤖 Generated with Claude Code