### PR TITLE
fix(security): webhook/github_client 로그 인젝션 sanitize 5 site 보강 (기존 P2 백로그)

### DIFF
--- a/src/github_client/diff.py
+++ b/src/github_client/diff.py
@@ -5,6 +5,7 @@ from github import Auth, Github, GithubException
 
 from src.constants import HTTP_CLIENT_TIMEOUT
 from src.github_client.models import ChangedFile
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ def _collect_changed_files(repo, files, ref: str) -> list[ChangedFile]:
         try:
             content = repo.get_contents(f.filename, ref=ref).decoded_content.decode("utf-8")
         except (GithubException, UnicodeDecodeError) as exc:
-            logger.debug("파일 내용 로드 실패 %s@%s: %s", f.filename, ref, exc)
+            logger.debug("파일 내용 로드 실패 %s@%s: %s", sanitize_for_log(f.filename), sanitize_for_log(ref), exc)
             content = ""
         result.append(ChangedFile(
             filename=f.filename,

--- a/src/github_client/graphql.py
+++ b/src/github_client/graphql.py
@@ -28,6 +28,7 @@ import httpx
 from src.constants import GITHUB_API
 from src.github_client.helpers import github_api_headers
 from src.shared.http_client import get_http_client
+from src.shared.log_safety import sanitize_for_log
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +163,7 @@ async def get_pr_node_id(
     except httpx.HTTPError as exc:
         logger.warning(
             "get_pr_node_id 실패 (repo=%s, pr=%d): %s",
-            repo_full_name, pr_number, exc,
+            sanitize_for_log(repo_full_name), pr_number, type(exc).__name__,
         )
         return None
 

--- a/src/webhook/providers/github.py
+++ b/src/webhook/providers/github.py
@@ -133,7 +133,7 @@ async def _handle_merged_pr_event(data: dict) -> dict:
             # Log only the exception type — exc body may contain GitHub API response details.
             logger.warning(
                 "Auto-close failed (repo=%s, issue=%d): %s",
-                repo_name, issue_number, type(exc).__name__,
+                sanitize_for_log(repo_name), issue_number, type(exc).__name__,
             )
 
     return {"status": "accepted"}
@@ -459,7 +459,7 @@ async def _handle_check_suite_completed(  # NOSONAR python:S7503 — caller awai
     now = time.monotonic()
     if now - _check_suite_debounce.get(key, 0.0) < _CHECK_SUITE_DEBOUNCE_TTL:
         logger.debug(
-            "check_suite: debounced (repo=%s, sha=%.7s)", repo_full_name, head_sha
+            "check_suite: debounced (repo=%s, sha=%.7s)", sanitize_for_log(repo_full_name), sanitize_for_log(head_sha)
         )
         return {"status": "debounced"}
     _check_suite_debounce[key] = now
@@ -498,7 +498,7 @@ async def _trigger_retry_for_sha(repo_full_name: str, commit_sha: str) -> None:
     except Exception as exc:  # pylint: disable=broad-except
         logger.warning(
             "_trigger_retry_for_sha 실패 (repo=%s, sha=%.7s): %s",
-            repo_full_name, commit_sha, type(exc).__name__,
+            sanitize_for_log(repo_full_name), sanitize_for_log(commit_sha), type(exc).__name__,
         )
 
 

--- a/tests/unit/github_client/test_diff.py
+++ b/tests/unit/github_client/test_diff.py
@@ -64,3 +64,27 @@ def test_get_pr_files_handles_content_error():
         MockGithub.return_value.get_repo.return_value = mock_repo
         result = get_pr_files("token", "owner/repo", 1)
     assert result[0].content == ""
+
+
+def test_collect_changed_files_log_sanitizes_filename_and_ref(caplog):
+    """파일 로드 실패 debug 로그가 filename·ref 를 sanitize 해 CR/LF 로그 인젝션을 차단한다.
+    The file-load-failure log sanitizes filename/ref so CR/LF cannot inject fake log lines."""
+    import logging
+    from github import GithubException
+    from src.github_client.diff import _collect_changed_files
+
+    mock_repo = MagicMock()
+    mock_repo.get_contents.side_effect = GithubException(404, "Not found")
+    f = MagicMock()
+    f.filename = "evil.py\nINJECTED-FAKE-LOG-LINE"
+    f.patch = ""
+
+    with caplog.at_level(logging.DEBUG, logger="src.github_client.diff"):
+        _collect_changed_files(mock_repo, [f], "main\nINJECTED-REF")
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert msgs, "파일 로드 실패 시 debug 로그가 기록되어야 함"
+    # 개행이 그대로 들어가면 가짜 로그 라인 주입 가능 — sanitize_for_log 가 제거해야 함
+    # Raw newlines would allow fake log-line injection — sanitize_for_log must strip them.
+    for m in msgs:
+        assert "\n" not in m, f"로그 라인에 개행 주입됨 (sanitize 누락): {m!r}"


### PR DESCRIPTION
## Summary

기존 P2 백로그 트리아지(grep 실측) — webhook 페이로드 유래 **user-controlled 값**(`repo_name`/`repo_full_name`·`head_sha`/`commit_sha`·`filename`·`ref`)을 `sanitize_for_log` 없이 로깅하는 **5 site** 발견. CR/LF 가 그대로 들어가면 **가짜 로그 라인 주입** 가능 (SonarCloud S5145). `%.7s` 트렁케이션은 길이만 제한하고 제어문자는 미제거 → 인젝션 차단 못 함.

## 변경 내용 (5 site)

| 파일:라인 | 함수 | 값 |
|-----------|------|-----|
| `webhook/providers/github.py:136` | auto-close 실패 | `repo_name` (동일 함수 L129 는 이미 sanitize인데 L136만 raw였음) |
| `webhook/providers/github.py:461` | check_suite debounce | `repo_full_name`·`head_sha` |
| `webhook/providers/github.py:500` | `_trigger_retry_for_sha` 실패 | `repo_full_name`·`commit_sha` |
| `github_client/graphql.py:164` | `get_pr_node_id` 실패 | `repo_full_name` + `exc`→`type(exc).__name__` (exc 본문 API URL/응답 누출 차단) + import |
| `github_client/diff.py:39` | 파일 로드 실패 | `filename`·`ref` + import |

## 테스트

- `tests/unit/github_client/test_diff.py` 회귀 가드 1건 `test_collect_changed_files_log_sanitizes_filename_and_ref` — CR/LF 주입 → 로그 라인 개행 부재 검증 (**TDD RED→GREEN**, RED 시 로그에 가짜 라인 주입 확인됨)
- `github_client` + `webhook` **200 passed** · `pylint` 10.00 · flake8 0
- 나머지 4 site = 동일 `sanitize_for_log`(vetted, `test_log_safety.py`) 적용 + **SonarCloud S5145 taint** 로 CI 검증

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인 (특히 SonarCloud S5145 hotspot 해소)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) Codex 토큰 만료 지속 → **Claude 직접검증 fallback** (사이클 119/125/161 전례, 정책 18 환경통합 신규 명시)
- 근거: TDD RED→GREEN + 회귀 200 passed + sanitize_for_log vetted + 트리아지 grep 실측(false-positive ~25 site 제외)

## ⚠️ 자율 판단 보고 (정책 3)

- 기존 P2 백로그를 ultracode 트리아지 워크플로우로 검증 후 **자율 분류 = autonomous** 항목 우선 진행
- `graphql.py` 의 `exc` 원문도 `type(exc).__name__` 로 축약 (httpx exc 가 API URL/응답 일부 포함 가능 — github.py 패턴과 일관)
- 트리아지 발견 `check_suite backoff` 항목은 **false-positive(이미 debounce+retry_policy backoff 정상)** 로 판정 — 수정 안 함

🤖 Generated with [Claude Code](https://claude.com/claude-code)