### PR TITLE
fix(ci): GITHUB_TOKEN 최소권한 + trufflehog SHA 핀 — 공급망 하드닝 (회고 P2 즉시위험 1위)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+# 최소 권한 원칙 — GITHUB_TOKEN 을 읽기 전용으로 제한 (회고 P2 공급망 하드닝).
+# 모든 job(secret-scan/test-and-analyze/pg-concurrency)이 read 만 필요 — write 필요 step 없음.
+# (SonarCloud PR 데코레이션은 SonarCloud GitHub App 경유 — GITHUB_TOKEN write 불필요.)
+# Least-privilege — restrict GITHUB_TOKEN to read-only (retro P2 supply-chain hardening).
+# All jobs need read only — no write step. (SonarCloud PR decoration goes via the SonarCloud
+# GitHub App, not GITHUB_TOKEN.)
+permissions:
+  contents: read
+
 jobs:
   # Layer 2: CI 시크릿 스캔 — 커밋 메시지 + 코드 diff 동시 탐지
   # Layer 2: CI secret scan — detects secrets in both commit messages and code diffs
@@ -22,7 +31,7 @@ jobs:
         # PR diff 범위만 스캔 — 2026-05-03 사고 유형 방어
         # Scans PR diff range only — guards against 2026-05-03 incident type
         if: github.event_name == 'pull_request'
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51  # v3.95.5 (SHA 핀 — 공급망 무결성, @main 가변 태그 위험 차단)
         with:
           path: ./
           base: ${{ github.event.pull_request.base.sha }}
@@ -33,7 +42,7 @@ jobs:
         # before == zeros(첫 push / force-push) 시 invalid SHA 오류 방지를 위해 건너뜀
         # Skip when before is zeros (first push / force-push) to avoid invalid SHA error
         if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@d411fff7b8879a62509f3fa98c07f247ac089a51  # v3.95.5 (SHA 핀 — 공급망 무결성, @main 가변 태그 위험 차단)
         with:
           path: ./
           base: ${{ github.event.before }}


### PR DESCRIPTION
## Summary

5+1 회고(cross-verify, **즉시위험 1위**) — [`ci.yml`](../blob/main/.github/workflows/ci.yml) 에 `permissions` 블록이 **전무**해 `GITHUB_TOKEN` 이 repo 기본 권한(다수 scope read/write)으로 실행되고, `trufflehog` 가 **가변 태그 `@main`** 으로 2회 참조됐다. upstream `main` 침해 시 시크릿 스캐닝 액션이 악성 코드로 교체 + 광범위 토큰 = supply-chain 표면.

## 변경 내용

- **top-level `permissions: contents: read`** — 최소권한(least-privilege). 3 job(secret-scan/test-and-analyze/pg-concurrency) 모두 read 만 필요 (write step 없음)
- **trufflehog `@main` → `@d411fff7b8879a62509f3fa98c07f247ac089a51` (v3.95.5)** SHA 핀 2곳 — `gh api` 로 v3.95.5 lightweight tag → commit SHA 실측 해석

### SonarCloud 영향 분석
test-and-analyze 의 SonarCloud step 이 `GITHUB_TOKEN` 을 받지만(L118), 본 repo 는 SonarCloud GitHub App 연동(QG OK 추적)이라 PR 데코레이션은 **App 경유** → `GITHUB_TOKEN` write 불필요로 판단. **본 PR 자체 CI 가 3 job 전수 실행으로 empirical 검증** — SonarCloud QG 체크가 깨지면 fix-up 으로 test-and-analyze 에 `pull-requests: write` 최소 추가 예정.

## 테스트

- `ci.yml` YAML parse OK + `permissions: {contents: read}` + 핀 2곳 grep 확인
- **본 PR 의 CI run 이 검증 게이트** — 권한 제한이 어떤 job 도 깨지 않는지 PR 머지 전 확인

## 🔍 사용자 검증 필요

- [ ] **PR CI 3 job 전부 SUCCESS 확인** (특히 SonarCloud step — 권한 제한 영향 핵심 검증 지점)
- [ ] (선택) Security 탭에서 GITHUB_TOKEN 권한 축소 반영 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) Codex 액세스 토큰 만료 지속 → **Claude 직접검증 fallback** (사이클 119/125 전례)
- 근거: YAML parse OK + job별 write step 부재 grep 실측 + trufflehog SHA `gh api` 실측 해석 + **PR CI 가 최종 empirical 검증**

## ⚠️ 자율 판단 보고 (정책 3)

- 회고 P2×4 중 **즉시위험 1위(CI 공급망)** 를 사용자 옵션 선택(다음작업)으로 진행
- SHA 핀은 최신 안정 릴리스 **v3.95.5**(2026-06-02) 선택 — 주기적 bump 권장(ci.yml 주석 명시)
- 최소권한을 `contents: read` 로 시작 — SonarCloud 가 GITHUB_TOKEN write 를 실제 요구하면 PR CI 가 드러내고 fix-up (보수적 과다권한 부여보다 검증 후 추가가 least-privilege 에 부합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)