### PR TITLE
fix(gate): merge_retry 만료 행을 'expired' 로 기록 — failed_terminal 오기록 + mark_expired dead code (정합성 감사 P1)

### DIFF
--- a/src/models/merge_retry.py
+++ b/src/models/merge_retry.py
@@ -7,7 +7,7 @@ When a merge fails because CI is still running, enqueue and retry.
   pending → succeeded        — 재시도 성공
   pending → failed_terminal  — 재시도 가능하지 않은 오류 (권한 없음, branch protection 등)
   pending → abandoned        — max_attempts 초과
-  pending → expired          — 커밋 SHA 가 더 이상 PR head 가 아님
+  pending → expired          — 커밋 SHA 가 더 이상 PR head 가 아님(force-push) 또는 max_age 초과
 """
 from datetime import datetime, timezone
 

--- a/src/repositories/merge_retry_repo.py
+++ b/src/repositories/merge_retry_repo.py
@@ -391,8 +391,10 @@ def mark_expired(
     reason: str | None = None,
     now: datetime | None = None,
 ) -> bool:
-    """status='expired' 마킹 — SHA 가 PR head 가 아닐 때 (force-push 등).
-    Mark status as 'expired' — when SHA is no longer PR head (e.g. force-push).
+    """status='expired' 마킹 — 더 이상 머지 시도하지 않는 비-실패 종료.
+    SHA 가 PR head 가 아닐 때(force-push 등) 또는 max_age 초과로 만료된 경우.
+    Mark status as 'expired' — a non-failure stop: SHA no longer PR head (e.g. force-push)
+    or the row aged out past max_age (merge_retry_service terminal 분기에서 사용).
     행 없으면 False 반환.
     Returns False if row not found.
     """

