### PR TITLE
docs(reorg-phase3d): CLAUDE.md 보수적 축소 — 정책 18 cross-ref 표 active.md 외부화

### DIFF
--- a/.claude/policies/active.md
+++ b/.claude/policies/active.md
@@ -389,6 +389,20 @@ git push -u origin <branch>
   2. Codex GitHub App + GitHub Actions workflow `codex-mutual-review.yml` (사이클 94+ 옵션, 사용자 confirm 후)
 - ⚠️ **`.codex/hooks.json` Windows hard-coded path** — `f:\DEVELOPMENT\...` 경로 → Codespaces (Linux) 환경에서 hook 0% 발화. mutual 자동화 검토 시 사전 인지 의무 (사이클 93 관점 5 발견).
 
+### 17 정책 cross-reference 표 (CLAUDE.md 정책 18 본문서 이관 — docs reorg Phase 3d)
+
+mutual 검증이 다른 정책과 맺는 충돌/페어 7건:
+
+| 정책 | mutual 페어 영역 |
+|------|----------------|
+| 3 (자율 판단) | 자율 판단 = mutual OK 받은 영역으로 한정 |
+| 5 (사이클 종료) | 종료 신호 = 두 LLM 동의 의무 구성요소 (3 조건 AND) |
+| 7 (PR 단위) | mutual = **push 전** Codex 검증 OK 후 push (사이클 94 정정) — push 후 의뢰 안티패턴 |
+| 8 (회고 5+1) | 5+1 (Claude 내부) ↔ mutual (외부 LLM) 2-layer 격리 — cross-verify 6차 생략 시도 mutual 별도 의무 |
+| 10 (PR 직접 생성) | Codex/Claude 생성 PR = **push 전 상호 검증 OK 후 push** (사이클 94 정정 — Codex NG #2 학습) — push 후 의뢰 안티패턴 |
+| 12 (MCP scope) | MCP destructive = 사용자 사전 승인 우선 (mutual 면제 — 사용자 직접 결정 영역) |
+| 16 (단순화 5번 토큰 효율) | mutual = 사용자 명시 의무 (단순화 5번 default 위반 면제) |
+
 ### NG 회기 ≤ 3회 default 가드
 
 | 회기 | default 동작 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,17 +297,7 @@ Why + How to apply (자가 검토 4 자문) 상세: [.claude/policies/active.md#
 4. **사이클 종료 = 3 조건 AND 의무** (정책 5 강화 페어) — (a) 사용자 신호 + (b) Claude OK + (c) Codex OK. 1 조건 부재 시 종료 보류.
 5. **5+1 cross-verify ↔ mutual = 2-layer 격리 의무** — 정책 8 5+1 = Claude 내부 self-verify (관점 다양성) / mutual = 외부 LLM (모델 다양성). "Codex OK 받았으니 5+1 6차 생략 OK" 오해 차단 — 양 layer 독립 의무 보존.
 
-**🔴 17 정책 cross-reference 표** (충돌/페어 7건 본문 명시):
-
-| 정책 | mutual 페어 영역 |
-|------|----------------|
-| 3 (자율 판단) | 자율 판단 = mutual OK 받은 영역으로 한정 |
-| 5 (사이클 종료) | 종료 신호 = 두 LLM 동의 의무 구성요소 (3 조건 AND) |
-| 7 (PR 단위) | mutual = **push 전** Codex 검증 OK 후 push (사이클 94 정정) — push 후 의뢰 안티패턴 |
-| 8 (회고 5+1) | 5+1 (Claude 내부) ↔ mutual (외부 LLM) 2-layer 격리 — cross-verify 6차 생략 시도 mutual 별도 의무 |
-| 10 (PR 직접 생성) | Codex/Claude 생성 PR = **push 전 상호 검증 OK 후 push** (사이클 94 정정 — Codex NG #2 학습) — push 후 의뢰 안티패턴 |
-| 12 (MCP scope) | MCP destructive = 사용자 사전 승인 우선 (mutual 면제 — 사용자 직접 결정 영역) |
-| 16 (단순화 5번 토큰 효율) | mutual = 사용자 명시 의무 (단순화 5번 default 위반 면제) |
+**🔴 17 정책 cross-reference 표** (충돌/페어 7건 — 정책 3/5/7/8/10/12/16): 상세 표는 [.claude/policies/active.md#정책-18](.claude/policies/active.md#정책-18) §"17 정책 cross-reference 표" 참조.
 
 **예외 영역 4종** (mutual 검증 면제):
 - 사용자가 "mutual 생략 OK" 명시 발화 시


### PR DESCRIPTION
## Summary
문서 재구조화 **Phase 3d — CLAUDE.md 보수적 축소**. 사용자 결정 '3d만 진행'. Anthropic "짧게" 표준 + 정책 16/17 안정성 우선 — **default rule 본문 보존, detail만 외부화**.

## 변경
- `CLAUDE.md`: 정책 18 "17 정책 cross-reference 표"(7행 detail) → 1줄 포인터로 교체. **421→411줄 (-10)**. default 의무 5영역 + 예외 4종 본문 보존(행동 rule 무손실).
- `.claude/policies/active.md` §정책 18: cross-ref 표 7행 이관(중복 없음).

## 정직한 보고 (정책 3)
CLAUDE.md 는 이미 사이클 95/102 에서 active.md(33참조)·history.md(15참조)로 대량 외부화 완료 → **추가 안전 축소 여지 제한적**. 본 3d 는 가장 명확한 안전 detail-table 1건만 외부화한 의도적 보수 trim. 3b(.claude/skills 디렉토리)·3c(architecture/STATE 이동)는 정책 17#1(안정성>규격 — 특히 3c 표준 근거 없음·순수 위험) 대로 **보류**.

## 🔍 사용자 검증 필요
- [ ] CI 통과 + CLAUDE.md 정책 18 rule 보존 + active.md 표 렌더 확인
- [ ] 문서 재구조화 전체(Phase 0~3) 완료 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)
