### PR TITLE
fix(pipeline): 동시 insert race 시 중복 알림/PR 코멘트 차단 — save_new created 신호 (정합성 감사 P1)

### DIFF
--- a/src/repositories/analysis_repo.py
+++ b/src/repositories/analysis_repo.py
@@ -17,17 +17,20 @@ def find_by_id(db: Session, analysis_id: int) -> Analysis | None:
     return db.query(Analysis).filter_by(id=analysis_id).first()
 
 
-def save_new(db: Session, analysis: Analysis) -> Analysis:
-    """신규 Analysis를 저장하고 DB에서 refresh한 뒤 반환한다.
+def save_new(db: Session, analysis: Analysis) -> tuple[Analysis, bool]:
+    """신규 Analysis를 저장하고 (analysis, created) 를 반환한다.
+    Save a new Analysis and return (analysis, created).
 
-    DB unique constraint(uq_analyses_repo_sha) 위반 시 기존 레코드를 반환.
-    pipeline의 TOCTOU 완화 이후 마지막 안전망.
+    created=True = 신규 삽입. created=False = DB unique constraint(uq_analyses_repo_sha) 위반으로
+    기존 레코드를 반환 (동시 insert race — pipeline TOCTOU 완화 이후 마지막 안전망).
+    created=False 는 호출자가 중복 알림/게이트를 차단하는 신호다.
+    created=False signals the caller to skip duplicate notify/gate (concurrent-insert race).
     """
     try:
         db.add(analysis)
         db.commit()
         db.refresh(analysis)
-        return analysis
+        return analysis, True
     except IntegrityError:
         db.rollback()
         logger.warning(
@@ -38,7 +41,7 @@ def save_new(db: Session, analysis: Analysis) -> Analysis:
         existing = find_by_sha(db, analysis.commit_sha, analysis.repo_id)
         if existing is None:
             raise
-        return existing
+        return existing, False
 
 
 def delete_by_repo_id(db: Session, repo_id: int) -> int:

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -422,7 +422,7 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
     if params.static_incomplete:
         result_dict["static_analysis_incomplete"] = True
     ai = params.ai_review
-    analysis = analysis_repo.save_new(db, Analysis(
+    analysis, created = analysis_repo.save_new(db, Analysis(
         repo_id=repo.id,
         commit_sha=params.commit_sha,
         commit_message=params.commit_message,
@@ -435,6 +435,19 @@ async def _save_and_gate(db: Session, params: _AnalysisSaveParams):
         input_tokens=getattr(ai, "input_tokens", None) or None,
         output_tokens=getattr(ai, "output_tokens", None) or None,
     ))
+    if not created:
+        # 동시 insert 가 find_by_sha 재확인(410)을 통과했으나 DB unique 제약이 차단 →
+        # 기존 레코드 반환. find_by_sha race 경로와 동일 처리: 중복 알림/PR 코멘트 방지
+        # (result_dict=None race-recovery 신호 재사용).
+        # Concurrent insert raced past the find_by_sha re-check but was blocked by the DB
+        # constraint → existing returned. Same handling as the find_by_sha race path:
+        # prevent duplicate notify/PR-comment via the result_dict=None race-recovery signal.
+        logger.info(
+            "Concurrent insert blocked by DB constraint (sha=%s) — race-recovery, skipping duplicate gate/notify",
+            params.commit_sha,
+        )
+        repo_config = await _race_recover_existing(db, params, analysis)
+        return repo_config, None, None
     analysis_id = analysis.id
     try:
         repo_config = get_repo_config(db, params.repo_name)

--- a/tests/unit/repositories/test_analysis_repo.py
+++ b/tests/unit/repositories/test_analysis_repo.py
@@ -45,7 +45,8 @@ def test_find_by_sha_returns_none_when_missing(db_session):
 def test_save_new_persists_and_returns_analysis(db_session):
     repo = _seed_repo(db_session)
     a = Analysis(repo_id=repo.id, commit_sha="abc123", score=80, grade="B")
-    saved = analysis_repo.save_new(db_session, a)
+    saved, created = analysis_repo.save_new(db_session, a)
+    assert created is True  # 신규 삽입
     assert saved.id is not None
     assert saved.commit_sha == "abc123"
     assert db_session.query(Analysis).count() == 1
@@ -61,14 +62,16 @@ def test_find_by_sha_returns_existing(db_session):
 
 
 def test_save_new_returns_existing_on_duplicate_sha(db_session):
-    """DB unique constraint 위반 시 기존 레코드를 반환 — race condition 안전망."""
+    """DB unique constraint 위반 시 (기존 레코드, created=False) 반환 — race condition 안전망."""
     repo = _seed_repo(db_session)
     first = Analysis(repo_id=repo.id, commit_sha="dup123", score=75, grade="B")
-    saved_first = analysis_repo.save_new(db_session, first)
+    saved_first, created_first = analysis_repo.save_new(db_session, first)
+    assert created_first is True
 
     second = Analysis(repo_id=repo.id, commit_sha="dup123", score=90, grade="A")
-    result = analysis_repo.save_new(db_session, second)
+    result, created_second = analysis_repo.save_new(db_session, second)
 
+    assert created_second is False  # 동시 insert race — 신규 아님 (중복 알림/게이트 차단 신호)
     assert result.id == saved_first.id
     assert result.score == 75  # 첫 번째 레코드 그대로
     assert db_session.query(Analysis).count() == 1

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -156,6 +156,28 @@ async def test_non_python_files_still_run_ai_review(mock_deps):
     mock_deps["telegram"].assert_called_once()
 
 
+async def test_concurrent_insert_race_skips_duplicate_notify(mock_deps):
+    """save_new 가 DB unique 제약으로 기존 레코드(created=False)를 반환하면 알림을 재발송하지 않는다.
+
+    동시 webhook 가 find_by_sha 재확인을 통과해도 마지막 안전망인 DB 제약이 중복 삽입을 차단한다.
+    이때 기존 레코드가 이미 알림/게이트를 처리했으므로 중복 알림·PR 코멘트를 방지해야 한다
+    (정합성 감사 P1 — result_dict=None race-recovery 신호 재사용).
+    """
+    from unittest.mock import AsyncMock, MagicMock, patch
+    from src.worker.pipeline import run_analysis_pipeline
+
+    # 이미 존재하는 레코드 (다른 webhook 가 처리 완료, pr_number 이미 설정)
+    # Existing record already handled by a concurrent webhook (pr_number already set)
+    existing = MagicMock(id=99, pr_number=7, result={"score": 85})
+    with patch("src.worker.pipeline.analysis_repo.save_new", return_value=(existing, False)):
+        with patch("src.worker.pipeline.run_gate_check", new_callable=AsyncMock):
+            await run_analysis_pipeline("pull_request", PR_DATA)
+
+    # 중복 알림 차단 — result_dict=None 으로 notify 스킵
+    # Duplicate notification blocked — notify skipped via result_dict=None
+    mock_deps["telegram"].assert_not_called()
+
+
 async def test_no_python_files_still_creates_repository(mock_deps):
     """Even when no Python files changed, the Repository should be created in DB."""
     mock_deps["push"].return_value = []


### PR DESCRIPTION
## Summary

integrity-audit `area=gate` 발견 **P1**: 두 webhook 가 같은 SHA 로 find_by_sha 재확인(pipeline.py:410)을 동시 통과하면, 두 번째의 `save_new` 가 DB unique 제약 위반으로 기존 레코드를 반환한다. `_save_and_gate` 가 이를 신규 저장과 구분 못 해 → **run_gate_check 재실행(PR 코멘트 재게시·approve/merge 재시도) + 비-None result_dict 반환 → notify 가 알림을 재발송**했다. DB 제약은 중복 "행" 은 막았으나 중복 "알림/코멘트" 는 못 막던 구조.

## 변경 내용

- `analysis_repo.save_new` → `(analysis, created)` 반환. `created=False` = DB 제약으로 기존 레코드 반환(동시 insert race 신호). 단일 호출자(pipeline.py)만 영향.
- `_save_and_gate` 가 `not created` 시 **find_by_sha race 경로와 동일 처리** → `_race_recover_existing`(pr_number 보정 + 조건부 1회 재게이트만, **재알림 X**) + `result_dict=None` 반환 → 중복 notify 스킵.

## 테스트

- TDD 3건: save_new created 신호 2(신규 True / 중복 False) + 파이프라인 중복 notify 차단 1.
- **307 passed** (pipeline+repo+gate+integration, 회귀 0), pylint **10.00/10**, flake8 clean.

## 🔍 사용자 검증 필요 (정책 2)

- [ ] CI 통과 확인
- [ ] (운영) 동시 webhook(같은 SHA push+PR 동시 도착)이 잦은 리포에서 알림이 1회만 발송되는지(중복 제거).

## ⚠️ 자율 판단 보고 (정책 3)

- 적대적 self-verify 1 에이전트 `VERDICT: OK`, P0/P1/P2 0건 (체인 정확성·회귀 0·find_by_sha race 경로 일관성·ORM 엣지 확인).
- IntegrityError race window 는 순차 HTTP 로 비결정적이라 단위 mock 으로 커버(실 DB 동시성 테스트 비대상) — self-verify 가 적정 커버리지로 판정.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [ ] ~~Codex 검증 의뢰 완료~~ — **불가**
- [x] **(예외) Codex 토큰 무효화 → Claude 직접 적대적 self-verify 대체** (정책 18 #773, 사용자 승인 하). 🔴 복구 강제 가드 — 다음 세션 `codex login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
