### PR TITLE
fix(test): doc_review_gate 절대경로 테스트 런타임 루트 독립화 — 로컬 make test 깨짐 해소

### DIFF
--- a/tests/unit/hooks/test_doc_review_gate.py
+++ b/tests/unit/hooks/test_doc_review_gate.py
@@ -62,10 +62,19 @@ class TestClassifyFileGrade:
         p = str(root / ".claude" / "agents" / "test-writer.md").replace("/", "\\")
         assert classify_file_grade(p) == "critical"
 
-    def test_stale_hardcoded_prefix_not_relied_on(self):
-        # 과거 버그 prefix(d:/source/scamanager/)에 더 이상 의존하지 않음 — 실 루트와 다른
-        # 임의 절대경로는 strip 되지 않아 'skip' 이 정상 (상대경로만 분류).
-        assert classify_file_grade("d:/source/scamanager/CLAUDE.md") == "skip"
+    def test_non_runtime_root_absolute_path_is_skip(self):
+        # 실 런타임 루트가 아닌 절대경로는 strip 되지 않아 'skip' 이 정상 (상대 doc 경로만 분류).
+        # 루트에 접미사를 붙인 형제 경로 — 어떤 머신에서도 런타임 루트와 불일치 보장.
+        # An absolute path NOT under the runtime root stays unstripped → 'skip' (only relative doc paths classify).
+        # Use a sibling of the real root (root + suffix) so it never equals the root on any machine.
+        #
+        # 🔴 기존 하드코딩 'd:/source/scamanager/' 는 본 리포 실제 루트와 우연히 일치 →
+        # 루트가 d:\Source\SCAManager 인 머신에서만 strip 되어 'critical' 로 분류, 머신 의존 실패 유발
+        # (CI Linux 루트는 불일치해 통과 → 결함 은폐). 런타임 루트 파생으로 머신 독립 보장.
+        # The old hardcoded 'd:/source/scamanager/' collided with this repo's real root —
+        # it failed only on machines rooted at d:\Source\SCAManager (CI Linux root differed → passed, hiding the flaw).
+        root = str(Path(__file__).resolve().parents[3]).replace("\\", "/")
+        assert classify_file_grade(f"{root}_external/CLAUDE.md") == "skip"
 
 
 class TestApplyVetoMatrix:


### PR DESCRIPTION
## Summary

`test_doc_review_gate.py::test_stale_hardcoded_prefix_not_relied_on` 이 **이 리포의 실제 루트가 `d:\Source\SCAManager` 인 머신(= 본 프로젝트 소유자 로컬)에서만 실패**하던 결함 수정. 머지 후 전체 스위트 실측 중 발견(`1 failed, 4763 passed`).

## 근본 원인

- 테스트가 `classify_file_grade("d:/source/scamanager/CLAUDE.md") == "skip"` 를 기대 — `d:/source/scamanager/` 를 "실 루트와 다른 임의 경로"로 가정
- 그러나 [`doc_review_gate._project_root()`](../blob/main/.claude/hooks/doc_review_gate.py#L37-L41) 가 런타임 루트를 `…/.lower() + "/"` 로 resolve → 이 머신에선 정확히 `d:/source/scamanager/`
- → `_normalise()` 가 prefix strip → `CLAUDE.md` → `critical` (skip 아님) → **실패**
- CI(Linux, 루트 `/home/runner/...`)는 prefix 불일치 → strip 안 됨 → `skip` → **통과**. 그래서 #759/#760 era(사이클 160)에 머지됐으나 결함 은폐

## 변경 내용

- `tests/unit/hooks/test_doc_review_gate.py` — 하드코딩 `d:/source/scamanager/` → **런타임 루트(`parents[3]`) + `_external` 접미사 형제 경로**로 교체. 어떤 머신에서도 런타임 루트와 불일치 보장 → 테스트 의도(비-루트 절대경로 → skip) 머신 독립적으로 보존
- 테스트명 `test_stale_hardcoded_prefix_not_relied_on` → `test_non_runtime_root_absolute_path_is_skip` (의도 명확화)
- **src 무변경** — `classify_file_grade`/`_normalise` 는 정상, 테스트만 결함

## 테스트

- `tests/unit/hooks/test_doc_review_gate.py` **33 passed** (수정 전: 1 failed)
- 전체 스위트 `pytest tests/` 재실행 시 **0 failed** 예상 (이 1건이 유일 실패였음)

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] 로컬 `make test` 0 failed 확인 (이 머신에서 직접 — 본 결함의 핵심)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) Codex 액세스 토큰 만료 지속 → **Claude 직접검증 fallback** (사이클 119/125 전례, 본 사이클 일괄 승인 연장)
- 근거: ① 근본 원인 grep 실측(`_project_root`/`_normalise` 로직) ② RED(critical)→GREEN(skip) 확인 ③ 33 passed ④ src 무변경(테스트 전용)

## ⚠️ 자율 판단 보고 (정책 3)

- 본 결함은 P1 백로그(옵션 A) **범위 밖**이었으나, P1 머지 후 전체 스위트 실측 중 발견된 **로컬 환경 차단 결함**이라 즉시 별도 PR 로 수정 판단 (정책 17 §5 누적 결함 정기 검증 정신 + 로컬 dev 영향)
- tests/ 단일 도메인이라 docs 동기화 PR 과 분리 (정책 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)