### PR TITLE
fix(db): issue_registrations RLS policy 추가 (alembic 0037) — 정합성 감사 P1

### DIFF
--- a/alembic/versions/0037_issue_registrations_rls.py
+++ b/alembic/versions/0037_issue_registrations_rls.py
@@ -1,0 +1,78 @@
+"""issue_registrations RLS policy — PostgreSQL only (정합성 감사 P1).
+
+issue_registrations RLS policy — PostgreSQL only (integrity-audit P1).
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-06-06
+
+정합성 감사 발견: issue_registrations 는 11개 앱 테이블 중 유일하게 DB-레벨 RLS 2차 격리
+안전망이 없었다 (1차 = 앱 레벨 필터). 0029 의 repo_configs/gate_decisions 간접 격리 패턴을
+계승하되 issue_registrations 는 repo_id 컬럼을 직접 보유하므로 1-hop 격리를 적용한다.
+
+Integrity-audit finding: issue_registrations was the only one of 11 app tables without a
+DB-level RLS 2nd-tier guard (app-level filter is the 1st). Mirrors the 0029 indirect-isolation
+pattern but uses 1-hop (issue_registrations has a repo_id column).
+
+legacy NULL 호환: user_id IS NULL 행 허용 (repositories RLS 정합 — 0026/0029 패턴 페어).
+legacy NULL compat: allow user_id IS NULL rows (pairs with repositories RLS — 0026/0029).
+
+회귀 가드: tests/unit/migrations/test_0037_issue_registrations_rls.py
+"""
+from alembic import op
+
+from src.shared.alembic_dialect import is_postgresql
+
+
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+
+# issue_registrations — 간접 1-hop (repo_id → repositories.user_id)
+# issue_registrations — indirect 1-hop (repo_id → repositories.user_id)
+_RLS_ISSUE_REGISTRATIONS = """
+ALTER TABLE issue_registrations ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS issue_registrations_user_isolation ON issue_registrations;
+
+CREATE POLICY issue_registrations_user_isolation ON issue_registrations
+    FOR ALL
+    USING (
+        repo_id IN (
+            SELECT id FROM repositories
+            WHERE user_id IS NULL
+               OR user_id = NULLIF(current_setting('app.user_id', true), '')::integer
+        )
+    );
+"""
+
+
+_DROP_ISSUE_REGISTRATIONS = (
+    "DROP POLICY IF EXISTS issue_registrations_user_isolation ON issue_registrations; "
+    "ALTER TABLE issue_registrations DISABLE ROW LEVEL SECURITY;"
+)
+
+
+def upgrade() -> None:
+    """issue_registrations 에 RLS policy 적용 (PostgreSQL 만).
+
+    Apply the RLS policy to issue_registrations (PostgreSQL only).
+    SQLite 단위 테스트 환경에서는 자동 skip.
+    """
+    bind = op.get_bind()
+    if not is_postgresql(bind):
+        return  # SQLite 단위 테스트 호환 — RLS skip
+    op.execute(_RLS_ISSUE_REGISTRATIONS)
+
+
+def downgrade() -> None:
+    """RLS policy 제거 + RLS 비활성 (PostgreSQL 만).
+
+    Drop the RLS policy + disable RLS (PostgreSQL only).
+    """
+    bind = op.get_bind()
+    if not is_postgresql(bind):
+        return
+    op.execute(_DROP_ISSUE_REGISTRATIONS)

