### PR TITLE
fix(gate): ApproveAction auto 경로 정적분석 불완전 가드 확장 — 인플레 점수 간접 머지 차단 (정합성 감사 area=gate)

### DIFF
--- a/src/gate/actions/approve.py
+++ b/src/gate/actions/approve.py
@@ -43,7 +43,21 @@ class ApproveAction(GateAction):
             await self._run_semi_auto(ctx)
 
     async def _run_auto(self, ctx: GateContext) -> None:
-        """Auto Approve — score 기준 approve/reject/skip."""
+        """Auto Approve — score 기준 approve/reject/skip.
+
+        정적분석 불완전(타임아웃) 시 자동 approve 보류 — 미분석 코드는 점수가 인플레이션될 수
+        있고, auto-approve 가 branch-protection "approval 시 자동머지" 를 간접 트리거할 수
+        있으므로 결정을 내리지 않는다 (#779 auto-merge 가드의 approve 경로 확장).
+        Hold auto-approve when static analysis is incomplete (timeout) — unanalyzed code may have an
+        inflated score, and an auto-approve could indirectly trigger branch-protection
+        "auto-merge on approval", so make no decision (#779 auto-merge guard extended to approve).
+        """
+        if ctx.result.get("static_analysis_incomplete"):
+            logger.warning(
+                "static analysis incomplete — auto-approve skipped (repo=%s, pr=%s)",
+                ctx.repo_name, ctx.pr_number,
+            )
+            return
         # 알림 언어 결정 (3-layer fallback) — GitHub PR 댓글을 리포 소유자 언어로 게시
         # Resolve notification language (3-layer fallback) — post PR review in owner's language
         with SessionLocal() as db:

--- a/tests/unit/gate/test_gate_actions.py
+++ b/tests/unit/gate/test_gate_actions.py
@@ -168,6 +168,30 @@ async def test_approve_action_semi_auto_calls_send_gate_request():
     mock_gate.assert_awaited_once()
 
 
+@pytest.mark.asyncio
+async def test_approve_action_auto_skips_when_static_analysis_incomplete():
+    """정적분석 불완전(타임아웃) 시 score 충족이어도 post_github_review 를 호출하지 않아야 한다.
+    Must not call post_github_review even when score qualifies, if static analysis is incomplete.
+
+    result["static_analysis_incomplete"]=True → 인플레 점수의 auto-approve 차단 (#779 approve 경로 확장).
+    """
+    from src.gate.actions.approve import ApproveAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(approve_mode="auto")
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        result={"score": 90, "static_analysis_incomplete": True},  # 90 >= threshold(70) 이나 불완전
+        github_token="ghp_test", config=cfg, score=90,
+    )
+    with patch("src.gate.actions.approve.post_github_review", new=AsyncMock()) as mock_review, \
+         patch("src.gate.actions.approve.gate_decision_repo"), \
+         patch("src.gate.actions.approve.SessionLocal") as mock_sess:
+        mock_sess.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+        await ApproveAction().execute(ctx)
+    mock_review.assert_not_awaited()
+
+
 # ─── AutoMergeAction ─────────────────────────────────────────────────────────
 
 def test_auto_merge_action_is_applicable_when_enabled():

--- a/tests/unit/test_gate_i18n_seam.py
+++ b/tests/unit/test_gate_i18n_seam.py
@@ -25,6 +25,7 @@ async def test_approve_auto_threads_japanese_language_to_review():
 
     ctx = MagicMock()
     ctx.score = 90
+    ctx.result = {"score": 90}  # 정적분석 완료(불완전 마커 부재) — 가드 통과 / static analysis complete
     ctx.config.approve_mode = "auto"
     ctx.config.approve_threshold = 75
     ctx.config.reject_threshold = 40
@@ -58,6 +59,7 @@ async def test_approve_auto_threads_english_language_to_review():
 
     ctx = MagicMock()
     ctx.score = 90
+    ctx.result = {"score": 90}  # 정적분석 완료(불완전 마커 부재) — 가드 통과 / static analysis complete
     ctx.config.approve_mode = "auto"
     ctx.config.approve_threshold = 75
     ctx.config.reject_threshold = 40
