### PR TITLE
fix(i18n): 웹 UI 에러 메시지 i18n (사이클 150 Sprint 1)

### DIFF
--- a/src/api/issue_registration.py
+++ b/src/api/issue_registration.py
@@ -2,14 +2,16 @@
 issue_registration API — endpoints for registering GitHub Issues and querying state.
 """
 import asyncio
+
 import httpx
 from fastapi import APIRouter, HTTPException, Request
-from src.middleware.rate_limiter import limiter, RATE_LIMIT_API, RATE_LIMIT_HEAVY
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from src.auth.session import get_current_user
 from src.database import SessionLocal
+from src.i18n.loader import get_text
+from src.middleware.rate_limiter import limiter, RATE_LIMIT_API, RATE_LIMIT_HEAVY
 from src.models.analysis import Analysis
 from src.models.repository import Repository
 from src.services.issue_registration_service import (
@@ -19,6 +21,7 @@ from src.services.issue_registration_service import (
     make_static_issue_key,
     register_issue,
 )
+from src.ui._helpers import get_locale
 
 router = APIRouter(prefix="/api/issues")
 
@@ -81,6 +84,7 @@ async def register(request: Request, req: RegisterRequest):
     if not current_user:
         raise HTTPException(status_code=401, detail="Login required")
 
+    locale = get_locale(request)
     issue_key = _make_issue_key(req)
 
     # A2: 소유권 검증은 sync DB 쿼리 — asyncio.to_thread로 이벤트 루프 차단 방지
@@ -112,16 +116,19 @@ async def register(request: Request, req: RegisterRequest):
                 issue_num = str(exc).split(":")[1]
                 raise HTTPException(
                     status_code=409,
-                    detail=f"이미 등록된 이슈입니다 (#{issue_num})",
+                    detail=get_text("errors.issue_duplicate", locale, num=issue_num),
                 ) from exc
             raise HTTPException(status_code=500, detail=str(exc)) from exc
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 403:
                 raise HTTPException(
                     status_code=403,
-                    detail="Issues 쓰기 권한이 없습니다. GitHub 토큰을 확인해 주세요.",
+                    detail=get_text("errors.issue_no_write_permission", locale),
                 ) from exc
-            raise HTTPException(status_code=502, detail="GitHub API 오류") from exc
+            raise HTTPException(
+                status_code=502,
+                detail=get_text("errors.github_api_error", locale),
+            ) from exc
 
     return result
 

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -237,6 +237,7 @@
     "load_failed_option": "Failed to load repo list",
     "error_prefix": "Error: ",
     "api_error_prefix": "API error: ",
+    "error_already_registered": "This repository is already registered by another user",
     "submit": "Create Webhook + Add Repository"
   },
   "repo_detail": {
@@ -665,7 +666,12 @@
     "not_found": "Resource not found",
     "validation_error": "Validation failed: {details}",
     "database_error": "Database error occurred",
-    "no_api_key": "ANTHROPIC_API_KEY not set"
+    "no_api_key": "ANTHROPIC_API_KEY not set",
+    "issue_duplicate": "Issue already registered (#{num})",
+    "issue_no_write_permission": "No write permission for Issues. Please check your GitHub token.",
+    "github_api_error": "GitHub API error",
+    "invalid_url": "Invalid URL: {field}. Internal network addresses are not allowed.",
+    "repo_name_required": "Repository name is required"
   },
   "notifier": {
     "no_issues": "No issues",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -237,6 +237,7 @@
     "load_failed_option": "リポリスト読み込み失敗",
     "error_prefix": "エラー: ",
     "api_error_prefix": "APIエラー: ",
+    "error_already_registered": "既に他のユーザーが登録したリポジトリです",
     "submit": "Webhook生成 + リポ追加"
   },
   "repo_detail": {
@@ -665,7 +666,12 @@
     "not_found": "リソースが見つかりません",
     "validation_error": "検証失敗: {details}",
     "database_error": "データベースエラー発生",
-    "no_api_key": "ANTHROPIC_API_KEY 未設定"
+    "no_api_key": "ANTHROPIC_API_KEY 未設定",
+    "issue_duplicate": "既に登録されたイシューです (#{num})",
+    "issue_no_write_permission": "Issuesの書き込み権限がありません。GitHubトークンを確認してください。",
+    "github_api_error": "GitHub APIエラー",
+    "invalid_url": "無効なURL: {field}。内部ネットワークアドレスは使用できません。",
+    "repo_name_required": "リポジトリ名が必要です"
   },
   "notifier": {
     "no_issues": "問題なし",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -237,6 +237,7 @@
     "load_failed_option": "리포 목록 로드 실패",
     "error_prefix": "오류: ",
     "api_error_prefix": "API 오류: ",
+    "error_already_registered": "이미 다른 사용자가 등록한 리포입니다",
     "submit": "Webhook 생성 + 리포 추가"
   },
   "repo_detail": {
@@ -665,7 +666,12 @@
     "not_found": "리소스를 찾을 수 없음",
     "validation_error": "유효성 검사 실패: {details}",
     "database_error": "데이터베이스 오류 발생",
-    "no_api_key": "ANTHROPIC_API_KEY 미설정"
+    "no_api_key": "ANTHROPIC_API_KEY 미설정",
+    "issue_duplicate": "이미 등록된 이슈입니다 (#{num})",
+    "issue_no_write_permission": "Issues 쓰기 권한이 없습니다. GitHub 토큰을 확인해 주세요.",
+    "github_api_error": "GitHub API 오류",
+    "invalid_url": "유효하지 않은 URL: {field}. 내부 네트워크 주소는 사용할 수 없습니다.",
+    "repo_name_required": "리포 이름이 필요합니다"
   },
   "notifier": {
     "no_issues": "이슈 없음",

--- a/src/templates/add_repo.html
+++ b/src/templates/add_repo.html
@@ -163,7 +163,8 @@
         data-i18n-loaded-template="{{ 'add_repo.loaded_hint' | i18n_args(locale | default('ko'), count='__N__') }}"
         data-i18n-load-failed="{{ 'add_repo.load_failed_option' | i18n_args(locale | default('ko')) }}"
         data-i18n-error-prefix="{{ 'add_repo.error_prefix' | i18n_args(locale | default('ko')) }}"
-        data-i18n-api-error-prefix="{{ 'add_repo.api_error_prefix' | i18n_args(locale | default('ko')) }}">
+        data-i18n-api-error-prefix="{{ 'add_repo.api_error_prefix' | i18n_args(locale | default('ko')) }}"
+        data-i18n-error-already-registered="{{ 'add_repo.error_already_registered' | i18n_args(locale | default('ko')) }}">
 
     {# Step 1: GitHub 리포지터리 선택
        Step 1: Select GitHub repository #}
@@ -205,6 +206,7 @@
     loadFailed: i18nForm.dataset.i18nLoadFailed,
     errorPrefix: i18nForm.dataset.i18nErrorPrefix,
     apiErrorPrefix: i18nForm.dataset.i18nApiErrorPrefix,
+    errorAlreadyRegistered: i18nForm.dataset.i18nErrorAlreadyRegistered,
   };
 
   // 페이지 이탈 시 fetch abort 제어 — hx-boost 뒤로가기 freezing 방지
@@ -265,8 +267,12 @@
   var params = new URLSearchParams(window.location.search);
   var errorMsg = params.get('error');
   if (errorMsg) {
+    // 알려진 에러 코드면 i18n 메시지로 매핑, 아니면 raw 표시 (하위 호환)
+    // Map known error codes to i18n messages, else show raw (backward compatible)
+    var ERROR_MAP = { already_registered: I18N.errorAlreadyRegistered };
+    var displayMsg = ERROR_MAP[errorMsg] || errorMsg;
     const toast = document.getElementById('errorToast');
-    toast.textContent = errorMsg;
+    toast.textContent = displayMsg;
     toast.classList.add('show');
     setTimeout(() => toast.classList.remove('show'), 4000);
     // URL에서 쿼리 파라미터 제거

--- a/src/ui/routes/add_repo.py
+++ b/src/ui/routes/add_repo.py
@@ -15,6 +15,7 @@ from src.github_client.repos import (
     create_webhook,
     list_user_repos,
 )
+from src.i18n.loader import get_text
 from src.models.repo_config import RepoConfig
 from src.models.repository import Repository
 from src.repositories import repo_config_repo, repository_repo
@@ -83,17 +84,23 @@ async def add_repo(
     current_user: Annotated[CurrentUser, Depends(require_login)],
 ):
     """리포를 등록하고 GitHub Webhook을 생성한다."""
+    locale = get_locale(request)
     form = await request.form()
     repo_full_name = (form.get("repo_full_name") or "").strip()
     if not repo_full_name:
-        raise HTTPException(status_code=400, detail="리포 이름이 필요합니다")
+        raise HTTPException(
+            status_code=400,
+            detail=get_text("errors.repo_name_required", locale),
+        )
 
     with SessionLocal() as db:
         existing = repository_repo.find_by_full_name(db, repo_full_name)
         if existing:
             if existing.user_id is not None:
+                # 에러 코드만 URL 로 전달 → 템플릿이 코드→i18n 매핑 (한국어 URL 노출 제거)
+                # Pass only error code in URL → template maps code→i18n (no hardcoded text in URL)
                 return RedirectResponse(
-                    url="/repos/add?error=이미+다른+사용자가+등록한+리포입니다",
+                    url="/repos/add?error=already_registered",
                     status_code=303,
                 )
             existing.user_id = current_user.id

--- a/src/ui/routes/settings.py
+++ b/src/ui/routes/settings.py
@@ -27,6 +27,7 @@ from src.github_client.repos import (
     delete_webhook,
     list_webhooks,
 )
+from src.i18n.loader import get_text
 from src.models.repo_config import RepoConfig
 from src.repositories import repo_config_repo
 from src.shared.log_safety import sanitize_for_log
@@ -82,8 +83,9 @@ def _is_safe_webhook_url(url: str | None) -> bool:  # pylint: disable=too-many-r
         return False
 
 
-def _validate_webhook_urls(form) -> None:
-    """폼의 모든 webhook URL을 검증한다. 안전하지 않으면 HTTPException(400)."""
+def _validate_webhook_urls(form, locale: str) -> None:
+    """폼의 모든 webhook URL을 검증한다. 안전하지 않으면 HTTPException(400).
+    Validate all webhook URLs in the form. Raises HTTPException(400) if unsafe."""
     webhook_fields = (
         "n8n_webhook_url", "discord_webhook_url",
         "slack_webhook_url", "custom_webhook_url",
@@ -93,7 +95,7 @@ def _validate_webhook_urls(form) -> None:
         if url and not _is_safe_webhook_url(url):
             raise HTTPException(
                 status_code=400,
-                detail=f"유효하지 않은 URL: {field}. 내부 네트워크 주소는 사용할 수 없습니다.",
+                detail=get_text("errors.invalid_url", locale, field=field),
             )
 
 
@@ -225,7 +227,7 @@ async def update_repo_settings(
     form = await request.form()
     # SSRF 방어: webhook URL 사전 검증 — 내부 네트워크 요청 차단
     # SSRF defence: validate webhook URLs before saving — blocks internal network requests.
-    _validate_webhook_urls(form)
+    _validate_webhook_urls(form, get_locale(request))
     with SessionLocal() as db:
         get_accessible_repo(db, repo_name, current_user)
         try:

--- a/tests/unit/test_i18n_web_errors.py
+++ b/tests/unit/test_i18n_web_errors.py
@@ -1,0 +1,41 @@
+"""웹 UI 에러 메시지 i18n 키 — 사이클 150 Sprint 1.
+
+Web UI error message i18n keys — cycle 150 Sprint 1.
+"""
+from __future__ import annotations
+import json
+import pathlib
+
+import pytest
+
+_TRANS_DIR = pathlib.Path("src/i18n/translations")
+_LOCALES = ["ko", "en", "ja"]
+_ERROR_KEYS = [
+    "issue_duplicate",
+    "issue_no_write_permission",
+    "github_api_error",
+    "invalid_url",
+    "repo_name_required",
+]
+
+
+def _load(locale):
+    return json.loads((_TRANS_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _ERROR_KEYS)
+def test_error_key_exists(locale, key):
+    assert key in _load(locale)["errors"], f"[{locale}] errors.{key} 없음"
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+def test_add_repo_already_registered_key(locale):
+    assert "error_already_registered" in _load(locale)["add_repo"], \
+        f"[{locale}] add_repo.error_already_registered 없음"
+
+
+def test_get_text_renders_issue_duplicate():
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+    out = get_text("errors.issue_duplicate", "en", num=42)
+    assert "42" in out and "{num}" not in out


### PR DESCRIPTION
## Summary
웹 UI 사용자 노출 에러 메시지 6건 i18n — en/ja 사용자 locale 적용.

## 변경 내용
- errors.* 신규 5키 (issue_duplicate/issue_no_write_permission/github_api_error/invalid_url/repo_name_required)
- add_repo.error_already_registered 신규 (redirect 코드 방식)
- issue_registration.py(3)·settings.py(1)·add_repo.py(2): get_locale + get_text
- add_repo redirect: 한국어 URL → 에러 코드(already_registered) + 템플릿 data-i18n 매핑

## 보류 (자율 판단 — 정책 3)
hook.py 4건 CLI/webhook 에러 — hook 토큰 인증으로 per-user locale 없음, 별도 검토

## 테스트
- test_i18n_web_errors.py 신규 (19 케이스) ✅
- 회귀 없음 (api/ui/templates 439 passed) + pylint 10.00

## 🔍 사용자 검증 필요 (정책 11)
| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |
- [ ] CI 통과 확인
- [ ] EN locale에서 중복 이슈 등록/잘못된 URL/리포 중복 시 에러가 영어로 표시 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증 의뢰 완료 — push 전 Codex OK 회신 대기 중

🤖 Generated with [Claude Code](https://claude.com/claude-code)