### PR TITLE
chore(cycle159-D): pg-concurrency job name 에 round-trip 반영

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,10 @@ jobs:
   # claim_batch 의 SKIP LOCKED 회귀를 CI 에서 실측 차단 (Theme B S3). test-and-analyze 와 병렬(needs: secret-scan).
   # SKIP LOCKED concurrency proof — needs a real Postgres (SQLite has no FOR UPDATE SKIP LOCKED).
   pg-concurrency:
-    name: PG SKIP LOCKED concurrency
+    # job name 은 step(SKIP LOCKED + round-trip)을 모두 반영 — 사이클 157 #8 에서 round-trip 추가됐으나
+    # 명칭이 미반영이라 GitHub checks UI 에서 round-trip 회귀 담당이 가려졌음 (사이클 159 — 158 회고 P2).
+    # main 은 branch protection 미적용 — required-check 명 변경 영향 없음(2026-06-03 실측 확인).
+    name: PG-only tests (SKIP LOCKED + migration round-trip)
     runs-on: ubuntu-latest
     needs: secret-scan
     services:


### PR DESCRIPTION
## Summary
사이클 158 회고 백로그 P2 **마지막 항목 (⑩)** — pg-concurrency job name 가독성/가시성. 테스트·src 무변경.

## 변경
`.github/workflows/ci.yml`
- job name: `PG SKIP LOCKED concurrency` → `PG-only tests (SKIP LOCKED + migration round-trip)`
- 사이클 157 #8 에서 round-trip 테스트가 step 에 추가됐으나 job name 미반영 → GitHub checks UI 에서 round-trip 회귀 담당이 가려졌음. step name 과 일치.

## 위험 해소 (정책 15/17#4 사전 확인)
- ⚠️ job name 변경은 branch protection required-check 명과 연결될 수 있어 사전 실측:
- `gh api repos/xzawed/SCAManager/branches/main/protection` → **404 'Branch not protected'** → **main 에 보호 규칙 없음** → required-check 명 변경 영향 **없음**.

## 검증
- `ci.yml` **YAML valid** (job name 반영 확인)
- IDE 진단의 pip-install S85xx 경고는 **기존 항목**(본 변경 L118-121 무관)

## 🔍 Codex 검증
사용자 지시로 stop-time Codex 게이트 비활성화 — 정책 18 면제. Claude 직접 검증.

## 🔍 사용자 검증 필요
- [ ] CI 통과 확인 (job name 변경 후 pg-concurrency 정상 실행)
- [ ] (참고) GitHub checks UI 에서 새 job name 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)