--- a/tests/unit/migrations/test_0037_issue_registrations_rls.py
+++ b/tests/unit/migrations/test_0037_issue_registrations_rls.py
@@ -1,0 +1,98 @@
+"""정합성 감사 — alembic 0037 issue_registrations RLS 회귀 가드.
+
+Integrity-audit — alembic 0037 issue_registrations RLS regression guard.
+
+검증:
+    C.1 — revision = '0037' / down_revision = '0036'
+    C.2 — postgresql dialect: issue_registrations ALTER + CREATE POLICY 호출
+    C.3 — sqlite dialect: op.execute 호출 0회 (skip — 단위 테스트 호환)
+    C.4 — legacy NULL 호환 (repo_id → repositories.user_id IS NULL 허용)
+"""
+# pylint: disable=wrong-import-position
+import importlib.util
+import os
+import pathlib
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+
+def _load_0037_module():
+    """alembic/versions/0037_*.py 동적 로드 — 0029 가드 패턴 차용."""
+    versions_dir = pathlib.Path(__file__).resolve().parents[3] / "alembic" / "versions"
+    candidates = sorted(versions_dir.glob("0037_*.py"))
+    assert len(candidates) >= 1, (
+        f"alembic/versions/0037_*.py 파일 미존재. 검색 경로: {versions_dir}"
+    )
+    module_path = candidates[0]
+    spec = importlib.util.spec_from_file_location(
+        f"alembic_0037_{module_path.stem}", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _capture_pg_upgrade_sql() -> list[str]:
+    """postgresql dialect mock + upgrade() 호출 + SQL 캡처."""
+    module = _load_0037_module()
+    fake_bind = MagicMock()
+    fake_bind.dialect.name = "postgresql"
+    captured: list[str] = []
+
+    def _capture(sql, *_args, **_kwargs):
+        captured.append(str(sql))
+
+    with patch.object(module, "op") as mock_op:
+        mock_op.get_bind.return_value = fake_bind
+        mock_op.execute.side_effect = _capture
+        module.upgrade()
+    return captured
+
+
+def test_alembic_0037_revision_metadata():
+    """C.1 — revision = '0037' + down_revision = '0036'."""
+    module = _load_0037_module()
+    assert getattr(module, "revision", None) == "0037", (
+        f"revision = '0037' 기대, 실제: {getattr(module, 'revision', None)!r}"
+    )
+    assert getattr(module, "down_revision", None) == "0036", (
+        f"down_revision = '0036' 기대, 실제: {getattr(module, 'down_revision', None)!r}"
+    )
+
+
+def test_alembic_0037_postgresql_applies_rls():
+    """C.2 — postgresql dialect 시 issue_registrations ALTER + CREATE POLICY 호출."""
+    captured = _capture_pg_upgrade_sql()
+    assert len(captured) >= 1, "PG dialect 시 op.execute 호출 0회 — RLS 분기 미진입"
+
+    joined = " ".join(captured).upper()
+    assert "ISSUE_REGISTRATIONS" in joined, "PG 분기에서 issue_registrations ALTER 누락"
+    assert "ROW LEVEL SECURITY" in joined, "ENABLE ROW LEVEL SECURITY 의무"
+    assert "CREATE POLICY" in joined, "CREATE POLICY 의무"
+
+
+def test_alembic_0037_sqlite_skip():
+    """C.3 — sqlite dialect 시 op.execute 호출 0회 (RLS skip — 단위 테스트 호환)."""
+    module = _load_0037_module()
+    fake_bind = MagicMock()
+    fake_bind.dialect.name = "sqlite"
+
+    with patch.object(module, "op") as mock_op:
+        mock_op.get_bind.return_value = fake_bind
+        module.upgrade()
+        mock_op.execute.assert_not_called()
+
+
+def test_alembic_0037_legacy_null_compat():
+    """C.4 — legacy NULL 호환: repo_id 서브쿼리가 user_id IS NULL 행을 허용해야 한다."""
+    captured = _capture_pg_upgrade_sql()
+    joined = " ".join(captured)
+    assert "repo_id IN" in joined, "repo_id 기반 1-hop 격리 누락"
+    assert "user_id IS NULL" in joined, (
+        "legacy NULL 호환 누락 — repositories RLS 정합(0026/0029) 깨짐"
+    )


### PR DESCRIPTION
@
## 요약 (정합성 감사 P1, DB)
`issue_registrations` 는 11개 앱 테이블 중 **유일하게 DB-레벨 RLS 2차 격리 안전망이 없던** 테이블. 앱 레벨 필터(1차)는 있으나 RLS(2차 defense-in-depth) 부재. 0029 패턴을 계승해 보강.

## 변경
- **alembic/versions/0037_issue_registrations_rls.py** (신규): `repo_id → repositories.user_id` 1-hop 격리 정책. legacy `user_id IS NULL` 호환 (0026/0029 정합). **PostgreSQL 전용** (`is_postgresql` 가드 — SQLite 단위 테스트 자동 skip).
- `down_revision = "0036"` → **배포 DB head(0036)와 정합**, 단일 head `0037` (alembic heads 실측).
- 회귀 가드 테스트 +4 (revision 메타 / PG 적용 / sqlite skip / legacy NULL 호환).

## ⚠️ 자율 판단 보고 (정책 3)
- DB 마이그레이션 = High-tier. **배포 DB(0036)에 다음 배포 시 자동 적용**됨. RLS 활성화는 앱 레벨 `SET LOCAL app.user_id` 미들웨어(기존)와 페어 동작 — 기존 RLS 테이블과 동일 메커니즘이라 추가 운영 변경 불필요.
- 관련 P2(RLS 회귀 가드가 하드코딩 테이블 리스트라 신규 테이블 자동 미탐지)는 본 PR 의 test_0037 추가로 issue_registrations 한정 부분 보강 — 범용 자동탐지는 별도 후속.

## 검증
- `pytest tests/unit/migrations/test_0037_issue_registrations_rls.py` → **4 passed**
- `alembic heads` → 단일 `0037` / flake8 clean
- SQLite 단위 환경에서 마이그레이션 skip 확인 (기존 테스트 무영향)

## 🔍 사용자 검증 필요 (정책 2)
- 운영(Supabase/PG) 배포 후 `issue_registrations` RLS 활성 + 정상 조회 확인 (멀티테넌트).

## 🔍 Codex 검증 (정책 18)
- Codex 인증 만료 → Claude-직접검증 fallback (사용자 승인). `codex login` 후 재검증 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@