### PR TITLE
fix(i18n): engine.py 동기 머지 알림 i18n (사이클 152 Sprint 2, P0-B/C)

### DIFF
--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -32,6 +32,7 @@ from src.gate.native_automerge import (
 )
 from src.gate.retry_policy import parse_reason_tag, should_retry
 from src.github_client.checks import get_ci_status, get_required_check_contexts
+from src.i18n.loader import get_text
 from src.notifier.merge_failure_issue import create_merge_failure_issue
 from src.notifier.telegram import telegram_post_message
 from src.models.gate_decision import GateDecision
@@ -336,6 +337,12 @@ async def _enqueue_merge_retry(  # pylint: disable=too-many-arguments
             initial_next_retry_seconds=settings.merge_retry_initial_backoff_seconds,
         )
         if enqueued.is_first_deferral:
+            # 3-layer 사용자 언어 결정 (User → RepoConfig → settings.default_locale)
+            # 사이클 152 Sprint 2 — deferred 알림도 동기 경로 i18n 적용.
+            # 3-layer language resolve; Cycle 152 Sprint 2 — localize deferred notice.
+            from src.notifier._language import resolve_notification_language  # noqa: WPS433  # pylint: disable=import-outside-toplevel
+            with SessionLocal() as db_lang:
+                language = resolve_notification_language(db_lang, config=config)
             await _notify_merge_deferred(
                 repo_name=repo_name,
                 pr_number=pr_number,
@@ -344,6 +351,7 @@ async def _enqueue_merge_retry(  # pylint: disable=too-many-arguments
                 reason_tag=reason_tag,
                 ci_status=ci_status,
                 chat_id=config.notify_chat_id or settings.telegram_chat_id,
+                language=language,
             )
     except Exception as exc:  # pylint: disable=broad-except
         logger.warning(
@@ -443,6 +451,7 @@ async def _run_auto_merge_legacy(  # pylint: disable=too-many-arguments,too-many
             reason=reason or "unknown",
             advice=advice,
             chat_id=config.notify_chat_id or settings.telegram_chat_id,
+            language=language,
         )
         if config.auto_merge_issue_on_failure:
             try:
@@ -518,6 +527,7 @@ async def _handle_terminal_merge_failure(  # pylint: disable=too-many-arguments
         reason=reason or "unknown",
         advice=advice,
         chat_id=config.notify_chat_id or settings.telegram_chat_id,
+        language=language,
     )
     if config.auto_merge_issue_on_failure:
         try:
@@ -546,19 +556,25 @@ async def _notify_merge_failure(
     reason: str,
     advice: str,
     chat_id: str | None,
+    language: str = "ko",
 ) -> None:
-    """auto_merge 실패를 Telegram 으로 알린다. chat_id 없으면 스킵."""
+    """auto_merge 실패를 Telegram 으로 알린다. chat_id 없으면 스킵.
+
+    Notify auto_merge failure via Telegram; skip when chat_id is missing.
+    사이클 152 Sprint 2 — 하드코딩 한국어 → i18n (language 기반 get_text 조합).
+    Cycle 152 Sprint 2 — hardcoded Korean replaced with language-aware get_text.
+    """
     if not chat_id or not settings.telegram_bot_token:
         return
     # Phase F QW3: GitHub PR 링크 추가 — 사용자 즉시 접근
     pr_url = f"https://github.com/{repo_name}/pull/{pr_number}"
     text = (
-        "⚠️ <b>Auto Merge 실패</b>\n"
-        f"📁 <code>{escape(repo_name)}</code> — PR #{pr_number}\n"
-        f"점수: {score}점 (기준 {threshold}점 이상)\n"
-        f"사유: <code>{escape(reason)}</code>\n"
-        f"💡 {escape(advice)}\n"
-        f"🔗 <a href=\"{escape(pr_url)}\">GitHub 에서 보기</a>"
+        get_text("notifier.gate.merge_failed_title", language) + "\n"
+        + get_text("notifier.gate.retry_repo_line", language, repo=escape(repo_name), pr=pr_number) + "\n"
+        + get_text("notifier.gate.merge_score_threshold", language, score=score, threshold=threshold) + "\n"
+        + get_text("notifier.gate.merge_reason_line", language, reason=escape(reason)) + "\n"
+        + get_text("notifier.gate.merge_advice_line", language, advice=escape(advice)) + "\n"
+        + get_text("notifier.gate.merge_view_github", language, url=escape(pr_url))
     )
     try:
         await telegram_post_message(
@@ -579,18 +595,25 @@ async def _notify_merge_deferred(
     reason_tag: str,
     ci_status: str,
     chat_id: str | None,
+    language: str = "ko",
 ) -> None:
     """CI 대기 중임을 사용자에게 알린다 (최초 지연 1회).
     Notify user that merge is deferred while waiting for CI (first deferral only).
+
+    사이클 152 Sprint 2 — 하드코딩 한국어 → i18n (language 기반 get_text 조합).
+    Cycle 152 Sprint 2 — hardcoded Korean replaced with language-aware get_text.
     """
     if not chat_id or not settings.telegram_bot_token:
         return
     msg = (
-        "⏳ <b>자동 머지 대기 중</b>\n"
-        f"📁 <code>{escape(repo_name)}</code> — PR #{pr_number}\n"
-        f"점수: {score}점 (기준: {threshold}점)\n"
-        f"사유: CI {ci_status} ({escape(reason_tag)})\n"
-        "<i>CI 완료 후 자동으로 머지를 재시도합니다.</i>"
+        get_text("notifier.gate.merge_deferred_title", language) + "\n"
+        + get_text("notifier.gate.retry_repo_line", language, repo=escape(repo_name), pr=pr_number) + "\n"
+        + get_text("notifier.gate.merge_deferred_score", language, score=score, threshold=threshold) + "\n"
+        + get_text(
+            "notifier.gate.merge_deferred_reason", language,
+            ci_status=ci_status, reason=escape(reason_tag),
+        ) + "\n"
+        + get_text("notifier.gate.merge_deferred_retry", language)
     )
     try:
         await telegram_post_message(

--- a/src/gate/github_review.py
+++ b/src/gate/github_review.py
@@ -145,10 +145,14 @@ async def merge_pr(  # pylint: disable=too-many-locals
             await asyncio.sleep(retry_delay)
 
     if state in _MERGEABLE_BLOCK:
+        # 사이클 152 Sprint 2 (P1-1): reason 을 정규 태그만 반환 (language-neutral).
+        # 하드코딩 한국어 설명 제거 — get_advice 는 태그만 사용, 알림은 advice(i18n)로 안내.
+        # Cycle 152 Sprint 2 (P1-1): return reason as the canonical tag only (language-neutral).
+        # Korean detail removed — get_advice uses the tag; notifications rely on advice (i18n).
         reason_tag = merge_reasons.mergeable_state_to_reason(state)
-        return (False, f"{reason_tag}: 머지 조건 미충족 (state={state})", head_sha)
+        return (False, reason_tag, head_sha)
     if state == "unknown":
-        return (False, f"{merge_reasons.UNKNOWN_STATE_TIMEOUT}: GitHub mergeable 계산 미완료", head_sha)
+        return (False, merge_reasons.UNKNOWN_STATE_TIMEOUT, head_sha)
 
     url = f"{GITHUB_API}/repos/{repo_full_name}/pulls/{pr_number}/merge"
     try:

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -827,7 +827,16 @@
       "retry_view_github": "🔗 <a href=\"{url}\">View on GitHub</a>",
       "retry_terminal_title": "⚠️ <b>Auto-merge Final Failure</b>",
       "retry_terminal_reason": "Reason: <code>{reason}</code>",
-      "retry_advice_line": "💡 {advice}"
+      "retry_advice_line": "💡 {advice}",
+      "merge_failed_title": "⚠️ <b>Auto Merge Failed</b>",
+      "merge_score_threshold": "Score: {score} (threshold: {threshold}+)",
+      "merge_reason_line": "Reason: <code>{reason}</code>",
+      "merge_advice_line": "💡 {advice}",
+      "merge_view_github": "🔗 <a href=\"{url}\">View on GitHub</a>",
+      "merge_deferred_title": "⏳ <b>Auto-merge Pending</b>",
+      "merge_deferred_score": "Score: {score} (threshold: {threshold})",
+      "merge_deferred_reason": "Reason: CI {ci_status} ({reason})",
+      "merge_deferred_retry": "<i>Will automatically retry merge after CI completes.</i>"
     },
     "common": {
       "commit_ref": "Commit {sha}"

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -827,7 +827,16 @@
       "retry_view_github": "🔗 <a href=\"{url}\">GitHubで見る</a>",
       "retry_terminal_title": "⚠️ <b>自動マージ最終失敗</b>",
       "retry_terminal_reason": "理由: <code>{reason}</code>",
-      "retry_advice_line": "💡 {advice}"
+      "retry_advice_line": "💡 {advice}",
+      "merge_failed_title": "⚠️ <b>自動マージ失敗</b>",
+      "merge_score_threshold": "スコア: {score}点 (基準: {threshold}点以上)",
+      "merge_reason_line": "理由: <code>{reason}</code>",
+      "merge_advice_line": "💡 {advice}",
+      "merge_view_github": "🔗 <a href=\"{url}\">GitHubで見る</a>",
+      "merge_deferred_title": "⏳ <b>自動マージ待機中</b>",
+      "merge_deferred_score": "スコア: {score}点 (基準: {threshold}点)",
+      "merge_deferred_reason": "理由: CI {ci_status} ({reason})",
+      "merge_deferred_retry": "<i>CI完了後、自動的にマージを再試行します。</i>"
     },
     "common": {
       "commit_ref": "コミット {sha}"

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -827,7 +827,16 @@
       "retry_view_github": "🔗 <a href=\"{url}\">GitHub에서 보기</a>",
       "retry_terminal_title": "⚠️ <b>자동 머지 최종 실패</b>",
       "retry_terminal_reason": "사유: <code>{reason}</code>",
-      "retry_advice_line": "💡 {advice}"
+      "retry_advice_line": "💡 {advice}",
+      "merge_failed_title": "⚠️ <b>Auto Merge 실패</b>",
+      "merge_score_threshold": "점수: {score}점 (기준 {threshold}점 이상)",
+      "merge_reason_line": "사유: <code>{reason}</code>",
+      "merge_advice_line": "💡 {advice}",
+      "merge_view_github": "🔗 <a href=\"{url}\">GitHub에서 보기</a>",
+      "merge_deferred_title": "⏳ <b>자동 머지 대기 중</b>",
+      "merge_deferred_score": "점수: {score}점 (기준: {threshold}점)",
+      "merge_deferred_reason": "사유: CI {ci_status} ({reason})",
+      "merge_deferred_retry": "<i>CI 완료 후 자동으로 머지를 재시도합니다.</i>"
     },
     "common": {
       "commit_ref": "커밋 {sha}"

--- a/tests/unit/test_i18n_gate_messages.py
+++ b/tests/unit/test_i18n_gate_messages.py
@@ -87,3 +87,104 @@ def test_retry_view_github_preserves_html():
     from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
     out = get_text("notifier.gate.retry_view_github", "en", url="http://x")
     assert "<a href=" in out
+
+
+# 사이클 152 Sprint 2 — engine.py 동기 머지 알림 키 (HTML parse_mode)
+# Cycle 152 Sprint 2 — engine.py synchronous merge notification keys (HTML parse_mode)
+_ENGINE_MERGE_KEYS = [
+    "merge_failed_title", "merge_score_threshold", "merge_reason_line",
+    "merge_advice_line", "merge_view_github", "merge_deferred_title",
+    "merge_deferred_score", "merge_deferred_reason", "merge_deferred_retry",
+]
+
+
+@pytest.mark.parametrize("locale", _LOCALES)
+@pytest.mark.parametrize("key", _ENGINE_MERGE_KEYS)
+def test_engine_merge_key_exists(locale, key):
+    assert key in _load(locale)["notifier"]["gate"], f"[{locale}] notifier.gate.{key} 없음"
+
+
+def test_merge_failed_title_no_korean_en():
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+    out = get_text("notifier.gate.merge_failed_title", "en")
+    assert "실패" not in out and "Failed" in out
+
+
+def test_merge_deferred_title_no_korean_en():
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+    out = get_text("notifier.gate.merge_deferred_title", "en")
+    assert "대기" not in out and "Pending" in out
+
+
+def test_merge_score_threshold_renders():
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+    out = get_text("notifier.gate.merge_score_threshold", "en", score=82, threshold=70)
+    assert "82" in out and "70" in out and "{score}" not in out
+
+
+def test_merge_deferred_reason_renders():
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+    out = get_text(
+        "notifier.gate.merge_deferred_reason", "en",
+        ci_status="pending", reason="unstable_ci",
+    )
+    assert "pending" in out and "unstable_ci" in out
+
+
+def test_merge_view_github_preserves_html():
+    from src.i18n.loader import get_text  # pylint: disable=import-outside-toplevel
+    out = get_text("notifier.gate.merge_view_github", "en", url="http://x")
+    assert "<a href=" in out
+
+
+@pytest.mark.asyncio
+async def test_notify_merge_failure_en_has_no_korean(monkeypatch):
+    """_notify_merge_failure(language='en') 메시지에 한국어 누출이 없어야 한다.
+
+    push 이벤트 누출 회귀 가드 — engine 동기 경로 i18n (사이클 152 Sprint 2).
+    """
+    from unittest.mock import AsyncMock  # pylint: disable=import-outside-toplevel
+    from src.gate import engine  # pylint: disable=import-outside-toplevel
+
+    captured = {}
+
+    async def _fake_post(_token, _chat, payload):
+        captured["text"] = payload["text"]
+
+    monkeypatch.setattr(engine.settings, "telegram_bot_token", "x")
+    monkeypatch.setattr(engine, "telegram_post_message", AsyncMock(side_effect=_fake_post))
+
+    await engine._notify_merge_failure(  # pylint: disable=protected-access
+        repo_name="owner/repo", pr_number=7, score=82, threshold=70,
+        reason="unstable_ci", advice="Wait for CI", chat_id="123",
+        language="en",
+    )
+    text = captured["text"]
+    for korean in ["실패", "점수", "사유", "기준", "보기"]:
+        assert korean not in text, f"한국어 누출: {korean!r} in {text!r}"
+    assert "Failed" in text and "Reason" in text
+
+
+@pytest.mark.asyncio
+async def test_notify_merge_deferred_en_has_no_korean(monkeypatch):
+    """_notify_merge_deferred(language='en') 메시지에 한국어 누출이 없어야 한다."""
+    from unittest.mock import AsyncMock  # pylint: disable=import-outside-toplevel
+    from src.gate import engine  # pylint: disable=import-outside-toplevel
+
+    captured = {}
+
+    async def _fake_post(_token, _chat, payload):
+        captured["text"] = payload["text"]
+
+    monkeypatch.setattr(engine.settings, "telegram_bot_token", "x")
+    monkeypatch.setattr(engine, "telegram_post_message", AsyncMock(side_effect=_fake_post))
+
+    await engine._notify_merge_deferred(  # pylint: disable=protected-access
+        repo_name="owner/repo", pr_number=7, score=82, threshold=70,
+        reason_tag="unstable_ci", ci_status="pending", chat_id="123",
+        language="en",
+    )
+    text = captured["text"]
+    for korean in ["대기", "점수", "사유", "재시도"]:
+        assert korean not in text, f"한국어 누출: {korean!r} in {text!r}"
+    assert "Pending" in text


### PR DESCRIPTION
## Summary
통합 회고 P0-B/C+P1-1 — `gate/engine.py` 동기 머지 알림 i18n 우회 해소.

## 배경
`gate/engine.py` 의 `_notify_merge_failure`/`_notify_merge_deferred` 가 하드코딩 한국어 → en/ja 사용자도 한국어 머지 알림 수신. `merge_retry_service` 는 i18n 처리하는데 engine 동기 경로만 비대칭. 호출처는 이미 language 해소함 (L432/507).

## 변경 내용
- `notifier.gate.merge_*` 신규 9키 (failure/deferred 메시지, ko/en/ja)
  - `merge_failed_title` · `merge_score_threshold` · `merge_reason_line` · `merge_advice_line` · `merge_view_github`
  - `merge_deferred_title` · `merge_deferred_score` · `merge_deferred_reason` · `merge_deferred_retry`
  - repo 라인은 기존 `retry_repo_line` 재사용 (텍스트 동일)
- `_notify_merge_failure`/`_notify_merge_deferred`: `*, language: str = "ko"` 파라미터 + `get_text` 조합 (escape 는 동적값에 유지)
- 호출처 3곳 language 전달:
  - L438 (`_run_auto_merge_legacy`) · L513 (`_handle_terminal_merge_failure`) — 기존 resolve 재사용
  - `_enqueue_merge_retry` first-deferral 분기 — 신규 `resolve_notification_language` (config 파라미터 활용, first deferral 시에만 DB 세션 오픈)
- **P1-1**: `github_review.py::merge_pr` reason 을 tag-only 반환 (한국어 설명 제거)
  - `reason_tag` (예: `dirty_conflict`) / `UNKNOWN_STATE_TIMEOUT` 만 반환
  - `get_advice`/`parse_reason_tag` 는 `reason.split(":")[0]` tag 만 사용 → 동작 불변
  - 영향: DB `MergeAttempt.detail_message` 가 "tag: 한국어 설명" → "tag" 로 축소 (관측용, 사용자 미노출). 알림 사유는 tag(language-neutral) + 💡 advice(이미 i18n)로 충분

## reason 사용처 영향 (grep 확인)
- `parse_reason_tag(reason)` → `split(":")[0]` tag만 사용 — 불변
- `get_advice(reason)` → `split(":")[0]` tag만 사용 — 불변
- `log_merge_attempt(reason=)` → `detail_message` = reason 전체. tag-only 로 축소 (관측 로그, 사용자 미노출)
- `merge_retry_service.py::merge_pr` 호출 (L169) → `parse_reason_tag` 경유 — 불변

## 테스트
- `test_i18n_gate_messages.py`: engine merge 9키 존재 + en 한국어 누출 회귀 가드 + `_notify_merge_failure`/`_notify_merge_deferred` en 렌더 회귀 가드 ✅
- gate 회귀 없음 (248 passed: `tests/unit/gate/` + `test_merge_retry_service.py` + `test_merge_metrics.py` + `test_merge_attempt.py` + `test_merge_failure_issue.py`)
- pylint 10.00 (engine.py + github_review.py)
- 기존 테스트 영향: `test_notify_merge_failure_includes_advice_in_telegram` (default ko, 통과) / `test_github_review.py` dirty 테스트 (`dirty_conflict` 에 "dirty" 포함, 통과)

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인
- [ ] EN/JA 사용자 auto-merge 실패/대기 시 Telegram 알림이 해당 언어로 표시되는지 운영 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증은 컨트롤러가 별도 진행 (본 작업 보고 시 mutual 검증 대기 명시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)