### PR TITLE
fix(i18n): hook.py CLI 에러 i18n (사이클 151 Sprint 1)

### DIFF
--- a/src/api/hook.py
+++ b/src/api/hook.py
@@ -7,13 +7,16 @@ import logging
 from typing import Any
 
 from fastapi import APIRouter, Header, HTTPException, Query, Request
-from src.middleware.rate_limiter import limiter, RATE_LIMIT_API
 from pydantic import BaseModel
 
+from src.middleware.rate_limiter import limiter, RATE_LIMIT_API
+from src.config import settings
 from src.database import SessionLocal
+from src.i18n.loader import get_text
 from src.shared.log_safety import sanitize_for_log
 from src.models.analysis import Analysis
 from src.models.repository import Repository
+from src.models.user import User
 from src.repositories import repo_config_repo
 from src.analyzer.io.ai_review import AiReviewResult
 from src.scorer.calculator import calculate_score
@@ -23,6 +26,27 @@ from src.constants import AI_DEFAULT_COMMIT_RAW, AI_DEFAULT_DIRECTION_RAW, AI_DE
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/hook")
+
+
+def _resolve_hook_locale(db, repo_name: str) -> str:
+    """hook 엔드포인트용 — repo 소유자 preferred_language 해소. 없으면 default.
+
+    Resolve repo owner's preferred_language for hook endpoints; default otherwise.
+
+    hook 토큰 인증은 per-user 세션 locale 이 없으므로, repo full_name 으로
+    소유자(User.preferred_language) 언어를 해소한다. 미지원 언어/소유자 부재 시 default.
+    Hook token auth has no per-user session locale, so resolve the owner's
+    language via repo full_name. Falls back to default for unsupported/missing owner.
+    """
+    repo = db.query(Repository).filter(Repository.full_name == repo_name).first()
+    if repo and repo.user_id:
+        user = db.query(User).filter(User.id == repo.user_id).first()
+        if user and user.preferred_language:
+            lang = user.preferred_language
+            supported = {code.strip() for code in settings.supported_locales.split(",")}
+            if lang in supported:
+                return lang
+    return settings.default_locale
 
 
 # ---------------------------------------------------------------------------
