### PR TITLE
fix(i18n): Gate 자동 승인/반려 메시지 i18n (사이클 149 Sprint 1)

### DIFF
--- a/src/gate/actions/approve.py
+++ b/src/gate/actions/approve.py
@@ -14,6 +14,8 @@ from src.gate._common import score_from_result as _score_from_result
 from src.gate.actions import GateAction, GateContext, register
 from src.gate.github_review import post_github_review
 from src.gate.telegram_gate import send_gate_request
+from src.i18n.loader import get_text
+from src.notifier._language import resolve_notification_language
 from src.repositories import gate_decision_repo
 from src.shared.log_safety import sanitize_for_log
 
@@ -42,12 +44,22 @@ class ApproveAction(GateAction):
 
     async def _run_auto(self, ctx: GateContext) -> None:
         """Auto Approve — score 기준 approve/reject/skip."""
+        # 알림 언어 결정 (3-layer fallback) — GitHub PR 댓글을 리포 소유자 언어로 게시
+        # Resolve notification language (3-layer fallback) — post PR review in owner's language
+        with SessionLocal() as db:
+            language = resolve_notification_language(db, config=ctx.config)
         if ctx.score >= ctx.config.approve_threshold:
             decision = "approve"
-            body = f"✅ 자동 승인: 점수 {ctx.score}점 (기준: {ctx.config.approve_threshold}점 이상)"
+            body = get_text(
+                "notifier.gate.auto_approve", language,
+                score=ctx.score, threshold=ctx.config.approve_threshold,
+            )
         elif ctx.score < ctx.config.reject_threshold:
             decision = "reject"
-            body = f"❌ 자동 반려: 점수 {ctx.score}점 (기준: {ctx.config.reject_threshold}점 미만)"
+            body = get_text(
+                "notifier.gate.auto_reject", language,
+                score=ctx.score, threshold=ctx.config.reject_threshold,
+            )
         else:
             with SessionLocal() as db:
                 gate_decision_repo.upsert(db, ctx.analysis_id, "skip", "auto")

--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -20,9 +20,8 @@ from src.gate.actions import GATE_ACTIONS, GateContext
 import src.gate.actions.review_comment  # noqa: F401 — registers ReviewCommentAction  # pylint: disable=cyclic-import,unused-import
 import src.gate.actions.approve  # noqa: F401 — registers ApproveAction  # pylint: disable=cyclic-import,unused-import
 import src.gate.actions.auto_merge  # noqa: F401 — registers AutoMergeAction  # pylint: disable=cyclic-import,unused-import
-from src.gate._common import score_from_result as _score_from_result
 from src.gate.github_review import (
-    post_github_review, get_pr_mergeable_state, get_pr_base_ref,
+    get_pr_mergeable_state, get_pr_base_ref,
 )
 from src.gate import _merge_attempt_states as _states
 from src.gate.merge_failure_advisor import get_advice
