### PR TITLE
fix(pipeline): 정적분석 타임아웃 시 auto-merge 차단 + 불완전 마커 — 점수 인플레이션 안전 결함 (정합성 감사 P1)

### DIFF
--- a/src/gate/actions/auto_merge.py
+++ b/src/gate/actions/auto_merge.py
@@ -37,7 +37,18 @@ class AutoMergeAction(GateAction):
     async def execute(self, ctx: GateContext) -> None:
         """engine.py의 _run_auto_merge에 위임한다.
         Delegates to engine.py's _run_auto_merge.
+
+        정적분석 불완전(타임아웃) 시 auto-merge 차단 — 미분석 코드는 점수가 인플레이션될 수
+        있으므로 자동 머지하지 않는다 (Approve/Review 옵션은 영향 없음).
+        Block auto-merge when static analysis is incomplete (timeout) — unanalyzed code may have an
+        inflated score, so never auto-merge it (Approve/Review options are unaffected).
         """
+        if ctx.result.get("static_analysis_incomplete"):
+            logger.warning(
+                "static analysis incomplete — auto-merge skipped (repo=%s, pr=%s)",
+                ctx.repo_name, ctx.pr_number,
+            )
+            return
         from src.gate import engine  # pylint: disable=import-outside-toplevel
         await engine._run_auto_merge(  # pylint: disable=protected-access
             ctx.config,

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -44,6 +44,9 @@ class _AnalysisSaveParams:  # pylint: disable=too-many-instance-attributes
     ai_review: object  # AiReviewResult
     score_result: object  # ScoreResult
     author_login: str | None = None
+    # 정적분석 타임아웃 등 불완전 분석 여부 — True 시 result 에 마커 + auto-merge 차단
+    # Static analysis incomplete (e.g. timeout) — when True, marks result + blocks auto-merge
+    static_incomplete: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -154,23 +157,29 @@ async def _run_static_analysis(
 
 async def _run_static_with_timeout(
     files: list[ChangedFile], repo_config: object | None = None
-) -> list[StaticAnalysisResult]:
+) -> tuple[list[StaticAnalysisResult], bool]:
     """_run_static_analysis를 PIPELINE_ANALYSIS_TIMEOUT 초 상한으로 실행한다.
     Run _run_static_analysis bounded by PIPELINE_ANALYSIS_TIMEOUT seconds.
-    타임아웃 초과 시 빈 리스트 반환 — AI 리뷰는 계속 진행.
-    Returns empty list on timeout — AI review continues unaffected.
+
+    Returns:
+        (results, timed_out). 타임아웃 시 ([], True) — 빈 결과가 "이슈 없음"(만점)으로
+        오인되어 미분석 코드가 auto-merge 되는 것을 막기 위해 timed_out 신호를 함께 반환한다.
+        On timeout returns ([], True) — the bool flags incomplete analysis so the empty list
+        is not mistaken for "no issues" (perfect score) and auto-merging unanalyzed code.
+        AI 리뷰는 계속 진행 / AI review continues unaffected.
     """
     try:
-        return await asyncio.wait_for(
+        results = await asyncio.wait_for(
             _run_static_analysis(files, repo_config=repo_config),
             timeout=PIPELINE_ANALYSIS_TIMEOUT,
         )
+        return results, False
     except asyncio.TimeoutError:
         logger.warning(
-            "static analysis timed out after %ss — continuing with empty results",
+            "static analysis timed out after %ss — marking incomplete (auto-merge blocked)",
             PIPELINE_ANALYSIS_TIMEOUT,
         )
-        return []
+        return [], True
 
 
 def build_notification_tasks(  # pylint: disable=too-many-positional-arguments,too-many-arguments
@@ -407,6 +416,11 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
         params.ai_review, params.score_result, params.analysis_results,
         source="pr" if params.pr_number else "push",
     )
+    # 정적분석 불완전(타임아웃) 시 마커 — run_gate_check 가 읽어 auto-merge 차단 + DB 관측 보존
+    # Mark incomplete static analysis (timeout) — run_gate_check reads it to block
+    # auto-merge; also persisted on the Analysis row for observability.
+    if params.static_incomplete:
+        result_dict["static_analysis_incomplete"] = True
     ai = params.ai_review
     analysis = analysis_repo.save_new(db, Analysis(
         repo_id=repo.id,
@@ -546,7 +560,7 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
                 )
 
             with stage_timer("analyze", repo=repo_log) as ctx:
-                analysis_results, ai_review = await asyncio.gather(
+                static_outcome, ai_review = await asyncio.gather(
                     _run_static_with_timeout(files, repo_config=_static_repo_cfg),
                     review_code(
                         settings.anthropic_api_key, commit_message, patches,
@@ -554,6 +568,9 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
                         model=repo_review_model,
                     ),
                 )
+                # (결과 리스트, 타임아웃 여부) — 타임아웃 시 auto-merge 차단 신호로 전파
+                # (results, timed_out) — timed_out propagates as the auto-merge block signal
+                analysis_results, static_timed_out = static_outcome
                 ctx["file_count"] = len(analysis_results)
                 ctx["issue_count"] = sum(len(r.issues) for r in analysis_results)
 
@@ -570,6 +587,7 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
                     ai_review=ai_review,
                     score_result=score_result,
                     author_login=_extract_author_login(event, data),
+                    static_incomplete=static_timed_out,
                 )
                 with SessionLocal() as db:
                     repo_config, analysis_id, result_dict = await _save_and_gate(db, save_params)

--- a/tests/unit/gate/test_gate_actions.py
+++ b/tests/unit/gate/test_gate_actions.py
@@ -194,6 +194,25 @@ async def test_auto_merge_action_execute_delegates_to_impl():
 
 
 @pytest.mark.asyncio
+async def test_auto_merge_action_skips_when_static_analysis_incomplete():
+    """정적분석 불완전(타임아웃) 시 score 충족이어도 _run_auto_merge 를 호출하지 않아야 한다.
+
+    result["static_analysis_incomplete"]=True → 미분석 코드 자동 머지 차단 (auto-merge 안전성).
+    """
+    from src.gate.actions.auto_merge import AutoMergeAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(auto_merge=True)
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        result={"score": 90, "static_analysis_incomplete": True},  # 90 >= threshold 이나 불완전
+        github_token="ghp_test", config=cfg, score=90,
+    )
+    with patch("src.gate.engine._run_auto_merge", new=AsyncMock()) as mock_impl:
+        await AutoMergeAction().execute(ctx)
+    mock_impl.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_auto_merge_action_skips_when_score_below_threshold():
     """score < merge_threshold이면 execute()가 내부 구현을 호출하지 않아야 한다."""
     from src.gate.actions.auto_merge import AutoMergeAction  # pylint: disable=import-outside-toplevel

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -544,6 +544,64 @@ async def test_pipeline_passes_new_gate_signature(mock_deps):
     assert call_kwargs["config"] is not None, "config가 None으로 전달됨 — get_repo_config 재조회 발생"
 
 
+async def test_pipeline_marks_result_incomplete_on_static_timeout(mock_deps):
+    """정적분석 타임아웃 시 run_gate_check 에 전달되는 result 에 static_analysis_incomplete=True 마커가 있어야 한다.
+
+    이 마커가 AutoMergeAction 의 auto-merge 차단 신호 — 미분석 코드 자동 머지 방지(관측 마커 겸용).
+    """
+    from src.worker.pipeline import run_analysis_pipeline
+    from unittest.mock import AsyncMock, patch
+
+    mock_db = mock_deps["db"]
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [
+        MagicMock(id=1), None, MagicMock(id=1), None,
+    ]
+    mock_db.refresh = MagicMock()
+
+    from src.config_manager.manager import RepoConfigData
+
+    # 정적분석이 타임아웃 → ([], True) 반환
+    # Static analysis times out → returns ([], True)
+    with patch("src.worker.pipeline._run_static_with_timeout",
+               new=AsyncMock(return_value=([], True))):
+        with patch("src.worker.pipeline.run_gate_check", new_callable=AsyncMock) as mock_gate:
+            with patch("src.worker.pipeline.get_repo_config",
+                       return_value=RepoConfigData(repo_full_name="owner/repo")):
+                await run_analysis_pipeline("pull_request", PR_DATA)
+
+    mock_gate.assert_called_once()
+    result_arg = mock_gate.call_args.kwargs["result"]
+    assert result_arg.get("static_analysis_incomplete") is True, \
+        "정적분석 타임아웃 시 result 에 static_analysis_incomplete=True 마커가 없음 — auto-merge 차단 불가"
+
+
+async def test_pipeline_no_incomplete_marker_when_static_ok(mock_deps):
+    """정적분석 정상 완료 시 result 에 static_analysis_incomplete 마커가 없어야 한다 (회귀 가드)."""
+    from src.worker.pipeline import run_analysis_pipeline
+    from unittest.mock import AsyncMock, patch
+    from src.analyzer.io.static import StaticAnalysisResult
+
+    mock_db = mock_deps["db"]
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [
+        MagicMock(id=1), None, MagicMock(id=1), None,
+    ]
+    mock_db.refresh = MagicMock()
+
+    from src.config_manager.manager import RepoConfigData
+
+    with patch("src.worker.pipeline._run_static_with_timeout",
+               new=AsyncMock(return_value=([StaticAnalysisResult(filename="a.py", issues=[])], False))):
+        with patch("src.worker.pipeline.run_gate_check", new_callable=AsyncMock) as mock_gate:
+            with patch("src.worker.pipeline.get_repo_config",
+                       return_value=RepoConfigData(repo_full_name="owner/repo")):
+                await run_analysis_pipeline("pull_request", PR_DATA)
+
+    mock_gate.assert_called_once()
+    result_arg = mock_gate.call_args.kwargs["result"]
+    assert "static_analysis_incomplete" not in result_arg, \
+        "정상 완료인데 static_analysis_incomplete 마커가 잘못 설정됨"
+
+
 # ---------------------------------------------------------------------------
 # Task 1 — SHA 중복 체크 이동 및 result dict ai_review_status 필드 테스트
 # (Red 단계: SHA 중복 체크가 아직 review_code 이전으로 이동하지 않음)
@@ -992,7 +1050,10 @@ async def test_collect_files_wrapped_in_asyncio_to_thread(mock_deps):
 
 @pytest.mark.asyncio
 async def test_run_static_with_timeout_returns_empty_on_timeout():
-    """분석이 PIPELINE_ANALYSIS_TIMEOUT 초과 시 빈 리스트를 반환해야 한다."""
+    """분석이 PIPELINE_ANALYSIS_TIMEOUT 초과 시 (빈 리스트, timed_out=True) 를 반환해야 한다.
+
+    timed_out=True 는 auto-merge 차단 신호 — 미분석 코드 자동 머지 방지.
+    """
     import asyncio
     from src.worker.pipeline import _run_static_with_timeout
 
@@ -1004,12 +1065,12 @@ async def test_run_static_with_timeout_returns_empty_on_timeout():
         with patch("src.worker.pipeline.PIPELINE_ANALYSIS_TIMEOUT", 0.01):
             result = await _run_static_with_timeout([])
 
-    assert result == []
+    assert result == ([], True)
 
 
 @pytest.mark.asyncio
 async def test_run_static_with_timeout_returns_results_when_fast():
-    """분석이 타임아웃 내에 완료되면 정상 결과를 반환해야 한다."""
+    """분석이 타임아웃 내에 완료되면 (정상 결과, timed_out=False) 를 반환해야 한다."""
     from src.worker.pipeline import _run_static_with_timeout
     from src.analyzer.io.static import StaticAnalysisResult
 
@@ -1021,7 +1082,7 @@ async def test_run_static_with_timeout_returns_results_when_fast():
     with patch("src.worker.pipeline._run_static_analysis", side_effect=_fast):
         result = await _run_static_with_timeout([])
 
-    assert result == fake_result
+    assert result == (fake_result, False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

integrity-audit `area=gate` 검증이 발견한 **P1 안전 결함**: `_run_static_with_timeout` 가 타임아웃 시 `[]` 를 반환하면 `calculate_score([])` 가 이슈 0건을 **만점**(code_quality 25 + security 20 = 45/45)으로 환산 → 무분석 코드가 점수 인플레이션으로 `score >= merge_threshold` **auto-merge 를 통과**할 수 있었다 (빈 결과 ≠ "이슈 없음" 미구분 + 관측 마커 부재).

**사용자 결정 = ⓐ auto-merge 차단 + 관측 마커.**

## 변경 내용

- `_run_static_with_timeout` → `(results, timed_out)` 튜플 반환 (타임아웃 = `([], True)`).
- 파이프라인이 `static_timed_out` 을 `_AnalysisSaveParams.static_incomplete` 로 전파 → `_save_and_gate` 가 `result_dict["static_analysis_incomplete"]=True` 설정 (run_gate_check 가 읽음 + Analysis.result JSON 에 영속 = 관측).
- `AutoMergeAction.execute` 가 해당 마커 시 `_run_auto_merge` 위임 **전 skip** — 미분석 코드 자동 머지 차단. Approve/Review 옵션은 무영향(머지만 차단).

## 테스트

- TDD 가드 5건: timeout 튜플 2 + AutoMergeAction skip 1 + 파이프라인 wiring 마커 유/무 2.
- **302 passed** (pipeline + gate + integration, 회귀 0), pylint **10.00/10**, bandit·flake8 clean.

## 🔍 사용자 검증 필요 (정책 2)

- [ ] CI 통과 확인
- [ ] (운영) 정적분석이 자주 타임아웃하는 대형 리포에서 auto-merge 가 의도대로 보류되는지 — 타임아웃 시 수동 머지 필요(설계상 trade-off).

## ⚠️ 자율 판단 보고 (정책 3) + 🔴 잔여 리스크 (by-design)

- 적대적 self-verify 2 에이전트 `overallVerdict OK`, P0/P1/P2 0건. 체인 airtight 확인(타임아웃 시 merge-retry 큐 미진입 + 마커 DB 라운드트립으로 re-gate 경로도 차단).
- 🔴 **잔여(사용자 결정 ⓐ 범위 밖)**: `ApproveAction` 은 인플레이션 점수로 **여전히 auto-approve 가능** — 본 PR 은 ⓐ(auto-merge 차단)만 적용, Approve 는 미포함. `approve_mode='auto'` + GitHub branch-protection "approval 시 자동 머지" 설정과 결합 시 **간접 머지 가능**. Approve 까지 차단을 원하시면 별도 PR 로 확장 가능(동일 마커 1줄 가드).
- hook.py(CLI pre-push)도 `calculate_score([])` 로 점수 인플레이션되나 **auto-merge 없음 → out-of-scope**(확인됨).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [ ] ~~Codex 검증 의뢰 완료~~ — **불가**
- [x] **(예외) Codex 토큰 무효화(`refresh_token_reused`) → Claude 직접 적대적 self-verify 대체** (정책 18 #773, 사용자 승인 하). 2 에이전트 OK. 🔴 복구 강제 가드 — 다음 세션 `codex login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
