### PR TITLE
fix(i18n): format_ref 커밋 레퍼런스 i18n — push 이벤트 P0-A (사이클 152 Sprint 1)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -828,6 +828,9 @@
       "retry_terminal_title": "⚠️ <b>Auto-merge Final Failure</b>",
       "retry_terminal_reason": "Reason: <code>{reason}</code>",
       "retry_advice_line": "💡 {advice}"
+    },
+    "common": {
+      "commit_ref": "Commit {sha}"
     }
   },
   "repo_insights": {

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -828,6 +828,9 @@
       "retry_terminal_title": "⚠️ <b>自動マージ最終失敗</b>",
       "retry_terminal_reason": "理由: <code>{reason}</code>",
       "retry_advice_line": "💡 {advice}"
+    },
+    "common": {
+      "commit_ref": "コミット {sha}"
     }
   },
   "repo_insights": {

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -828,6 +828,9 @@
       "retry_terminal_title": "⚠️ <b>자동 머지 최종 실패</b>",
       "retry_terminal_reason": "사유: <code>{reason}</code>",
       "retry_advice_line": "💡 {advice}"
+    },
+    "common": {
+      "commit_ref": "커밋 {sha}"
     }
   },
   "repo_insights": {

--- a/src/notifier/_common.py
+++ b/src/notifier/_common.py
@@ -7,14 +7,21 @@ from src.constants import (
 )
 
 
-def format_ref(commit_sha: str, pr_number: int | None) -> str:
+def format_ref(commit_sha: str, pr_number: int | None, language: str = "ko") -> str:
     """PR 번호 또는 단축 커밋 SHA 레퍼런스 문자열을 반환한다.
 
     Format a PR number or short commit SHA reference string.
+    language: 커밋 레퍼런스 i18n (push 이벤트 — pr_number 없을 때).
+    language: i18n for the commit reference (push event — when pr_number is absent).
     """
     if pr_number:
         return f"PR #{pr_number}"
-    return f"커밋 {commit_sha[:COMMIT_SHA_DISPLAY_LENGTH]}"
+    # 커밋 레퍼런스 i18n — push 이벤트 시 수신자 언어 적용 (사이클 152 P0-A)
+    # Commit reference i18n — apply recipient language on push events
+    from src.i18n.loader import get_text  # noqa: WPS433  # pylint: disable=import-outside-toplevel
+    return get_text(
+        "notifier.common.commit_ref", language, sha=commit_sha[:COMMIT_SHA_DISPLAY_LENGTH],
+    )
 
 
 def get_all_issues(analysis_results: list) -> list:

--- a/src/notifier/discord.py
+++ b/src/notifier/discord.py
@@ -29,7 +29,7 @@ def _build_embed(  # pylint: disable=too-many-positional-arguments
     language: str = "en",
 ) -> dict:
     grade_emoji = GRADE_EMOJI.get(score_result.grade, "⚪")
-    ref = format_ref(commit_sha, pr_number)
+    ref = format_ref(commit_sha, pr_number, language)
     bd = score_result.breakdown
 
     lines = [

--- a/src/notifier/email.py
+++ b/src/notifier/email.py
@@ -30,7 +30,7 @@ def _build_html_body(  # pylint: disable=too-many-positional-arguments,too-many-
     ai_review: AiReviewResult | None = None,
     language: str = "en",
 ) -> str:
-    ref = format_ref(commit_sha, pr_number)
+    ref = format_ref(commit_sha, pr_number, language)
     bd = score_result.breakdown
     color = GRADE_COLOR_HTML.get(score_result.grade, "#6366f1")
 

--- a/src/notifier/slack.py
+++ b/src/notifier/slack.py
@@ -34,7 +34,7 @@ def _build_payload(  # pylint: disable=too-many-positional-arguments,too-many-lo
     language: str = "en",
 ) -> dict:
     grade_emoji = _SLACK_GRADE_EMOJI.get(score_result.grade, ":white_circle:")
-    ref = format_ref(commit_sha, pr_number)
+    ref = format_ref(commit_sha, pr_number, language)
     bd = score_result.breakdown
 
     text = get_text(

--- a/src/notifier/telegram.py
+++ b/src/notifier/telegram.py
@@ -114,7 +114,7 @@ def _build_message(  # pylint: disable=too-many-positional-arguments,too-many-lo
     Args:
         language: 사용자 언어 ('ko'/'en'/'ja'). 3-layer fallback (resolve_notification_language).
     """
-    ref = format_ref(commit_sha, pr_number)
+    ref = format_ref(commit_sha, pr_number, language)
     all_issues = get_all_issues(analysis_results)
     top_issues = [
         f"- [{escape(i.tool)}] {escape(truncate_issue_msg(i.message))}"

--- a/tests/unit/test_i18n_format_ref.py
+++ b/tests/unit/test_i18n_format_ref.py
@@ -1,0 +1,62 @@
+"""format_ref i18n + push 이벤트 커밋 레퍼런스 회귀 가드 — 사이클 152 P0-A.
+
+format_ref i18n + push-event commit reference regression guard (cycle 152 P0-A).
+"""
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from src.notifier._common import format_ref
+
+_TRANS_DIR = pathlib.Path("src/i18n/translations")
+_LOCALES = ["ko", "en", "ja"]
+
+
+def _load(locale: str) -> dict:
+    return json.loads((_TRANS_DIR / f"{locale}.json").read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+def test_commit_ref_key_exists(locale: str):
+    """notifier.common.commit_ref가 모든 locale에 존재해야 한다.
+    notifier.common.commit_ref must exist in all locales.
+    """
+    assert "common" in _load(locale)["notifier"], f"[{locale}] notifier.common 없음"
+    assert "commit_ref" in _load(locale)["notifier"]["common"], f"[{locale}] commit_ref 없음"
+
+
+def test_format_ref_pr_number_unchanged():
+    """pr_number 있으면 'PR #N' 반환 (language 무관).
+    Returns 'PR #N' when pr_number is present (language-agnostic).
+    """
+    assert format_ref("abc1234def", 5, "en") == "PR #5"
+    assert format_ref("abc1234def", 5, "ja") == "PR #5"
+
+
+def test_format_ref_commit_english_no_korean():
+    """push 이벤트(pr_number=None) + en — '커밋' 한국어 누출 없어야 한다 (P0-A 회귀 가드).
+    Push event + en — must not leak '커밋' Korean (P0-A regression guard).
+    """
+    out = format_ref("abc1234def", None, "en")
+    assert "커밋" not in out, f"영어 locale에 한국어 '커밋' 누출: {out!r}"
+    assert "Commit" in out
+
+
+def test_format_ref_commit_japanese():
+    """push 이벤트 + ja — 일본어 커밋 레퍼런스.
+    Push event + ja — Japanese commit reference.
+    """
+    out = format_ref("abc1234def", None, "ja")
+    assert "커밋" not in out
+    assert "コミット" in out
+
+
+def test_format_ref_commit_korean_default():
+    """language 미전달 시 ko default (하위 호환).
+    Defaults to ko when language omitted (backward compat).
+    """
+    out = format_ref("abc1234def", None)
+    assert "커밋" in out


### PR DESCRIPTION
## Summary

통합 회고(143~151) P0-A 이행 — format_ref가 push 이벤트 시 "커밋" 한국어를 4채널 알림에 누출하던 문제 수정.

## 배경
`format_ref(commit_sha, pr_number)`가 push 이벤트(pr_number=None) 시 `"커밋 {sha}"` 반환 → telegram/slack/discord/email의 `get_text(...ref_line, ref=...)` 인자로 주입 → en/ja 사용자도 메시지 내부에 한국어 "커밋" 노출.

## 변경 내용
- notifier.common.commit_ref 신규 ({sha}, ko/en/ja)
- format_ref에 language 파라미터 추가 (default ko 하위 호환)
- 4채널 builder가 보유한 language 전달

## 회귀 가드 (cross-verify 신규 발견)
- test_i18n_format_ref.py: `assert "커밋" not in out` (en/ja push 이벤트)
- 기존 test_build_message_english가 이 leak을 무가드 통과하던 사각 해소

## 테스트
- test_i18n_format_ref.py 7건 ✅ / notifier 235 passed / pylint 10.00

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인
- [ ] EN 사용자 push 이벤트(PR 아님) 알림에서 "Commit abc1234" 영어 표시 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [x] Claude 직접 검증 (7 passed + 235 회귀 없음 + pylint 10.00)

🤖 Generated with Claude Code