### PR TITLE
fix(security): n8n issue 릴레이 GitHub 토큰 유출 차단 — opt-in + 시크릿 게이트 (P1)

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -27,6 +27,7 @@
 | `DISABLE_PROMPT_CACHE` | Anthropic prompt caching (5분 ephemeral) opt-out — `1` 시 비활성 (Phase 3 PR 1 #218 신설). 운영 비용 통제용 — default `0` (caching 적용) | `0` (기본) / `1` (비활성) |
 | `TELEGRAM_WEBHOOK_SECRET` | Telegram `setWebhook` 시크릿 토큰 — **미설정 시 401 fail-closed** (사이클 142 Phase B S1 #674 보안 강화 — 이전 "헤더 검증 생략"에서 변경). Railway에서 반드시 설정 필요, 미설정 시 Telegram gate callback 전체 비활성 | 빈 문자열 (기본, **운영 시 반드시 설정**) |
 | `N8N_WEBHOOK_SECRET` | n8n 전송 HMAC 서명 시크릿 (미설정 시 서명 생략) | 빈 문자열 (기본) |
+| `N8N_RELAY_REPO_TOKEN` | n8n issue 릴레이에 GitHub repo OAuth 토큰 포함 여부 — 명시적 opt-in (자격증명 유출 차단). `1`/`true` 이고 `N8N_WEBHOOK_SECRET` 설정 시에만 토큰 전송 | `false` (기본) |
 
 ## 내부 인증 (cron · admin · loop guard)
 

--- a/src/config.py
+++ b/src/config.py
@@ -42,6 +42,9 @@ class Settings(BaseSettings):
     # a token_encryption_key. Defaults to False for backwards-compatible warnings.
     strict_token_encryption: bool = False
     n8n_webhook_secret: str = ""  # n8n 전송 HMAC 서명 시크릿 (빈 문자열이면 서명 생략)
+    # n8n issue 릴레이에 GitHub repo 토큰 포함 여부 — 명시적 opt-in (default off, 자격증명 유출 차단)
+    # Whether to include the GitHub repo token in the n8n issue relay — explicit opt-in (default off)
+    n8n_relay_repo_token: bool = False
     smtp_host: str = ""
     smtp_port: int = 587
     smtp_user: str = ""

--- a/src/notifier/n8n.py
+++ b/src/notifier/n8n.py
@@ -90,6 +90,9 @@ async def notify_n8n_issue(
         body = body_bytes[:N8N_BODY_MAX_BYTES].decode(errors="replace")
         issue = {**issue, "body": body}
 
+    # 방어 심화: repo_token 은 HMAC 서명 시크릿이 설정된 인증 채널로만 전송 (시크릿 없으면 토큰 생략)
+    # Defense-in-depth: relay repo_token only over an authenticated channel (HMAC secret set); omit otherwise
+    relayed_token = repo_token if (repo_token and n8n_secret) else ""
     payload = _build_envelope(
         event_type="issue",
         repo=repo_full_name,
@@ -98,7 +101,7 @@ async def notify_n8n_issue(
             "issue": issue,
             "sender": sender,
             "body_truncated": body_truncated,
-            "repo_token": repo_token,
+            "repo_token": relayed_token,
         },
     )
     await _post_to_n8n(webhook_url, payload, n8n_secret)

--- a/src/webhook/providers/github.py
+++ b/src/webhook/providers/github.py
@@ -244,9 +244,12 @@ async def _handle_issues_event(data: dict, background_tasks: BackgroundTasks) ->
         with SessionLocal() as db:
             config = get_repo_config(db, repo_name)
             n8n_url = config.n8n_webhook_url
-            repo = repository_repo.find_by_full_name(db, repo_name)
-            if repo and repo.owner:
-                repo_token = repo.owner.plaintext_token
+            # n8n 으로의 GitHub 토큰 릴레이는 명시적 opt-in(N8N_RELAY_REPO_TOKEN) + HMAC 시크릿 설정 시에만 수행 (자격증명 유출 차단)
+            # Relay the GitHub token only when opted-in AND an HMAC secret is set (credential-leak guard)
+            if settings.n8n_relay_repo_token and settings.n8n_webhook_secret:
+                repo = repository_repo.find_by_full_name(db, repo_name)
+                if repo and repo.owner:
+                    repo_token = repo.owner.plaintext_token
     except (SQLAlchemyError, KeyError, AttributeError) as exc:
         logger.warning(
             "issues relay: repo config lookup failed for %s: %s",

--- a/tests/unit/notifier/test_n8n.py
+++ b/tests/unit/notifier/test_n8n.py
@@ -109,6 +109,7 @@ async def test_notify_n8n_issue_includes_repo_token_in_payload():
             action="opened",
             issue={"number": 1, "title": "test", "body": ""},
             sender={"login": "octocat"},
+            n8n_secret="shh",
             repo_token="ghp_abc",
         )
 
@@ -146,3 +147,32 @@ async def test_notify_n8n_issue_repo_token_defaults_empty():
         "data 딕셔너리에 'repo_token' 키가 없음 — notify_n8n_issue()에 repo_token 파라미터 추가 필요"
     assert data["repo_token"] == "", \
         f"repo_token 기본값이 ''이어야 하지만 실제 값: {data.get('repo_token')!r}"
+
+
+async def test_notify_n8n_issue_omits_repo_token_without_secret():
+    # 자격증명 유출 가드: n8n_secret 미설정 시 repo_token 이 전달돼도 페이로드에서 빈 문자열로 생략돼야 한다
+    # Credential-leak guard: with no n8n_secret, a passed repo_token must be omitted (empty) from the payload
+    from src.notifier.n8n import notify_n8n_issue
+    mock_response = MagicMock()
+    mock_response.raise_for_status = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.post = AsyncMock(return_value=mock_response)
+
+    with patch("src.notifier.n8n.validate_external_url", return_value=True), \
+         patch("src.notifier.n8n.build_safe_client", return_value=mock_client):
+        await notify_n8n_issue(
+            webhook_url="https://n8n.example.com/webhook/abc",
+            repo_full_name="owner/repo",
+            action="opened",
+            issue={"number": 1, "title": "test", "body": ""},
+            sender={"login": "octocat"},
+            repo_token="ghp_secret_token",  # n8n_secret 미설정 → 토큰 유출 금지 / no secret → must not leak
+        )
+
+    mock_client.post.assert_called_once()
+    payload = mock_client.post.call_args.kwargs.get("json") or mock_client.post.call_args.args[1]
+    data = payload["data"]
+    assert data["repo_token"] == "", \
+        f"시크릿 없이 repo_token 이 유출됨 (자격증명 유출 결함): {data.get('repo_token')!r}"

--- a/tests/unit/webhook/test_issues.py
+++ b/tests/unit/webhook/test_issues.py
@@ -259,7 +259,10 @@ def test_issues_event_passes_repo_token_to_notify():
          patch("src.webhook.providers.github.SessionLocal", return_value=mock_db), \
          patch("src.webhook.providers.github.get_repo_config", return_value=repo_config):
         mock_settings.github_webhook_secret = SECRET
-        mock_settings.n8n_webhook_secret = ""
+        # opt-in(N8N_RELAY_REPO_TOKEN) + HMAC 시크릿 둘 다 충족 시에만 토큰 릴레이
+        # token relayed only when opt-in flag AND HMAC secret are both set
+        mock_settings.n8n_webhook_secret = "shh"
+        mock_settings.n8n_relay_repo_token = True
         with patch("fastapi.BackgroundTasks.add_task", side_effect=_capture_add_task):
             resp = client.post(
                 "/webhooks/github",
@@ -275,3 +278,52 @@ def test_issues_event_passes_repo_token_to_notify():
         f"notify_n8n_issue 호출 시 repo_token kwarg가 전달되지 않음. 실제 kwargs: {captured_kwargs}"
     assert captured_kwargs["repo_token"] == "ghp_owner_token", \
         f"repo_token이 'ghp_owner_token'이어야 하지만 실제 값: {captured_kwargs.get('repo_token')!r}"
+
+
+def test_issues_event_omits_repo_token_when_not_opted_in():
+    # 자격증명 유출 가드: opt-in(N8N_RELAY_REPO_TOKEN) 미설정 시 시크릿이 있어도 owner 토큰을 읽지 않고 repo_token=""로 전달
+    # Credential-leak guard: without the opt-in flag, the owner token is NOT read even if a secret is set; repo_token passed as ""
+    payload = _issues_payload()
+    repo_config = _mock_repo_config(n8n_webhook_url="https://n8n.example.com/webhook/abc")
+
+    mock_owner = MagicMock()
+    mock_owner.plaintext_token = "ghp_owner_token"
+    mock_repo_obj = MagicMock()
+    mock_repo_obj.full_name = "owner/repo"
+    mock_repo_obj.owner = mock_owner
+    mock_repo_obj.webhook_secret = None
+
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_repo_obj
+    mock_db.query.return_value.filter_by.return_value.first.return_value = mock_repo_obj
+    mock_db.__enter__ = MagicMock(return_value=mock_db)
+    mock_db.__exit__ = MagicMock(return_value=None)
+
+    captured_kwargs = {}
+
+    def _capture_add_task(func, *args, **kwargs):
+        func_name = getattr(func, "__name__", "") or str(func)
+        if "notify_n8n_issue" in func_name or "issue" in func_name.lower():
+            captured_kwargs.update(kwargs)
+
+    with patch("src.webhook.providers.github.settings") as mock_settings, \
+         patch("src.webhook.providers.github.get_webhook_secret", return_value=SECRET), \
+         patch("src.webhook.providers.github.SessionLocal", return_value=mock_db), \
+         patch("src.webhook.providers.github.get_repo_config", return_value=repo_config):
+        mock_settings.github_webhook_secret = SECRET
+        # 시크릿은 설정됐으나 opt-in off → 토큰 생략 / secret set but opt-in off → omit token
+        mock_settings.n8n_webhook_secret = "shh"
+        mock_settings.n8n_relay_repo_token = False
+        with patch("fastapi.BackgroundTasks.add_task", side_effect=_capture_add_task):
+            resp = client.post(
+                "/webhooks/github",
+                content=payload,
+                headers={
+                    "X-Hub-Signature-256": _sign(payload),
+                    "X-GitHub-Event": "issues",
+                },
+            )
+
+    assert resp.status_code == 202
+    assert captured_kwargs.get("repo_token") == "", \
+        f"opt-in off 인데 owner 토큰이 유출됨 (자격증명 유출 결함): {captured_kwargs.get('repo_token')!r}"


### PR DESCRIPTION
@
## 요약 (정합성 감사 P1 보안)
n8n issue 릴레이가 repo 소유자의 **복호화된 full-repo GitHub OAuth 토큰**을 사용자 설정 `n8n_webhook_url` 로 **무조건(시크릿 없어도) 전송**하던 자격증명 유출 벡터를 차단. 사용자 선택(**opt-in + secret 결합**)대로 구현.

## ⚠️ 자율 판단 보고 (정책 3)
- **opt-in 을 per-repo RepoConfig(5-way sync + DB 마이그레이션) 대신 전역 env-var `N8N_RELAY_REPO_TOKEN` 로 구현**했습니다. 사유: (a) 보안 control 은 ops 통제(웹 UI 비노출)가 더 안전, (b) 운영 DB 마이그레이션 리스크 회피, (c) 변경 표면 최소화. **per-repo granularity 가 필요하면 알려주세요** — RepoConfig 필드로 확장 가능.

## 게이트 동작 (opt-in AND secret)
| 조건 | 토큰 전송 |
|------|----------|
| 기본 (flag off) | ❌ 조회조차 안 함 (기본 안전) |
| `N8N_RELAY_REPO_TOKEN=1` + `N8N_WEBHOOK_SECRET` 설정 | ✅ 전송 (기능 보존) |
| flag on, secret 없음 | ❌ 미전송 |
| (방어 심화) n8n.py: secret 없으면 payload 에서 생략 | ❌ |

## 변경
- `src/config.py`: `n8n_relay_repo_token: bool = False` 신설
- `src/webhook/providers/github.py`: opt-in AND secret 충족 시에만 `owner.plaintext_token` 조회
- `src/notifier/n8n.py`: 방어 심화 — secret 없으면 `repo_token` 생략
- `docs/reference/env-vars.md`: `N8N_RELAY_REPO_TOKEN` 등재
- 회귀 가드 테스트 +2 (n8n: 시크릿 없이 토큰 생략 / issues: opt-in off 시 미전송)

## 검증
- `pytest tests/unit/notifier/test_n8n.py tests/unit/webhook/test_issues.py` → **15 passed**
- flake8 clean (config/n8n/github)
- **현재 main(#759) 기준** (앞선 stale feat 브랜치 아님)

## 🔍 사용자 검증 필요 (정책 2)
- 운영에서 n8n 토큰 릴레이를 쓰고 있었다면 `N8N_RELAY_REPO_TOKEN=1` + `N8N_WEBHOOK_SECRET` 설정 필요 (미설정 시 토큰 전송 중단 = 의도된 동작).
- per-repo opt-in vs 전역 env-var 결정 검토.

## 🔍 Codex 검증 (정책 18)
- Codex CLI 인증 토큰 만료로 mutual 검증 불가 → 사용자 승인 하 **Claude-직접 검증 fallback** (STATE.md 사이클 119/125 전례). `codex login` 재인증 시 재검증 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@