### PR TITLE
docs(policy): 정책 18 Codex 토큰 만료 fallback 예외 + 복구 강제 가드 (회고 P2)

### DIFF
--- a/.claude/policies/active.md
+++ b/.claude/policies/active.md
@@ -388,6 +388,8 @@ git push -u origin <branch>
   1. PR template `[ ] Codex OK 회신 받음` 체크박스 (즉시 — 위험 0)
   2. Codex GitHub App + GitHub Actions workflow `codex-mutual-review.yml` (사이클 94+ 옵션, 사용자 confirm 후)
 - ⚠️ **`.codex/hooks.json` Windows hard-coded path** — `f:\DEVELOPMENT\...` 경로 → Codespaces (Linux) 환경에서 hook 0% 발화. mutual 자동화 검토 시 사전 인지 의무 (사이클 93 관점 5 발견).
+- 🔴 **토큰 만료/런타임 오류 fallback 예외 (사이클 161 회고 신설)** — Codex 액세스 토큰 만료(`refresh token already used`)·샌드박스 제약·CLI 런타임 오류로 mutual 자동 검증 불능 시 = **사용자 명시 승인 하 Claude 직접검증 fallback** 정당 (정책 18 예외 "사용자 직접 결정 영역" + 사이클 119/125/161 전례). fallback PR 본문에 ① 만료/오류 사유 ② 사용자 승인 ③ 직접검증 근거(적대적 분석·TDD·lint) 3종 명시 의무.
+  - 🔴 **복구 강제 가드 (mutual 2-layer 가치 회귀 차단)** — 동일 fallback 이 **≥ 2 사이클 또는 ≥ 5 PR 연속** 시 = 다음 세션 진입 전 `codex logout; codex login` 복구를 **사용자 1줄 확인으로 강제 트리거** (메모리 [[feedback-codex-post-validation-mandatory]] + [[integrity-audit-session]] 재개법 "codex login 권장" → "복구 강제"로 강화). mutual = 외부 LLM 다양성 핵심 가치이므로 장기 1-layer 운영 금지.
 
 ### 17 정책 cross-reference 표 (CLAUDE.md 정책 18 본문서 이관 — docs reorg Phase 3d)
 


### PR DESCRIPTION
## Summary

5+1 회고(cross-verify) **P2(프로세스)** — 이번 사이클의 Codex fallback(토큰 만료 → Claude 직접검증)은 정당했으나 [정책 18](../blob/main/.claude/policies/active.md) 본문/메모리 예외 목록에 **'토큰 만료 fallback' 이 미명시**였고, 반복 fallback 시 `codex login` 복구를 강제하는 가드가 부재했다. mutual 2-layer(외부 LLM 다양성) 가치가 사이클 119→125→161 누적으로 **장기 1-layer 로 회귀**할 여지.

## 변경 내용

- `.claude/policies/active.md` §"정책 18 환경 통합" —
  - **'토큰 만료/런타임 오류 fallback' 예외 명시**: 사용자 승인 하 Claude 직접검증 정당 (전례 119/125/161) + fallback PR 본문 3종 명시 의무(만료 사유·사용자 승인·직접검증 근거)
  - **복구 강제 가드**: 동일 fallback ≥2 사이클 또는 ≥5 PR 연속 시 → 다음 세션 진입 전 `codex logout; codex login` 복구를 사용자 1줄 확인으로 강제 트리거
- 메모리 `feedback-codex-post-validation-mandatory` + `integrity-audit-session` 동기 갱신 (repo 외 — 본 PR 제외)

## 테스트

- 문서(.claude/policies) 전용 변경, 코드 무영향

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] 복구 강제 가드 임계(≥2 사이클/≥5 PR)가 의도와 일치하는지 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) **본 PR 이 정의하는 바로 그 '토큰 만료 fallback' 예외 적용** — Codex 토큰 만료 지속, 사용자 승인. 문서 전용 변경
- 근거: active.md 1 블록 추가, 코드 무영향, 회고 cross-verify CONFIRMED 권고 반영

## ⚠️ 자율 판단 보고 (정책 3)

- 회고 P2 권장 순서 중 effects.js(설계 결정 필요) 대신 **정책 docs(자율 가능)** 를 사용자 선택으로 진행
- default rule 은 CLAUDE.md 보존, detail(예외+가드)은 active.md 에 배치 — 정책 17 §2(안정성 우선, CLAUDE.md 본문 stable) 준수

🤖 Generated with [Claude Code](https://claude.com/claude-code)