### PR TITLE
test(quality): dead/누락 assertion 2건 보강 — CLI no-files 메시지 + malformed JSON 파이프라인 미진입 (기존 P2 백로그)

### DIFF
--- a/tests/integration/test_e2e_pipeline_scenarios.py
+++ b/tests/integration/test_e2e_pipeline_scenarios.py
@@ -542,6 +542,15 @@ def test_malformed_json_payload_returns_401(integration_db, mock_deps):
     # signature 자체는 유효하므로 200/202/422 중 하나, mock_deps 미호출 보장이 핵심
     assert response.status_code in (200, 202, 400, 401, 422)
 
+    # 핵심 보장: malformed JSON 은 파이프라인에 진입하면 안 됨 (run_gate_check 미호출 + Analysis 0).
+    # Key guarantee: malformed JSON must never reach the pipeline (gate not called + no Analysis).
+    mock_deps.assert_not_called()
+    session = integration_db()
+    try:
+        assert session.query(Analysis).count() == 0
+    finally:
+        session.close()
+
 
 # ──────────────────────────────────────────────────────────────────────────
 # G. Repository / ownership integration

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -46,7 +46,9 @@ def test_main_no_files_exits_zero(m_diff, capsys):
     with pytest.raises(SystemExit) as exc_info:
         main(["review"])
     assert exc_info.value.code == 0
-    assert "변경" in capsys.readouterr().out or True  # message printed
+    # "변경된 파일이 없습니다." 안내 메시지가 실제 출력되는지 검증 (dead `or True` 제거)
+    # Verify the "no changed files" notice is actually printed (removed dead `or True`).
+    assert "변경된 파일이 없습니다." in capsys.readouterr().out
 
 
 @patch("src.cli.__main__.format_result", return_value="output")


### PR DESCRIPTION
## Summary

정합성 감사 P2 백로그(test-quality): **항상 통과하는 dead assertion 1건** + **의도한 핵심 보장을 검증하지 않는 누락 assertion 1건**을 실효성 있게 보강. 테스트 코드만 변경(런타임 동작 무변경).

## 변경 내용

- **`tests/unit/cli/test_main.py`** (`test_main_no_files_exits_zero`) — `assert "변경" in capsys.readouterr().out or True` 의 `or True`(항상 참, dead) 제거 → 실제 안내 메시지 `"변경된 파일이 없습니다."` 출력을 검증.
- **`tests/integration/test_e2e_pipeline_scenarios.py`** (`test_malformed_json_payload_returns_401`) — 주석은 "mock_deps 미호출 보장이 핵심"이라 명시했으나 status code 만 단언했음. **malformed JSON 이 파이프라인에 진입하지 않음**을 실측: `mock_deps.assert_not_called()` + `Analysis.count() == 0` 추가.

## 테스트

- 두 파일 전수 green (32 passed) — clean 상태 3회 연속 결정성 확인
- flake8 clean

## 체크리스트

### 기본
- [x] `make test` 통과 (관련 32 테스트 green — 0 failed)
- [x] `make lint` 통과 (flake8 clean — 테스트 전용 변경)

> 신규/삭제 파일 없음 · ORM 변경 없음 · 운영 수치 변경 없음 (architecture/STATE/README 동기화 비대상).

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인 (`pytest + Codecov + SonarCloud`)

## ⚠️ 자율 판단 보고 (정책 3)

- malformed JSON 테스트에 `assert_not_called()` **뿐 아니라** `Analysis.count() == 0` 을 추가 결정 — 적대적 검증에서 **push 이벤트는 `run_gate_check`(=mock_deps)를 원래 호출하지 않으므로 `assert_not_called()` 단독으로는 push 파이프라인 실행을 못 잡음**이 확인됨. `Analysis.count()==0` 이 실제 load-bearing 가드.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [ ] ~~Codex 검증 의뢰 완료~~ — **불가**
- [x] **(예외) Codex 토큰 무효화(`refresh_token_reused`, 4연속) → Claude 직접 적대적 self-verify 대체** — 정책 18 #773 "토큰 만료 fallback 예외" 적용, **사용자 승인 하** 진행. 2 에이전트 적대적 검증 워크플로우 `overallVerdict: OK`, P0/P1/P2 0건. **mutation testing 으로 두 단언의 비-vacuity 입증**(소스 단락 제거 시 테스트 FAIL → revert 확인).
  - 🔴 **정책 18 복구 강제 가드 트리거** — 다음 세션 전 `codex login` 재인증 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
