### PR TITLE
fix(p0): doc_review_gate 하드코딩 경로 회귀 복구 — 문서 거버넌스 게이트 silent bypass 차단

### DIFF
--- a/.claude/hooks/doc_review_gate.py
+++ b/.claude/hooks/doc_review_gate.py
@@ -12,10 +12,6 @@ from pathlib import Path
 # ─── 파일 등급 분류 ──────────────────────────────────────────────────────────
 # File grade classification
 
-_PROJECT_PREFIXES = (
-    "d:/source/scamanager/",
-)
-
 _CRITICAL = [
     r"^CLAUDE\.md$",
     r"^docs/STATE\.md$",
@@ -38,15 +34,20 @@ _LOW_RISK = [
 ]
 
 
+def _project_root() -> str:
+    """프로젝트 루트를 런타임 결정 — 훅은 `.claude/hooks/` 에 위치 (WBS P0 회귀 복구, 사이클 160).
+    하드코딩 절대경로(commit 7d20dc6 회귀 — `d:/source/scamanager/`) 제거: 드라이브/대소문자/구분자 무관.
+    Resolve project root at runtime (hook lives in .claude/hooks/); no hardcoded path."""
+    return str(Path(__file__).resolve().parents[2]).replace("\\", "/").rstrip("/").lower() + "/"
+
+
 def _normalise(path: str) -> str:
-    """경로를 슬래시로 정규화하고 프로젝트 루트 접두사를 제거한다.
-    Normalise path to forward-slashes and strip project root prefix."""
+    """경로를 슬래시 정규화 + 런타임 프로젝트 루트 접두사 제거 (절대/상대 모두 처리).
+    Normalise to forward-slashes and strip the runtime-resolved project root prefix."""
     p = path.replace("\\", "/")
-    lower = p.lower()
-    for prefix in _PROJECT_PREFIXES:
-        if lower.startswith(prefix.lower()):
-            p = p[len(prefix):]
-            break
+    root = _project_root()
+    if p.lower().startswith(root):
+        return p[len(root):]
     return p
 
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python -c \"import sys,json; d=json.load(sys.stdin); f=d.get('tool_input',{}).get('file_path',''); exit(0 if 'SCAManager/src/' in f else 1)\" && cd \"d:/Source/SCAManager\" && python -m pytest tests/ -x -q 2>&1 | tail -8 || true",
+            "command": "python -c \"import sys,json; d=json.load(sys.stdin); f=d.get('tool_input',{}).get('file_path','').replace(chr(92),'/'); exit(0 if 'SCAManager/src/' in f else 1)\" && python -m pytest tests/ -x -q 2>&1 | tail -8 || true",
             "timeout": 60
           }
         ]

--- a/tests/unit/hooks/test_doc_review_gate.py
+++ b/tests/unit/hooks/test_doc_review_gate.py
@@ -49,17 +49,23 @@ class TestClassifyFileGrade:
     def test_python_source_is_skip(self):
         assert classify_file_grade("src/main.py") == "skip"
 
-    def test_absolute_windows_path_normalized(self):
-        grade = classify_file_grade(
-            "d:/Source/SCAManager/CLAUDE.md"
-        )
-        assert grade == "critical"
+    def test_absolute_path_from_runtime_root_is_critical(self):
+        # 런타임 프로젝트 루트 기반 절대경로 — 하드코딩 경로 회귀 차단 (WBS P0, 사이클 160).
+        # 기존 'd:/Source/SCAManager' 하드코딩 테스트는 버그 prefix 와 동일해 결함을 은폐했음.
+        # Absolute path from the real repo root must classify regardless of drive/case/separator.
+        root = Path(__file__).resolve().parents[3]  # repo root (test: tests/unit/hooks/)
+        assert classify_file_grade(str(root / "CLAUDE.md")) == "critical"
 
-    def test_backslash_path_normalized(self):
-        grade = classify_file_grade(
-            "d:\\Source\\SCAManager\\.claude\\agents\\test-writer.md"
-        )
-        assert grade == "critical"
+    def test_absolute_path_uppercase_drive_backslash_is_critical(self):
+        # 대문자 드라이브 + 백슬래시 변형도 critical (Windows 경로 회귀 가드).
+        root = Path(__file__).resolve().parents[3]
+        p = str(root / ".claude" / "agents" / "test-writer.md").replace("/", "\\")
+        assert classify_file_grade(p) == "critical"
+
+    def test_stale_hardcoded_prefix_not_relied_on(self):
+        # 과거 버그 prefix(d:/source/scamanager/)에 더 이상 의존하지 않음 — 실 루트와 다른
+        # 임의 절대경로는 strip 되지 않아 'skip' 이 정상 (상대경로만 분류).
+        assert classify_file_grade("d:/source/scamanager/CLAUDE.md") == "skip"
 
 
 class TestApplyVetoMatrix:


### PR DESCRIPTION
## Summary
WBS 코드베이스 감사 **유일 P0** 수정 — 문서 거버넌스 게이트 복구. 보고서: docs/_archive/reports/2026-06-03-wbs-codebase-audit.md (#753).

## 문제 (확정 재현)
활성 PreToolUse 훅 `doc_review_gate.py` 의 하드코딩 prefix `d:/source/scamanager/` 가 실 루트 `F:/DEVELOPMENT/SOURCE/CLAUDE/SCAManager` 와 미스매치 → `_normalise` strip 실패 → anchored 정규식 전부 불일치 → CLAUDE.md/STATE.md/agents/skills 변경 시 3-에이전트 심의 **100% 무음 스킵**. 회귀 출처 commit `7d20dc6` + 기존 회귀 가드 테스트가 버그 prefix 와 동일 값을 써서 결함 은폐.

## 수정 3종
- `doc_review_gate.py`: 하드코딩 prefix → `_project_root()` 런타임 결정 (`parents[2]`). 드라이브/대소문자/구분자 무관.
- `settings.json:26`: 망가진 `cd "d:/Source/SCAManager"` 제거(훅 cwd=프로젝트 루트) + 백슬래시 정규화.
- `test_doc_review_gate.py`: 은폐 테스트 2건 → **환경독립 회귀 가드 3건** 교체.

## 검증
- py_compile ✓ / settings.json valid JSON ✓
- **P0 재현**: 실 경로 `F:/.../CLAUDE.md`·STATE.md·settings.json·agents 모두 `critical` 복구 (수정 전 `skip`)
- 테스트 **33 passed** (+1)

## 🔍 사용자 검증 필요
- [ ] CI 통과
- [ ] 머지 후 실 환경에서 CLAUDE.md edit 시 문서 심의 훅 작동 manual 확인 (게이트 복구 확인)
- [ ] STATE/README 카운트(4717)는 cycle 160 remediation wrap-up 일괄 동기화 (정책 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
