### PR TITLE
fix(i18n): 머지 재시도 Telegram 알림 i18n (사이클 149 Sprint 4)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -808,7 +808,16 @@
       "tg_score_line": "Score: *{score}* ({grade})",
       "tg_choose": "Please choose approve or reject.",
       "tg_btn_approve": "✅ Approve",
-      "tg_btn_reject": "❌ Reject"
+      "tg_btn_reject": "❌ Reject",
+      "retry_stopped_title": "🚫 <b>Auto-merge Retry Stopped</b>",
+      "retry_repo_line": "📁 <code>{repo}</code> — PR #{pr}",
+      "retry_stopped_reason": "<i>Retry stopped: auto_merge disabled or threshold changed.</i>",
+      "retry_succeeded_title": "✅ <b>Auto-merge Succeeded (Retry)</b>",
+      "retry_score_attempts": "Score: {score} | Attempts: {attempts}",
+      "retry_view_github": "🔗 <a href=\"{url}\">View on GitHub</a>",
+      "retry_terminal_title": "⚠️ <b>Auto-merge Final Failure</b>",
+      "retry_terminal_reason": "Reason: <code>{reason}</code>",
+      "retry_advice_line": "💡 {advice}"
     }
   },
   "repo_insights": {

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -808,7 +808,16 @@
       "tg_score_line": "スコア: *{score}点* ({grade})",
       "tg_choose": "承認または却下を選択してください。",
       "tg_btn_approve": "✅ 承認",
-      "tg_btn_reject": "❌ 却下"
+      "tg_btn_reject": "❌ 却下",
+      "retry_stopped_title": "🚫 <b>自動マージ再試行停止</b>",
+      "retry_repo_line": "📁 <code>{repo}</code> — PR #{pr}",
+      "retry_stopped_reason": "<i>設定変更により再試行が停止されました (auto_merge無効化またはスコア基準変更)。</i>",
+      "retry_succeeded_title": "✅ <b>自動マージ成功 (再試行)</b>",
+      "retry_score_attempts": "スコア: {score}点 | 試行回数: {attempts}回",
+      "retry_view_github": "🔗 <a href=\"{url}\">GitHubで見る</a>",
+      "retry_terminal_title": "⚠️ <b>自動マージ最終失敗</b>",
+      "retry_terminal_reason": "理由: <code>{reason}</code>",
+      "retry_advice_line": "💡 {advice}"
     }
   },
   "repo_insights": {

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -808,7 +808,16 @@
       "tg_score_line": "점수: *{score}점* ({grade}등급)",
       "tg_choose": "승인 또는 반려를 선택하세요.",
       "tg_btn_approve": "✅ 승인",
-      "tg_btn_reject": "❌ 반려"
+      "tg_btn_reject": "❌ 반려",
+      "retry_stopped_title": "🚫 <b>자동 머지 재시도 중단</b>",
+      "retry_repo_line": "📁 <code>{repo}</code> — PR #{pr}",
+      "retry_stopped_reason": "<i>설정이 변경되어 재시도가 중단되었습니다 (auto_merge 비활성 또는 점수 기준 변경).</i>",
+      "retry_succeeded_title": "✅ <b>자동 머지 성공 (재시도)</b>",
+      "retry_score_attempts": "점수: {score}점 | 시도 횟수: {attempts}회",
+      "retry_view_github": "🔗 <a href=\"{url}\">GitHub에서 보기</a>",
+      "retry_terminal_title": "⚠️ <b>자동 머지 최종 실패</b>",
+      "retry_terminal_reason": "사유: <code>{reason}</code>",
+      "retry_advice_line": "💡 {advice}"
     }
   },
   "repo_insights": {

--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -29,6 +29,7 @@ from src.gate.retry_policy import (
 )
 from src.github_client.checks import get_ci_status, get_required_check_contexts
 from src.github_client.helpers import github_api_headers
+from src.i18n.loader import get_text
 from src.models.merge_retry import MergeRetryQueue
 from src.notifier._language import resolve_notification_language
 from src.notifier.merge_failure_issue import create_merge_failure_issue
@@ -130,11 +131,14 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
 
     # ── b. 설정 재확인 (D5) ────────────────────────────────────────
     cfg = get_repo_config(db, row.repo_full_name)
+    # 사이클 149 Sprint 4 — 알림 사용자 언어 결정 (재시도 알림 텍스트 i18n)
+    # Cycle 149 Sprint 4 — resolve user language for retry notification text i18n
+    language = resolve_notification_language(db, config=cfg)
     if not (cfg.auto_merge and row.score >= cfg.merge_threshold):
         # 설정이 변경되어 자동 머지 조건 미충족 → 포기
         # Config changed so auto-merge condition no longer met → abandon
         merge_retry_repo.mark_abandoned(db, row.id, reason="config_changed")
-        await _notify_config_changed(row, cfg)
+        await _notify_config_changed(row, cfg, language=language)
         counts["abandoned"] += 1
         return
 
@@ -174,7 +178,7 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
             threshold=row.threshold_at_enqueue, success=True, reason=None,
         )
         merge_retry_repo.mark_succeeded(db, row.id)
