### PR TITLE
fix(p2-pr4): SSRF/검증 일관성 — CGNAT 단일출처 + 폼 https-only + URL 인코딩 + 훅 Bearer (WBS 감사 P2)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,8 @@ src/
 │   ├── rls_context.py           # contextvars 기반 request scope user_id (Phase 3 postlude)
 │   ├── feature_kill_switch.py   # is_disabled(feature) helper (Cycle 78 NEW-P0-2)
 │   ├── alembic_dialect.py       # is_postgresql(bind_or_conn) (Cycle 82 PR 1 — 사용처 12)
-│   └── lang_names.py            # LANG_NAMES dict — locale 코드 → Claude 프롬프트 언어명 (단일 출처)
+│   ├── lang_names.py            # LANG_NAMES dict — locale 코드 → Claude 프롬프트 언어명 (단일 출처)
+│   └── ssrf.py                  # is_dangerous_ip() — SSRF IP 분류 단일 출처 (_http.py 발신 가드 + settings.py 폼 검증)
 ├── middleware/
 │   ├── rls_session.py           # RLSSessionMiddleware (ASGI, BaseHTTPMiddleware 우회)
 │   └── locale.py                # LocaleMiddleware — 5단계 locale 감지 (Cookie > Accept-Language q-weight > User > settings > fallback)

--- a/src/github_client/checks.py
+++ b/src/github_client/checks.py
@@ -4,10 +4,12 @@ GitHub Check Runs / Status API — Phase 12 CI status queries.
 import logging
 import re
 import time
+from urllib.parse import quote
 
 import httpx
 
 from src.constants import GITHUB_API
+from src.github_client.helpers import repo_path
 from src.shared.http_client import get_http_client
 from src.shared.log_safety import sanitize_for_log
 
