### PR TITLE
fix(i18n): Telegram 반자동 Gate 메시지 i18n (사이클 149 Sprint 2)

### DIFF
--- a/src/gate/actions/approve.py
+++ b/src/gate/actions/approve.py
@@ -81,6 +81,10 @@ class ApproveAction(GateAction):
                 sanitize_for_log(ctx.repo_name),
             )
             return
+        # 알림 언어 결정 (3-layer fallback) — Telegram 검토 요청을 수신자 언어로 발송
+        # Resolve notification language (3-layer fallback) — send Telegram request in recipient's language
+        with SessionLocal() as db:
+            language = resolve_notification_language(db, config=ctx.config)
         try:
             score_result = _score_from_result(ctx.result)
             await send_gate_request(
@@ -90,6 +94,7 @@ class ApproveAction(GateAction):
                 repo_full_name=ctx.repo_name,
                 pr_number=ctx.pr_number,
                 score_result=score_result,
+                language=language,
             )
         except (httpx.HTTPError, KeyError) as exc:
             logger.error("Telegram Gate 요청 실패: %s", type(exc).__name__)

--- a/src/gate/telegram_gate.py
+++ b/src/gate/telegram_gate.py
@@ -2,6 +2,7 @@
 import hashlib
 import hmac
 
+from src.i18n.loader import get_text
 from src.notifier.telegram import telegram_post_message
 from src.scorer.calculator import ScoreResult
 
@@ -49,19 +50,41 @@ async def send_gate_request(
     repo_full_name: str,
     pr_number: int,
     score_result: ScoreResult,
+    language: str = "ko",
 ) -> None:
-    """반자동 Gate PR 검토 요청을 Telegram 인라인 키보드로 전송한다."""
+    """반자동 Gate PR 검토 요청을 Telegram 인라인 키보드로 전송한다.
+    Send a semi-auto gate PR review request via Telegram inline keyboard.
+
+    language: 알림 수신자 언어 (ko/en/ja) — 메시지 본문 + 버튼 텍스트 i18n.
+    language: recipient's language (ko/en/ja) — i18n for message body and button labels.
+    Telegram Markdown(백틱/별표)은 키 값에 보존되어 parse_mode="Markdown"으로 렌더된다.
+    Telegram Markdown (backtick/asterisk) is preserved in key values and rendered via parse_mode="Markdown".
+    """
+    # 4개 i18n 키를 Python 측에서 줄바꿈으로 조합 (제목/리포/점수/선택)
+    # Compose the 4 i18n keys with newlines on the Python side (title/repo/score/choose)
     text = (
-        f"🔍 *PR 검토 요청*\n"
-        f"리포: `{repo_full_name}` — PR #{pr_number}\n"
-        f"점수: *{score_result.total}점* ({score_result.grade}등급)\n\n"
-        f"승인 또는 반려를 선택하세요."
+        get_text("notifier.gate.tg_review_title", language) + "\n"
+        + get_text(
+            "notifier.gate.tg_repo_line", language,
+            repo=repo_full_name, pr=pr_number,
+        ) + "\n"
+        + get_text(
+            "notifier.gate.tg_score_line", language,
+            score=score_result.total, grade=score_result.grade,
+        ) + "\n\n"
+        + get_text("notifier.gate.tg_choose", language)
     )
     token = _gate_callback_token(bot_token, analysis_id)
     reply_markup = {
         "inline_keyboard": [[
-            {"text": "✅ 승인", "callback_data": f"gate:approve:{analysis_id}:{token}"},
-            {"text": "❌ 반려", "callback_data": f"gate:reject:{analysis_id}:{token}"},
+            {
+                "text": get_text("notifier.gate.tg_btn_approve", language),
+                "callback_data": f"gate:approve:{analysis_id}:{token}",
+            },
+            {
+                "text": get_text("notifier.gate.tg_btn_reject", language),
+                "callback_data": f"gate:reject:{analysis_id}:{token}",
+            },
         ]]
     }
     await telegram_post_message(bot_token, chat_id, {

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -784,7 +784,13 @@
     },
     "gate": {
       "auto_approve": "✅ Auto-approved: score {score} (threshold: {threshold}+)",
-      "auto_reject": "❌ Auto-rejected: score {score} (threshold: below {threshold})"
+      "auto_reject": "❌ Auto-rejected: score {score} (threshold: below {threshold})",
+      "tg_review_title": "🔍 *PR Review Request*",
+      "tg_repo_line": "Repo: `{repo}` — PR #{pr}",
+      "tg_score_line": "Score: *{score}* ({grade})",
+      "tg_choose": "Please choose approve or reject.",
+      "tg_btn_approve": "✅ Approve",
+      "tg_btn_reject": "❌ Reject"
     }
   },
   "repo_insights": {

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -784,7 +784,13 @@
     },
     "gate": {
       "auto_approve": "✅ 自動承認: スコア {score}点 (基準: {threshold}点以上)",
-      "auto_reject": "❌ 自動却下: スコア {score}点 (基準: {threshold}点未満)"
+      "auto_reject": "❌ 自動却下: スコア {score}点 (基準: {threshold}点未満)",
+      "tg_review_title": "🔍 *PRレビュー依頼*",
+      "tg_repo_line": "リポ: `{repo}` — PR #{pr}",
+      "tg_score_line": "スコア: *{score}点* ({grade})",
+      "tg_choose": "承認または却下を選択してください。",
+      "tg_btn_approve": "✅ 承認",
+      "tg_btn_reject": "❌ 却下"
     }
   },
   "repo_insights": {

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -784,7 +784,13 @@
     },
     "gate": {
       "auto_approve": "✅ 자동 승인: 점수 {score}점 (기준: {threshold}점 이상)",
-      "auto_reject": "❌ 자동 반려: 점수 {score}점 (기준: {threshold}점 미만)"
+      "auto_reject": "❌ 자동 반려: 점수 {score}점 (기준: {threshold}점 미만)",
+      "tg_review_title": "🔍 *PR 검토 요청*",
+      "tg_repo_line": "리포: `{repo}` — PR #{pr}",
+      "tg_score_line": "점수: *{score}점* ({grade}등급)",
+      "tg_choose": "승인 또는 반려를 선택하세요.",
+      "tg_btn_approve": "✅ 승인",
+      "tg_btn_reject": "❌ 반려"
     }
   },
   "repo_insights": {

--- a/tests/unit/test_i18n_gate_messages.py
+++ b/tests/unit/test_i18n_gate_messages.py
@@ -32,3 +32,31 @@ def test_get_text_renders_gate_approve():
     from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
     out = get_text("notifier.gate.auto_approve", "en", score=85, threshold=75)
     assert "85" in out and "75" in out and "{score}" not in out
+
+
+# 사이클 149 Sprint 2 — Telegram 반자동 Gate 메시지 키
+# Cycle 149 Sprint 2 — Telegram semi-auto gate message keys
+_TG_KEYS = [
+    "tg_review_title", "tg_repo_line", "tg_score_line",
+    "tg_choose", "tg_btn_approve", "tg_btn_reject",
+]
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _TG_KEYS)
+def test_gate_tg_key_exists(locale, key):
+    assert key in _load(locale)["notifier"]["gate"], f"[{locale}] notifier.gate.{key} 없음"
+
+
+def test_get_text_renders_tg_score():
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+    out = get_text("notifier.gate.tg_score_line", "en", score=85, grade="B")
+    assert "85" in out and "B" in out
+
+
+def test_tg_repo_line_preserves_markdown():
+    """리포 라인은 Telegram Markdown 백틱을 보존한다 (parse_mode=Markdown)."""
+    g_ko = _load("ko")["notifier"]["gate"]
+    assert "`{repo}`" in g_ko["tg_repo_line"], "ko tg_repo_line 백틱 누락"
+    g_en = _load("en")["notifier"]["gate"]
+    assert "`{repo}`" in g_en["tg_repo_line"], "en tg_repo_line 백틱 누락"


