### PR TITLE
fix(p2-pr6): GitHub 페이로드 present-but-None 정규화 + retry_policy dead 함수 제거 (WBS 감사 P2)

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -46,7 +46,7 @@
 | `src/worker/pipeline.py` | 분석 파이프라인 + build_analysis_result_dict |
 | `src/models/merge_retry.py` | MergeRetryQueue ORM — 재시도 큐 (append-only claim 패턴) |
 | `src/repositories/merge_retry_repo.py` | enqueue_or_bump · claim_batch · mark_succeeded/terminal/expired — 원자적 SKIP LOCKED 클레임 |
-| `src/gate/retry_policy.py` | 순수 함수: should_retry · compute_next_retry_at · is_expired · mergeable_state_terminality |
+| `src/gate/retry_policy.py` | 순수 함수: parse_reason_tag · should_retry · compute_next_retry_at · is_expired |
 | `src/github_client/checks.py` | get_ci_status · get_required_check_contexts (5분 TTL 캐시) |
 | `src/services/merge_retry_service.py` | process_pending_retries — CI-aware 재시도 워커 |
 | `src/gate/native_automerge.py` | enable_or_fallback() — GraphQL `enablePullRequestAutoMerge` 우선 + REST `merge_pr` 폴백 (Tier 3 PR-A, 그룹 52) |

--- a/src/gate/retry_policy.py
+++ b/src/gate/retry_policy.py
@@ -30,45 +30,6 @@ def parse_reason_tag(reason: str | None) -> str:
     return reason.split(":")[0].strip() or "unknown"
 
 
-# mergeable_state → terminality 매핑 상수 (순수 데이터)
-# Constant mapping of mergeable_state → terminality (pure data)
-_STATE_TERMINALITY: dict[str, str] = {
-    # GitHub가 여전히 계산 중 — 잠시 대기 후 재시도
-    # GitHub is still computing — wait briefly and retry
-    "unknown": "retriable",
-    # CI 진행 중일 수도, 실패했을 수도 있음 — 추가 판단 필요
-    # Could be CI running or a failing check — needs further disambiguation
-    "unstable": "needs_disambiguation",
-    # has_hooks: GitHub Branch Protection hook 대기 — CI 완료 후 해소되므로 재시도 가능
-    # has_hooks: GitHub Branch Protection hook pending — resolves after CI completes, so retriable
-    "has_hooks": "retriable",
-    # 이하 모두 즉시 종료 (재시도 불가)
-    # All states below are immediately terminal (no retry)
-    "clean": "terminal",
-    "blocked": "terminal",
-    "behind": "terminal",
-    "dirty": "terminal",
-    "draft": "terminal",
-}
-
-
-def mergeable_state_terminality(state: str) -> str:
-    """mergeable_state → 'retriable'|'terminal'|'needs_disambiguation'.
-
-    Args:
-        state: GitHub PR mergeable_state 문자열.
-               GitHub PR mergeable_state string.
-
-    Returns:
-        'retriable'            — 잠시 후 재시도 가능 / can retry shortly
-        'terminal'             — 재시도해도 결과 변화 없음 / no point retrying
-        'needs_disambiguation' — CI 상태 추가 조회 필요 / needs CI status check
-    """
-    # 알 수 없는 상태는 terminal 로 안전하게 처리
-    # Unknown states default to terminal for safety
-    return _STATE_TERMINALITY.get(state, "terminal")
-
-
 def should_retry(reason_tag: str, ci_status: str) -> bool:
     """재시도 여부 결정 — reason_tag 와 ci_status 조합으로 판단.
     Determines whether to retry based on reason_tag and ci_status combination.

--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -159,7 +159,9 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
         return
 
     # SHA drift — force-push 감지
-    head_sha = pr_data.get("head", {}).get("sha", "")
+    # head 키가 present-but-None 일 수 있어 `or {}` 정규화 (PR #124 패턴)
+    # head key may be present-but-None — normalize with `or {}` (PR #124 pattern)
+    head_sha = (pr_data.get("head") or {}).get("sha", "")
     if head_sha and head_sha != row.commit_sha:
         merge_retry_repo.mark_abandoned(db, row.id, reason="sha_drift")
         counts["abandoned"] += 1
@@ -185,7 +187,9 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
     # ── f. 실패 분류 ──────────────────────────────────────────────
     reason_tag = parse_reason_tag(reason)
     # F1: pr_data 에 이미 base.ref 가 있으므로 추가 호출 없이 활용
-    base_ref = pr_data.get("base", {}).get("ref", "main")
+    # base 키가 present-but-None 일 수 있어 `or {}` 정규화 (PR #124 패턴)
+    # base key may be present-but-None — normalize with `or {}` (PR #124 pattern)
+    base_ref = (pr_data.get("base") or {}).get("ref", "main")
     ci_status = await _get_ci_status_safe(
         token, row.repo_full_name, row.commit_sha, base_ref=base_ref,
     )

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -96,7 +96,9 @@ def build_analysis_result_dict(
 def _extract_commit_message(event: str, data: dict) -> str:
     """Extract the commit or PR message from the webhook payload."""
     if event == "pull_request":
-        pr = data.get("pull_request", {})
+        # pull_request 키가 present-but-None 일 수 있어 `or {}` 정규화 (PR #124 패턴)
+        # pull_request key may be present-but-None — normalize with `or {}` (PR #124 pattern)
+        pr = data.get("pull_request") or {}
         title = pr.get("title", "")
         body = pr.get("body") or ""
         return f"{title}\n\n{body}".strip() if body else title
@@ -117,9 +119,24 @@ def _extract_author_login(event_type: str, data: dict) -> str | None:
     On missing keys, returns None silently.
     """
     if event_type == "pull_request":
