### PR TITLE
chore(reorg-phase3a): hook check_edit_allowed.py Procfile dead 정규식 제거

### DIFF
--- a/.claude/hooks/check_edit_allowed.py
+++ b/.claude/hooks/check_edit_allowed.py
@@ -8,7 +8,6 @@
 - alembic/versions/  : DB 마이그레이션 (pytest로 검증 불가, 데이터 손실 위험)
 - src/templates/     : HTML 템플릿 (렌더링 오류는 pytest 미감지)
 - railway.toml       : 프로덕션 배포 설정
-- Procfile           : 프로덕션 시작 명령
 - alembic.ini        : Alembic 설정
 
 [허용 조건]
@@ -46,7 +45,6 @@ PROTECTED_PATTERNS = [
     (r"alembic/versions/",  "DB 마이그레이션 파일 — 잘못된 수정은 데이터 손실로 이어집니다"),
     (r"src/templates/",     "HTML 템플릿 — 렌더링 오류와 변수명 오류는 pytest로 감지되지 않습니다"),
     (r"railway\.toml$",     "프로덕션 배포 설정 — 오류는 실제 배포 시점에만 드러납니다"),
-    (r"(^|/)Procfile$",     "프로덕션 시작 명령 — 오류는 실제 배포 시점에만 드러납니다"),
     (r"alembic\.ini$",      "Alembic 설정 — 경로 오류는 앱 시작 시에만 드러납니다"),
 ]
 


### PR DESCRIPTION
## Summary
문서 재구조화 **Phase 3a (저위험)** — Procfile 삭제 후 잔존한 hook 보호 정규식 제거. Phase 0(docs 3곳 Procfile 제거)와 hook 정합 완성 (divergence 회피).

## 변경
- `.claude/hooks/check_edit_allowed.py`: docstring + PROTECTED_PATTERNS 의 `Procfile` 제거. 잔존 4 패턴(alembic/versions·src/templates·railway.toml·alembic.ini) 보존.

## 검증
- py_compile ✓ / Procfile 잔존 0 / 4 패턴 무결 / smoke(정상 파일→exit 0) ✓

## 다음 (Phase 3 잔여)
- 3d CLAUDE.md 보수적 축소 / 3b .claude/skills 디렉토리 표준 / 3c 단일출처 이동(위험 평가 동반)

## 🔍 사용자 검증 필요
- [ ] CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)