@@ -34,8 +33,6 @@ from src.gate.native_automerge import (
 from src.gate.retry_policy import parse_reason_tag, should_retry
 from src.github_client.checks import get_ci_status, get_required_check_contexts
 from src.notifier.merge_failure_issue import create_merge_failure_issue
-from src.gate.telegram_gate import send_gate_request
-from src.notifier.github_comment import post_pr_comment_from_result as post_pr_comment
 from src.notifier.telegram import telegram_post_message
 from src.models.gate_decision import GateDecision
 from src.repositories import gate_decision_repo, merge_retry_repo
@@ -93,84 +90,6 @@ async def run_gate_check(  # pylint: disable=too-many-positional-arguments
                 type(action).__name__, type(outcome).__name__,
                 exc_info=(type(outcome), outcome, outcome.__traceback__),
             )
-
-
-async def _run_review_comment(
-    config: RepoConfigData,
-    github_token: str,
-    repo_name: str,
-    pr_number: int,
-    result: dict,
-) -> None:
-    """PR Review Comment 옵션 — ReviewCommentAction이 위임받는 실제 구현.
-    Actual implementation delegated to by ReviewCommentAction.
-    """
-    if not config.pr_review_comment:
-        return
-    try:
-        from src.notifier._language import resolve_notification_language  # noqa: WPS433  # pylint: disable=import-outside-toplevel
-        with SessionLocal() as db:
-            language = resolve_notification_language(db, config=config)
-        await post_pr_comment(
-            github_token=github_token,
-            repo_name=repo_name,
-            pr_number=pr_number,
-            result=result,
-            language=language,
-        )
-    except (httpx.HTTPError, KeyError) as exc:
-        logger.error("PR Review Comment 실패: %s", type(exc).__name__)
-
-
-async def _run_approve_decision(  # pylint: disable=too-many-arguments
-    *,
-    config: RepoConfigData,
-    analysis_id: int,
-    github_token: str,
-    repo_name: str,
-    pr_number: int,
-    score: int,
-    result: dict,
-) -> None:
-    """Approve 옵션 (auto / semi-auto 분기) — ApproveAction이 위임받는 실제 구현.
-    Actual implementation delegated to by ApproveAction.
-    P0-H: 독립 SessionLocal() 사용.
-    """
-    if config.approve_mode == "auto":
-        if score >= config.approve_threshold:
-            decision = "approve"
-            body = f"✅ 자동 승인: 점수 {score}점 (기준: {config.approve_threshold}점 이상)"
-        elif score < config.reject_threshold:
-            decision = "reject"
-            body = f"❌ 자동 반려: 점수 {score}점 (기준: {config.reject_threshold}점 미만)"
-        else:
-            with SessionLocal() as db:
-                save_gate_decision(db, analysis_id, "skip", "auto")
-            return
-        try:
-            await post_github_review(github_token, repo_name, pr_number, decision, body)
-            with SessionLocal() as db:
-                save_gate_decision(db, analysis_id, decision, "auto")
-        except (httpx.HTTPError, KeyError) as exc:
-            logger.error("GitHub Review 실패: %s", type(exc).__name__)
-    elif config.approve_mode == "semi-auto":
-        if not config.notify_chat_id:
-            logger.warning(
-                "semi-auto 모드이나 notify_chat_id 미설정: %s", sanitize_for_log(repo_name),
-            )
-            return
-        try:
-            score_result = _score_from_result(result)
-            await send_gate_request(
-                bot_token=settings.telegram_bot_token,
-                chat_id=config.notify_chat_id,
-                analysis_id=analysis_id,
-                repo_full_name=repo_name,
-                pr_number=pr_number,
-                score_result=score_result,
-            )
-        except (httpx.HTTPError, KeyError) as exc:
-            logger.error("Telegram Gate 요청 실패: %s", type(exc).__name__)
 
 
 async def _run_auto_merge(  # pylint: disable=too-many-arguments,too-many-locals

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -781,6 +781,10 @@
       "stats_trend": " (vs 7d moving avg {diff:+.1f})",
       "settings_no_repos": "No repositories registered.",
       "settings_header": "📋 Registered repositories:"
+    },
+    "gate": {
+      "auto_approve": "✅ Auto-approved: score {score} (threshold: {threshold}+)",
+      "auto_reject": "❌ Auto-rejected: score {score} (threshold: below {threshold})"
     }
   },
   "repo_insights": {

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -781,6 +781,10 @@
       "stats_trend": " (7日移動平均比 {diff:+.1f}点)",
       "settings_no_repos": "登録されたリポジトリがありません。",
       "settings_header": "📋 登録されたリポジトリ:"
+    },
+    "gate": {
+      "auto_approve": "✅ 自動承認: スコア {score}点 (基準: {threshold}点以上)",
+      "auto_reject": "❌ 自動却下: スコア {score}点 (基準: {threshold}点未満)"
     }
   },
   "repo_insights": {

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -781,6 +781,10 @@
       "stats_trend": " (7일 이동평균 대비 {diff:+.1f}점)",
       "settings_no_repos": "등록된 리포지토리가 없습니다.",
       "settings_header": "📋 등록된 리포지토리:"
+    },
+    "gate": {
+      "auto_approve": "✅ 자동 승인: 점수 {score}점 (기준: {threshold}점 이상)",
+      "auto_reject": "❌ 자동 반려: 점수 {score}점 (기준: {threshold}점 미만)"
     }
   },
   "repo_insights": {

--- a/tests/unit/gate/test_engine.py
+++ b/tests/unit/gate/test_engine.py
@@ -610,7 +610,7 @@ async def test_config_provided_skips_get_repo_config():
 
 def test_score_from_result_empty_dict():
     """result={}인 경우 기본값(score=0, grade='F')으로 ScoreResult를 반환한다."""
-    from src.gate.engine import _score_from_result
+    from src.gate._common import score_from_result as _score_from_result
     sr = _score_from_result({})
     assert sr.total == 0
     assert sr.grade == "F"
@@ -620,7 +620,7 @@ def test_score_from_result_empty_dict():
 
 def test_score_from_result_breakdown_none():
     """result['breakdown']=None인 경우 AttributeError 없이 기본값으로 처리해야 한다."""
-    from src.gate.engine import _score_from_result
+    from src.gate._common import score_from_result as _score_from_result
     sr = _score_from_result({"score": 75, "grade": "B", "breakdown": None})
     assert sr.total == 75
     assert sr.code_quality_score == 0
@@ -629,7 +629,7 @@ def test_score_from_result_breakdown_none():
 
 def test_score_from_result_partial_breakdown():
     """breakdown에 일부 키만 있는 경우 누락 키는 0으로 처리한다."""
-    from src.gate.engine import _score_from_result
+    from src.gate._common import score_from_result as _score_from_result
     sr = _score_from_result({"score": 80, "grade": "B", "breakdown": {"code_quality": 20}})
     assert sr.code_quality_score == 20
     assert sr.security_score == 0

--- a/tests/unit/test_i18n_gate_messages.py
+++ b/tests/unit/test_i18n_gate_messages.py
@@ -1,0 +1,34 @@
+"""notifier.gate.* i18n 키 + approve.py 언어 적용 테스트 — 사이클 149 Sprint 1.
+notifier.gate.* i18n keys + approve.py language application test — Cycle 149 Sprint 1.
+"""
+from __future__ import annotations
+import json, pathlib, pytest
+
+_TRANS_DIR = pathlib.Path("src/i18n/translations")
+_LOCALES = ["ko", "en", "ja"]
+_KEYS = ["auto_approve", "auto_reject"]
+
+
+def _load(locale): return json.loads((_TRANS_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _KEYS)
+def test_gate_key_exists(locale, key):
+    assert "gate" in _load(locale)["notifier"], f"[{locale}] notifier.gate 없음"
+    assert key in _load(locale)["notifier"]["gate"], f"[{locale}] notifier.gate.{key} 없음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+def test_gate_placeholders(locale):
+    g = _load(locale)["notifier"]["gate"]
+    for key in _KEYS:
+        assert "{score}" in g[key], f"[{locale}] {key}에 {{score}} 없음"
+        assert "{threshold}" in g[key], f"[{locale}] {key}에 {{threshold}} 없음"
+
+
+def test_get_text_renders_gate_approve():
+    """get_text가 notifier.gate.auto_approve를 score/threshold로 렌더."""
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+    out = get_text("notifier.gate.auto_approve", "en", score=85, threshold=75)
+    assert "85" in out and "75" in out and "{score}" not in out


### PR DESCRIPTION
## Summary
Gate 자동 승인/반려 결정 메시지(GitHub PR 댓글) i18n — en/ja 리포 소유자 언어 적용. 기존엔 하드코딩 한국어라 `resolve_notification_language` 알림 언어 시스템을 우회했음.

## 변경 내용
- `notifier.gate.{auto_approve,auto_reject}` 신규 키 ({score}/{threshold} placeholder, ko/en/ja)
- `approve.py` _run_auto: `resolve_notification_language` + `get_text` 적용 (review_comment.py 패턴 차용). gate 로직(approve/reject/skip 분기, post_github_review, gate_decision_repo.upsert) 불변 — body 텍스트 생성만 i18n.
- `engine.py` dead code 제거: `_run_approve_decision`, `_run_review_comment` (사이클 141 Action 클래스 이전 후 호출처 0 — grep 확인). 두 함수 전용 import 4건 정리 (post_github_review, post_pr_comment, send_gate_request, _score_from_result).
- `test_engine.py`: `_score_from_result` 임포트를 제거된 engine alias → canonical `src.gate._common` 로 재지정 (함수 자체는 활성 — approve.py semi-auto 경로 사용).

## 테스트
- `tests/unit/test_i18n_gate_messages.py` 신규 (TDD Red→Green, 10 케이스) ✅
- gate 단위 테스트 회귀 없음 (244 passed) + i18n consistency 27 passed
- pylint 10.00/10 유지 (approve.py + engine.py) / flake8 신규 위반 0 (dead line 1건 감소)

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인
- [ ] EN/JA 리포에서 auto approve 모드 PR → GitHub PR 리뷰 댓글이 'Auto-approved' / '自動承認' 으로 표시 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] 컨트롤러 별도 진행 — push 후 Codex 검증 대기

🤖 Generated with [Claude Code](https://claude.com/claude-code)