### PR TITLE
fix(gate): should_retry retriable 판별 단일출처 위임 + parity 드리프트 가드 (#765 완성, 회고 P1)

### DIFF
--- a/src/gate/retry_policy.py
+++ b/src/gate/retry_policy.py
@@ -7,7 +7,7 @@ No DB / HTTP dependencies — enables fast unit testing.
 import random
 from datetime import datetime, timedelta
 
-from src.gate.merge_reasons import UNKNOWN_STATE_TIMEOUT, UNSTABLE_CI
+from src.gate.merge_reasons import UNKNOWN_STATE_TIMEOUT, UNSTABLE_CI, is_retriable_tag
 
 
 def parse_reason_tag(reason: str | None) -> str:
@@ -44,6 +44,13 @@ def should_retry(reason_tag: str, ci_status: str) -> bool:
         True이면 재시도 큐에 추가, False이면 최종 실패 처리.
         True to enqueue for retry, False to treat as terminal failure.
     """
+    # 재시도 가능 태그가 아니면 즉시 종료 — retriable 판별은 merge_reasons.is_retriable_tag 단일 출처.
+    # (아래 태그별 분기는 '언제(ci_status)' 재시도할지 세부 타이밍만 담당)
+    # Non-retriable tags terminate immediately — retriable membership is single-sourced via
+    # merge_reasons.is_retriable_tag. (The per-tag branches below only decide the WHEN/ci_status timing.)
+    if not is_retriable_tag(reason_tag):
+        return False
+
     if reason_tag == UNSTABLE_CI:
         # CI 진행 중이거나 방금 통과했으면 재시도 — merge API 갱신 지연 가능
         # Retry when CI is still running or just passed — merge API may lag
@@ -56,8 +63,8 @@ def should_retry(reason_tag: str, ci_status: str) -> bool:
         # Retry only while GitHub is still computing its state
         return ci_status == "running"
 
-    # 충돌·차단·뒤처짐·draft 등 재시도해도 해결 안 됨
-    # Conflict / blocked / behind / draft — retrying won't help
+    # _RETRIABLE_TAGS 에 추가됐으나 위 타이밍 분기가 없는 태그 — drift 방어 (parity 테스트가 가드)
+    # A tag in _RETRIABLE_TAGS but missing a timing branch above — drift guard (parity test enforces)
     return False
 
 

--- a/tests/unit/gate/test_retry_policy.py
+++ b/tests/unit/gate/test_retry_policy.py
@@ -89,6 +89,26 @@ def test_should_retry_matrix(reason_tag, ci_status, expected):
     assert should_retry(reason_tag, ci_status) is expected
 
 
+def test_retriable_tags_parity_with_should_retry():
+    """_RETRIABLE_TAGS 의 모든 태그는 should_retry 에서 최소 1개 ci_status 로 True 를 내야 한다.
+    Every tag in _RETRIABLE_TAGS must yield True from should_retry for at least one ci_status.
+
+    드리프트 가드: retriable 멤버십 단일 출처(merge_reasons._RETRIABLE_TAGS)에 새 태그를 추가하면서
+    retry_policy.should_retry 의 타이밍 분기를 빠뜨리면, is_retriable_tag 는 통과하지만 should_retry 가
+    어떤 ci_status 로도 True 를 못 내 silent 미재시도(즉시 터미널)가 발생한다. 본 테스트가 그 누락을 차단.
+    Drift guard: adding a tag to the single-source _RETRIABLE_TAGS without a matching timing branch in
+    should_retry would let is_retriable_tag pass yet should_retry never return True → silent no-retry.
+    """
+    from src.gate.merge_reasons import _RETRIABLE_TAGS
+
+    ci_statuses = ("running", "passed", "failed", "unknown")
+    for tag in _RETRIABLE_TAGS:
+        assert any(should_retry(tag, ci) for ci in ci_statuses), (
+            f"'{tag}' 가 _RETRIABLE_TAGS 에 있으나 should_retry 가 어떤 ci_status 로도 True 를 내지 못함 "
+            f"— retry_policy.should_retry 에 타이밍 분기 추가 필요 (단일출처 drift)"
+        )
+
+
 # ---------------------------------------------------------------------------
 # compute_next_retry_at
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

5+1 회고(cross-verify CONFIRMED) **P1** — #765 가 `engine.py` coarse gate 만 `is_retriable_tag` 로 통합하고, [`retry_policy.should_retry`](../blob/main/src/gate/retry_policy.py#L47-L54)(fine gate)는 `== UNSTABLE_CI` / `== UNKNOWN_STATE_TIMEOUT` 두 분기로 **동일 retriable 태그 집합을 병렬 하드코딩**한 채 남아 있던 drift 잔존을 해소. #765 의 "단일 출처 활성화"를 1 of 2 → 2 of 2 로 완성.

## 결함 (latent drift)

미래에 `_RETRIABLE_TAGS`([merge_reasons.py:48](../blob/main/src/gate/merge_reasons.py#L48))에만 새 태그를 추가하면:
- `is_retriable_tag(new)` → True → `engine.py:206` 이 retriable 로 통과
- `should_retry(new, *)` → 타이밍 분기 없음 → 최종 `return False`
- → **즉시 터미널 → silent 미재시도** (`merge_retry_service.py` 도 동일 전파)

현재는 태그 2개가 동일해 런타임 결함 없음 → P1(차기).

## 변경 내용

- `src/gate/retry_policy.py` — `should_retry` 진입부 `if not is_retriable_tag(reason_tag): return False` 위임 가드. **동작 보존**(기존 비-retriable 태그도 최종 `return False` 였음) + retriable 멤버십 단일출처화. 태그별 분기는 '언제(ci_status)' 만 담당하도록 책임 분리
- `tests/unit/gate/test_retry_policy.py` — **parity 드리프트 가드**: `_RETRIABLE_TAGS` 의 모든 태그가 `should_retry` 에서 최소 1개 ci_status 로 True 를 내는지 검증 (새 retriable 태그가 타이밍 분기 없이 추가되면 RED)

## 테스트

- `tests/unit/gate/` + `test_merge_retry_service.py` **242 passed** (기존 `should_retry` matrix 14 케이스 전수 통과 = 동작 보존)
- 신규 `test_retriable_tags_parity_with_should_retry` 수집·실행 확인 (1 passed)
- `pylint src/gate/retry_policy.py` 10.00/10

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인 (gate 회귀 0)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) Codex 액세스 토큰 만료 지속 → **Claude 직접검증 fallback** (사이클 119/125 전례, 본 사이클 일괄 승인)
- 근거: ① should_retry matrix 14 케이스 동작 보존 ② parity 가드 실행 확인 ③ 242 passed ④ pylint 10.00 ⑤ is_retriable_tag/_RETRIABLE_TAGS 동치 grep 실측

## ⚠️ 자율 판단 보고 (정책 3)

- 본 PR 은 회고에서 발견된 **내 #765 의 미완성(단언-가드 페어 불완전, 정책 4)** 을 닫는 자성 항목 — 같은 맥락에서 즉시 처리(옵션 A)
- parity 테스트가 `_RETRIABLE_TAGS` private 를 import — drift 가드 목적상 내부 접근 허용 판단

🤖 Generated with [Claude Code](https://claude.com/claude-code)