@@ -92,7 +94,7 @@ async def get_ci_status(
     # ── 1. Collect check runs via paginated API ────────────────────────
     all_check_runs: list[dict] = []
     url: str | None = (
-        f"{GITHUB_API}/repos/{repo_full_name}/commits/{commit_sha}/check-runs"
+        f"{GITHUB_API}/repos/{repo_path(repo_full_name)}/commits/{quote(commit_sha, safe='')}/check-runs"
     )
     page_count = 0
 
@@ -133,7 +135,7 @@ async def get_ci_status(
     # ── 4. 레거시 Commit Status fallback ─────────────────────────────
     # ── 4. Legacy Commit Status fallback ──────────────────────────────
     legacy_resp = await client.get(
-        f"{GITHUB_API}/repos/{repo_full_name}/commits/{commit_sha}/status",
+        f"{GITHUB_API}/repos/{repo_path(repo_full_name)}/commits/{quote(commit_sha, safe='')}/status",
         headers=_auth_headers(token),
     )
     legacy_resp.raise_for_status()
@@ -259,7 +261,9 @@ async def get_required_check_contexts(
 
     try:
         resp = await client.get(
-            f"{GITHUB_API}/repos/{repo_full_name}/branches/{branch}"
+            # branch 는 슬래시 포함 가능(feature/x) → safe='/' 로 슬래시 보존 (GitHub path 정합)
+            # branch may contain slashes (feature/x) → safe='/' preserves them (GitHub path semantics)
+            f"{GITHUB_API}/repos/{repo_path(repo_full_name)}/branches/{quote(branch, safe='/')}"
             f"/protection/required_status_checks",
             headers=_auth_headers(token),
         )

--- a/src/github_client/helpers.py
+++ b/src/github_client/helpers.py
@@ -1,4 +1,15 @@
 """Shared helpers for GitHub API client modules."""
+from urllib.parse import quote
+
+
+def repo_path(full_name: str) -> str:
+    """owner/repo 를 URL 안전하게 인코딩 (슬래시는 유지) — github_client URL 빌드 단일 출처.
+    URL-encode owner/repo defensively while preserving the path slash — single source for github_client URL builds.
+
+    GitHub 저장소 이름은 신뢰 입력이지만 방어적 인코딩으로 path injection 을 차단한다.
+    GitHub repo names are trusted input, but defensive encoding blocks path injection.
+    """
+    return quote(full_name, safe="/")
 
 
 def github_api_headers(token: str) -> dict:

--- a/src/github_client/repos.py
+++ b/src/github_client/repos.py
@@ -7,6 +7,7 @@ from urllib.parse import quote
 import httpx
 
 from src.constants import GITHUB_API
+from src.github_client.helpers import repo_path as _repo_path
 from src.shared.http_client import get_http_client
 from src.shared.log_safety import sanitize_for_log
 
@@ -21,14 +22,6 @@ WEBHOOK_EVENTS = ["push", "pull_request", "issues", "check_suite"]
 
 def _auth_headers(token: str) -> dict:
     return {**_HEADERS, "Authorization": f"Bearer {token}"}
-
-
-def _repo_path(full_name: str) -> str:
-    """owner/repo 를 URL 안전하게 인코딩 (슬래시는 유지).
-
-    GitHub 저장소 이름은 신뢰 입력이지만 방어적 인코딩으로 path injection 차단.
-    """
-    return quote(full_name, safe="/")
 
 
 async def list_user_repos(token: str) -> list[dict]:
@@ -154,7 +147,7 @@ REPO=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d['rep
 [ -n "${SERVER}" ] || exit 0
 
 REPO_ENC=$(python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1]))" "${REPO}")
-STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${SERVER}/api/hook/verify?repo=${REPO_ENC}&token=${TOKEN}" 2>/dev/null)
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${TOKEN}" "${SERVER}/api/hook/verify?repo=${REPO_ENC}" 2>/dev/null)
 [ "${STATUS}" = "200" ] || exit 0
 
 read -r LOCAL_REF LOCAL_SHA REMOTE_REF REMOTE_SHA < /dev/stdin 2>/dev/null || true

--- a/src/notifier/_http.py
+++ b/src/notifier/_http.py
@@ -8,25 +8,11 @@ from urllib.parse import urlparse
 import httpx
 
 from src.constants import HTTP_CLIENT_TIMEOUT
+from src.shared.ssrf import is_dangerous_ip
 
 logger = logging.getLogger(__name__)
 
 _ALLOWED_SCHEMES = {"https"}
-
-
-def _is_dangerous_ip(addr: str) -> bool:
-    """Return True if the IP address should be blocked (private/loopback/link-local/etc.)."""
-    try:
-        ip = ipaddress.ip_address(addr)
-        return (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_multicast
-        )
-    except ValueError:
-        return False
 
 
 async def validate_external_url(url: str) -> bool:
@@ -57,7 +43,7 @@ async def validate_external_url(url: str) -> bool:
     # Direct IP literal — check immediately without DNS lookup
     try:
         ipaddress.ip_address(hostname)
-        is_bad = _is_dangerous_ip(hostname)
+        is_bad = is_dangerous_ip(hostname)
         if is_bad:
             logger.warning("SSRF guard: rejected private/loopback IP literal '%s'", hostname)
         return not is_bad
@@ -80,7 +66,7 @@ async def validate_external_url(url: str) -> bool:
         )
         return False
 
-    bad_addr = next((a for a in addrs if _is_dangerous_ip(a)), None)
+    bad_addr = next((a for a in addrs if is_dangerous_ip(a)), None)
     if bad_addr:
         logger.warning(
             "SSRF guard: hostname '%s' resolved to blocked IP '%s'", hostname, bad_addr

--- a/src/shared/ssrf.py
+++ b/src/shared/ssrf.py
@@ -1,0 +1,42 @@
+"""SSRF 방어 IP 분류 — 발신 가드(_http.py)와 폼 검증(settings.py) 단일 출처.
+SSRF-defense IP classification — single source for the outbound guard (_http.py)
+and the settings form validator (settings.py).
+
+두 검증기가 각자 IP 위험 판정을 중복 구현하면 한쪽만 갱신돼 drift(예: CGNAT 누락)가
+발생한다 — 본 모듈로 단일화해 회귀를 차단한다 (WBS 감사 P2 — 검증 일관성).
+Duplicating the IP-danger check in two validators causes drift (e.g. a missing CGNAT
+range) when only one is updated — this module unifies it (WBS audit P2 — validation consistency).
+"""
+import ipaddress
+
+# CGNAT(Carrier-Grade NAT) 대역 — RFC 6598. ip.is_private/is_reserved 어디에도 안 잡혀 명시 차단.
+# CGNAT (Carrier-Grade NAT) range — RFC 6598. Not covered by is_private/is_reserved, so block it explicitly.
+_CGNAT_NETWORK = ipaddress.ip_network("100.64.0.0/10")
+
+
+def is_dangerous_ip(addr: str) -> bool:
+    """IP 문자열이 SSRF 차단 대상인지 판정한다.
+    Return True if the IP string should be blocked for SSRF.
+
+    차단 대역: 사설 / 루프백 / 링크-로컬 / 예약 / 멀티캐스트 / CGNAT(100.64.0.0/10).
+    Blocked ranges: private / loopback / link-local / reserved / multicast / CGNAT (100.64.0.0/10).
+
+    IP 리터럴이 아니면(도메인명) False 반환 — 호출자가 DNS 해석 후 각 주소로 재호출한다.
+    Returns False for non-IP strings (domain names) — callers resolve DNS and re-check each address.
+    """
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        # 도메인명 등 IP 가 아닌 입력 — 여기서 판정 불가 (DNS 해석은 호출자 책임)
+        # Non-IP input (e.g. domain name) — cannot classify here (caller resolves DNS)
+        return False
+    # `ip in _CGNAT_NETWORK` 은 버전 불일치(IPv6) 시 False 반환 — 안전 (ipaddress __contains__ 규약)
+    # `ip in _CGNAT_NETWORK` returns False on version mismatch (IPv6) — safe (ipaddress __contains__ contract)
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip in _CGNAT_NETWORK
+    )

--- a/src/ui/routes/settings.py
+++ b/src/ui/routes/settings.py
@@ -1,7 +1,6 @@
 """리포 설정 관련 페이지/폼/webhook 재설치 엔드포인트."""
 from __future__ import annotations
 
-import ipaddress
 import secrets
 from dataclasses import fields as dataclass_fields
 from typing import Annotated
@@ -31,6 +30,7 @@ from src.i18n.loader import get_text
 from src.models.repo_config import RepoConfig
 from src.repositories import repo_config_repo
 from src.shared.log_safety import sanitize_for_log
+from src.shared.ssrf import is_dangerous_ip
 from src.ui._helpers import (
     GITHUB_WEBHOOK_PATH,
     get_accessible_repo,
@@ -63,21 +63,23 @@ def _is_safe_webhook_url(url: str | None) -> bool:  # pylint: disable=too-many-r
         return True
     try:
         parsed = urlparse(url)
-        if parsed.scheme not in ("http", "https"):
+        # https-only — 발신 가드(_http.py _ALLOWED_SCHEMES)와 동일 정책. http 는 send-time 에 거부되므로
+        # 폼에서도 일관 차단 (저장됐으나 발송 안 되는 혼란 방지, WBS 감사 P2 — 스킴 비대칭 해소).
+        # https-only — matches the outbound guard (_http.py); http is rejected at send time anyway,
+        # so block it at the form too (avoids "saved but never sends" confusion).
+        if parsed.scheme != "https":
             return False
         host = (parsed.hostname or "").lower()
         if not host:
             return False
         if host in _BLOCKED_HOSTS:
             return False
-        # 사설 IP 대역, 루프백, 링크-로컬 주소 차단
-        # Block private/loopback/link-local IP ranges.
-        try:
-            ip = ipaddress.ip_address(host)
-            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
-                return False
-        except ValueError:
-            pass  # 호스트명(도메인)은 IP 파싱 실패가 정상 / Domain names will fail IP parsing — that is fine.
+        # 위험 IP 대역 차단 (사설/루프백/링크로컬/예약/멀티캐스트/CGNAT) — 발신 가드와 단일 출처 헬퍼 공유.
+        # 도메인명은 IP 가 아니므로 False → send-time validate_external_url 가 DNS 해석 후 차단.
+        # Block dangerous IP ranges via the shared single-source helper (same as the outbound guard).
+        # Domain names are not IPs (False) → resolved+blocked at send time by validate_external_url.
+        if is_dangerous_ip(host):
+            return False
         return True
     except Exception:  # pylint: disable=broad-except
         return False

--- a/tests/unit/github_client/test_checks.py
+++ b/tests/unit/github_client/test_checks.py
@@ -136,6 +136,41 @@ async def test_get_ci_status_passed_when_all_success():
     assert mock_client.get.call_count == 1
 
 
+# ── WBS 감사 P2: URL path 인코딩 일관성 (repos.py _repo_path 패턴 정합) ──────────
+# ── WBS audit P2: URL path encoding consistency (matches repos.py _repo_path) ──
+
+
+async def test_get_ci_status_encodes_repo_and_sha_in_url():
+    """repo_full_name/commit_sha 특수문자가 URL 인코딩됨 (슬래시 보존, path injection 방어).
+    repo_full_name/commit_sha special chars are URL-encoded (slash preserved, path-injection defence).
+    """
+    body = {"check_runs": [_check_run("ci", "completed", "success")], "total_count": 1}
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=_resp(200, body))
+
+    with patch("src.github_client.checks.get_http_client", return_value=mock_client):
+        await get_ci_status(TOKEN, "owner/re po", "ab cd")
+
+    called_url = mock_client.get.call_args[0][0]
+    assert "owner/re%20po" in called_url   # 슬래시 보존 + 공백 인코딩 / slash kept, space encoded
+    assert "ab%20cd" in called_url
+    assert "re po" not in called_url       # raw 미인코딩 문자열 미포함 / no raw unencoded value
+
+
+async def test_get_required_check_contexts_encodes_branch_in_url():
+    """branch 특수문자가 URL 인코딩되되 슬래시는 보존된다 (feature/x 정합).
+    branch special chars are URL-encoded while slashes are preserved (feature/x semantics).
+    """
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=_resp(200, {"contexts": ["ci/build"]}))
+
+    with patch("src.github_client.checks.get_http_client", return_value=mock_client):
+        await get_required_check_contexts(TOKEN, "owner/myrepo", "feat/x y")
+
+    called_url = mock_client.get.call_args[0][0]
+    assert "branches/feat/x%20y/" in called_url   # 슬래시 보존 + 공백 인코딩 / slash kept, space encoded
+
+
 async def test_get_ci_status_failed_when_any_failed():
     """completed 체크런 중 하나라도 failure이면 'failed' 반환.
     Returns 'failed' when any completed check run has a failure conclusion.

--- a/tests/unit/github_client/test_github_repos.py
+++ b/tests/unit/github_client/test_github_repos.py
@@ -277,6 +277,21 @@ def test_install_hook_sh_uses_anthropic_api():
     )
 
 
+def test_install_hook_sh_verify_uses_bearer_not_query_token():
+    """verify 호출이 토큰을 Authorization: Bearer 헤더로 전달하고 query param 으로는 노출 안 함.
+    The verify call sends the token via Authorization: Bearer header, not as a query param.
+
+    WBS 감사 P2 — 토큰이 URL(서버/프록시 access 로그·히스토리)에 노출되던 결함 봉인.
+    WBS audit P2 — seals the leak where the token appeared in the URL (server/proxy logs, history).
+    """
+    from src.github_client.repos import _INSTALL_HOOK_SH
+    verify_lines = [l for l in _INSTALL_HOOK_SH.splitlines() if "/api/hook/verify" in l]
+    assert verify_lines, "verify 호출 라인을 찾지 못함"
+    verify_line = verify_lines[0]
+    assert 'Authorization: Bearer ${TOKEN}' in verify_line, "verify 가 Bearer 헤더를 쓰지 않음"
+    assert "token=${TOKEN}" not in verify_line, "verify URL 에 token query param 이 남아있음"
+
+
 def test_install_hook_sh_reads_anthropic_api_key():
     """pre-push hook 스크립트가 ANTHROPIC_API_KEY 환경변수를 사용해야 한다."""
     from src.github_client.repos import _INSTALL_HOOK_SH

--- a/tests/unit/shared/test_ssrf.py
+++ b/tests/unit/shared/test_ssrf.py
@@ -1,0 +1,52 @@
+"""src/shared/ssrf.py 단위 테스트 — is_dangerous_ip 단일 출처 IP 분류.
+Unit tests for src/shared/ssrf.py — is_dangerous_ip single-source IP classification.
+"""
+import pytest
+
+from src.shared.ssrf import is_dangerous_ip
+
+
+@pytest.mark.parametrize(
+    "addr",
+    [
+        "10.0.0.1",            # private
+        "192.168.1.1",         # private
+        "172.16.0.1",          # private
+        "127.0.0.1",           # loopback
+        "169.254.169.254",     # link-local (cloud metadata)
+        "0.0.0.0",             # reserved
+        "224.0.0.1",           # multicast
+        "100.64.1.1",          # CGNAT (RFC 6598) — 핵심 회귀 가드 / key regression guard
+        "100.127.255.255",     # CGNAT 상단 경계 / CGNAT upper boundary
+        "::1",                 # IPv6 loopback
+        "fe80::1",             # IPv6 link-local
+    ],
+)
+def test_dangerous_ips_blocked(addr):
+    assert is_dangerous_ip(addr) is True
+
+
+@pytest.mark.parametrize(
+    "addr",
+    [
+        "8.8.8.8",             # public
+        "1.1.1.1",             # public
+        "100.63.255.255",      # CGNAT 직전 (공인) / just below CGNAT (public)
+        "100.128.0.0",         # CGNAT 직후 (공인) / just above CGNAT (public)
+    ],
+)
+def test_public_ips_allowed(addr):
+    assert is_dangerous_ip(addr) is False
+
+
+def test_domain_name_returns_false():
+    # 도메인명은 IP 파싱 실패 → False (DNS 해석은 호출자 책임)
+    # Domain names fail IP parsing → False (DNS resolution is the caller's responsibility)
+    assert is_dangerous_ip("example.com") is False
+    assert is_dangerous_ip("") is False
+
+
+def test_cgnat_check_no_version_error_for_ipv6():
+    # IPv6 주소가 IPv4 CGNAT 네트워크와 비교돼도 TypeError 없이 동작 (다른 사유로 차단/허용)
+    # IPv6 vs IPv4-CGNAT comparison must not raise TypeError (blocked/allowed by other rules)
+    assert is_dangerous_ip("2001:4860:4860::8888") is False  # public IPv6 (Google DNS)

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -233,7 +233,7 @@ def test_post_settings_redirects():
                     "approve_threshold": "85",
                     "reject_threshold": "55",
                     "notify_chat_id": "-123",
-                    "n8n_webhook_url": "http://n8n.local/webhook/abc",
+                    "n8n_webhook_url": "https://n8n.example.com/webhook/abc",
                 },
                 follow_redirects=False,
             )
@@ -242,7 +242,7 @@ def test_post_settings_redirects():
     assert called_config.approve_mode == "auto"
     assert called_config.approve_threshold == 85
     assert called_config.reject_threshold == 55
-    assert called_config.n8n_webhook_url == "http://n8n.local/webhook/abc"
+    assert called_config.n8n_webhook_url == "https://n8n.example.com/webhook/abc"
     assert r.status_code == 303
 
 

--- a/tests/unit/ui/test_settings_ssrf.py
+++ b/tests/unit/ui/test_settings_ssrf.py
@@ -1,0 +1,69 @@
+"""src/ui/routes/settings.py::_is_safe_webhook_url SSRF 폼 검증 단위 테스트.
+Unit tests for the settings form SSRF validator (_is_safe_webhook_url).
+
+WBS 감사 P2 — 발신 가드(_http.py)와의 검증 일관성 회귀 가드:
+https-only + CGNAT(100.64.0.0/10) 차단 + 위험 IP/호스트 차단.
+WBS audit P2 — regression guard for consistency with the outbound guard:
+https-only + CGNAT block + dangerous IP/host block.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("GITHUB_CLIENT_ID", "test-id")
+os.environ.setdefault("GITHUB_CLIENT_SECRET", "test-secret")
+os.environ.setdefault("SESSION_SECRET", "test-session-secret-32-chars-long!")
+
+import pytest
+
+from src.ui.routes.settings import _is_safe_webhook_url
+
+
+def test_none_and_empty_allowed():
+    # 미설정(None/빈문자열) webhook 은 허용 — 선택 필드
+    # Unset (None/empty) webhook is allowed — optional field
+    assert _is_safe_webhook_url(None) is True
+    assert _is_safe_webhook_url("") is True
+
+
+def test_https_public_domain_allowed():
+    assert _is_safe_webhook_url("https://hooks.example.com/abc") is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://hooks.example.com/abc",   # https-only — http 거부 (발신 가드 일관)
+        "ftp://example.com/x",            # 비-https 스킴
+        "file:///etc/passwd",             # file 스킴
+    ],
+)
+def test_non_https_scheme_rejected(url):
+    assert _is_safe_webhook_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://10.0.0.1/hook",          # private
+        "https://127.0.0.1/hook",         # loopback
+        "https://169.254.169.254/hook",   # link-local (cloud metadata)
+        "https://100.64.1.1/hook",        # CGNAT (RFC 6598) — 핵심 회귀 가드 / key regression guard
+    ],
+)
+def test_dangerous_ip_literals_rejected(url):
+    assert _is_safe_webhook_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://localhost/hook",
+        "https://metadata.google.internal/x",
+    ],
+)
+def test_blocked_hosts_rejected(url):
+    assert _is_safe_webhook_url(url) is False


