### PR TITLE
fix(ui): base.html hx-boost 핸들러 누적 차단 — _initReveal/_finishProgress remove-before-add (정합성 감사 P1)

### DIFF
--- a/e2e/test_navigation.py
+++ b/e2e/test_navigation.py
@@ -148,3 +148,53 @@ def test_nav_handler_survives_hx_boost_renavigation(seeded_page, base_url):
         "3회 hx-boost 후 themeToggle 클릭해도 aria-expanded 미변경 "
         "— _initNavHandlers 핸들러 등록 실패 (PR #604 회귀)"
     )
+
+
+def test_reveal_progress_handlers_use_remove_before_add(seeded_page, base_url):
+    """hx-boost 재방문 시 _initReveal·_finishProgress 가 remove-before-add 가드로
+    document 슬롯에 단일 저장되어 누적되지 않아야 한다.
+    On hx-boost re-navigation, _initReveal/_finishProgress must be stored on a
+    document slot via remove-before-add so they don't accumulate.
+
+    정합성 감사 P1 회귀 가드: 수정 전 두 핸들러는 htmx:afterSettle/historyRestore 에
+    remove-before-add 없이 직접 등록되어 hx-boost 재실행마다 누적됐다 (document 슬롯 미사용).
+    수정 후 document._initRevealHandler / document._finishProgressHandler 슬롯에 저장되어
+    매 재실행 시 이전 핸들러를 제거 후 재등록한다.
+    Integrity-audit P1 regression guard: before the fix the two handlers were added
+    directly (no document slot) and accumulated on every hx-boost re-execution. After
+    the fix they live on document._initRevealHandler / document._finishProgressHandler.
+
+    시나리오: goto(full load) → settings(hx#1) → detail(hx#2) → settings(hx#3)
+    Scenario: full load → settings(hx#1) → detail(hx#2) → settings(hx#3)
+    """
+    # 초기 full load — JS 컨텍스트 초기화 (script 1번째 실행)
+    # Initial full load — fresh JS context (1st script execution)
+    seeded_page.goto(f"{base_url}/repos/owner%2Ftestrepo")
+    seeded_page.wait_for_load_state("networkidle")
+
+    # hx-boost 3회 재방문 (script 2~4번째 실행 — 누적 발생 지점)
+    # 3 hx-boost re-navigations (2nd–4th script executions — accumulation point)
+    seeded_page.click(".settings-btn")
+    seeded_page.wait_for_url("**/settings", timeout=5000)
+    seeded_page.click("a.back-btn")
+    seeded_page.wait_for_url(
+        lambda url: "owner" in url and "testrepo" in url and "/settings" not in url,
+        timeout=5000,
+    )
+    seeded_page.click(".settings-btn")
+    seeded_page.wait_for_url("**/settings", timeout=5000)
+
+    # 수정 후: 두 핸들러가 document 슬롯에 function 으로 저장됨 (remove-before-add 증거).
+    # 수정 전: 슬롯 미사용 → typeof === "undefined" → RED.
+    # After fix: both handlers stored as functions on a document slot (remove-before-add).
+    # Before fix: slot unused → typeof === "undefined" → RED.
+    init_reveal_type = seeded_page.evaluate("typeof document._initRevealHandler")
+    finish_progress_type = seeded_page.evaluate("typeof document._finishProgressHandler")
+    assert init_reveal_type == "function", (
+        "document._initRevealHandler 가 function 이 아님 "
+        "— _initReveal remove-before-add 가드 누락 (hx-boost 핸들러 누적 회귀)"
+    )
+    assert finish_progress_type == "function", (
+        "document._finishProgressHandler 가 function 이 아님 "
+        "— _finishProgress remove-before-add 가드 누락 (hx-boost 핸들러 누적 회귀)"
+    )

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -985,8 +985,15 @@
 
     // hx-boost popstate/historyRestore 후 .reveal 요소 재초기화 (opacity:0 고착 방지)
     // Re-initialize reveal elements after hx-boost popstate/historyRestore (prevent opacity:0 freeze)
-    document.addEventListener('htmx:afterSettle', _initReveal);
-    document.addEventListener('htmx:historyRestore', _initReveal);
+    // hx-boost 재실행마다 누적 방지 — remove-before-add 패턴 (핸들러 단일 슬롯 저장)
+    // Prevent accumulation on each hx-boost re-execution — remove-before-add (single document slot)
+    if (document._initRevealHandler) {
+      document.removeEventListener('htmx:afterSettle', document._initRevealHandler);
+      document.removeEventListener('htmx:historyRestore', document._initRevealHandler);
+    }
+    document._initRevealHandler = _initReveal;
+    document.addEventListener('htmx:afterSettle', document._initRevealHandler);
+    document.addEventListener('htmx:historyRestore', document._initRevealHandler);
 
     // KPI 카운트업 (data-count 속성 기반)
     // KPI count-up (data-count attribute based)