-        await _notify_merge_succeeded(row, cfg)
+        await _notify_merge_succeeded(row, cfg, language=language)
         counts["succeeded"] += 1
         return
 
@@ -195,9 +199,8 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
             threshold=row.threshold_at_enqueue, success=False, reason=reason,
         )
         merge_retry_repo.mark_terminal(db, row.id, reason=reason_tag)
-        # 사이클 149 Sprint 3 — 알림 + Issue 사용자 언어 결정 (조언 텍스트 i18n)
-        # Cycle 149 Sprint 3 — resolve user language for notify + Issue (advice text i18n)
-        language = resolve_notification_language(db, config=cfg)
+        # 사이클 149 Sprint 3/4 — 알림 + Issue 사용자 언어 (상단 b 단계에서 결정)
+        # Cycle 149 Sprint 3/4 — user language for notify + Issue (resolved in step b above)
         await _notify_merge_terminal(row, cfg, reason, reason_tag, language=language)
         if cfg.auto_merge_issue_on_failure:
             await _create_failure_issue_safe(token, row, cfg, reason, reason_tag, language=language)
@@ -307,18 +310,24 @@ def _resolve_retry_chat_id(row: MergeRetryQueue, cfg: RepoConfigData) -> str | N
     return cfg.notify_chat_id or row.notify_chat_id or settings.telegram_chat_id
 
 
-async def _notify_config_changed(row: MergeRetryQueue, cfg: RepoConfigData) -> None:
+async def _notify_config_changed(
+    row: MergeRetryQueue, cfg: RepoConfigData, *, language: str = "ko"
+) -> None:
     """설정 변경으로 재시도가 중단됐음을 알린다.
     Notify user that retry was stopped due to config change.
     """
     chat_id = _resolve_retry_chat_id(row, cfg)
     if not chat_id or not settings.telegram_bot_token:
         return
