### PR TITLE
fix(p1): AsyncAnthropic httpx 풀 누수 차단 — 3 사이트 aclose 헬퍼

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -21,7 +21,7 @@ from src.analyzer.pure.review_prompt import build_review_prompt, get_system_prom
 from src.config import settings
 from src.constants import AI_DEFAULT_COMMIT_RAW, AI_DEFAULT_DIRECTION_RAW, AI_RAW_COMMIT_MAX, AI_RAW_DIRECTION_MAX
 from src.shared.anthropic_caching import build_cached_system_param
-from src.shared.claude_metrics import extract_anthropic_usage, log_claude_api_call
+from src.shared.claude_metrics import aclose_anthropic_client, extract_anthropic_usage, log_claude_api_call
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +142,10 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
         )
         logger.exception("AI review failed, using default scores")
         return _default_result("api_error")
+    finally:
+        # 호출당 생성한 AsyncAnthropic httpx 커넥션 풀 해제 — 미종료 시 FD 누수 (WBS P1).
+        # Close the per-call AsyncAnthropic httpx pool — leaks FDs/connections if left open.
+        await aclose_anthropic_client(client)
 
 
 def _extract_test_score(data: dict) -> int:

--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -37,7 +37,7 @@ from src.models.merge_attempt import MergeAttempt
 from src.models.repository import Repository
 from src.scorer.calculator import calculate_grade
 from src.shared.anthropic_caching import build_cached_system_param
-from src.shared.claude_metrics import extract_anthropic_usage, log_claude_api_call
+from src.shared.claude_metrics import aclose_anthropic_client, extract_anthropic_usage, log_claude_api_call
 from src.repositories import insight_narrative_cache_repo
 from src.shared.lang_names import LANG_NAMES
 
