### PR TITLE
fix(i18n): base.html langName/langIcon FOUC 해소 (사이클 148, 회고 P2-1)

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -672,8 +672,11 @@
     {% if current_user %}
     <div class="theme-switcher" id="langSwitcher">
       <button class="theme-btn" id="langToggle" aria-label="{{ 'common.lang_aria' | i18n_args(locale | default('ko')) }}" aria-haspopup="true" aria-expanded="false">
-        <span id="langIcon">🌍</span>
-        <span id="langName">한국어</span>
+        {# 초기 렌더는 locale endonym/flag 직접 출력 — JS 실행 전 FOUC 방지 (사이클 148, 회고 P2-1).
+           endonym 은 i18n 비번역 (각 언어 자기 표기). JS(applyLang)가 전환 시 갱신.
+           Initial render outputs locale endonym/flag directly to avoid pre-JS FOUC. #}
+        <span id="langIcon">{% if locale == 'en' %}🇺🇸{% elif locale == 'ja' %}🇯🇵{% else %}🇰🇷{% endif %}</span>
+        <span id="langName">{% if locale == 'en' %}English{% elif locale == 'ja' %}日本語{% else %}한국어{% endif %}</span>
         <span class="chevron">▾</span>
       </button>
       <div class="theme-dropdown" id="langDropdown" role="menu">


### PR DESCRIPTION
## Summary

사이클 146 회고 P2-1 이행 — base.html langName 초기 렌더 FOUC 해소.

## 배경

잔여 소형 템플릿(admin_operations/add_repo/overview/admin_rls_audit/admin_tenants) 조사 결과 **이미 모두 i18n 완료** (사용자 노출 한국어 0건). 이전 카운트(18/10/9)는 전부 주석·CSS였음.

전체 템플릿 중 유일한 실제 잔존 = base.html L676 langName FOUC.

## 문제 (회고 P2-1)
- `<span id="langName">한국어</span>` 초기 서버 렌더값이 locale 무관 "한국어" 고정
- en/ja 사용자는 JS(applyLang) 실행 전 순간 "한국어" 노출 (FOUC)

## 변경 내용
- langName/langIcon 초기값을 locale별 endonym/flag 직접 렌더
  - en → English / 🇺🇸
  - ja → 日本語 / 🇯🇵
  - ko (default) → 한국어 / 🇰🇷
- endonym 은 i18n 비번역 (각 언어 자기 표기 — i18n 표준). JS applyLang 전환 갱신 유지.

## 검증
- 렌더 테스트: ko/en/ja 초기 langName = 한국어/English/日本語 실측 ✅
- templates + i18n smoke 127 passed ✅
- **전체 템플릿 사용자 노출 한국어 0건 달성** (endonym/JS fallback 제외)

## 🔍 사용자 검증 필요 (정책 11)
| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |
- [ ] CI 통과 확인
- [ ] EN/JA locale cookie 설정 후 페이지 진입 시 헤더 언어명이 처음부터 English/日本語로 표시 (한국어 깜빡임 없음)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [x] Claude 직접 검증 (3언어 렌더 실측 + 127 passed)

🤖 Generated with Claude Code