### PR TITLE
fix(i18n): notification_language validator + seam 테스트 (사이클 152 Sprint 3)

### DIFF
--- a/src/api/repos.py
+++ b/src/api/repos.py
@@ -1,7 +1,8 @@
 """Repository and config REST API endpoints (/api/repos/*)."""
 from typing import Annotated, Literal
 from fastapi import APIRouter, Query, Request
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+from src.config import settings
 from src.middleware.rate_limiter import limiter, RATE_LIMIT_API, RATE_LIMIT_HEAVY
 from src.api.auth import require_api_key
 from src.api.deps import get_repo_or_404
@@ -49,6 +50,29 @@ class RepoConfigUpdate(BaseModel):
     # Per-repo disabled analyzer names — JSON array, defaults to empty list (Alembic 0035)
     disabled_tools: list = Field(default_factory=list)
     # leaderboard_opt_in 폐기 (그룹 60 사용자 결정 정정 — alembic 0025)
+
+    @field_validator("notification_language")
+    @classmethod
+    def validate_notification_language(cls, v):
+        """notification_language SUPPORTED_LOCALES 검증 (None/빈값 허용 — preferred_language fallback).
+
+        Validate notification_language against SUPPORTED_LOCALES.
+        None/empty is allowed (intended fallback to user preferred_language).
+        """
+        if v is None or v == "":
+            # None/빈값 = fallback 의도, 허용 (조용한 영문 fallback 아님 — 정상 설계)
+            # None/empty = intended fallback, allowed
+            return None
+        v = v.strip().lower()
+        if v == "":
+            return None
+        supported = {lang.strip() for lang in settings.supported_locales.split(",")}
+        if v not in supported:
+            raise ValueError(
+                f"notification_language '{v}' not in SUPPORTED_LOCALES "
+                f"({settings.supported_locales})"
+            )
+        return v
 
     @model_validator(mode="after")
     def validate_thresholds(self) -> "RepoConfigUpdate":

--- a/tests/unit/api/test_repos.py
+++ b/tests/unit/api/test_repos.py
@@ -429,3 +429,61 @@ def test_config_update_with_commit_comment_and_create_issue():
     called_data = mock_upsert.call_args[0][1]
     assert called_data.commit_comment is True
     assert called_data.create_issue is True
+
+
+# --- notification_language validator (사이클 152 Sprint 3 P1-2) ---
+# 미지원 값(예: "de")은 422 차단 → 조용한 영문 fallback 방지.
+# None/빈값은 valid (사용자 preferred_language fallback 의도).
+# Unsupported value (e.g. "de") rejected with 422 → prevents silent English fallback.
+# None/empty is valid (intended fallback to user preferred_language).
+
+
+def test_repo_config_rejects_invalid_notification_language():
+    """미지원 notification_language("de") 입력 시 ValidationError 발생."""
+    from src.api.repos import RepoConfigUpdate  # pylint: disable=import-outside-toplevel
+    import pytest  # pylint: disable=import-outside-toplevel
+    with pytest.raises(Exception):  # noqa: B017  # pydantic ValidationError
+        RepoConfigUpdate(
+            approve_threshold=80, reject_threshold=40,
+            notification_language="de",
+        )
+
+
+def test_repo_config_allows_none_notification_language():
+    """notification_language=None 은 fallback 의도 — 허용."""
+    from src.api.repos import RepoConfigUpdate  # pylint: disable=import-outside-toplevel
+    cfg = RepoConfigUpdate(
+        approve_threshold=80, reject_threshold=40,
+        notification_language=None,
+    )
+    assert cfg.notification_language is None
+
+
+def test_repo_config_allows_empty_notification_language():
+    """notification_language="" 은 fallback 의도로 정규화 → None 반환."""
+    from src.api.repos import RepoConfigUpdate  # pylint: disable=import-outside-toplevel
+    cfg = RepoConfigUpdate(
+        approve_threshold=80, reject_threshold=40,
+        notification_language="",
+    )
+    assert cfg.notification_language is None
+
+
+def test_repo_config_allows_supported_notification_language():
+    """지원 locale("ja") 은 정규화 후 그대로 통과."""
+    from src.api.repos import RepoConfigUpdate  # pylint: disable=import-outside-toplevel
+    cfg = RepoConfigUpdate(
+        approve_threshold=80, reject_threshold=40,
+        notification_language="ja",
+    )
+    assert cfg.notification_language == "ja"
+
+
+def test_repo_config_normalizes_notification_language_case():
+    """대문자/공백 입력 시 lower+strip 정규화."""
+    from src.api.repos import RepoConfigUpdate  # pylint: disable=import-outside-toplevel
+    cfg = RepoConfigUpdate(
+        approve_threshold=80, reject_threshold=40,
+        notification_language="  JA  ",
+    )
+    assert cfg.notification_language == "ja"