--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -73,6 +73,7 @@ async def process_pending_retries(
         "claimed": len(claimed),
         "succeeded": 0,
         "terminal": 0,
+        "expired": 0,
         "abandoned": 0,
         "released": 0,
         "skipped": 0,
@@ -100,7 +101,7 @@ async def process_pending_retries(
     return counts
 
 
-async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-return-statements
+async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-return-statements,too-many-statements
     db: Session,
     row,
     now: datetime,
@@ -199,20 +200,30 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
     )
     expired = is_expired(row, now=now, max_age_hours=settings.merge_retry_max_age_hours)
 
-    if (not should_retry(reason_tag, ci_status)) or expired:
-        # 재시도 불가 또는 만료 → terminal
+    is_terminal_failure = not should_retry(reason_tag, ci_status)
+    if is_terminal_failure or expired:
+        # 재시도 불가(terminal) 또는 max_age 초과(expired) → 재시도 중단
+        # 두 경우를 상태로 구분: 실제 종료 실패는 failed_terminal, 재시도 가능했으나
+        # 만료된 행은 'expired' (정합성 감사 P1 — mark_expired dead code 활성화, 오기록 방지).
+        # Non-retriable (terminal) or aged out (expired) → stop retrying. Distinguish by status:
+        # a genuine terminal failure → failed_terminal; a retriable row that aged out → 'expired'.
         log_merge_attempt(
             db, analysis_id=row.analysis_id, repo_name=row.repo_full_name,
             pr_number=row.pr_number, score=row.score,
             threshold=row.threshold_at_enqueue, success=False, reason=reason,
         )
-        merge_retry_repo.mark_terminal(db, row.id, reason=reason_tag)
+        if is_terminal_failure:
+            merge_retry_repo.mark_terminal(db, row.id, reason=reason_tag)
+            counts["terminal"] += 1
+        else:
+            # 재시도 가능했으나 max_age 초과 — terminal 실패와 구분해 'expired' 기록
+            merge_retry_repo.mark_expired(db, row.id, reason=reason_tag)
+            counts["expired"] += 1
         # 사이클 149 Sprint 3/4 — 알림 + Issue 사용자 언어 (상단 b 단계에서 결정)
         # Cycle 149 Sprint 3/4 — user language for notify + Issue (resolved in step b above)
         await _notify_merge_terminal(row, cfg, reason, reason_tag, language=language)
         if cfg.auto_merge_issue_on_failure:
             await _create_failure_issue_safe(token, row, cfg, reason, reason_tag, language=language)
-        counts["terminal"] += 1
         return
 
     # ── g. 일시적 실패 — 백오프 후 재시도 대기로 복귀 ────────────

--- a/tests/integration/test_retry_end_to_end.py
+++ b/tests/integration/test_retry_end_to_end.py
@@ -231,9 +231,11 @@ async def test_config_changed_abandons_row(db):
     assert counts["abandoned"] == 1
 
 
-async def test_expired_row_marks_terminal(db):
-    """max_age_hours 초과 행 → terminal 처리됨.
-    Row older than max_age_hours → marked as failed_terminal.
+async def test_expired_row_marks_expired(db):
+    """max_age_hours 초과(재시도 가능했으나 만료) 행 → 'expired' 처리됨.
+    Row older than max_age_hours (retriable but aged out) → marked as 'expired'.
+
+    정합성 감사 P1: 과거엔 failed_terminal 로 오기록(mark_expired dead code)됐다.
     """
     # created_at 을 25시간 전으로 설정 (기본 max_age_hours=24 초과)
     # Set created_at to 25 hours ago (exceeds default max_age_hours=24)
@@ -260,5 +262,6 @@ async def test_expired_row_marks_terminal(db):
         counts = await process_pending_retries(db)
 
     db.refresh(row)
-    assert row.status == "failed_terminal"
-    assert counts["terminal"] == 1
+    assert row.status == "expired"
+    assert counts["expired"] == 1
+    assert counts["terminal"] == 0

--- a/tests/unit/services/test_merge_retry_service.py
+++ b/tests/unit/services/test_merge_retry_service.py
@@ -518,15 +518,18 @@ class TestProcessPendingRetries:
 
     # T9-9: 만료된 행 → terminal 마킹
     # T9-9: Expired row → terminal
-    async def test_process_expired_row_marks_terminal(self, db_session):
-        """만료된 행은 CI 상태가 running 이어도 terminal 처리.
-        Expired rows are terminal even when CI status is running.
+    async def test_process_expired_row_marks_expired(self, db_session):
+        """만료(max_age 초과)된 retriable 행은 terminal 실패가 아니라 'expired' 로 기록.
+        Age-expired retriable rows are recorded as 'expired', not a terminal CI failure.
+
+        정합성 감사 P1: mark_expired(status='expired') 가 dead code 였고, 만료 행이
+        mark_terminal(reason=CI태그)로 오기록돼 'expired' 상태가 운영에 발생하지 않던 결함.
         """
         row = _seed_queue_row(db_session)
 
         patches = _standard_patches(
             merge_return=(False, "unstable_ci: state=unstable, merged=False", ""),
-            ci_return="running",
+            ci_return="running",  # 재시도 가능 상태이나 max_age 초과 → expired
         )
         with (
             patches["token"],
@@ -545,13 +548,14 @@ class TestProcessPendingRetries:
         ):
             result = await process_pending_retries(db_session, only_ids=[row.id])
 
-        assert result["terminal"] == 1
+        assert result["expired"] == 1       # 만료는 expired 카운트
+        assert result["terminal"] == 0      # terminal 실패 아님
         assert result["released"] == 0
-        mock_notify_t.assert_called_once()
+        mock_notify_t.assert_called_once()  # 재시도 중단 알림은 유지
         mock_log.assert_called_once()
 
         db_session.refresh(row)
-        assert row.status == "failed_terminal"
+        assert row.status == "expired"      # failed_terminal 아님
 
     # T9-10: 인프라 에러 → 30초 백오프로 클레임 해제
     # T9-10: Infra error → release with 30s backoff


### PR DESCRIPTION
## Summary

integrity-audit `area=gate` 발견 **P1**: `_process_single_retry` 가 `(not should_retry) or expired` 를 한 분기로 묶어, **max_age 초과(expired)된 재시도-가능 행도 `mark_terminal`(status='failed_terminal', reason=CI태그)로 기록**했다. 결과적으로 `mark_expired`(status='expired')는 **dead code** 였고, "나이 들어 포기" 한 행이 "터미널 CI 실패" 로 오기록돼 운영 상태·통계가 부정확했다.

## 변경 내용

- 종료 분기를 `is_terminal_failure`(= `not should_retry`) vs `expired` 로 구분:
  - 실제 종료 실패 → `mark_terminal`(failed_terminal) + `counts["terminal"]`
  - 재시도 가능했으나 max_age 초과 → `mark_expired`(**expired**) + `counts["expired"]`(신규 키, additive)
  - 둘 다면 **terminal 우선**(실패가 주 사유). 알림/Issue 동작 동일(재시도 중단 통지).
- `mark_expired` + 모델 status 전이 docstring 에 age-만료 의미 추가(force-push 외).

## 테스트

- TDD: 버그를 인코딩하던 기존 테스트 2건(unit `test_process_expired_row_marks_terminal` + integration `test_expired_row_marks_terminal`)을 올바른 동작(`expired`)으로 뒤집음.
- **69+ passed** (service+repo+cron+integration+check_suite), src **pylint 10.00/10**·flake8 clean.

## 🔍 사용자 검증 필요 (정책 2)

- [ ] CI 통과 확인
- [ ] (운영) admin/cron 통계에서 `expired`(나이 만료)와 `terminal`(CI 실패)이 구분되는지 — 24h 초과 대기 행이 'expired' 로 집계.

## ⚠️ 자율 판단 보고 (정책 3)

- **데이터 모델 status 의미 활성화**: `mark_expired`(status='expired')는 기존 dead code 였고 docstring 상 force-push 용이었으나, age-만료도 "비-실패 종료" 로 동일 상태에 귀속(이름 'expired' 가 age 에 더 적합). status 소비처가 `failed_terminal`/`expired` 로 분기하는 곳 없음(`_NON_TERMINAL_STATUSES={'pending'}` 만 사용 — 재처리 영향 0) — self-verify 확인.
- 적대적 self-verify 1 에이전트 `VERDICT: OK`, P0/P1/P2 0건 (terminal 우선 로직·counts additive·status 소비처 무영향·192 broad passed). nit 1건(모델 docstring) 반영 커밋.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [ ] ~~Codex 검증 의뢰 완료~~ — **불가**
- [x] **(예외) Codex 토큰 무효화 → Claude 직접 적대적 self-verify 대체** (정책 18 #773, 사용자 승인 하). 🔴 복구 강제 가드 — 다음 세션 `codex login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