+    # HTML 태그는 키 값에 보존, 동적 값(repo)만 escape 후 kwargs 전달
+    # HTML tags kept in key values; only dynamic value (repo) escaped before kwargs
     msg = (
-        "🚫 <b>자동 머지 재시도 중단</b>\n"
-        f"📁 <code>{escape(row.repo_full_name)}</code> — PR #{row.pr_number}\n"
-        "<i>설정이 변경되어 재시도가 중단되었습니다 (auto_merge 비활성 또는 점수 기준 변경).</i>\n"
-        "<i>Retry stopped: auto_merge disabled or threshold changed.</i>"
+        get_text("notifier.gate.retry_stopped_title", language) + "\n"
+        + get_text(
+            "notifier.gate.retry_repo_line", language,
+            repo=escape(row.repo_full_name), pr=row.pr_number,
+        ) + "\n"
+        + get_text("notifier.gate.retry_stopped_reason", language)
     )
     try:
         await telegram_post_message(
@@ -328,7 +337,9 @@ async def _notify_config_changed(row: MergeRetryQueue, cfg: RepoConfigData) -> N
         logger.warning("_notify_config_changed 전송 실패: %s", type(exc).__name__)
 
 
-async def _notify_merge_succeeded(row: MergeRetryQueue, cfg: RepoConfigData) -> None:
+async def _notify_merge_succeeded(
+    row: MergeRetryQueue, cfg: RepoConfigData, *, language: str = "ko"
+) -> None:
     """재시도 후 머지 성공을 알린다 (시도 횟수 포함).
     Notify user of successful merge after retries (includes attempt count).
     """
@@ -336,11 +347,19 @@ async def _notify_merge_succeeded(row: MergeRetryQueue, cfg: RepoConfigData) -> 
     if not chat_id or not settings.telegram_bot_token:
         return
     pr_url = f"https://github.com/{row.repo_full_name}/pull/{row.pr_number}"
+    # HTML 태그는 키 값에 보존, 동적 값(repo/url)만 escape 후 kwargs 전달
+    # HTML tags kept in key values; only dynamic values (repo/url) escaped
     msg = (
-        "✅ <b>자동 머지 성공 (재시도)</b>\n"
-        f"📁 <code>{escape(row.repo_full_name)}</code> — PR #{row.pr_number}\n"
-        f"점수: {row.score}점 | 시도 횟수: {row.attempts_count}회\n"
-        f'🔗 <a href="{escape(pr_url)}">GitHub에서 보기</a>'
+        get_text("notifier.gate.retry_succeeded_title", language) + "\n"
+        + get_text(
+            "notifier.gate.retry_repo_line", language,
+            repo=escape(row.repo_full_name), pr=row.pr_number,
+        ) + "\n"
+        + get_text(
+            "notifier.gate.retry_score_attempts", language,
+            score=row.score, attempts=row.attempts_count,
+        ) + "\n"
+        + get_text("notifier.gate.retry_view_github", language, url=escape(pr_url))
     )
     try:
         await telegram_post_message(
@@ -366,13 +385,24 @@ async def _notify_merge_terminal(
         return
     advice = get_advice(reason_tag, language)
     pr_url = f"https://github.com/{row.repo_full_name}/pull/{row.pr_number}"
+    # HTML 태그는 키 값에 보존, 동적 값(repo/reason/advice/url)만 escape 후 kwargs 전달
+    # HTML tags kept in key values; only dynamic values escaped before kwargs
     msg = (
-        "⚠️ <b>자동 머지 최종 실패</b>\n"
-        f"📁 <code>{escape(row.repo_full_name)}</code> — PR #{row.pr_number}\n"
-        f"점수: {row.score}점 | 시도 횟수: {row.attempts_count}회\n"
-        f"사유: <code>{escape(reason or reason_tag)}</code>\n"
-        f"💡 {escape(advice)}\n"
-        f'🔗 <a href="{escape(pr_url)}">GitHub에서 보기</a>'
+        get_text("notifier.gate.retry_terminal_title", language) + "\n"
+        + get_text(
+            "notifier.gate.retry_repo_line", language,
+            repo=escape(row.repo_full_name), pr=row.pr_number,
+        ) + "\n"
+        + get_text(
+            "notifier.gate.retry_score_attempts", language,
+            score=row.score, attempts=row.attempts_count,
+        ) + "\n"
+        + get_text(
+            "notifier.gate.retry_terminal_reason", language,
+            reason=escape(reason or reason_tag),
+        ) + "\n"
+        + get_text("notifier.gate.retry_advice_line", language, advice=escape(advice)) + "\n"
+        + get_text("notifier.gate.retry_view_github", language, url=escape(pr_url))
     )
     try:
         await telegram_post_message(

--- a/tests/unit/test_i18n_gate_messages.py
+++ b/tests/unit/test_i18n_gate_messages.py
@@ -60,3 +60,30 @@ def test_tg_repo_line_preserves_markdown():
     assert "`{repo}`" in g_ko["tg_repo_line"], "ko tg_repo_line 백틱 누락"
     g_en = _load("en")["notifier"]["gate"]
     assert "`{repo}`" in g_en["tg_repo_line"], "en tg_repo_line 백틱 누락"
+
+
+# 사이클 149 Sprint 4 — 머지 재시도 Telegram 알림 키 (HTML parse_mode)
+# Cycle 149 Sprint 4 — merge retry Telegram notification keys (HTML parse_mode)
+_RETRY_KEYS = [
+    "retry_stopped_title", "retry_repo_line", "retry_stopped_reason",
+    "retry_succeeded_title", "retry_score_attempts", "retry_view_github",
+    "retry_terminal_title", "retry_terminal_reason", "retry_advice_line",
+]
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _RETRY_KEYS)
+def test_gate_retry_key_exists(locale, key):
+    assert key in _load(locale)["notifier"]["gate"], f"[{locale}] notifier.gate.{key} 없음"
+
+
+def test_retry_score_attempts_renders():
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+    out = get_text("notifier.gate.retry_score_attempts", "en", score=85, attempts=3)
+    assert "85" in out and "3" in out
+
+
+def test_retry_view_github_preserves_html():
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+    out = get_text("notifier.gate.retry_view_github", "en", url="http://x")
+    assert "<a href=" in out


### PR DESCRIPTION
## Summary
머지 재시도 3개 Telegram 알림(중단/성공/최종실패) i18n — en/ja 사용자 언어 적용.

## 변경 내용
- notifier.gate.retry_* 신규 9키 (HTML 태그 보존, ko/en/ja)
- _notify_config_changed/_notify_merge_succeeded: language 파라미터 추가 (keyword-only)
- _notify_merge_terminal: 기존 language로 메시지 텍스트 i18n
- _process_single_retry: language를 b 단계에서 1회 결정 (Sprint 3 terminal 중복 resolve 제거)
- HTML parse_mode 태그(<b>/<code>/<i>/<a>) + escape() 보존 — 동적 값(repo/url/reason/advice)만 escape

## 테스트
- test_i18n_gate_messages.py retry_* 케이스 추가 (TDD Red→Green) ✅
- 회귀 없음 (services 324 + i18n smoke 72 통과) + pylint 10.00
- 기존 merge_retry 테스트는 _notify_* 함수를 mock — 메시지 본문 assert 없어 영향 0

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인
- [ ] EN 사용자 머지 재시도 성공/실패 시 Telegram 알림 영어 표시 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증 — 컨트롤러 별도 진행 (push + PR 우선 요청)

🤖 Generated with [Claude Code](https://claude.com/claude-code)