@@ -91,6 +93,7 @@ async def test_approve_auto_reject_threads_language_to_review():
 
     ctx = MagicMock()
     ctx.score = 10
+    ctx.result = {"score": 10}  # 정적분석 완료(불완전 마커 부재) — 가드 통과 / static analysis complete
     ctx.config.approve_mode = "auto"
     ctx.config.approve_threshold = 75
     ctx.config.reject_threshold = 40


### PR DESCRIPTION
## Summary

`ApproveAction._run_auto()` 진입부에 `static_analysis_incomplete` 가드를 추가해, 정적분석 타임아웃 시 인플레 점수의 auto-approve가 branch-protection "approval 시 자동머지"를 간접 트리거하는 경로를 차단한다. #779가 `auto_merge.py:46`에 추가한 동일 마커 가드의 **approve 경로 확장**(정합성 감사 area=gate self-verify 발견 — #779 범위 밖 명시 잔여).

## 변경 내용

- `src/gate/actions/approve.py` `_run_auto` 진입부: `ctx.result.get("static_analysis_incomplete")` truthy 시 결정 보류(`return`) + 관측 WARNING 로그 — `auto_merge.py:46`와 동일 패턴 미러
- `tests/unit/gate/test_gate_actions.py`: 회귀 가드 `test_approve_action_auto_skips_when_static_analysis_incomplete` 1건 (가드 제거 시 실패 → 회귀 봉인)

## 테스트

- `pytest tests/unit/gate/` — **228 passed** (신규 1 포함)
- `pylint src/gate/actions/approve.py` 클린 (메시지 0) · `flake8` exit 0
- TDD Red→Green: 가드 미구현 시 `post_github_review` 1회 await → `assert_not_awaited()` 실패(Red) 확인 후 구현

## 체크리스트

### 기본
- [x] `make test` (gate 스위트 228 passed)
- [x] `make lint` (pylint 클린 · flake8 0)

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] (선택) 운영에서 정적분석 타임아웃 발생 시 auto-approve가 보류되고 WARNING 로그(`static analysis incomplete — auto-approve skipped`)가 남는지 확인

## ⚠️ 자율 판단 보고 (정책 3)

- **semi-auto 경로 의도적 미적용**: `_run_semi_auto`(Telegram 인라인 키보드)는 human-in-loop이라 가드 미적용. 메모리/리포트 scope가 auto 경로 한정(branch-protection 간접 머지 위험)이고, 반자동은 사람이 점수를 보고 결정하므로 알림 차단이 오히려 감독을 제거. 별도 UX 개선(사람에게 불완전 표시)은 범위 외.
- **reject도 함께 보류 결정**: 불완전 정적분석 → 점수 신뢰 불가이므로 approve뿐 아니라 reject도 보류(`return`). 불완전 데이터 기반 `REQUEST_CHANGES`도 부당. auto_merge.py 가드와 동일한 "결정 보류" 의미.
- **STATE/cycle-history sync 후속 분리**: 단위 테스트 +1 수치 반영은 관례(#768/#782)대로 머지 후 별도 docs sync PR로 처리 예정(이 PR은 정책 7 응집 단위 — gate fix 1건 집중).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) **Codex 토큰 만료로 검증 차단** — `codex login status`는 "Logged in"이나 실제 exec 시 토큰 만료(401). 5연속 fallback 도달(사이클 119/125/161/162 + 본 건). 정책 18 복구 강제 가드 트리거 — 다음 세션 전 `codex login` 필수.
- [x] **Claude 적대적 self-verify 대체**(사용자 승인 — 정책 18 fallback 예외 #773): 독립 skeptic 에이전트 5렌즈 반증(correctness 가드 위치 / None 안전성 / semi-auto 미적용 / 테스트 봉인력 / 엣지케이스) → **전부 refuted, VERDICT OK**. 마커 키 byte-동일(pipeline.py:423 ↔ approve.py:55 ↔ auto_merge.py:46), `GateContext.result` non-Optional + 3 호출처 None pre-guard 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
