### PR TITLE
fix(cycle157-#9): WCAG tap-target E2E silent-skip → fail-fast (156 회고 P1)

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,7 +2,7 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-06-02 기준 — **사이클 156 Theme B 완료**: 안전망 회귀가드 봉인 — "존재하나 미실행" false-confidence 가드 활성화. S1 SSRF `_http.py` fail-closed(#735) + S2 4채널 SSRF 차단(#736) + S4 coverage-tail (checks.py legacy CI 매핑·security_scan 본체, #737) + S3 PG SKIP LOCKED 동시성 CI container (test_retry_concurrency_postgres CI 영구 skip→pass, barrier 결정성). mutation 전부 KILLED, src 무변경. **사이클 157 (156 회고 반영 — 메타 scope 완성)**: #8 round_trip 마이그레이션 테스트 CI 활성화 (Theme B 회고가 발견한 인접 동일 클래스 false-confidence — alembic upgrade/downgrade 왕복이 모든 CI서 영구 skip이던 것 → pg-concurrency job 추가)): 162+ PR #188~#739+ — 누적 정책 본문 18건 + 메모리 18건. 전체 4712 수집 (단위 4559 + 통합 153) / E2E 112 (100 표준 + 12 perf) / pylint **10.00/10**
+## 현재 수치 (2026-06-02 기준 — **사이클 156 Theme B 완료**: 안전망 회귀가드 봉인 — "존재하나 미실행" false-confidence 가드 활성화. S1 SSRF `_http.py` fail-closed(#735) + S2 4채널 SSRF 차단(#736) + S4 coverage-tail (checks.py legacy CI 매핑·security_scan 본체, #737) + S3 PG SKIP LOCKED 동시성 CI container (test_retry_concurrency_postgres CI 영구 skip→pass, barrier 결정성). mutation 전부 KILLED, src 무변경. **사이클 157 (156 회고 반영 — 메타 scope 완성)**: #8 round_trip 마이그레이션 테스트 CI 활성화 (Theme B 회고가 발견한 인접 false-confidence — alembic 왕복이 모든 CI서 영구 skip → pg-concurrency job 추가. 활성화가 또 다른 잠재 결함 노출: env.py 가 cfg URL 을 settings.database_url 로 덮어써 SQLite 실행 → 싱글톤 patch 수정) + #9 WCAG tap-target E2E silent-skip→fail-fast (셀렉터 미존재 시 회귀를 skip 흡수하던 것 — base.html `.nav-hamburger`·overview `.btn--sm` 은 항상 렌더, 미존재=회귀)): 162+ PR #188~#740+ — 누적 정책 본문 18건 + 메모리 18건. 전체 4712 수집 (단위 4559 + 통합 153) / E2E 112 (100 표준 + 12 perf) / pylint **10.00/10**
 
 | 지표 | 값 | 비고 |
 |------|-----|------|

--- a/e2e/test_theme_mobile_guards.py
+++ b/e2e/test_theme_mobile_guards.py
@@ -122,7 +122,10 @@ def _min_height_px(page, selector: str) -> float:
         f"}}"
     )
     if raw is None:
-        pytest.skip(f"셀렉터 '{selector}' 미존재 — 페이지 구조 변경 가능성")
+        # fail-fast — 셀렉터 미존재 = 페이지 구조 회귀 (silent skip 금지, 사이클 157 #9).
+        # docstring 의 fail-fast 의도 정합. 호출처(.btn--sm) 는 overview 에 정적 존재 보장(L178).
+        # Missing selector = structural regression — fail rather than silently skip.
+        pytest.fail(f"셀렉터 '{selector}' 미존재 — 페이지 구조 회귀 (fail-fast)")
     if not raw.endswith("px"):
         return 0.0
     return float(raw[:-2])
@@ -197,7 +200,10 @@ def test_mobile_nav_hamburger_44x44(page, base_url):
         "}"
     )
     if raw_height is None:
-        pytest.skip(".nav-hamburger 셀렉터 미존재 — 페이지 구조 변경 가능성")
+        # fail-fast — .nav-hamburger 는 e2e conftest 가 current_user 를 override(get_current_user)하므로
+        # 항상 렌더(base.html:635 `{% if current_user %}`). 미존재 = 진짜 회귀 (사이클 157 #9).
+        # The e2e conftest overrides get_current_user, so .nav-hamburger always renders; absence = regression.
+        pytest.fail(".nav-hamburger 셀렉터 미존재 — current_user 인증 시 항상 렌더 (fail-fast)")
     min_w_str, min_h_str = raw_height
     assert min_w_str.endswith("px") and min_h_str.endswith("px"), (
         f".nav-hamburger min-w/h px 단위 아님 — minWidth={min_w_str}, minHeight={min_h_str}"


### PR DESCRIPTION
## 🔍 사용자 검증 필요 (E2E — 메인 CI 미포함)
- [ ] **`make test-e2e`** 실행 시 `test_theme_mobile_guards.py` 의 WCAG tap-target 테스트가 green (셀렉터 정상 존재 → fail 트리거 안 됨). 이 변경은 메인 CI(`pytest tests/`)에 미포함이라 자동 검증 안 됨.

## 156 회고 반영 (#9) — silent-skip → fail-fast
WCAG 2.5.5 tap-target 가드가 셀렉터 미존재 시 `pytest.skip` → **구조 회귀(셀렉터 사라짐)를 fail 아닌 skip으로 흡수**. docstring은 fail-fast 의도인데 본문은 skip(모순).

### 수정 (2곳, E2E 테스트만 — src/template 무변경)
- `_min_height_px`(L128): `skip` → `fail`. `.btn--sm`은 overview 정적 존재 보장(주석 L178)
- nav-hamburger(L206): `skip` → `fail`. **e2e conftest가 `get_current_user` override → `current_user` 항상 truthy → `base.html:635 {% if current_user %}` .nav-hamburger 항상 렌더** → 미존재=회귀

### 셀렉터 항상 존재 근거 (fail 오탐 아님)
- `.nav-hamburger`: base.html:636, `{% if current_user %}` 조건 + e2e conftest:133 `get_current_user` override
- `.btn--sm`: overview 정적 존재 (기존 주석 명시)

### 정책 11 (UI)
template/css **무변경** → 4-테마 8조합 시각 검증 대상 아님 (E2E 테스트 로직 skip→fail 변경).

⚠️ Codex 샌드박스 지속 불능 → Claude 직접 검증 (py_compile OK, 셀렉터 렌더 조건 실측).

🤖 Generated with [Claude Code](https://claude.com/claude-code)