### PR TITLE
test(cycle157-#8): round_trip 마이그레이션 테스트 CI 활성화 (156 회고 인접 false-confidence)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,12 +150,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements-dev.txt
 
-      - name: Run PG SKIP LOCKED concurrency tests
+      - name: Run PG-only tests (SKIP LOCKED 동시성 + 마이그레이션 round-trip)
         # DATABASE_URL_TEST_POSTGRES 단일 env 가 필수 — DATABASE_URL 은 conftest.py 가 sqlite 로 덮어씀(무의미).
         # Only DATABASE_URL_TEST_POSTGRES matters — conftest.py overrides DATABASE_URL with sqlite.
-        # 명시 단일 파일 경로만 실행 — e2e/integration 혼입 방지 (testing.md 🔴 격리 규칙). --timeout=60 deadlock guard.
-        # Run only this one file — avoid e2e/integration mixing (testing.md isolation rule).
+        # 명시 파일 경로만 실행 — e2e/integration 혼입 방지 (testing.md 🔴 격리 규칙). --timeout=60 deadlock guard.
+        # 순서: 동시성 테스트(drop_all cleanup) → round-trip(clean DB 에서 alembic from base) (사이클 157 #8).
+        # Order: concurrency tests (drop_all cleanup) → round-trip (alembic from a clean base, Cycle 157 #8).
         env:
           DATABASE_URL_TEST_POSTGRES: "postgresql://scatest:scatest@localhost:5432/scatest"
         run: |
-          python -m pytest tests/integration/test_retry_concurrency_postgres.py -v -rs --timeout=60
+          python -m pytest \
+            tests/integration/test_retry_concurrency_postgres.py \
+            tests/unit/migrations/test_0020_round_trip.py::test_migration_alembic_round_trip \
+            -v -rs --timeout=60

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,7 +2,7 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-06-02 기준 — **사이클 156 Theme B 완료**: 안전망 회귀가드 봉인 — "존재하나 미실행" false-confidence 가드 활성화. S1 SSRF `_http.py` fail-closed(#735) + S2 4채널 SSRF 차단(#736) + S4 coverage-tail (checks.py legacy CI 매핑·security_scan 본체, #737) + S3 PG SKIP LOCKED 동시성 CI container (test_retry_concurrency_postgres CI 영구 skip→pass, barrier 결정성). mutation 전부 KILLED, src 무변경): 162+ PR #188~#738+ — 누적 정책 본문 18건 + 메모리 18건. 전체 4712 수집 (단위 4559 + 통합 153) / E2E 112 (100 표준 + 12 perf) / pylint **10.00/10**
+## 현재 수치 (2026-06-02 기준 — **사이클 156 Theme B 완료**: 안전망 회귀가드 봉인 — "존재하나 미실행" false-confidence 가드 활성화. S1 SSRF `_http.py` fail-closed(#735) + S2 4채널 SSRF 차단(#736) + S4 coverage-tail (checks.py legacy CI 매핑·security_scan 본체, #737) + S3 PG SKIP LOCKED 동시성 CI container (test_retry_concurrency_postgres CI 영구 skip→pass, barrier 결정성). mutation 전부 KILLED, src 무변경. **사이클 157 (156 회고 반영 — 메타 scope 완성)**: #8 round_trip 마이그레이션 테스트 CI 활성화 (Theme B 회고가 발견한 인접 동일 클래스 false-confidence — alembic upgrade/downgrade 왕복이 모든 CI서 영구 skip이던 것 → pg-concurrency job 추가)): 162+ PR #188~#739+ — 누적 정책 본문 18건 + 메모리 18건. 전체 4712 수집 (단위 4559 + 통합 153) / E2E 112 (100 표준 + 12 perf) / pylint **10.00/10**
 
 | 지표 | 값 | 비고 |
 |------|-----|------|

--- a/tests/unit/migrations/test_0020_round_trip.py
+++ b/tests/unit/migrations/test_0020_round_trip.py
@@ -93,13 +93,15 @@ def test_migration_alembic_round_trip():
     Note: Legacy migrations (e.g. 0009) use ALTER TABLE UNIQUE which SQLite does not support,
     so full history replay is not possible on SQLite. This test runs on PostgreSQL only.
     """
-    db_url = os.environ.get("DATABASE_URL", "sqlite:///:memory:")
-
-    # SQLite 환경(로컬 단위 테스트)에서는 건너뜀 — PostgreSQL CI/프로덕션에서만 실행
-    # Skip on SQLite (local unit tests) — run only on PostgreSQL CI/production.
-    if db_url.startswith("sqlite"):
+    # PG 전용 — DATABASE_URL_TEST_POSTGRES 설정 시에만 실행 (사이클 157 #8: CI 활성화).
+    # conftest.py 가 DATABASE_URL 을 sqlite 로 강제하므로 별도 PG 전용 env 를 읽는다
+    # (S3 의 test_retry_concurrency_postgres 와 동일 패턴 — pg-concurrency CI job 에서 실행).
+    # PG-only — runs only when DATABASE_URL_TEST_POSTGRES is set (Cycle 157 #8: CI activation).
+    # conftest forces DATABASE_URL to sqlite, so we read a dedicated PG env (same pattern as S3).
+    db_url = os.environ.get("DATABASE_URL_TEST_POSTGRES", "")
+    if not db_url:
         pytest.skip(
-            "Alembic full-history replay requires PostgreSQL "
+            "Alembic full-history replay requires PostgreSQL — set DATABASE_URL_TEST_POSTGRES "
             "(SQLite does not support ALTER TABLE UNIQUE constraint)"
         )
 

--- a/tests/unit/migrations/test_0020_round_trip.py
+++ b/tests/unit/migrations/test_0020_round_trip.py
@@ -105,28 +105,35 @@ def test_migration_alembic_round_trip():
             "(SQLite does not support ALTER TABLE UNIQUE constraint)"
         )
 
+    from unittest.mock import patch
+
     from alembic.config import Config
     from alembic import command as alembic_command
+    from src.config import settings as app_settings
 
     cfg = Config("alembic.ini")
     cfg.set_main_option("sqlalchemy.url", db_url)
 
-    # 0020mergeretryqueue 로 업그레이드
-    # Upgrade to 0020mergeretryqueue.
-    alembic_command.upgrade(cfg, "0020mergeretryqueue")
+    # 🔴 alembic/env.py:30 이 cfg URL 을 settings.database_url 로 덮어씀 (싱글톤, import 시 sqlite 고정).
+    # → cfg.set_main_option 만으로는 SQLiteImpl 로 실행돼 0009 의 ALTER constraint 에서 실패.
+    # settings 싱글톤 속성을 PG URL 로 patch (monkeypatch.setenv 무효 — testing.md 규칙). (사이클 157 #8 fix-up)
+    # env.py overrides cfg URL with settings.database_url (singleton fixed to sqlite at import),
+    # so patch the singleton attribute to the PG URL; patch.object restores it automatically.
+    with patch.object(app_settings, "database_url", db_url):
+        # 0020mergeretryqueue 로 업그레이드 / Upgrade to 0020mergeretryqueue.
+        alembic_command.upgrade(cfg, "0020mergeretryqueue")
 
-    eng = create_engine(db_url)
-    tables = inspect(eng).get_table_names()
-    eng.dispose()
-    assert "merge_retry_queue" in tables, "업그레이드 후 테이블이 존재해야 한다 / Table must exist after upgrade"
+        eng = create_engine(db_url)
+        tables = inspect(eng).get_table_names()
+        eng.dispose()
+        assert "merge_retry_queue" in tables, "업그레이드 후 테이블이 존재해야 한다 / Table must exist after upgrade"
 
-    # 0019leaderboardoptin 으로 다운그레이드
-    # Downgrade back to 0019leaderboardoptin.
-    alembic_command.downgrade(cfg, "0019leaderboardoptin")
+        # 0019leaderboardoptin 으로 다운그레이드 / Downgrade back to 0019leaderboardoptin.
+        alembic_command.downgrade(cfg, "0019leaderboardoptin")
 
-    eng2 = create_engine(db_url)
-    tables2 = inspect(eng2).get_table_names()
-    eng2.dispose()
-    assert "merge_retry_queue" not in tables2, (
-        "다운그레이드 후 테이블이 제거되어야 한다 / Table must be gone after downgrade"
-    )
+        eng2 = create_engine(db_url)
+        tables2 = inspect(eng2).get_table_names()
+        eng2.dispose()
+        assert "merge_retry_queue" not in tables2, (
+            "다운그레이드 후 테이블이 제거되어야 한다 / Table must be gone after downgrade"
+        )


### PR DESCRIPTION
## 🔍 사용자 검증 필요 (운영 — CI)
- [ ] **CI `pg-concurrency` job** 이 `4 passed` (기존 3 동시성 + round_trip 1) — alembic upgrade(0020)→downgrade(0019) 왕복이 실 PG에서 검증.

## 운영 smoke check (정책 13 — yaml 변경)
- src/마이그레이션 파일 무변경 → 앱 런타임 영향 0. CI 테스트 활성화만.

## 156 회고 반영 (#8) — 인접 false-confidence 봉인
사이클 156 회고가 발견: `test_migration_alembic_round_trip`이 `DATABASE_URL`=sqlite(conftest 강제) 조건으로 **모든 CI에서 영구 skip** → alembic 왕복 회귀 미검출. **Theme B(S3)와 동일 false-confidence 클래스** — "Theme B 완료" 메타 scope가 가렸던 인접 갭.

### 변경 (src/마이그레이션 무변경 — 테스트 skip 조건 + yaml)
- `test_0020_round_trip.py`: skip 조건 `DATABASE_URL` → **`DATABASE_URL_TEST_POSTGRES`** (S3 패턴, conftest override 회피)
- `ci.yml` pg-concurrency job: round_trip 추가. **순서 = 동시성(drop_all) → round_trip(clean DB alembic from base)** 격리

### 검증
- 로컬 1 skipped(정상). CI `pg-concurrency`에서 실측. 단위 +0(skip→pass-in-CI).
- ⚠️ Codex 샌드박스 지속 불능 → Claude 직접 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)