### PR TITLE
fix(hook): CLI hook AI 점수 클램핑 — breakdown cap 정합성 위반 차단 (정합성 감사 P1)

### DIFF
--- a/src/api/hook.py
+++ b/src/api/hook.py
@@ -21,7 +21,14 @@ from src.repositories import repo_config_repo
 from src.analyzer.io.ai_review import AiReviewResult
 from src.scorer.calculator import calculate_score
 from src.worker.pipeline import build_analysis_result_dict
-from src.constants import AI_DEFAULT_COMMIT_RAW, AI_DEFAULT_DIRECTION_RAW, AI_DEFAULT_TEST_RAW
+from src.constants import (
+    AI_DEFAULT_COMMIT_RAW,
+    AI_DEFAULT_DIRECTION_RAW,
+    AI_DEFAULT_TEST_RAW,
+    AI_RAW_COMMIT_MAX,
+    AI_RAW_DIRECTION_MAX,
+    AI_RAW_TEST_MAX,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -162,9 +169,13 @@ def save_hook_result(request: Request, body: HookResultRequest):  # pylint: disa
         required_keys = ("commit_message_score", "direction_score", "test_score")
         ai_status = "success" if all(k in ar for k in required_keys) else "parse_error"
         ai_review = AiReviewResult(
-            commit_score=int(ar.get("commit_message_score", AI_DEFAULT_COMMIT_RAW)),
-            ai_score=int(ar.get("direction_score", AI_DEFAULT_DIRECTION_RAW)),
-            test_score=int(ar.get("test_score", AI_DEFAULT_TEST_RAW)),
+            # raw 점수를 0~MAX 범위로 클램프 — ai_review.py 의 클램프 패턴 미러.
+            # 범위 밖 값이 calculator 스케일링을 거쳐 breakdown cap 을 넘는 정합성 위반 방지.
+            # Clamp raw scores to 0~MAX, mirroring ai_review.py — prevents out-of-range
+            # values from pushing breakdown categories past their caps after scaling.
+            commit_score=max(0, min(AI_RAW_COMMIT_MAX, int(ar.get("commit_message_score", AI_DEFAULT_COMMIT_RAW)))),
+            ai_score=max(0, min(AI_RAW_DIRECTION_MAX, int(ar.get("direction_score", AI_DEFAULT_DIRECTION_RAW)))),
+            test_score=max(0, min(AI_RAW_TEST_MAX, int(ar.get("test_score", AI_DEFAULT_TEST_RAW)))),
             summary=ar.get("summary", ""),
             suggestions=ar.get("suggestions", []),
             commit_message_feedback=ar.get("commit_message_feedback", ""),

--- a/tests/unit/api/test_hook.py
+++ b/tests/unit/api/test_hook.py
@@ -14,6 +14,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 from fastapi.testclient import TestClient
 from src.main import app
+from src.constants import COMMIT_MSG_MAX, AI_REVIEW_MAX, TEST_COVERAGE_MAX
 
 client = TestClient(app)
 
@@ -178,6 +179,82 @@ def test_hook_result_calculates_score():
     analysis_obj = saved_analyses[0]
     assert analysis_obj.score == 90
     assert analysis_obj.grade == "A"
+
+
+# ------------------------------------------------------------------
+# AI 점수 클램핑 회귀 가드 — CLI hook 의 raw 점수가 범위(0~MAX)를 벗어나면
+# breakdown 카테고리 점수가 cap 을 초과/미만해 정합성이 깨지는 결함 방지.
+# ai_review.py 의 max(0, min(MAX, ...)) 패턴을 hook.py 가 동일하게 미러하는지 검증.
+# AI score clamping regression guard — out-of-range raw scores from the CLI hook
+# must not push breakdown category scores past their caps (or below 0), mirroring
+# the max(0, min(MAX, ...)) clamp pattern already used in ai_review.py.
+# ------------------------------------------------------------------
+
+def _post_hook_capturing(ai_result: dict) -> list:
+    """주어진 ai_result 로 /api/hook/result 를 호출하고 저장된 Analysis 객체 목록을 반환.
+    Call /api/hook/result with the given ai_result and return captured Analysis objects."""
+    mock_db = MagicMock()
+    mock_config = MagicMock()
+    mock_config.hook_token = "clamp-token"
+    mock_repo = MagicMock()
+    mock_repo.id = 99
+
+    call_count = {"n": 0}
+
+    def _first_side_effect():
+        idx = call_count["n"]
+        call_count["n"] += 1
+        return {0: mock_config, 1: mock_repo}.get(idx)
+
+    mock_db.query.return_value.filter.return_value.first.side_effect = _first_side_effect
+    mock_db.query.return_value.filter_by.return_value.first.return_value = None  # no duplicate
+    saved: list = []
+    mock_db.add.side_effect = lambda obj: saved.append(obj)
+
+    with patch("src.api.hook.SessionLocal", return_value=_make_session_mock(mock_db)):
+        r = client.post("/api/hook/result", json={
+            "repo": "owner/repo",
+            "token": "clamp-token",
+            "commit_sha": "shaclamp",
+            "commit_message": "feat: clamp",
+            "ai_result": ai_result,
+        })
+    assert r.status_code == 200
+    return saved
+
+
+def test_hook_result_clamps_overrange_scores():
+    # 범위 초과 raw 점수(commit=999/direction=50/test=99, 모든 키 존재 → success)는
+    # 상한(20/20/10)으로 클램프되어 breakdown 카테고리 점수가 cap 을 넘지 않는다.
+    saved = _post_hook_capturing({
+        **_AI_RESULT,
+        "commit_message_score": 999,
+        "direction_score": 50,
+        "test_score": 99,
+    })
+    assert len(saved) == 1
+    breakdown = saved[0].result["breakdown"]
+    # 클램프 후 raw 20/20/10 → 스케일 결과가 정확히 각 cap 과 동일
+    # After clamp raw 20/20/10 → scaled exactly to each cap
+    assert breakdown["commit_message"] == COMMIT_MSG_MAX
+    assert breakdown["ai_review"] == AI_REVIEW_MAX
+    assert breakdown["test_coverage"] == TEST_COVERAGE_MAX
+
+
+def test_hook_result_negative_scores_clamped_to_zero():
+    # 음수 raw 점수는 하한 0 으로 클램프되어 breakdown 카테고리 점수가 음수가 되지 않는다.
+    # Negative raw scores clamp to a 0 floor so breakdown categories never go negative.
+    saved = _post_hook_capturing({
+        **_AI_RESULT,
+        "commit_message_score": -5,
+        "direction_score": -1,
+        "test_score": -3,
+    })
+    assert len(saved) == 1
+    breakdown = saved[0].result["breakdown"]
+    assert breakdown["commit_message"] == 0
+    assert breakdown["ai_review"] == 0
+    assert breakdown["test_coverage"] == 0
 
 
 def test_hook_result_invalid_token():


### PR DESCRIPTION
## Summary

CLI hook(`POST /api/hook/result`)이 `ai_result` 의 raw 점수를 클램프 없이 `int()` 캐스팅만 하여, 범위 밖 값이 calculator 스케일링을 거쳐 **breakdown 카테고리 점수가 cap 을 초과하거나 음수가 되는 정합성 위반**을 일으키던 결함 수정. (직전 세션 #759 full 감사 confirmed P1)

## 변경 내용

- `src/api/hook.py:24` — `AI_RAW_COMMIT_MAX`/`AI_RAW_DIRECTION_MAX`/`AI_RAW_TEST_MAX` import 추가 (multi-line)
- `src/api/hook.py:169-177` — `AiReviewResult` 생성부 commit/ai/test_score 를 `max(0, min(AI_RAW_*_MAX, int(...)))` 로 클램프. [ai_review.py:184-185](../blob/main/src/analyzer/io/ai_review.py#L184-L185) 패턴 미러
- `tests/unit/api/test_hook.py` — 회귀 가드 2건 추가 (범위초과→cap / 음수→0)

### 동작 보존 근거
- 클램프 상한(20/20/10)이 [calculator.py:66-68](../blob/main/src/scorer/calculator.py#L66-L68) 스케일링 분모와 정확히 일치 → 클램프 후 breakdown 이 cap(15/25/15) 초과 불가
- 유효 범위(0~MAX) 입력은 `min/max` 가 원값 그대로 통과 → **기존 동작 100% 보존**
- `parse_error` 경로는 calculator 가 `status!='success'` 시 `AI_DEFAULT_*` 중립값 사용 → 클램프 무영향

## 테스트

- `tests/unit/api/test_hook.py` 18 passed (기존 16 + 신규 2: `test_hook_result_clamps_overrange_scores` / `test_hook_result_negative_scores_clamped_to_zero`)
- 직접 결합 영역 회귀: `tests/unit/api/` + `tests/unit/scorer/` 190 passed · `tests/unit/worker/` 91 passed
- `pylint src/api/hook.py` 10.00/10 · `flake8` 0
- TDD: RED(749≠15, -4≠0) → GREEN 확인. **신규 테스트는 raw 가 아닌 `result["breakdown"]` cap 기준 assert** (build_analysis_result_dict 는 raw 점수 미직렬화 — 적대적 검증이 정정)

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] (선택) pre-push hook 실사용 시 비정상 AI 응답에서 점수 정합성 정상화 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) Codex 액세스 토큰 만료(`refresh token already used`) → **사용자 승인 하 Claude 직접검증 fallback** (사이클 119/125 전례)
- Claude 직접검증 근거: ① 적대적 분석 워크플로우(analyze+refute) `diff_is_safe=true` ② TDD RED→GREEN ③ pylint 10.00/10 ④ 직접 결합 영역 281 passed ⑤ 클램프 상한 = calculator 분모 정합 확인
- 재로그인(`codex logout; codex login`) 시 정상 mutual 검증 복원 가능

## ⚠️ 자율 판단 보고 (정책 3)

- `test_score` 클램프 상한을 미러 소스(ai_review.py:154 하드코딩 10) 대신 `AI_RAW_TEST_MAX`(=10) **상수**로 작성 — 값 동일(동작 차이 0)이나 calculator.py:68 분모와 단일 출처 일치가 더 우수하다고 판단

🤖 Generated with [Claude Code](https://claude.com/claude-code)