### PR TITLE
chore: .gitignore 에 .playwright-mcp/ 추가 (stale 잡파일 정리)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,10 @@ Thumbs.db
 # Claude Code 런타임 상태 파일
 .claude/scheduled_tasks.lock
 
+# Playwright MCP 세션 산출물 (로컬 디버깅용 — console 로그·page 스냅샷)
+# Playwright MCP session artifacts (local debugging — console logs, page snapshots)
+.playwright-mcp/
+
 # superpowers plan/spec working dir (완료된 plan은 docs/_archive/ 로 수동 이동)
 docs/superpowers/
 


### PR DESCRIPTION
## Summary
사이클 158 회고 백로그 — **stale 잡파일 정리** (사용자 승인).

Playwright MCP 세션 산출물 디렉토리(`.playwright-mcp/`)가 repo 루트에 untracked 로 누적되던 것을 gitignore 에 추가.

## 변경
- `.gitignore` +4 — `.playwright-mcp/` 패턴 (`git check-ignore` 동작 확인)

## working tree 정리 (untracked — 커밋 대상 아님)
- `.playwright-mcp/` 로그·page 스냅샷 (2026-05-25, 사이클 135) 삭제
- `before/after-mobile-grid.png` (사이클 135 모바일 그리드 비교) 삭제
- `C:tmppr673~677.txt`·`f:tmprailway_diff.txt` (사이클 142 redirect 사고로 생성된 garbled-name 파일) 삭제

## 🔍 Codex 검증 (push 전, 정책 18)
Codex 미로그인으로 게이트 down (사용자 `!codex login` 대기). trivial gitignore 1블록 — Claude 직접 검증(`git check-ignore -v` 매칭 확인). 무거운 백로그 P2 작업은 로그인 복구 후 mutual 검증.

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인 (변경 없는 gitignore — 영향 없음 예상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)