### PR DESCRIPTION
## 요약
WBS 감사 P2 **SSRF/검증 일관성 묶음**(PR-4). risk-order 진행의 3번째 PR. 두 SSRF 검증기 간 drift(CGNAT 누락) + URL 인코딩 비일관 + 훅 토큰 URL 노출을 해소합니다. **#1 `_http.py` DNS rebinding IP pin 은 사용자 결정으로 전용 후속 PR 로 보류**(아키텍처/알림 발송 위험 — 별도 설계+운영 검증 필요).

## 변경 내용
| 파일 | 변경 |
|------|------|
| `src/shared/ssrf.py` (신규) | `is_dangerous_ip()` — SSRF 차단 IP 분류 **단일 출처** (private/loopback/link-local/reserved/multicast + **CGNAT 100.64.0.0/10**) |
| `src/notifier/_http.py` | 로컬 `_is_dangerous_ip` 제거 → 공용 헬퍼 사용 (발신 가드도 CGNAT 차단) |
| `src/ui/routes/settings.py` | `_is_safe_webhook_url`: **https-only** + `is_dangerous_ip` (CGNAT/멀티캐스트 추가) + `import ipaddress` 제거 |
| `src/github_client/helpers.py` (+repos/checks) | `repo_path()` 단일출처 + checks.py 3 URL 빌드 인코딩 (branch 슬래시 보존) |
| `src/github_client/repos.py` `_INSTALL_HOOK_SH` | verify 토큰 query param → `Authorization: Bearer` 헤더 (URL 노출 차단) |
| `docs/architecture.md` | 신규 `src/shared/ssrf.py` 트리 등재 (6-step ⑥) |