--- a/tests/unit/test_gate_i18n_seam.py
+++ b/tests/unit/test_gate_i18n_seam.py
@@ -1,0 +1,174 @@
+"""Gate/알림 오케스트레이션 seam 테스트 — resolve_notification_language → 메시지 언어 배선 검증 (사이클 152 P1-3).
+
+Gate/notification orchestration seam tests — verify resolve_notification_language
+result is correctly threaded into actual message language (approve.py / merge_retry / engine).
+
+PR-5C 트랩 동형 사각 해소: 코드는 정상이나 "언어 배선" 회귀 가드 테스트가 부재했던 영역.
+Closes the PR-5C-style blind spot: code is correct but lacked a regression guard
+asserting the resolved language actually flows into generated message text.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: E402
+
+import pytest  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_approve_auto_threads_japanese_language_to_review():
+    """approve.py _run_auto 가 resolve된 'ja' 언어로 일본어 post_github_review body 생성."""
+    from src.gate.actions.approve import ApproveAction  # pylint: disable=import-outside-toplevel
+
+    ctx = MagicMock()
+    ctx.score = 90
+    ctx.config.approve_mode = "auto"
+    ctx.config.approve_threshold = 75
+    ctx.config.reject_threshold = 40
+    ctx.repo_name = "owner/repo"
+    ctx.pr_number = 7
+    ctx.analysis_id = 1
+    ctx.github_token = "ghp_x"
+
+    # resolve_notification_language → "ja" patch → body 가 일본어여야 함
+    with patch(
+        "src.gate.actions.approve.resolve_notification_language", return_value="ja"
+    ), patch(
+        "src.gate.actions.approve.post_github_review", new_callable=AsyncMock
+    ) as mock_review, patch(
+        "src.gate.actions.approve.SessionLocal"
+    ), patch(
+        "src.gate.actions.approve.gate_decision_repo"
+    ):
+        await ApproveAction()._run_auto(ctx)  # pylint: disable=protected-access
+
+    assert mock_review.await_count == 1
+    # post_github_review(github_token, repo, pr_number, decision, body) — body = 마지막 positional
+    body = mock_review.await_args.args[-1]
+    assert "自動承認" in body or "承認" in body, f"일본어 body 아님: {body!r}"
+
+
+@pytest.mark.asyncio
+async def test_approve_auto_threads_english_language_to_review():
+    """approve.py _run_auto 가 resolve된 'en' 언어로 영어 body 생성 (한국어 부재)."""
+    from src.gate.actions.approve import ApproveAction  # pylint: disable=import-outside-toplevel
+
+    ctx = MagicMock()
+    ctx.score = 90
+    ctx.config.approve_mode = "auto"
+    ctx.config.approve_threshold = 75
+    ctx.config.reject_threshold = 40
+    ctx.repo_name = "owner/repo"
+    ctx.pr_number = 7
+    ctx.analysis_id = 1
+    ctx.github_token = "ghp_x"
+
+    with patch(
+        "src.gate.actions.approve.resolve_notification_language", return_value="en"
+    ), patch(
+        "src.gate.actions.approve.post_github_review", new_callable=AsyncMock
+    ) as mock_review, patch(
+        "src.gate.actions.approve.SessionLocal"
+    ), patch(
+        "src.gate.actions.approve.gate_decision_repo"
+    ):
+        await ApproveAction()._run_auto(ctx)  # pylint: disable=protected-access
+
+    assert mock_review.await_count == 1
+    body = mock_review.await_args.args[-1]
+    assert "Auto-approved" in body
+    # 영어 선택 시 한국어 텍스트가 새지 않아야 함
+    assert "자동 승인" not in body, f"영어 body 에 한국어 누출: {body!r}"
+
+
+@pytest.mark.asyncio
+async def test_approve_auto_reject_threads_language_to_review():
+    """낮은 점수 → reject 분기도 resolve된 언어('ja')로 body 생성."""
+    from src.gate.actions.approve import ApproveAction  # pylint: disable=import-outside-toplevel
+
+    ctx = MagicMock()
+    ctx.score = 10
+    ctx.config.approve_mode = "auto"
+    ctx.config.approve_threshold = 75
+    ctx.config.reject_threshold = 40
+    ctx.repo_name = "owner/repo"
+    ctx.pr_number = 7
+    ctx.analysis_id = 1
+    ctx.github_token = "ghp_x"
+
+    with patch(
+        "src.gate.actions.approve.resolve_notification_language", return_value="ja"
+    ), patch(
+        "src.gate.actions.approve.post_github_review", new_callable=AsyncMock
+    ) as mock_review, patch(
+        "src.gate.actions.approve.SessionLocal"
+    ), patch(
+        "src.gate.actions.approve.gate_decision_repo"
+    ):
+        await ApproveAction()._run_auto(ctx)  # pylint: disable=protected-access
+
+    assert mock_review.await_count == 1
+    body = mock_review.await_args.args[-1]
+    assert "自動却下" in body or "却下" in body, f"일본어 reject body 아님: {body!r}"
+
+
+@pytest.mark.asyncio
+async def test_merge_retry_terminal_threads_language_to_telegram():
+    """merge_retry_service._notify_merge_terminal 가 language='ja'로 일본어 텍스트 생성."""
+    from src.services import merge_retry_service  # pylint: disable=import-outside-toplevel
+
+    row = MagicMock()
+    row.repo_full_name = "owner/repo"
+    row.pr_number = 7
+    row.score = 88
+    row.attempts_count = 3
+    cfg = MagicMock()
+
+    with patch(
+        "src.services.merge_retry_service._resolve_retry_chat_id", return_value="-100123"
+    ), patch(
+        "src.services.merge_retry_service.telegram_post_message", new_callable=AsyncMock
+    ) as mock_post, patch(
+        "src.services.merge_retry_service.get_advice", return_value="advice text"
+    ):
+        await merge_retry_service._notify_merge_terminal(  # pylint: disable=protected-access
+            row, cfg, "merge conflict", "conflict", language="ja",
+        )
+
+    assert mock_post.await_count == 1
+    # telegram_post_message(bot_token, chat_id, {"text": msg, ...}) — text = 3번째 positional dict
+    payload = mock_post.await_args.args[2]
+    text = payload["text"]
+    assert "自動マージ最終失敗" in text or "理由" in text, f"일본어 terminal 아님: {text!r}"
+    assert "자동 머지" not in text, f"일본어 선택인데 한국어 누출: {text!r}"
+
+
+@pytest.mark.asyncio
+async def test_engine_notify_merge_failure_threads_english_no_korean():
+    """engine._notify_merge_failure(language='en') 시 telegram text 에 한국어 부재."""
+    from src.gate import engine  # pylint: disable=import-outside-toplevel
+
+    with patch(
+        "src.gate.engine.telegram_post_message", new_callable=AsyncMock
+    ) as mock_post:
+        await engine._notify_merge_failure(  # pylint: disable=protected-access
+            repo_name="owner/repo",
+            pr_number=7,
+            score=50,
+            threshold=75,
+            reason="below threshold",
+            advice="raise score",
+            chat_id="-100123",
+            language="en",
+        )
+
+    assert mock_post.await_count == 1
+    payload = mock_post.await_args.args[2]
+    text = payload["text"]
+    assert "Auto Merge Failed" in text, f"영어 merge-failed 아님: {text!r}"
+    # 영어 선택 시 한국어 텍스트 (사유/머지 등) 가 새지 않아야 함
+    assert "사유" not in text and "자동 머지" not in text, \
+        f"영어 선택인데 한국어 누출: {text!r}"


### PR DESCRIPTION
## Summary
통합 회고 P1-2/P1-3 이행 — 방어/회귀 가드 보강 (사이클 152 Sprint 3, TDD).

## 변경 내용
- **P1-2**: `repos.py` `RepoConfigUpdate.notification_language` `field_validator` 추가
  - SUPPORTED_LOCALES 검증 (`users.py` 패턴 차용, 단 None/빈값 허용 — preferred_language fallback 의도)
  - 미지원 값(예: `"de"`) 입력 시 422 차단 → 조용한 영문 fallback 방지
  - `settings` import 추가 (기존 미import) + `field_validator` import 추가
- **P1-3**: 오케스트레이션 seam 테스트 (`tests/unit/test_gate_i18n_seam.py`, 신규)
  - `resolve_notification_language` → 메시지 언어 배선 검증 (PR-5C 트랩 동형 사각 해소)
  - approve.py auto-approve(ja) / english(en 누출 없음) / auto-reject(ja)
  - merge_retry_service `_notify_merge_terminal`(ja) Telegram text 배선
  - engine `_notify_merge_failure`(en, 한국어 누출 없음)

## 테스트
- validator 5건 (reject de / allow None / allow 빈값 / allow ja / 정규화) + seam 5건 ✅
- `tests/unit/test_gate_i18n_seam.py` + `tests/unit/api/test_repos.py` + `tests/unit/gate/` = 264 passed
- merge_retry 회귀 30 passed
- 회귀 없음 + pylint(src/) 10.00

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인
- [ ] 운영: 리포 설정 폼에서 미지원 언어 입력 시 422 응답 (브라우저 확인 — Claude 시각 검증 불가)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [ ] Codex 검증 — 컨트롤러 별도 진행 (본 PR push 후 검증 의뢰 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
