### PR TITLE
fix(scorer): calculate_score breakdown 중앙 클램프 + _extract_test_score 상수화 (회고 P2)

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -19,7 +19,10 @@ import anthropic
 
 from src.analyzer.pure.review_prompt import build_review_prompt, get_system_prompt
 from src.config import settings
-from src.constants import AI_DEFAULT_COMMIT_RAW, AI_DEFAULT_DIRECTION_RAW, AI_RAW_COMMIT_MAX, AI_RAW_DIRECTION_MAX
+from src.constants import (
+    AI_DEFAULT_COMMIT_RAW, AI_DEFAULT_DIRECTION_RAW,
+    AI_RAW_COMMIT_MAX, AI_RAW_DIRECTION_MAX, AI_RAW_TEST_MAX,
+)
 from src.shared.anthropic_caching import build_cached_system_param
 from src.shared.claude_metrics import aclose_anthropic_client, extract_anthropic_usage, log_claude_api_call
 
@@ -151,8 +154,8 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
 def _extract_test_score(data: dict) -> int:
     """test_score 추출. 구 포맷(has_tests boolean) 하위 호환."""
     if "test_score" in data:
-        return max(0, min(10, int(data["test_score"])))
-    return 10 if data.get("has_tests", False) else 0
+        return max(0, min(AI_RAW_TEST_MAX, int(data["test_score"])))
+    return AI_RAW_TEST_MAX if data.get("has_tests", False) else 0
 
 
 def _extract_json_payload(text: str) -> str:

