### PR TITLE
fix(p2-pr5): cron 세션 격리(rollback) + N+1 config batch + security_scan 병렬 fetch (WBS 감사 P2)

### DIFF
--- a/src/repositories/repo_config_repo.py
+++ b/src/repositories/repo_config_repo.py
@@ -17,6 +17,25 @@ def find_by_full_name(db: Session, full_name: str) -> RepoConfig | None:
     return db.query(RepoConfig).filter(RepoConfig.repo_full_name == full_name).first()
 
 
+def find_by_full_names(db: Session, full_names: list[str]) -> dict[str, RepoConfig]:
+    """다건 full_name 을 단일 IN 쿼리로 조회 → {full_name: RepoConfig} 매핑.
+    Batch-fetch multiple full_names in a single IN query → {full_name: RepoConfig} map.
+
+    루프 내 per-repo 조회(N+1)를 단일 쿼리로 대체할 때 사용 (cron 등).
+    Used to replace per-repo lookups in a loop (N+1) with one query (e.g. cron).
+    빈 리스트면 쿼리 없이 빈 dict 반환.
+    Returns an empty dict without querying when the list is empty.
+    """
+    if not full_names:
+        return {}
+    rows = (
+        db.query(RepoConfig)
+        .filter(RepoConfig.repo_full_name.in_(full_names))
+        .all()
+    )
+    return {row.repo_full_name: row for row in rows}
+
+
 def find_by_railway_webhook_token(db: Session, token: str) -> RepoConfig | None:
     """Railway webhook 토큰으로 조회 (POST /webhooks/railway/{token})."""
     return db.query(RepoConfig).filter(

--- a/src/services/cron_service.py
+++ b/src/services/cron_service.py
@@ -41,11 +41,15 @@ async def run_weekly_reports(db: Session, *, now: datetime | None = None) -> int
     # Fetch all repository records
     repos = repository_repo.find_all(db)
 
+    # N+1 방지 — 전체 repo config 를 단일 IN 쿼리로 batch 조회
+    # Avoid N+1 — batch-fetch all repo configs in one IN query
+    configs = repo_config_repo.find_by_full_names(db, [r.full_name for r in repos])
+
     for repo in repos:
         try:
             # 리포별 설정 조회 (없으면 None)
             # Fetch per-repo config (None if absent)
-            config = repo_config_repo.find_by_full_name(db, repo.full_name)
+            config = configs.get(repo.full_name)
 
             # chat_id 우선순위 라우팅 — None 이면 skip
             # Resolve chat_id with priority routing — skip if None
@@ -79,6 +83,10 @@ async def run_weekly_reports(db: Session, *, now: datetime | None = None) -> int
             logger.warning(
                 "weekly_report: failed for repo=%s: %s", repo.full_name, exc
             )
+            # 세션 오염 방지 — DB 에러로 세션이 failed 상태면 다음 repo 가 연쇄 실패
+            # (security_scan_service.scan_all_repos 와 동일 패턴, #745 / api.md 세션 격리)
+            # Roll back so a poisoned session doesn't cascade into the next repo
+            db.rollback()
 
     return sent
 
@@ -109,7 +117,11 @@ def _format_weekly_message(
     )
 
 
-async def run_trend_check(db: Session, *, now: datetime | None = None) -> int:
+# N+1 방지용 configs batch 지역변수 추가로 16/15 — 함수 응집 보호 위해 inline disable (testing.md R0914)
+# configs batch local for N+1 fix pushes to 16/15 — inline disable to keep function cohesion
+async def run_trend_check(  # pylint: disable=too-many-locals
+    db: Session, *, now: datetime | None = None
+) -> int:
     """7일 이동 평균이 10점 이상 하락한 리포에 트렌드 경고를 발송한다.
     Send trend alerts for repos whose 7-day moving average drops by 10+ points.
 
@@ -124,11 +136,15 @@ async def run_trend_check(db: Session, *, now: datetime | None = None) -> int:
     # Fetch all repository records
     repos = repository_repo.find_all(db)
 
+    # N+1 방지 — 전체 repo config 를 단일 IN 쿼리로 batch 조회
+    # Avoid N+1 — batch-fetch all repo configs in one IN query
+    configs = repo_config_repo.find_by_full_names(db, [r.full_name for r in repos])
+
     for repo in repos:
         try:
             # 리포별 설정 조회 (없으면 None)
             # Fetch per-repo config (None if absent)
-            config = repo_config_repo.find_by_full_name(db, repo.full_name)
+            config = configs.get(repo.full_name)
 
             # chat_id 우선순위 라우팅 — None 이면 skip
             # Resolve chat_id with priority routing — skip if None
@@ -176,6 +192,10 @@ async def run_trend_check(db: Session, *, now: datetime | None = None) -> int:
             logger.warning(
                 "trend_check: failed for repo=%s: %s", repo.full_name, exc
             )
+            # 세션 오염 방지 — DB 에러로 세션이 failed 상태면 다음 repo 가 연쇄 실패
+            # (security_scan_service.scan_all_repos 와 동일 패턴, #745 / api.md 세션 격리)
+            # Roll back so a poisoned session doesn't cascade into the next repo
+            db.rollback()
 
     return alerted
 

--- a/src/services/security_scan_service.py
+++ b/src/services/security_scan_service.py
@@ -14,6 +14,7 @@ Phase 1 = read-only (자동 dismiss X). 사용자 1-click confirm 은 dashboard 
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from typing import Any
@@ -145,8 +146,15 @@ async def scan_repo_alerts(
         counts[_SKIPPED_KEY] = 1
         return counts
 
-    for kind, key in (("code-scanning", _CODE_SCANNING_KEY), ("secret-scanning", _SECRET_SCANNING_KEY)):
-        alerts = await _fetch_alerts(token, repo.full_name, kind)
+    # 두 종류 alert 를 병렬 fetch (독립 read-only GET) — DB upsert 는 단일 세션 직렬 유지
+    # Fetch both alert kinds in parallel (independent read-only GETs); DB upserts stay serial
+    # (_fetch_alerts 는 자체적으로 에러 시 None 반환 — gather return_exceptions 불요)
+    # (_fetch_alerts returns None on error itself — no need for gather return_exceptions)
+    kinds = (("code-scanning", _CODE_SCANNING_KEY), ("secret-scanning", _SECRET_SCANNING_KEY))
+    fetched = await asyncio.gather(
+        *(_fetch_alerts(token, repo.full_name, kind) for kind, _ in kinds)
+    )
+    for (kind, key), alerts in zip(kinds, fetched):
         if alerts is None:
             continue
         for alert in alerts:

--- a/tests/unit/repositories/test_repo_config_repo.py
+++ b/tests/unit/repositories/test_repo_config_repo.py
@@ -61,3 +61,22 @@ def test_delete_by_full_name_returns_row_count(db_session):
     db_session.commit()
     assert deleted == 1
     assert repo_config_repo.find_by_full_name(db_session, "owner/repo") is None
+
+
+def test_find_by_full_names_batch_maps_existing(db_session):
+    # 다건 full_name 을 단일 IN 쿼리로 조회해 dict 로 매핑 (N+1 방지)
+    # Batch-fetch multiple full_names in one IN query, mapped to a dict (avoids N+1)
+    _seed(db_session, full_name="owner/a")
+    _seed(db_session, full_name="owner/b")
+    result = repo_config_repo.find_by_full_names(
+        db_session, ["owner/a", "owner/b", "owner/missing"]
+    )
+    assert set(result.keys()) == {"owner/a", "owner/b"}
+    assert result["owner/a"].repo_full_name == "owner/a"
+    assert "owner/missing" not in result
+
+
+def test_find_by_full_names_empty_list_returns_empty_dict(db_session):
+    # 빈 리스트 입력 시 빈 dict (쿼리 미실행)
+    # Empty list input returns an empty dict (no query executed)
+    assert repo_config_repo.find_by_full_names(db_session, []) == {}

--- a/tests/unit/services/test_cron_service.py
+++ b/tests/unit/services/test_cron_service.py
@@ -8,11 +8,12 @@ telegram_post_message is isolated via AsyncMock to prevent real HTTP calls.
 """
 # pylint: disable=redefined-outer-name
 from datetime import datetime, timezone, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from src.database import Base
@@ -218,6 +219,63 @@ class TestRunWeeklyReports:
         assert mock_tg.call_count == 2
         assert sent == 1
 
+    @patch("src.services.cron_service.telegram_post_message", new_callable=AsyncMock)
+    @patch("src.services.cron_service._format_weekly_message", return_value="msg")
+    @patch("src.services.cron_service.weekly_summary")
+    async def test_run_weekly_reports_rolls_back_on_db_error(
+        self, mock_ws, _mock_fmt, mock_tg, db, monkeypatch
+    ):
+        """첫 repo 에서 SQLAlchemyError → db.rollback() 호출 + 다음 repo 정상 처리 (세션 격리).
+        SQLAlchemyError on first repo → db.rollback() called + next repo still processed.
+        """
+        import src.services.cron_service as cs
+        monkeypatch.setattr(cs.settings, "telegram_chat_id", "")
+        u1 = User(github_id=20, github_login="r1", email="r1@x.com", display_name="R1")
+        u2 = User(github_id=21, github_login="r2", email="r2@x.com", display_name="R2")
+        db.add_all([u1, u2])
+        db.commit()
+        r1 = Repository(full_name="owner/db-fail", user_id=u1.id, telegram_chat_id="-100a")
+        r2 = Repository(full_name="owner/db-ok", user_id=u2.id, telegram_chat_id="-100b")
+        db.add_all([r1, r2])
+        db.commit()
+
+        # 첫 repo weekly_summary 가 DB 에러, 둘째는 정상 summary 반환
+        # First repo's weekly_summary raises a DB error; second returns a valid summary
+        mock_ws.side_effect = [SQLAlchemyError("db boom"), {"avg_score": 80.0, "count": 5}]
+        rollback_spy = MagicMock(side_effect=db.rollback)
+        monkeypatch.setattr(db, "rollback", rollback_spy)
+
+        sent = await cs.run_weekly_reports(db, now=datetime.now(timezone.utc))
+
+        rollback_spy.assert_called()  # DB 에러 시 rollback 호출됨
+        assert sent == 1  # 둘째 repo 정상 처리 (연쇄 실패 없음)
+
+    @patch("src.services.cron_service.telegram_post_message", new_callable=AsyncMock)
+    async def test_run_weekly_reports_batches_config_lookup(self, _mock_tg, db, monkeypatch):
+        """config 조회는 루프 진입 전 batch 1회 — per-repo find_by_full_name 미호출 (N+1 방지).
+        Config lookup is a single pre-loop batch — per-repo find_by_full_name is not called (no N+1).
+        """
+        import src.services.cron_service as cs
+        monkeypatch.setattr(cs.settings, "telegram_chat_id", "")
+        u1 = User(github_id=30, github_login="b1", email="b1@x.com", display_name="B1")
+        u2 = User(github_id=31, github_login="b2", email="b2@x.com", display_name="B2")
+        db.add_all([u1, u2])
+        db.commit()
+        db.add_all([
+            Repository(full_name="owner/b1", user_id=u1.id, telegram_chat_id="-100a"),
+            Repository(full_name="owner/b2", user_id=u2.id, telegram_chat_id="-100b"),
+        ])
+        db.commit()
+
+        with patch.object(
+            cs.repo_config_repo, "find_by_full_names",
+            wraps=cs.repo_config_repo.find_by_full_names,
+        ) as batch_spy, patch.object(cs.repo_config_repo, "find_by_full_name") as per_repo_spy:
+            await cs.run_weekly_reports(db, now=datetime.now(timezone.utc))
+
+        batch_spy.assert_called_once()      # batch 조회 1회
+        per_repo_spy.assert_not_called()    # 루프 내 per-repo 조회 없음 (N+1 제거)
+
 
 # ---------------------------------------------------------------------------
 # Test: run_trend_check
@@ -306,3 +364,34 @@ class TestRunTrendCheck:
         # drop=9 < _TREND_DROP_THRESHOLD=10 → no alert
         mock_tg.assert_not_called()
         assert alerted == 0
+
+    @patch("src.services.cron_service.telegram_post_message", new_callable=AsyncMock)
+    @patch("src.services.cron_service.moving_average")
+    async def test_run_trend_check_rolls_back_on_db_error(
+        self, mock_ma, mock_tg, db, monkeypatch
+    ):
+        """첫 repo 에서 SQLAlchemyError → db.rollback() 호출 + 다음 repo 정상 경고 발송.
+        SQLAlchemyError on first repo → db.rollback() called + next repo's alert still sent.
+        """
+        import src.services.cron_service as cs
+        monkeypatch.setattr(cs.settings, "telegram_chat_id", "")
+        u1 = User(github_id=40, github_login="t1", email="t1@x.com", display_name="T1")
+        u2 = User(github_id=41, github_login="t2", email="t2@x.com", display_name="T2")
+        db.add_all([u1, u2])
+        db.commit()
+        db.add_all([
+            Repository(full_name="owner/t-fail", user_id=u1.id, telegram_chat_id="-100a"),
+            Repository(full_name="owner/t-ok", user_id=u2.id, telegram_chat_id="-100b"),
+        ])
+        db.commit()
+
+        # 첫 repo: moving_average DB 에러 / 둘째 repo: current=70, prev=80 → drop=10 경고
+        # First repo: moving_average DB error / second: current=70, prev=80 → drop=10 alert
+        mock_ma.side_effect = [SQLAlchemyError("db boom"), 70.0, 80.0]
+        rollback_spy = MagicMock(side_effect=db.rollback)
+        monkeypatch.setattr(db, "rollback", rollback_spy)
+
+        alerted = await cs.run_trend_check(db, now=datetime.now(timezone.utc))
+
+        rollback_spy.assert_called()  # DB 에러 시 rollback 호출됨
+        assert alerted == 1  # 둘째 repo 정상 경고 (연쇄 실패 없음)

--- a/tests/unit/services/test_security_scan_service.py
+++ b/tests/unit/services/test_security_scan_service.py
@@ -275,3 +275,33 @@ async def test_scan_repo_alerts_rollback_does_not_abort_secret_scanning():
     # 핵심: rollback 후에도 outer loop 가 secret-scanning 을 계속 처리해 1건 집계
     # Key: after rollback, the outer loop continues to secret-scanning and counts 1
     assert counts["secret_scanning"] == 1
+
+
+@pytest.mark.asyncio
+async def test_scan_repo_alerts_fetches_kinds_concurrently():
+    """code/secret scanning 2종 fetch 가 asyncio.gather 로 병렬 실행됨을 검증.
+    Verifies code/secret scanning fetches run concurrently via asyncio.gather.
+
+    회귀 가드: 직렬 await 로 되돌리면 max 동시성이 1 로 떨어져 실패.
+    Regression guard: reverting to serial awaits drops max concurrency to 1 and fails.
+    """
+    import asyncio
+    repo = MagicMock(id=7, full_name="owner/test")
+    db = MagicMock()
+    concurrency = {"cur": 0, "max": 0}
+
+    async def fake_fetch(_token, _full_name, _kind):
+        concurrency["cur"] += 1
+        concurrency["max"] = max(concurrency["max"], concurrency["cur"])
+        await asyncio.sleep(0.02)  # 다른 코루틴이 동시 진입할 윈도우 / window for concurrent entry
+        concurrency["cur"] -= 1
+        return []
+
+    with patch.object(security_scan_service, "is_kill_switch_active", return_value=False), \
+         patch.object(security_scan_service, "_resolve_token", return_value="tok"), \
+         patch.object(security_scan_service, "_fetch_alerts", new=fake_fetch):
+        await security_scan_service.scan_repo_alerts(db, repo)
+
+    # gather 병렬이면 두 fetch 가 동시에 진입 → max 동시성 2
+    # With gather, both fetches enter concurrently → max concurrency 2
+    assert concurrency["max"] == 2


### PR DESCRIPTION
## 요약
WBS 코드베이스 감사(2026-06-03)의 잔여 P2 중 **cron 안정성/병렬화 묶음**(PR-5). risk-order 진행의 2번째 PR (중위험).

## 변경 내용
| 파일 | 변경 |
|------|------|
| `src/services/cron_service.py` | `run_weekly_reports`·`run_trend_check` except 블록 `db.rollback()` 추가 (세션 격리, #745 패턴) + 루프 내 N+1 config 조회 → batch 1회 |
| `src/repositories/repo_config_repo.py` | 신규 `find_by_full_names(db, names) -> dict` (단일 IN 쿼리, 빈 리스트 조기 반환) |
| `src/services/security_scan_service.py` | `scan_repo_alerts` code/secret 2종 fetch `asyncio.gather` 병렬화 (DB upsert 는 gather 이후 직렬) |

## 자율 판단 보고 (정책 3)
- ⚠️ **security_scan repo-레벨 병렬화는 보류**: `scan_all_repos` 의 repo 루프 병렬화는 단일 Session 공유 → SQLAlchemy 동시 commit 경합 위험(api.md gather-Session 규칙). 따라서 1차로 **kind 2건만 gather**(read-only GET, DB 미관여) 적용. repo 병렬은 별도 세션 설계 필요 — 사용자 결정 영역으로 보류.
- ⚠️ **STATE.md 누적 테스트 카운트 동기화 보류**: PR-5/PR-6 등 다중 미머지 브랜치 병행 중 — 누적 카운트 중복/충돌 방지 위해 머지 후 일괄 sync 권장 (본 PR +6 단위 테스트).

## 검증
- **테스트**: cron/security_scan/repo_config **36 passed** (+6: rollback 격리 2 + batch 단일쿼리 1 + find_by_full_names 2 + gather 동시성 가드 1)
- **pylint**: 변경 3 src 파일 **10.00/10** (run_trend_check R0914 16/15 → inline disable, testing.md 결정트리 패턴 2)
- **적대적 검증** (general-purpose): 결함 0건 승인 — gather-Session 규칙 위반 없음(gather 내 `_fetch_alerts` 만, DB는 gather 밖 직렬) / gather 순서·매핑 동등 / `_fetch_alerts` 전 경로 None 반환(raise 없음) / rollback 안전(cron 루프 DB write 0) / N+1 batch 동등.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- **현재 면제 상태**: Codex stop-time 게이트 2026-06-03 사용자 지시로 비활성(미로그인) — 정책 18 mutual 면제 (메모리 `feedback_codex_sandbox_precheck.md`). 대체로 Claude-side 적대적 검증 1회 수행.

## 🔍 사용자 검증 필요 (정책 2)
- [ ] cron 주간 리포트/트렌드 경고 운영 동작 — DB 에러 발생 repo 가 나머지 repo 알림을 막지 않는지 (rollback 격리). Railway cron 트리거 후 로그 확인 권장.
- [ ] security_scan 병렬 fetch 후 code/secret alert 집계 정확성.