@@ -56,14 +80,24 @@ def verify_hook(
         bearer_token = authorization[7:]
 
     effective_token = bearer_token or token
-    if not effective_token:
-        raise HTTPException(status_code=401, detail="토큰이 필요합니다")
 
+    # locale 해소는 에러 발생 시에만 (정상 경로 쿼리 순서 불변 — 토큰 검증 로직 보존)
+    # Resolve locale only on error (keep happy-path query order intact — preserve token check)
     with SessionLocal() as db:
-        config = repo_config_repo.find_by_full_name(db, repo)
+        if not effective_token:
+            locale = _resolve_hook_locale(db, repo)
+            raise HTTPException(
+                status_code=401,
+                detail=get_text("errors.hook_token_required", locale),
+            )
 
-    if config is None or not hmac.compare_digest(config.hook_token or "", effective_token):
-        raise HTTPException(status_code=404, detail="등록되지 않은 리포 또는 유효하지 않은 토큰")
+        config = repo_config_repo.find_by_full_name(db, repo)
+        if config is None or not hmac.compare_digest(config.hook_token or "", effective_token):
+            locale = _resolve_hook_locale(db, repo)
+            raise HTTPException(
+                status_code=404,
+                detail=get_text("errors.hook_invalid_repo_or_token", locale),
+            )
 
     return {"status": "active"}
 
@@ -92,14 +126,24 @@ def save_hook_result(request: Request, body: HookResultRequest):  # pylint: disa
         config = repo_config_repo.find_by_full_name(db, body.repo)
 
         if config is None or not hmac.compare_digest(config.hook_token or "", body.token):
-            raise HTTPException(status_code=403, detail="유효하지 않은 토큰")
+            # locale 해소는 에러 시에만 (정상 경로 쿼리 순서 불변)
+            # Resolve locale only on error (keep happy-path query order intact)
+            locale = _resolve_hook_locale(db, body.repo)
+            raise HTTPException(
+                status_code=403,
+                detail=get_text("errors.hook_invalid_token", locale),
+            )
 
         repo = db.query(Repository).filter(
             Repository.full_name == body.repo
         ).first()
 
         if repo is None:
-            raise HTTPException(status_code=404, detail="리포지토리를 찾을 수 없습니다")
+            locale = _resolve_hook_locale(db, body.repo)
+            raise HTTPException(
+                status_code=404,
+                detail=get_text("errors.hook_repo_not_found", locale),
+            )
 
         existing = db.query(Analysis).filter_by(
             commit_sha=body.commit_sha, repo_id=repo.id

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -671,7 +671,11 @@
     "issue_no_write_permission": "No write permission for Issues. Please check your GitHub token.",
     "github_api_error": "GitHub API error",
     "invalid_url": "Invalid URL: {field}. Internal network addresses are not allowed.",
-    "repo_name_required": "Repository name is required"
+    "repo_name_required": "Repository name is required",
+    "hook_token_required": "Token is required",
+    "hook_invalid_repo_or_token": "Unregistered repository or invalid token",
+    "hook_invalid_token": "Invalid token",
+    "hook_repo_not_found": "Repository not found"
   },
   "notifier": {
     "no_issues": "No issues",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -671,7 +671,11 @@
     "issue_no_write_permission": "Issuesの書き込み権限がありません。GitHubトークンを確認してください。",
     "github_api_error": "GitHub APIエラー",
     "invalid_url": "無効なURL: {field}。内部ネットワークアドレスは使用できません。",
-    "repo_name_required": "リポジトリ名が必要です"
+    "repo_name_required": "リポジトリ名が必要です",
+    "hook_token_required": "トークンが必要です",
+    "hook_invalid_repo_or_token": "未登録のリポジトリまたは無効なトークン",
+    "hook_invalid_token": "無効なトークン",
+    "hook_repo_not_found": "リポジトリが見つかりません"
   },
   "notifier": {
     "no_issues": "問題なし",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -671,7 +671,11 @@
     "issue_no_write_permission": "Issues 쓰기 권한이 없습니다. GitHub 토큰을 확인해 주세요.",
     "github_api_error": "GitHub API 오류",
     "invalid_url": "유효하지 않은 URL: {field}. 내부 네트워크 주소는 사용할 수 없습니다.",
-    "repo_name_required": "리포 이름이 필요합니다"
+    "repo_name_required": "리포 이름이 필요합니다",
+    "hook_token_required": "토큰이 필요합니다",
+    "hook_invalid_repo_or_token": "등록되지 않은 리포 또는 유효하지 않은 토큰",
+    "hook_invalid_token": "유효하지 않은 토큰",
+    "hook_repo_not_found": "리포지토리를 찾을 수 없습니다"
   },
   "notifier": {
     "no_issues": "이슈 없음",

--- a/tests/unit/test_i18n_hook_errors.py
+++ b/tests/unit/test_i18n_hook_errors.py
@@ -1,0 +1,86 @@
+"""hook.py CLI 에러 i18n 키 + repo owner locale 해소 — 사이클 151 Sprint 1.
+
+hook.py CLI error i18n keys + repo owner locale resolution — Cycle 151 Sprint 1.
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+from unittest.mock import MagicMock
+
+import pytest
+
+_TRANS_DIR = pathlib.Path("src/i18n/translations")
+_LOCALES = ["ko", "en", "ja"]
+_KEYS = [
+    "hook_token_required",
+    "hook_invalid_repo_or_token",
+    "hook_invalid_token",
+    "hook_repo_not_found",
+]
+
+
+def _load(locale):
+    return json.loads((_TRANS_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _KEYS)
+def test_hook_error_key_exists(locale, key):
+    # 3 언어 모두 errors.<key> 존재 의무 (en 누락 시 fallback 깨짐)
+    # All 3 locales must contain errors.<key> (en missing breaks fallback)
+    assert key in _load(locale)["errors"], f"[{locale}] errors.{key} 없음"
+
+
+def test_get_text_hook_errors():
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+
+    assert get_text("errors.hook_token_required", "en") != get_text(
+        "errors.hook_token_required", "ko"
+    )
+
+
+def _make_db_with(repo, user):
+    """repo / user 조회 결과를 순차 반환하는 mock db 생성.
+
+    Build a mock db returning repo then user on successive .first() calls.
+    """
+    db = MagicMock()
+    query_chain = MagicMock()
+    db.query.return_value.filter.return_value = query_chain
+    # 1st .first() → repo, 2nd .first() → user
+    query_chain.first.side_effect = [repo, user]
+    return db
+
+
+def test_resolve_hook_locale_owner_language():
+    from src.api.hook import _resolve_hook_locale  # pylint: disable=import-outside-toplevel
+
+    repo = MagicMock()
+    repo.user_id = 7
+    user = MagicMock()
+    user.preferred_language = "en"
+    db = _make_db_with(repo, user)
+
+    assert _resolve_hook_locale(db, "owner/repo") == "en"
+
+
+def test_resolve_hook_locale_repo_not_found_returns_default():
+    from src.api.hook import _resolve_hook_locale  # pylint: disable=import-outside-toplevel
+    from src.config import settings  # pylint: disable=import-outside-toplevel
+
+    db = _make_db_with(None, None)
+    assert _resolve_hook_locale(db, "owner/missing") == settings.default_locale
+
+
+def test_resolve_hook_locale_unsupported_language_returns_default():
+    from src.api.hook import _resolve_hook_locale  # pylint: disable=import-outside-toplevel
+    from src.config import settings  # pylint: disable=import-outside-toplevel
+
+    repo = MagicMock()
+    repo.user_id = 1
+    user = MagicMock()
+    user.preferred_language = "zz"  # 미지원 언어 → default fallback
+    db = _make_db_with(repo, user)
+
+    assert _resolve_hook_locale(db, "owner/repo") == settings.default_locale


### PR DESCRIPTION
## Summary
hook.py(pre-push hook CLI 인증) 에러 4건 i18n — repo 소유자 언어 해소.

## 배경
hook 토큰 인증이라 per-user 세션 locale 없음 → repo full_name 으로 소유자 preferred_language 해소 (Repository.user_id → User.preferred_language). 사이클 150 보류 항목.

## 변경 내용
- `errors.hook_*` 신규 4키 (ko/en/ja): hook_token_required / hook_invalid_repo_or_token / hook_invalid_token / hook_repo_not_found
- `_resolve_hook_locale(db, repo)` 헬퍼 (src/api/hook.py) — Repository → user → preferred_language → SUPPORTED_LOCALES 검증 → default_locale fallback
- verify_hook(2건: 401/404) + save_hook_result(2건: 403/404) 에러 i18n
- **인증 로직(hmac.compare_digest, 200 응답) 불변** — 에러 텍스트만 i18n
- locale 해소는 **에러 경로에서만** 호출 → 정상 경로 쿼리 순서 보존 → 기존 mock 테스트 회귀 0

## 테스트
- `tests/unit/test_i18n_hook_errors.py` 신규 (키 12 + get_text 1 + _resolve_hook_locale 3) ✅
- tests/unit/api/ 144 passed (회귀 0)
- pylint src/api/hook.py **10.00/10**

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인
- [ ] EN 소유자 리포에서 잘못된 hook 토큰으로 pre-push → 영어 에러("Invalid token" 등) 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증 의뢰 — 컨트롤러 별도 진행 (본 PR push 후 검증 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)