### PR TITLE
chore(cycle159-C): CI 결정성 — postgres minor 핀 + round_trip clean-base self-isolating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,11 @@ jobs:
     needs: secret-scan
     services:
       postgres:
-        image: postgres:16
+        # minor 핀 — `postgres:16` 은 패치 릴리스마다 silently 변경됨. 이 job 은 FOR UPDATE
+        # SKIP LOCKED + alembic ALTER constraint 등 PG 버전 민감 동작을 검증하므로 재현성을
+        # 위해 minor 고정 (사이클 159 — 158 회고 P2). 주기적으로 최신 16.x 로 bump 권장.
+        # Minor pin for reproducibility — `postgres:16` drifts on each patch release.
+        image: postgres:16.4
         env:
           POSTGRES_USER: scatest
           POSTGRES_PASSWORD: scatest
@@ -154,8 +158,12 @@ jobs:
         # DATABASE_URL_TEST_POSTGRES 단일 env 가 필수 — DATABASE_URL 은 conftest.py 가 sqlite 로 덮어씀(무의미).
         # Only DATABASE_URL_TEST_POSTGRES matters — conftest.py overrides DATABASE_URL with sqlite.
         # 명시 파일 경로만 실행 — e2e/integration 혼입 방지 (testing.md 🔴 격리 규칙). --timeout=60 deadlock guard.
-        # 순서: 동시성 테스트(drop_all cleanup) → round-trip(clean DB 에서 alembic from base) (사이클 157 #8).
-        # Order: concurrency tests (drop_all cleanup) → round-trip (alembic from a clean base, Cycle 157 #8).
+        # 순서: 동시성 테스트(drop_all cleanup) → round-trip (사이클 157 #8). round-trip 은 사이클 159 부터
+        #   DROP/CREATE SCHEMA 로 self-isolating — 순서·선행 cleanup 에 의존하지 않는다 (158 회고 P2).
+        # 🔴 round_trip 파일에 PG 전용 테스트를 추가하면 아래 ::node-id 핀에 함께 등재해야 자동 수집됨
+        #    (node-id 고정이라 신규 테스트는 자동 미수집 — 사이클 159 cross-verify 신규).
+        # Order: concurrency → round-trip (self-isolating since Cycle 159). Add new PG-only tests in
+        #   test_0020_round_trip.py to the ::node-id pin below, else they won't be collected.
         env:
           DATABASE_URL_TEST_POSTGRES: "postgresql://scatest:scatest@localhost:5432/scatest"
         run: |

--- a/tests/unit/migrations/test_0020_round_trip.py
+++ b/tests/unit/migrations/test_0020_round_trip.py
@@ -14,7 +14,7 @@ os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
 os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
 
 import pytest
-from sqlalchemy import create_engine, inspect
+from sqlalchemy import create_engine, inspect, text
 
 from src.database import Base
 import src.models.merge_retry  # ensure model is registered on Base.metadata
@@ -120,6 +120,18 @@ def test_migration_alembic_round_trip():
     # env.py overrides cfg URL with settings.database_url (singleton fixed to sqlite at import),
     # so patch the singleton attribute to the PG URL; patch.object restores it automatically.
     with patch.object(app_settings, "database_url", db_url):
+        # 🔴 clean-base 보장 (사이클 159 — 158 회고 P2): 동일 pg-concurrency job 의 선행 테스트가
+        # Base.metadata.create_all 로 만든 잔여 테이블이 비정상 종료(barrier timeout 등)로 남으면
+        # from-base upgrade 가 DuplicateTable 로 spurious-fail — 격리를 CI 실행 순서에만 의존하지
+        # 않도록 스키마를 명시적으로 리셋해 round-trip 을 self-isolating 으로 만든다.
+        # Reset schema to guarantee a clean base — prior tests in the same PG job may leave residual
+        # tables on abnormal exit, which would make the from-base upgrade fail with DuplicateTable.
+        reset_eng = create_engine(db_url)
+        with reset_eng.begin() as conn:
+            conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+            conn.execute(text("CREATE SCHEMA public"))
+        reset_eng.dispose()
+
         # 0020mergeretryqueue 로 업그레이드 / Upgrade to 0020mergeretryqueue.
         alembic_command.upgrade(cfg, "0020mergeretryqueue")
 


### PR DESCRIPTION
## Summary
사이클 158 회고 백로그 P2 — **PR-C (CI 결정성)**. src 무변경, 테스트 카운트 무변경(4713).

## 변경
### ⑨ `postgres:16` → `postgres:16.4` (minor 핀) — 회고 P2
`.github/workflows/ci.yml`
- pg-concurrency job 은 `FOR UPDATE SKIP LOCKED` + alembic ALTER constraint 등 **PG 버전 민감 동작**을 검증 → 패치 릴리스 silent drift 제거(재현성). 주기적 16.x bump 권장 주석 동반.

### ⑥ round_trip clean-base 가드 — 회고 P2
`tests/unit/migrations/test_0020_round_trip.py`
- round_trip upgrade 전 `DROP/CREATE SCHEMA public` 으로 스키마 리셋 → 동일 pg-concurrency job 의 선행 테스트가 비정상 종료(barrier timeout 등)로 남긴 잔여 테이블이 from-base upgrade 를 `DuplicateTable` 로 spurious-fail 시키던 격리 취약점 해소. **round-trip 이 실행 순서에 의존하지 않는 self-isolating**.

### 신규 (cross-verify) — node-id 핀 가드 주석
`.github/workflows/ci.yml` round_trip step — 신규 PG 테스트 추가 시 `::node-id` 등재 의무 명시(자동 미수집 방지).

## 검증
- `test_0020_round_trip.py` 로컬 **2 passed + 1 skipped**(round_trip PG 부재 skip 정상)
- `ci.yml` **YAML valid** (image=postgres:16.4, 3 jobs 정상)
- ⑥ clean-base DROP/CREATE SCHEMA 는 **pg-concurrency CI job(required-check)에서 실측 검증**

## 🔍 Codex 검증
사용자 지시로 stop-time Codex 게이트 비활성화(`reviewGateEnabled:false`) — 정책 18 면제. Claude 직접 검증.

## 🔍 사용자 검증 필요
- [ ] **pg-concurrency job 통과 확인** (clean-base DROP SCHEMA + postgres:16.4 풀 — required-check)
- [ ] 잔여 백로그 PR-B(src DNS except OSError + scan_all_repos rollback) / PR-D(job name) 진행 여부

🤖 Generated with [Claude Code](https://claude.com/claude-code)