-        return (data.get("pull_request") or {}).get("user", {}).get("login")
+        # user 키도 present-but-None 가능 — 한 단계 더 `or {}` 정규화 (PR #124 패턴)
+        # user key may also be present-but-None — normalize one more level (PR #124 pattern)
+        return ((data.get("pull_request") or {}).get("user") or {}).get("login")
     head = data.get("head_commit") or {}
     return (head.get("author") or {}).get("username")
+
+
+def _extract_pr_head_ref(event: str, data: dict) -> str | None:
+    """PR 이벤트에서 head 브랜치 ref 를 추출한다 (PR 외 이벤트는 None).
+    Extract the head branch ref from a PR event (None for non-PR events).
+
+    pull_request / head 키가 present-but-None 일 수 있어 `or {}` 정규화 (PR #124 패턴).
+    pull_request / head keys may be present-but-None — normalize with `or {}` (PR #124 pattern).
+    """
+    if event != "pull_request":
+        return None
+    pr = data.get("pull_request") or {}
+    return (pr.get("head") or {}).get("ref")
 
 
 async def _run_static_analysis(
@@ -224,7 +241,9 @@ def _extract_event_metadata(event: str, data: dict) -> tuple[str, str, str, int 
     commit_message = _extract_commit_message(event, data)
     if event == "pull_request":
         pr_number: int | None = data["number"]
-        commit_sha: str = (data.get("pull_request") or {}).get("head", {}).get("sha", "")
+        # head 키도 present-but-None 가능 — 한 단계 더 `or {}` 정규화 (PR #124 패턴)
+        # head key may also be present-but-None — normalize one more level (PR #124 pattern)
+        commit_sha: str = ((data.get("pull_request") or {}).get("head") or {}).get("sha", "")
     else:
         pr_number = None
         # 브랜치 삭제 시 "after"가 없거나 0000...000일 수 있음 — .get() 방어
@@ -476,10 +495,7 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
             repo_name, commit_sha, commit_message, pr_number = _extract_event_metadata(event, data)
             # user-controlled webhook 입력이므로 로그 인젝션 방어 (CLAUDE.md 규약)
             repo_log = sanitize_for_log(repo_name)
-            pr_head_ref = (
-                data.get("pull_request", {}).get("head", {}).get("ref")
-                if event == "pull_request" else None
-            )
+            pr_head_ref = _extract_pr_head_ref(event, data)
 
             with SessionLocal() as db:
                 ensure_result = _ensure_repo(db, repo_name, commit_sha)

--- a/tests/unit/gate/test_retry_policy.py
+++ b/tests/unit/gate/test_retry_policy.py
@@ -16,7 +16,6 @@ import pytest
 from src.gate.retry_policy import (
     compute_next_retry_at,
     is_expired,
-    mergeable_state_terminality,
     parse_reason_tag,
     should_retry,
 )
@@ -58,31 +57,6 @@ def test_parse_reason_tag_whitespace_stripped():
     # Returns tag with surrounding whitespace stripped
     result = parse_reason_tag("  branch_protection_blocked  : details here")
     assert result == "branch_protection_blocked"
-
-
-# ---------------------------------------------------------------------------
-# mergeable_state_terminality — 8-state matrix
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "state,expected",
-    [
-        ("clean", "terminal"),
-        ("unstable", "needs_disambiguation"),
-        ("unknown", "retriable"),
-        ("blocked", "terminal"),
-        ("behind", "terminal"),
-        ("dirty", "terminal"),
-        ("draft", "terminal"),
-        ("has_hooks", "retriable"),
-        ("totally_made_up_state", "terminal"),
-    ],
-)
-def test_mergeable_state_terminality_matrix(state, expected):
-    # 8가지 GitHub mergeable_state 값 + 미지 상태 반환값 검증
-    # Validates return value for the 8 known GitHub mergeable_state values plus unknown
-    assert mergeable_state_terminality(state) == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_merge_retry_service.py
+++ b/tests/unit/services/test_merge_retry_service.py
@@ -346,6 +346,69 @@ class TestProcessPendingRetries:
         assert row.status == "abandoned"
         assert row.last_failure_reason == "sha_drift"
 
+    # PR #124 패턴: pr_data["head"] 가 present-but-None 일 때 AttributeError 없이 처리
+    # PR #124 pattern: head present-but-None must not raise AttributeError
+    async def test_process_head_present_but_none_no_attribute_error(self, db_session):
+        """pr_data['head'] is None → head_sha 빈 문자열 fallback, sha_drift 건너뜀, 머지 진행.
+        When pr_data['head'] is None, head_sha falls back to '' and merge proceeds (no crash).
+        """
+        row = _seed_queue_row(db_session, commit_sha="abc123")
+
+        patches = _standard_patches(
+            pr_data={"merged": False, "head": None, "state": "open"},
+            merge_return=(True, None, "abc123"),
+        )
+        with (
+            patches["token"],
+            patches["repo_config"],
+            patches["pr_data"],
+            patches["merge_pr"] as mock_merge,
+            patches["ci"],
+            patches["notify_succeeded"],
+            patches["notify_terminal"],
+            patches["notify_config"],
+            patches["log_attempt"],
+        ):
+            result = await process_pending_retries(db_session, only_ids=[row.id])
+
+        # head_sha='' → sha_drift 미발동 → merge_pr 호출됨
+        # head_sha='' → no sha_drift → merge_pr is called
+        mock_merge.assert_called_once()
+        assert result["succeeded"] == 1
+
+    # PR #124 패턴: pr_data["base"] 가 present-but-None 일 때 base_ref 'main' fallback
+    # PR #124 pattern: base present-but-None falls back to 'main' without crash
+    async def test_process_base_present_but_none_falls_back_to_main(self, db_session):
+        """머지 실패 경로에서 pr_data['base'] is None → base_ref='main' fallback (no crash)."""
+        row = _seed_queue_row(db_session, commit_sha="abc123")
+
+        ci_mock_holder = {}
+        patches = _standard_patches(
+            pr_data={"merged": False, "head": {"sha": "abc123"}, "base": None, "state": "open"},
+            merge_return=(False, "unstable_ci: state=unstable", ""),
+            ci_return="running",
+        )
+        with (
+            patches["token"],
+            patches["repo_config"],
+            patches["pr_data"],
+            patches["merge_pr"],
+            patches["ci"] as mock_ci,
+            patches["notify_succeeded"],
+            patches["notify_terminal"],
+            patches["notify_config"],
+            patches["log_attempt"],
+        ):
+            ci_mock_holder["ci"] = mock_ci
+            # AttributeError 없이 완료되어야 함
+            # Must complete without AttributeError
+            result = await process_pending_retries(db_session, only_ids=[row.id])
+
+        # base_ref='main' 으로 _get_ci_status_safe 호출됨
+        # _get_ci_status_safe called with base_ref='main'
+        assert ci_mock_holder["ci"].call_args.kwargs["base_ref"] == "main"
+        assert result["claimed"] == 1
+
     # T9-6: 머지 성공 → 알림 전송, log_merge_attempt 호출
     # T9-6: Merge succeeds → notify, log_merge_attempt called
     async def test_process_merge_succeeds_notifies(self, db_session):

--- a/tests/unit/worker/test_extract_author_login.py
+++ b/tests/unit/worker/test_extract_author_login.py
@@ -90,6 +90,13 @@ def test_pr_event_missing_user_key_returns_none():
     assert result is None
 
 
+def test_pr_event_user_present_but_none_returns_none():
+    # PR 이벤트에서 user 키가 present-but-None 이면 AttributeError 없이 None (PR #124 패턴)
+    # Returns None without AttributeError when user is present-but-None (PR #124 pattern).
+    result = _extract_author_login("pull_request", {"pull_request": {"user": None}})
+    assert result is None
+
+
 def test_push_event_missing_username_key_returns_none():
     # push 이벤트에서 head_commit.author.username 키가 없으면 None을 반환한다
     # Returns None when head_commit.author.username key is absent.

--- a/tests/unit/worker/test_pipeline_extract_helpers.py
+++ b/tests/unit/worker/test_pipeline_extract_helpers.py
@@ -17,7 +17,11 @@ os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
 os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
 
 # pylint: disable=wrong-import-position
-from src.worker.pipeline import _extract_commit_message
+from src.worker.pipeline import (
+    _extract_commit_message,
+    _extract_event_metadata,
+    _extract_pr_head_ref,
+)
 
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -46,6 +50,17 @@ def test_pr_empty_body_string_returns_title_only():
 def test_pr_missing_pull_request_key_returns_empty():
     """PR 페이로드에 pull_request 키 자체가 없으면 '' (방어적)."""
     data: dict = {}
+    assert _extract_commit_message("pull_request", data) == ""
+
+
+def test_pr_pull_request_present_but_none_returns_empty():
+    """pull_request 키가 present-but-None 일 때 AttributeError 없이 '' 반환.
+    When pull_request key is present-but-None, returns '' without AttributeError.
+
+    GitHub 가 키를 None 으로 보내는 경우 default `{}` 가 적용되지 않아 회귀 (PR #124 패턴).
+    GitHub may send the key as None — the default `{}` is not applied (PR #124 pattern).
+    """
+    data = {"pull_request": None}
     assert _extract_commit_message("pull_request", data) == ""
 
 
@@ -105,3 +120,58 @@ def test_unknown_event_type_falls_through_to_push_branch():
     """event != 'pull_request' 면 push 분기 진입 — 알 수 없는 이벤트도 graceful."""
     data = {"head_commit": {"message": "via unknown"}}
     assert _extract_commit_message("issues", data) == "via unknown"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _extract_pr_head_ref — PR head 브랜치 ref 추출 (None-안전)
+# _extract_pr_head_ref — extract PR head branch ref (None-safe)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_head_ref_returns_branch_on_pull_request():
+    """정상 PR 페이로드에서 head.ref 반환."""
+    data = {"pull_request": {"head": {"ref": "feature/x"}}}
+    assert _extract_pr_head_ref("pull_request", data) == "feature/x"
+
+
+def test_head_ref_none_when_not_pull_request_event():
+    """pull_request 이벤트가 아니면 None (push 등)."""
+    data = {"pull_request": {"head": {"ref": "feature/x"}}}
+    assert _extract_pr_head_ref("push", data) is None
+
+
+def test_head_ref_pull_request_present_but_none_returns_none():
+    """pull_request 가 present-but-None 일 때 AttributeError 없이 None (PR #124 패턴).
+    When pull_request is present-but-None, returns None without AttributeError.
+    """
+    data = {"pull_request": None}
+    assert _extract_pr_head_ref("pull_request", data) is None
+
+
+def test_head_ref_head_present_but_none_returns_none():
+    """head 키가 present-but-None 일 때 AttributeError 없이 None."""
+    data = {"pull_request": {"head": None}}
+    assert _extract_pr_head_ref("pull_request", data) is None
+
+
+def test_head_ref_missing_keys_returns_none():
+    """head/ref 키가 아예 없으면 None."""
+    assert _extract_pr_head_ref("pull_request", {}) is None
+    assert _extract_pr_head_ref("pull_request", {"pull_request": {}}) is None
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# _extract_event_metadata — head present-but-None 안전성 (PR #124 패턴)
+# _extract_event_metadata — head present-but-None safety (PR #124 pattern)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_event_metadata_pr_head_present_but_none_returns_empty_sha():
+    """PR 이벤트에서 head 키가 present-but-None 이면 commit_sha='' (AttributeError 없음).
+    When head is present-but-None on a PR event, commit_sha is '' without AttributeError.
+    """
+    data = {"number": 7, "pull_request": {"head": None}, "repository": {"full_name": "o/r"}}
+    repo_name, commit_sha, _msg, pr_number = _extract_event_metadata("pull_request", data)
+    assert repo_name == "o/r"
+    assert commit_sha == ""
+    assert pr_number == 7


### PR DESCRIPTION
## 요약
WBS 코드베이스 감사(2026-06-03)의 잔여 P2 중 **None 정규화 버그 묶음**(PR-6). risk-order 진행의 첫 PR (저위험). GitHub 웹훅/REST 페이로드의 `present-but-None` 키로 인한 잠재 `AttributeError`를 PR #124 패턴(`or {}`)으로 완결 적용하고, dead 함수 1건을 제거합니다.

## 변경 내용
| 파일 | 변경 |
|------|------|
| `src/worker/pipeline.py` | 4지점 정규화 — `_extract_commit_message`(pull_request), 신규 `_extract_pr_head_ref` 헬퍼(인라인 대체), `_extract_author_login`(user), `_extract_event_metadata`(head) |
| `src/services/merge_retry_service.py` | `_process_single_retry` head/base 2지점 정규화 |
| `src/gate/retry_policy.py` | dead 함수 `mergeable_state_terminality` + `_STATE_TERMINALITY` 제거 |
| `docs/STATE.md` | `retry_policy` 순수 함수 목록 동기화 (6-step ⑤) |

## 자율 판단 보고 (정책 3)
- ⚠️ **`mergeable_state_terminality` 제거 결정**: grep 실측상 production 호출자 0 (test만 참조) + live `should_retry`와 모순되던 `has_hooks: retriable` 매핑 포함 → 정책 16(dead code 제거)에 따라 **제거**(Option A) 선택. 매핑 정정(Option B) 대신 제거한 이유 = 영구히 dead이며 미래 mis-wiring footgun.
- ⚠️ **scope 확장**: `pipeline-reviewer`가 발견한 동일 클래스 None 버그 2건(`_extract_author_login` user / `_extract_event_metadata` head)을 같은 PR에 포함 — 같은 파일·같은 버그 클래스를 절반만 고치는 비대칭을 피하기 위함.

## 검증
- **테스트**: 영향 디렉토리(worker/gate/merge_retry) **348 passed** (+9 present-but-None 회귀 가드)
- **pylint**: 변경 3 src 파일 **10.00/10**
- **pipeline-reviewer**: 승인 (P0/P1 0건, 행동 동등성 보존 확인 — `or {}`는 None만 추가 정규화하고 빈 dict 산출값은 기존 default와 동일). 발견 P2 3건 본 PR 전량 반영.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- **현재 면제 상태**: Codex stop-time 리뷰 게이트가 2026-06-03 사용자 지시로 비활성(미로그인)이라 정책 18 mutual 검증 면제 적용 (메모리 `feedback_codex_sandbox_precheck.md` 기록). Codex 검증을 원하시면 알려주세요.
- 대체 검증: Claude-side `pipeline-reviewer` 적대적 검토 1회 수행 (승인).

## 🔍 사용자 검증 필요 (정책 2)
- [ ] 운영 영향 없음 예상 (방어적 None 가드 + dead code 제거, 행동 변경 0). 머지 후 webhook/merge-retry 정상 동작 확인 권장.
- [ ] 본 PR은 WBS P2 5개 PR 중 첫 번째 — 잔여 PR-5(cron)/PR-4(SSRF)/PR-7+8(rate-limit·CI) 순차 진행 예정.