@@ -1093,10 +1100,17 @@
 
       // hx-boost 네비게이션 완료 → 프로그레스 바 완료 (실제 지연 제거 핵심)
       // hx-boost navigation settled → finish progress bar (key to real latency elimination)
-      document.addEventListener('htmx:afterSettle', _finishProgress);
+      // hx-boost 재실행마다 누적 방지 — remove-before-add 패턴 (핸들러 단일 슬롯 저장)
+      // Prevent accumulation on each hx-boost re-execution — remove-before-add (single document slot)
+      if (document._finishProgressHandler) {
+        document.removeEventListener('htmx:afterSettle', document._finishProgressHandler);
+        document.removeEventListener('htmx:historyRestore', document._finishProgressHandler);
+      }
+      document._finishProgressHandler = _finishProgress;
+      document.addEventListener('htmx:afterSettle', document._finishProgressHandler);
       // 뒤로가기(historyRestore) 시 mid-animation 고착 방지
       // Prevent progress bar from freezing mid-animation on back navigation
-      document.addEventListener('htmx:historyRestore', _finishProgress);
+      document.addEventListener('htmx:historyRestore', document._finishProgressHandler);
 
       // 일반 페이지 언로드 폴백 (외부 링크, HTMX 미개입 경우)
       // Fallback for non-HTMX navigations (external links, forms bypassing HTMX)


### PR DESCRIPTION
## 🔍 UI/시각 변경 — Claude 시각 검증 불가 (정책 11)

`base.html` `<script>` 변경입니다. Claude 는 정적 코드만 검증 가능하며, **4-테마 × 2뷰포트 8조합 시각 정합성 + 실제 reveal/progress-bar 애니메이션 거동은 사용자 검증 몫**입니다. 본 수정은 핸들러 **누적(중복 실행) 제거**만 하며 '관찰 가능한 최종 DOM 상태'는 바꾸지 않습니다(멱등).

| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |

검증 포인트: 페이지 내 이동(hx-boost) 3회+ 반복 후 ① `.reveal` fade-in 정상 ② 상단 progress-bar 가 mid-animation 고착 없이 완료 ③ 뒤로가기 시 동일.

## Summary

`base.html` `<script>` 는 hx-boost body swap 마다 재실행되는데, `_initReveal`·`_finishProgress` 가 `htmx:afterSettle`/`htmx:historyRestore` 에 **remove-before-add 가드 없이 직접 등록**되어 재방문 N회마다 핸들러가 N개씩 누적되던 결함 수정. (직전 세션 #759 full 감사 confirmed P1)

## 변경 내용

- `src/templates/base.html:988-989` — `_initReveal` → `document._initRevealHandler` 단일 슬롯 remove-before-add
- `src/templates/base.html:1096-1099` — `_finishProgress` → `document._finishProgressHandler` 단일 슬롯 remove-before-add
- [base.html:953-959](../blob/main/src/templates/base.html#L953-L959) `_baseNavHandler` 미러 패턴 (ui.md 표준 핸들러 명명 규칙 준수)
- 전수 확인: 940-1120 구간에서 가드 누락 `addEventListener` 는 이 2곳뿐 (나머지는 모두 가드 보유)

## 테스트

- `e2e/test_navigation.py` **신규 회귀 가드 1건** `test_reveal_progress_handlers_use_remove_before_add` — 3회 hx-boost 재방문 후 `document._initRevealHandler`/`_finishProgressHandler` 가 `function`(단일 슬롯)인지 검증. **TDD RED(수정 전 typeof undefined)→GREEN** 확인
- `e2e/test_navigation.py` 전체 **11 passed** (기존 `test_nav_handler_survives_hx_boost_renavigation` 포함 — 스크립트 무결성)
- `tests/unit/ui/test_template_js_const.py` 통과 (top-level const/let 미도입)
- testing.md 🔴 의무 준수: base.html script 변경 → hx-boost 3회+ 재방문 E2E 작성

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] 위 4테마 × 2뷰포트 8조합 시각 확인 (reveal fade-in / progress-bar 완료)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) Codex 액세스 토큰 만료(`refresh token already used`) → **사용자 승인 하 Claude 직접검증 fallback** (사이클 119/125 전례, PR-1~3 일괄 승인)
- Claude 직접검증 근거: ① 적대적 분석 워크플로우(analyze+refute) `diff_is_safe=true` ② TDD RED→GREEN(E2E) ③ nav E2E 11 passed ④ JS 정적 스캔 통과 ⑤ 클로저 스코프(_initReveal outer / _finishProgress IIFE) + 슬롯명 비충돌 grep 실측

## ⚠️ 자율 판단 보고 (정책 3)

- 분석이 발견한 **인접 결함**(`_kpiCountupHandler` 가 historyRestore 미등록 — 비대칭 커버리지)은 **누적 결함이 아니므로 본 PR 범위에서 제외** (별개 P2, 백로그 유지). 본 PR 은 누적 가드만 응집(정책 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)