## 자율 판단 보고 (정책 3)
- ⚠️ **#1 IP pin 보류 — 사용자 결정**: DNS rebinding transport-level IP pin 은 알림 발송(SNI/cert) 회귀 위험으로 별도 PR. 본 PR 의 CGNAT 차단은 기존 사설 IP 차단을 보강하며 rebinding 과 독립.
- ⚠️ **단일출처 리팩터 확장**: `is_dangerous_ip`/`repo_path` 를 shared/helpers 로 추출 — drift(이 감사 finding 의 근본 원인) 재발 차단. `_http.py`·repos.py 도 위임 전환(pure 함수, 저위험).
- ⚠️ **CGNAT 를 발신 가드(_http.py)에도 적용**: 감사가 settings.py 항목으로 분류했으나 _http.py 도 동일 gap → 권위 가드(send-time)에 적용해야 실효. 단일출처로 양쪽 동시 해결.

## 🔴 폼 동작 변경 — 사용자 검증 필요 (정책 2)
- [ ] **settings 폼 webhook URL 이 이제 https-only** (http:// 입력 시 400). _http.py 발신 가드가 이미 https-only 라 http webhook 은 **이전에도 발송 불가**였음 — "저장됐으나 발송 안 됨" 혼란 제거 목적. 혹시 의도적으로 http webhook 을 form 에 저장하던 운영 패턴이 있으면 알려주세요 (1줄 revert 가능).
- [ ] Discord/Slack/n8n/custom webhook 발송 정상 동작 (CGNAT/멀티캐스트 차단 추가 후).
- [ ] pre-push 훅 재설치 후 verify 200 동작 (Bearer 헤더 전환). 기존 설치 훅은 query param fallback 으로 호환.

## 검증
- **테스트**: shared/ui/notifier/github_client/hook **678 passed** (+24 신규)
- **pylint**: 변경 6 src 파일 **10.00/10**
- **적대적 보안 검증** (general-purpose): 결함 0 — 모든 변경 strictly-additive(더 엄격), SSRF bypass 신규 0, CGNAT 경계 4점 정확, IPv6 TypeError 없음, branch 슬래시 보존, 훅 토큰 URL 미노출 + query fallback 호환, 구 `_is_dangerous_ip` 잔존 0.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- **현재 면제 상태**: Codex stop-time 게이트 2026-06-03 사용자 지시로 비활성(미로그인) — 정책 18 mutual 면제 (메모리 `feedback_codex_sandbox_precheck.md`). 대체로 Claude-side 적대적 보안 검증 1회 수행.