### PR DESCRIPTION
## Summary
Telegram 반자동 Gate PR 검토 요청 메시지 i18n — en/ja 사용자 언어 적용. 하드코딩 한국어 (telegram_gate.py L55-64) 제거.

## 변경 내용
- `notifier.gate.tg_*` 신규 6키 (제목/리포/점수/선택/승인·반려 버튼, ko/en/ja)
- `send_gate_request`: keyword-only `language: str = "ko"` 파라미터 추가 + `get_text` 적용 (본문 4키 Python 조합 + 버튼 텍스트 2키)
- `approve.py _run_semi_auto`: `resolve_notification_language(db, config=ctx.config)` 로 언어 결정 후 전달 (`_run_auto` 패턴 동일)
- Telegram Markdown(백틱 `` `{repo}` `` / 별표 `*{score}*`)은 키 값에 보존 → parse_mode="Markdown" 렌더 유지

## 테스트
- `test_i18n_gate_messages.py` tg_* 케이스 추가 (키 존재 3×6 + get_text 렌더 + Markdown 백틱 보존 가드)
- gate 회귀 없음: `tests/unit/test_i18n_gate_messages.py tests/unit/gate/` 264 passed
- pylint 10.00 (telegram_gate.py + approve.py)
- 기존 `test_telegram_gate.py` 영향 없음 (language 미전달 시 default "ko", 텍스트 내용 미검증)

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인
- [ ] EN 사용자 반자동 모드 PR → Telegram 검토 요청이 영어로 표시 확인
- [ ] JA 사용자 동일 확인 (점수 라인 `スコア: *85点* (B)`)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증은 컨트롤러 별도 진행 — push 후 의뢰 (본 Sprint 지시에 따름)

🤖 Generated with [Claude Code](https://claude.com/claude-code)