@@ -905,6 +905,9 @@ async def insight_narrative(  # pylint: disable=too-many-locals
     # Phase 2 d-🅓 (사이클 74) — Insight 영역 한정 Haiku (67% 비용 절감, AI 리뷰 Sonnet 보존)
     # Phase 2 d-🅓 (Cycle 74) — Insight-only Haiku (67% cheaper, AI review keeps Sonnet)
     text = await _call_insight_claude_api(client, settings.claude_insight_model, user_prompt)
+    # 헬퍼 호출 직후 AsyncAnthropic httpx 커넥션 풀 해제 (이후 client 미사용) — FD 누수 차단 (WBS P1).
+    # Close the AsyncAnthropic pool right after the helper call (client is unused afterward).
+    await aclose_anthropic_client(client)
     if text is None:
         return _handle_insight_error(
             db, user_id=user_id, days=days, language=language, error_type="api_error", now=_now,

--- a/src/services/repo_insight_service.py
+++ b/src/services/repo_insight_service.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Session
 from src.config import settings
 from src.models.analysis import Analysis
 from src.scorer.calculator import calculate_grade
-from src.shared.claude_metrics import extract_anthropic_usage, log_claude_api_call
+from src.shared.claude_metrics import aclose_anthropic_client, extract_anthropic_usage, log_claude_api_call
 from src.shared.lang_names import LANG_NAMES
 
 logger = logging.getLogger(__name__)
@@ -411,6 +411,10 @@ async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many
                 language=language, error_type=type(exc).__name__, now=_now,
             )
         return {"text": "", "status": "api_error"}
+    finally:
+        # 호출당 생성한 AsyncAnthropic httpx 커넥션 풀 해제 — 미종료 시 FD 누수 (WBS P1).
+        # Close the per-call AsyncAnthropic httpx pool — leaks FDs/connections if left open.
+        await aclose_anthropic_client(client)
 
     if user_id is not None:
         # pylint: disable=import-outside-toplevel

--- a/src/shared/claude_metrics.py
+++ b/src/shared/claude_metrics.py
@@ -13,9 +13,26 @@ Anthropic API 가격 정책 (USD per 1M tokens, **2026-04 기준**):
   - 월별 실제 청구액 vs 본 모듈 합계 차이 10% 초과 시 즉시 가격표 갱신.
   - 미지의 모델 이름은 sonnet 요율로 fallback — typo 시 과소/과대 추정 가능.
 """
+import inspect
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+async def aclose_anthropic_client(client) -> None:
+    """호출당 생성한 AsyncAnthropic(httpx 풀)를 안전 종료 — awaitable 일 때만 await (WBS P1 누수 차단).
+
+    실제 SDK 의 aclose 는 코루틴 → await. MagicMock 등 테스트 더블의 sync aclose 는 코루틴이
+    아니므로 조용히 무시 — 프로덕션/테스트 양쪽 호환. 정책 16 (≥3 사용처 헬퍼화).
+    Close a per-call AsyncAnthropic httpx pool; await only when aclose is awaitable (real SDK),
+    silently skip for sync test doubles.
+    """
+    closer = getattr(client, "aclose", None)
+    if closer is None:
+        return
+    result = closer()
+    if inspect.isawaitable(result):
+        await result
 
 # 모델 패밀리별 가격 (USD per 1M tokens, input/output)
 _PRICING_USD_PER_MTOK = {

--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -388,3 +388,17 @@ def test_build_review_prompt_backwards_compat_unchanged():
     if "python" in langs:
         # 단일 언어 시 ## Per-language review criteria inline
         assert "## Per-language review criteria" in user_prompt or "(none)" not in user_prompt
+
+
+async def test_review_code_closes_anthropic_client():
+    """review_code 가 호출 후 AsyncAnthropic httpx 풀을 닫는지 검증 — FD 누수 차단 회귀 가드 (WBS P1).
+
+    finally 가 성공/에러 양 경로에서 aclose_anthropic_client 호출 → 풀 해제. 에러 경로로 검증.
+    """
+    fake_client = MagicMock()
+    fake_client.messages = MagicMock()
+    fake_client.messages.create = AsyncMock(side_effect=httpx.ConnectError("boom"))
+    fake_client.aclose = AsyncMock()
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client):
+        await review_code("sk-test", "feat: x", [("app.py", "+ x = 1")])
+    fake_client.aclose.assert_awaited_once()

--- a/tests/unit/shared/test_claude_metrics.py
+++ b/tests/unit/shared/test_claude_metrics.py
@@ -268,3 +268,29 @@ class TestExtractUsage:
         input_tok, output_tok = claude_metrics.extract_anthropic_usage(mock_response)
         assert input_tok == 0
         assert output_tok == 0
+
+
+class TestAcloseAnthropicClient:
+    """aclose_anthropic_client — AsyncAnthropic httpx 풀 안전 종료 (WBS P1 누수 차단 회귀 가드)."""
+
+    @pytest.mark.asyncio
+    async def test_awaits_async_aclose(self):
+        # 실제 SDK 패턴: aclose 가 코루틴 → await 됨 (풀 해제 보장).
+        from unittest.mock import AsyncMock
+        client = MagicMock()
+        client.aclose = AsyncMock()
+        await claude_metrics.aclose_anthropic_client(client)
+        client.aclose.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_sync_aclose_without_error(self):
+        # 테스트 더블 패턴: sync MagicMock aclose() → 코루틴 아님 → await 생략, 에러 없음.
+        client = MagicMock()  # client.aclose 는 동기 MagicMock
+        await claude_metrics.aclose_anthropic_client(client)  # 예외 미발생
+        client.aclose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_aclose_attribute_is_noop(self):
+        # aclose 속성 부재 → no-op (AttributeError 미발생).
+        client = MagicMock(spec=[])  # 속성 없음
+        await claude_metrics.aclose_anthropic_client(client)  # 예외 미발생


### PR DESCRIPTION
## Summary
WBS 감사 **P1** (PR-3) — `AsyncAnthropic` 클라이언트가 호출당 생성·미종료 → httpx 커넥션 풀 누수(고빈도 시 FD 점진 고갈). 3 사이트 일괄 차단.

## 변경
- `src/shared/claude_metrics.py`: **`aclose_anthropic_client(client)` 헬퍼 신설** (정책 16 ≥3 사용처) — awaitable 일 때만 await (실 SDK async / 테스트 더블 sync 양쪽 호환).
- **3 사이트** (`ai_review.py:93` finally / `dashboard_service.py:904` 호출 직후 / `repo_insight_service.py:377` finally) → `await aclose_anthropic_client(client)`. 성공·에러 양 경로 풀 해제.

## 회귀 가드 (+4)
- `test_claude_metrics`: 헬퍼 3건 (async await / sync skip / 속성 부재 no-op)
- `test_ai_review_errors`: 사이트 1건 (에러 경로 aclose 호출 검증)
- 기존 insight/ai_review 테스트 29건 = 헬퍼 방어적 await(sync mock skip)로 **무수정 통과** (mock 일괄 갱신 회피)

## 검증
- 관련 **57 passed** / pylint 4 src **10.00**

## 🔍 사용자 검증 필요
- [ ] CI 통과
- [ ] STATE/README 카운트(+4)는 cycle 160 wrap-up 일괄 (정책 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
