### PR TITLE
fix(gate): is_retriable_tag 단일 출처 활성화 — engine 하드코딩 멤버십 제거 (정합성 감사 P1)

### DIFF
--- a/src/gate/engine.py
+++ b/src/gate/engine.py
@@ -25,7 +25,7 @@ from src.gate.github_review import (
 )
 from src.gate import _merge_attempt_states as _states
 from src.gate.merge_failure_advisor import get_advice
-from src.gate.merge_reasons import UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT, DEFERRED
+from src.gate.merge_reasons import is_retriable_tag, DEFERRED
 from src.gate.native_automerge import (
     PATH_NATIVE_ENABLE,
     enable_or_fallback_with_path as native_enable_with_path,
@@ -199,7 +199,11 @@ async def _run_auto_merge_retry(  # pylint: disable=too-many-arguments,too-many-
     # 4. 실패 분류 — 터미널이면 즉시 처리
     # 4. Classify failure — handle terminal immediately
     reason_tag = parse_reason_tag(reason)
-    if reason_tag not in (UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT):
+    # 재시도 가능 태그 판별을 merge_reasons.is_retriable_tag 단일 출처로 위임.
+    # (기존: (UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT) 튜플 하드코딩 — _RETRIABLE_TAGS 와 drift 위험)
+    # Delegate retriable-tag check to the single source merge_reasons.is_retriable_tag.
+    # (was: hardcoded (UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT) tuple — could drift from _RETRIABLE_TAGS)
+    if not is_retriable_tag(reason_tag):
         await _handle_terminal_merge_failure(
             config=config, github_token=github_token, repo_name=repo_name,
             pr_number=pr_number, score=score, reason=reason, reason_tag=reason_tag,


### PR DESCRIPTION
## Summary

`merge_reasons.is_retriable_tag()` 가 "단일 출처"로 문서화됐으나 **src 호출처 0인 dead code** 였고, `engine._run_auto_merge_retry` 가 동일 판별을 `(UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT)` 튜플로 하드코딩 중복하여 `_RETRIABLE_TAGS` frozenset 과 **drift 할 위험**이 있던 결함 수정. (직전 세션 #759 full 감사 confirmed P1)

## 변경 내용

- `src/gate/engine.py:202` — `reason_tag not in (UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT)` → `not is_retriable_tag(reason_tag)`
- `src/gate/engine.py:28` — import 정리: `UNSTABLE_CI`/`UNKNOWN_STATE_TIMEOUT` 제거 + `is_retriable_tag` 추가, **`DEFERRED` 보존**(engine.py:321 사용)
- 두 edit 는 **원자적 적용** — line 202 만 바꾸면 두 상수가 unused-import 가 되어 pylint W0611(10.00/10 정책) 회귀

### 동작 보존 근거 (behavior-preserving refactor)
- `_RETRIABLE_TAGS = frozenset({UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT})` → frozenset/tuple 멤버십 동치 → `not is_retriable_tag(x)` ≡ `x not in (UNSTABLE_CI, UNKNOWN_STATE_TIMEOUT)` (truth-table 완전 동일)
- 교체 **범위 격리**: `retry_policy.py:47/54`(태그별 CI-status 타이밍 `==` 분기)·`merge_failure_advisor.py`(i18n advice lookup literal)는 의미가 달라 교체 대상 아님

## 테스트

- `tests/unit/gate/` **225 passed** (회귀 0) — 양 분기 기존 커버: `test_auto_merge_enqueue` T8-1(unstable_ci 재시도)/T8-4(dirty_conflict 터미널) + `test_merge_reasons`(is_retriable_tag retriable·terminal 태그)
- `pylint src/gate/engine.py` 10.00/10 · flake8 신규 E501 0 (기존 soft-pass 라인만)
- **신규 테스트 미추가** — 동작 보존 refactor 이고 양 분기+헬퍼가 기존 테스트로 완전 커버. 중복 테스트 추가는 정책 16(단순화) 위배로 판단

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인 (gate 회귀 0)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) Codex 액세스 토큰 만료(`refresh token already used`) → **사용자 승인 하 Claude 직접검증 fallback** (사이클 119/125 전례, PR-1~3 일괄 승인)
- Claude 직접검증 근거: ① 적대적 분석 워크플로우(analyze+refute) `diff_is_safe=true` ② frozenset/tuple 멤버십 동치 증명 ③ gate 225 passed(양 분기 커버) ④ pylint 10.00/10 ⑤ grep 실측: UNSTABLE_CI/UNKNOWN_STATE_TIMEOUT 사용처는 28+202 뿐, DEFERRED 보존 확인

## ⚠️ 자율 판단 보고 (정책 3)

- 과거 메모 "engine 3곳 하드코딩"은 grep 실측 결과 **과대** — 실제 멤버십 사이트는 engine.py:202 **1곳**(+import 1곳). PR 범위를 1곳으로 확정
- 신규 회귀 테스트를 추가하지 않기로 자율 판단 — 동작 보존 refactor + 기존 완전 커버 + 정책 16

🤖 Generated with [Claude Code](https://claude.com/claude-code)