--- a/src/scorer/calculator.py
+++ b/src/scorer/calculator.py
@@ -61,11 +61,14 @@ def calculate_score(
 
     ai_defaults_applied = False
     if ai_review is not None and ai_review.status == "success":
-        # AI 점수를 새 배점으로 스케일링 (raw → 배점)
-        # Scale AI raw scores to the configured point allocation (raw → weighted).
-        commit_score = round(ai_review.commit_score * COMMIT_MSG_MAX / AI_RAW_COMMIT_MAX)
-        ai_score = round(ai_review.ai_score * AI_REVIEW_MAX / AI_RAW_DIRECTION_MAX)
-        test_score = round(ai_review.test_score * TEST_COVERAGE_MAX / AI_RAW_TEST_MAX)
+        # AI 점수를 새 배점으로 스케일링 (raw → 배점) 후 [0, cap] 중앙 클램프.
+        # producer(ai_review/hook)가 raw 클램프를 빠뜨려도 breakdown 카테고리가 cap 초과·음수가
+        # 되지 않도록 calculator 가 최종 방어 (유효 입력은 무영향 — 동작 보존).
+        # Scale AI raw scores to the point allocation, then clamp to [0, cap] as central defense —
+        # keeps breakdown within caps even if a producer forgets to clamp raw (no-op for valid input).
+        commit_score = max(0, min(round(ai_review.commit_score * COMMIT_MSG_MAX / AI_RAW_COMMIT_MAX), COMMIT_MSG_MAX))
+        ai_score = max(0, min(round(ai_review.ai_score * AI_REVIEW_MAX / AI_RAW_DIRECTION_MAX), AI_REVIEW_MAX))
+        test_score = max(0, min(round(ai_review.test_score * TEST_COVERAGE_MAX / AI_RAW_TEST_MAX), TEST_COVERAGE_MAX))
     else:
         # AI 리뷰 없거나 기본값 적용 시 중립적 기본값
         # No AI review or failed call — fall back to neutral defaults.

--- a/tests/unit/scorer/test_calculator.py
+++ b/tests/unit/scorer/test_calculator.py
@@ -53,6 +53,7 @@ def test_breakdown_keys_present():
 
 
 from src.analyzer.io.ai_review import AiReviewResult
+from src.constants import COMMIT_MSG_MAX, AI_REVIEW_MAX, TEST_COVERAGE_MAX
 
 
 def _make_ai_review(commit_score=18, ai_score=17, test_score=10):
@@ -88,6 +89,35 @@ def test_calculate_score_test_coverage_graduated():
     """test_score=7 → round(7*15/10) = round(10.5) = 10."""
     result = calculate_score([_make_result([])], ai_review=_make_ai_review(test_score=7))
     assert result.breakdown["test_coverage"] == 10
+
+
+def test_calculate_score_clamps_breakdown_to_caps():
+    """범위 밖 raw 점수(producer 클램프 누락 가정)도 calculator 중앙 방어로 breakdown 이 cap 이내.
+    Central defense: even if a producer forgets to clamp raw scores, breakdown stays within caps.
+
+    회고 P2: 클램프가 producer(ai_review/hook)에만 있고 calculator 자체는 미클램프였음 — 4번째
+    producer 가 클램프를 빠뜨리면 breakdown 카테고리가 cap 을 초과해 정합성 위반. 본 가드로 봉인.
+    """
+    result = calculate_score(
+        [_make_result([])],
+        ai_review=_make_ai_review(commit_score=999, ai_score=999, test_score=999),
+    )
+    assert result.breakdown["commit_message"] == COMMIT_MSG_MAX
+    assert result.breakdown["ai_review"] == AI_REVIEW_MAX
+    assert result.breakdown["test_coverage"] == TEST_COVERAGE_MAX
+    assert result.total <= 100
+
+
+def test_calculate_score_clamps_negative_breakdown_to_zero():
+    """음수 raw 점수도 calculator 중앙 방어로 breakdown 이 0 미만으로 내려가지 않는다.
+    Negative raw scores never drive a breakdown category below 0 (central defense floor)."""
+    result = calculate_score(
+        [_make_result([])],
+        ai_review=_make_ai_review(commit_score=-50, ai_score=-50, test_score=-50),
+    )
+    assert result.breakdown["commit_message"] == 0
+    assert result.breakdown["ai_review"] == 0
+    assert result.breakdown["test_coverage"] == 0
 
 
 def test_calculate_score_fallback_when_no_ai_review():


### PR DESCRIPTION
## Summary

5+1 회고(cross-verify) **P2** — AI 점수 클램프가 producer([ai_review.py](../blob/main/src/analyzer/io/ai_review.py#L184)/[hook.py](../blob/main/src/api/hook.py#L165)) 3곳에만 중복 적용되고 [`calculate_score`](../blob/main/src/scorer/calculator.py#L66-L68) 자체는 스케일링 후 breakdown 카테고리를 재클램프하지 않아(total 만 cap), **4번째 producer 가 클램프를 빠뜨리면 breakdown 이 cap 초과·음수**가 되는 정합성 위반 여지가 남아 있었다. 중앙 방어로 봉인.

## 변경 내용

- `src/scorer/calculator.py:66-68` — 스케일링 후 commit/ai/test_score 를 `max(0, min(round(...), CAP))` 로 **[0, cap] 중앙 클램프**. producer 누락에도 breakdown 정합 보장
- `src/analyzer/io/ai_review.py` — `_extract_test_score` 매직넘버 `min(10)`/`10` → `AI_RAW_TEST_MAX` 상수화 (값 동일 `10==MAX`, 상수 변경 시 drift 차단 — 정책 16 단일출처) + import 추가
- `tests/unit/scorer/test_calculator.py` — 회귀 가드 2건 (범위초과 999→cap / 음수 -50→0 floor)

### 동작 보존
유효 입력(raw ∈ [0,MAX])은 스케일 결과가 이미 [0,cap] → `max(0,min(..,cap))` 무영향. 기존 scorer 테스트 전수 통과.

## 테스트

- `tests/unit/scorer/` **57 passed** (신규 2: `test_calculate_score_clamps_breakdown_to_caps` / `_clamps_negative_breakdown_to_zero`, TDD RED 749≠15·-38≠0 → GREEN)
- ai_review 관련 57 passed · `tests/unit/api/` + `tests/unit/worker/` **226 passed** (calculate_score 소비처 동작 보존)
- `pylint` 10.00/10 · flake8 0

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인 (scorer 회귀 0)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) Codex 액세스 토큰 만료 지속 → **Claude 직접검증 fallback** (사이클 119/125 전례)
- 근거: ① TDD RED→GREEN ② 유효입력 동작 보존(scorer 57 + 소비처 226 passed) ③ 클램프 cap = breakdown cap 정합 ④ pylint 10.00

## ⚠️ 자율 판단 보고 (정책 3)

- 회고 P2 권장 순서(clamp 중앙방어 → effects.js → 정책 docs) 중 **1번 진행** (사용자 "다음 작업" 신호)
- `_extract_test_score` 의 `has_tests` fallback `10` 도 `AI_RAW_TEST_MAX` 로 상수화 — 의미상 "test 만점" 이라 동일 상수가 적합 판단
- 하한 `max(0,..)` 도 추가 (회고는 cap 초과만 지적했으나 음수 producer 도 방어 — 완전한 중앙 방어)

🤖 Generated with [Claude Code](https://claude.com/claude-code)