### PR TITLE
fix(ui): effects.js 탭 resize 리스너 hx-boost 재방문 누적 차단 — remove-before-add 단일 전역 핸들러 (정합성 감사 P2)

### DIFF
--- a/src/static/js/effects.js
+++ b/src/static/js/effects.js
@@ -259,6 +259,21 @@
   }
 
   /* ----- 7. Tabs sliding indicator --------------------------------------- */
+  // 모든 탭 인디케이터를 활성 탭 위치로 재배치 (resize 단일 전역 핸들러용)
+  // Reposition every tab indicator onto its active tab (used by the single resize handler).
+  function repositionAllTabIndicators() {
+    document.querySelectorAll(".tabs").forEach((group) => {
+      const ind = group.querySelector(".tabs__indicator");
+      const active = group.querySelector(".tabs__tab.is-active");
+      if (!ind || !active) return;
+      const groupRect = group.getBoundingClientRect();
+      const r = active.getBoundingClientRect();
+      ind.style.transition = "none";
+      ind.style.width = `${r.width}px`;
+      ind.style.transform = `translateX(${r.left - groupRect.left}px)`;
+    });
+  }
+
   function setupTabs() {
     document.querySelectorAll(".tabs").forEach((group) => {
       let ind = group.querySelector(".tabs__indicator");
@@ -286,11 +301,15 @@
           position(t);
         });
       });
-      // re-measure on layout shift
-      window.addEventListener("resize", () => {
-        position(group.querySelector(".tabs__tab.is-active"), false);
-      });
     });
+
+    // re-measure on layout shift — remove-before-add 단일 전역 핸들러 (hx-boost 재방문 시 누적 차단)
+    // Single global resize handler via remove-before-add: prevents listener pile-up across hx-boost re-navigations.
+    if (document._tabsResizeHandler) {
+      window.removeEventListener("resize", document._tabsResizeHandler);
+    }
+    document._tabsResizeHandler = repositionAllTabIndicators;
+    window.addEventListener("resize", document._tabsResizeHandler);
   }
 
   /* ----- 8. Nav sliding active indicator --------------------------------- */


### PR DESCRIPTION
## 🔍 사용자 검증 필요 (정책 11 — UI/시각 변경)

> Claude 는 정적 JS 코드만 검증 가능. 탭 인디케이터 슬라이드 동작의 4테마 × 2뷰포트 시각 정합성은 사용자 확인 의무. 특히 **창 크기 조절(resize) 시 활성 탭 인디케이터 재배치** + **hx-boost 페이지 이동 3회 이상 후에도 정상 동작**을 확인해 주세요.

| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |

## Summary

정합성 감사 P2: `effects.js` `setupTabs()` 가 `.tabs` 그룹마다 익명 `window.addEventListener("resize")` 를 등록 → hx-boost 재방문 시 IIFE `init()` 재실행으로 **window resize 리스너가 누적**됐다(window 는 body swap 후에도 유지). remove-before-add 단일 전역 핸들러로 전환해 재방문 횟수와 무관하게 항상 1개만 유지한다.

## 변경 내용

- `repositionAllTabIndicators()` 추출 — 모든 활성 탭 인디케이터를 재배치하는 단일 함수(DOM 을 매 호출 fresh 쿼리 → stale closure 없음).
- resize 바인딩을 `forEach` 밖으로 이동 + `document._tabsResizeHandler` remove-before-add 패턴 → 전역 단일 핸들러. `.claude/rules/ui.md` 의 `document._xHandler` 규약과 일치.
- **동작 보존**: init 시 그룹별 인디케이터 배치 / 탭 클릭 애니메이션 / resize 재배치(transition:"none") 모두 기존과 동일(math·transition 동일).

## 테스트

- `node --check src/static/js/effects.js` 통과 (외부 정적 JS — Python 테스트 의존 0)
- 잔존 `window.addEventListener("resize")` = 1개(전역 핸들러)만
- effects.js 참조 E2E 테스트 없음(static 파일) → 시각 검증은 위 8조합 체크리스트(사용자)

## 체크리스트

### 기본
- [x] `make test` 통과 (effects.js 는 정적 파일 — Python 테스트 영향 0)
- [x] `make lint` 통과 (JS 변경 — bandit/pylint 무관, node --check OK)

## ⚠️ 자율 판단 보고 (정책 3)

- 처리 방향 = **ⓐ remove-before-add 재등록**(사용자 결정). ⓑ(단순 제거) 대비 코드베이스 ui.md 규약 일치 + 완전 정확(재방문마다 1개 유지) 선택.
- 적대적 self-verify 1 에이전트 `VERDICT: OK`, P0/P1/P2 0건(behavior parity / remove-before-add 정확성 / 타 누적자 부재 / node --check).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [ ] ~~Codex 검증 의뢰 완료~~ — **불가**
- [x] **(예외) Codex 토큰 무효화(`refresh_token_reused`, 4연속) → Claude 직접 적대적 self-verify 대체** — 정책 18 #773 "토큰 만료 fallback 예외", **사용자 승인 하** 진행.
  - 🔴 **정책 18 복구 강제 가드 트리거** — 다음 세션 전 `codex login` 재인증 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
