### PR TITLE
fix(api): CLI hook 점수 필드 비숫자/Infinity 입력 안전 변환 — 500 차단 + parse_error graceful (정합성 감사 area=gate)

### DIFF
--- a/src/api/hook.py
+++ b/src/api/hook.py
@@ -60,17 +60,20 @@ def _coerce_raw_score(raw: Any, max_val: int, default: int) -> tuple[int, bool]:
     """raw 점수를 [0, max_val] 정수로 안전 클램프. 비숫자 타입/값은 default 로 폴백.
     Safely clamp a raw score to [0, max_val]; fall back to default on non-numeric type/value.
 
-    오작동·악성 CLI 가 점수 필드에 문자열·None 등을 보내면 int() 가 ValueError/TypeError 를
-    던져 500 이 된다. 이를 흡수해 default 폴백 + parse_error 분류로 graceful 처리한다.
-    A malfunctioning/malicious CLI may send a string/None for a score field, making int() raise
-    ValueError/TypeError → 500. Absorb it: fall back to the default and signal parse_error.
+    오작동·악성 CLI 가 점수 필드에 문자열·None·Infinity 등을 보내면 int() 가
+    TypeError/ValueError/OverflowError 를 던져 500 이 된다 (Infinity 는 json.loads 가
+    float('inf') 로 파싱 → int(float('inf')) OverflowError). 이를 흡수해 default 폴백 +
+    parse_error 분류로 graceful 처리한다.
+    A malfunctioning/malicious CLI may send a string/None/Infinity for a score field, making int()
+    raise TypeError/ValueError/OverflowError → 500 (json.loads parses Infinity to float('inf'),
+    and int(float('inf')) raises OverflowError). Absorb it: fall back to the default and signal parse_error.
 
     반환 (clamped, ok) — ok=False 시 호출자가 ai_review_status='parse_error' 로 분류.
     Returns (clamped, ok) — ok=False signals the caller to mark ai_review_status='parse_error'.
     """
     try:
         value = int(raw)
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
         return max(0, min(max_val, default)), False
     return max(0, min(max_val, value)), True
 

--- a/src/api/hook.py
+++ b/src/api/hook.py
@@ -56,6 +56,45 @@ def _resolve_hook_locale(db, repo_name: str) -> str:
     return settings.default_locale
 
 
+def _coerce_raw_score(raw: Any, max_val: int, default: int) -> tuple[int, bool]:
+    """raw 점수를 [0, max_val] 정수로 안전 클램프. 비숫자 타입/값은 default 로 폴백.
+    Safely clamp a raw score to [0, max_val]; fall back to default on non-numeric type/value.
+
+    오작동·악성 CLI 가 점수 필드에 문자열·None 등을 보내면 int() 가 ValueError/TypeError 를
+    던져 500 이 된다. 이를 흡수해 default 폴백 + parse_error 분류로 graceful 처리한다.
+    A malfunctioning/malicious CLI may send a string/None for a score field, making int() raise
+    ValueError/TypeError → 500. Absorb it: fall back to the default and signal parse_error.
+
+    반환 (clamped, ok) — ok=False 시 호출자가 ai_review_status='parse_error' 로 분류.
+    Returns (clamped, ok) — ok=False signals the caller to mark ai_review_status='parse_error'.
+    """
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return max(0, min(max_val, default)), False
+    return max(0, min(max_val, value)), True
+
+
+def _coerce_ai_scores(ar: dict) -> tuple[int, int, int, bool]:
+    """ai_result 의 3개 raw 점수를 안전 클램프하고 'success' 적격 여부를 함께 반환한다.
+    Coerce the three raw scores from ai_result and report whether they qualify as 'success'.
+
+    각 필드가 (키 존재 AND 숫자 변환 가능)일 때만 status_ok=True — 누락 또는 비숫자 시 False.
+    status_ok=True only when every field is present AND numeric — False if any is missing/non-numeric.
+
+    반환 (commit, direction, test, status_ok).
+    Returns (commit, direction, test, status_ok).
+    """
+    commit, commit_ok = _coerce_raw_score(
+        ar.get("commit_message_score", AI_DEFAULT_COMMIT_RAW), AI_RAW_COMMIT_MAX, AI_DEFAULT_COMMIT_RAW)
+    direction, direction_ok = _coerce_raw_score(
+        ar.get("direction_score", AI_DEFAULT_DIRECTION_RAW), AI_RAW_DIRECTION_MAX, AI_DEFAULT_DIRECTION_RAW)
+    test, test_ok = _coerce_raw_score(
+        ar.get("test_score", AI_DEFAULT_TEST_RAW), AI_RAW_TEST_MAX, AI_DEFAULT_TEST_RAW)
+    keys_present = all(k in ar for k in ("commit_message_score", "direction_score", "test_score"))
+    return commit, direction, test, (keys_present and commit_ok and direction_ok and test_ok)
+
+
 # ---------------------------------------------------------------------------
 # GET /api/hook/verify
 # ---------------------------------------------------------------------------
@@ -164,18 +203,16 @@ def save_hook_result(request: Request, body: HookResultRequest):  # pylint: disa
             }
 
         # ai_result → AiReviewResult 변환
-        # 필수 score 필드 누락 시 status="parse_error"로 표시 (대시보드 fallback 배너 노출)
+        # 필수 score 필드 누락 또는 비숫자 타입 시 status="parse_error" 표시 (대시보드 fallback 배너 노출).
+        # raw 점수는 0~MAX 클램프 + 안전 변환 — 범위 밖/비숫자 값이 500 또는 cap 초과를 유발하지 않게.
+        # Mark status="parse_error" on missing OR non-numeric score fields (dashboard fallback banner).
+        # Raw scores are clamped to 0~MAX with safe coercion — out-of-range/non-numeric never 500 or exceed cap.
         ar = body.ai_result
-        required_keys = ("commit_message_score", "direction_score", "test_score")
-        ai_status = "success" if all(k in ar for k in required_keys) else "parse_error"
+        commit_raw, direction_raw, test_raw, scores_ok = _coerce_ai_scores(ar)
         ai_review = AiReviewResult(
-            # raw 점수를 0~MAX 범위로 클램프 — ai_review.py 의 클램프 패턴 미러.
-            # 범위 밖 값이 calculator 스케일링을 거쳐 breakdown cap 을 넘는 정합성 위반 방지.
-            # Clamp raw scores to 0~MAX, mirroring ai_review.py — prevents out-of-range
-            # values from pushing breakdown categories past their caps after scaling.
-            commit_score=max(0, min(AI_RAW_COMMIT_MAX, int(ar.get("commit_message_score", AI_DEFAULT_COMMIT_RAW)))),
-            ai_score=max(0, min(AI_RAW_DIRECTION_MAX, int(ar.get("direction_score", AI_DEFAULT_DIRECTION_RAW)))),
-            test_score=max(0, min(AI_RAW_TEST_MAX, int(ar.get("test_score", AI_DEFAULT_TEST_RAW)))),
+            commit_score=commit_raw,
+            ai_score=direction_raw,
+            test_score=test_raw,
             summary=ar.get("summary", ""),
             suggestions=ar.get("suggestions", []),
             commit_message_feedback=ar.get("commit_message_feedback", ""),
@@ -184,7 +221,7 @@ def save_hook_result(request: Request, body: HookResultRequest):  # pylint: disa
             direction_feedback=ar.get("direction_feedback", ""),
             test_feedback=ar.get("test_feedback", ""),
             file_feedbacks=ar.get("file_feedbacks", []),
-            status=ai_status,
+            status="success" if scores_ok else "parse_error",
         )
 
         # CLI 훅은 정적 분석 없음 → 빈 리스트 (code_quality=25, security=20 만점)

--- a/tests/unit/api/test_hook.py
+++ b/tests/unit/api/test_hook.py
@@ -610,3 +610,19 @@ def test_hook_result_none_score_value_returns_parse_error():
     assert saved[0].result["ai_review_status"] == "parse_error"
     breakdown = saved[0].result["breakdown"]
     assert 0 <= breakdown["test_coverage"] <= TEST_COVERAGE_MAX
+
+
+def test_hook_result_infinity_score_value_returns_parse_error():
+    # JSON 비표준 리터럴 Infinity 는 json.loads 가 float('inf') 로 파싱 → int(float('inf'))
+    # 는 OverflowError. (TypeError, ValueError) 만 잡으면 500 으로 샌다 — OverflowError 도
+    # 흡수해 default 폴백 + parse_error 로 200 을 반환해야 한다 (적대적 self-verify 발견).
+    # The non-standard JSON literal Infinity is parsed by json.loads to float('inf'); int(float('inf'))
+    # raises OverflowError. Catching only (TypeError, ValueError) would leak a 500 — OverflowError must
+    # also be absorbed (default fallback + parse_error, 200). Found by adversarial self-verify.
+    r, saved = _post_hook_non_numeric({**_AI_RESULT, "commit_message_score": float("inf")})
+
+    assert r.status_code == 200
+    assert len(saved) == 1
+    assert saved[0].result["ai_review_status"] == "parse_error"
+    breakdown = saved[0].result["breakdown"]
+    assert 0 <= breakdown["commit_message"] <= COMMIT_MSG_MAX

--- a/tests/unit/api/test_hook.py
+++ b/tests/unit/api/test_hook.py
@@ -517,3 +517,96 @@ def test_verify_no_token_returns_401():
         )
 
     assert r.status_code == 401
+
+
+# ------------------------------------------------------------------
+# 비숫자 점수 필드 방어 회귀 가드 — CLI hook 의 점수 필드가 비숫자 타입
+# ("abc"/None/list 등)으로 오염돼도 int() ValueError/TypeError 가 500 으로
+# 새지 않고, default 폴백 + ai_review_status="parse_error" 분류로 graceful
+# 하게 처리되어 200 을 반환하는지 검증한다 (정합성 감사 area=gate P2).
+# Non-numeric score field defense regression guard — a CLI hook score field
+# polluted with a non-numeric type ("abc"/None/list) must NOT leak an int()
+# ValueError/TypeError as a 500. Instead it should fall back to defaults,
+# classify ai_review_status="parse_error", and still return 200 (integrity
+# audit area=gate P2).
+# ------------------------------------------------------------------
+
+def _post_hook_non_numeric(ai_result: dict):
+    """주어진 (비정상 가능) ai_result 로 /api/hook/result 를 호출하고 (response, saved) 반환.
+    Call /api/hook/result with the given (possibly malformed) ai_result and
+    return (response, saved) — status 단언을 호출자에게 맡겨 Red(500) 신호를 보존한다.
+
+    참고: _post_hook_capturing 헬퍼는 내부에서 status_code == 200 을 단언하므로,
+    현재 500 동작을 그 assert 가 가려 버린다. 따라서 여기서는 직접 client.post 후
+    status 단언을 호출자에게 위임한다 (test_hook_result_partial_ai_result_marks_parse_error
+    의 mock 설정을 정확히 미러).
+    Note: _post_hook_capturing asserts status == 200 internally, which would mask
+    the current 500. So this helper leaves the status assertion to the caller,
+    mirroring the mock setup of test_hook_result_partial_ai_result_marks_parse_error.
+    """
+    mock_db = MagicMock()
+    mock_config = MagicMock()
+    mock_config.hook_token = "coerce-token"
+    mock_repo = MagicMock()
+    mock_repo.id = 77
+
+    call_count = {"n": 0}
+
+    def _first_side_effect():
+        idx = call_count["n"]
+        call_count["n"] += 1
+        return {0: mock_config, 1: mock_repo}.get(idx)
+
+    mock_db.query.return_value.filter.return_value.first.side_effect = _first_side_effect
+    mock_db.query.return_value.filter_by.return_value.first.return_value = None  # no duplicate
+    saved: list = []
+    mock_db.add.side_effect = lambda obj: saved.append(obj)
+
+    with patch("src.api.hook.SessionLocal", return_value=_make_session_mock(mock_db)):
+        r = client.post("/api/hook/result", json={
+            "repo": "owner/repo",
+            "token": "coerce-token",
+            "commit_sha": "shacoerce",
+            "commit_message": "feat: coerce",
+            "ai_result": ai_result,
+        })
+    return r, saved
+
+
+def test_hook_result_non_numeric_score_returns_parse_error_not_500():
+    # 점수 필드 중 하나가 비숫자 문자열("abc")이면 int() ValueError 가 500 으로 새면 안 되고,
+    # default 폴백 + ai_review_status="parse_error" 로 graceful 처리되어 200 을 반환해야 한다.
+    # When one score field is a non-numeric string ("abc"), the int() ValueError must
+    # not leak as a 500; it must fall back to defaults, mark ai_review_status="parse_error",
+    # and return 200.
+    r, saved = _post_hook_non_numeric({**_AI_RESULT, "commit_message_score": "abc"})
+
+    # 핵심 단언: 현재 구현은 int("abc") → ValueError → 500 (= Red). 가드 추가 후 200.
+    # Core assertion: current impl raises ValueError → 500 (= Red). After the guard, 200.
+    assert r.status_code == 200
+    # 비숫자 점수는 parse_error 로 분류되어 fallback 경고 배너가 노출 가능해야 한다.
+    # A non-numeric score must be classified as parse_error so the fallback banner can show.
+    assert len(saved) == 1
+    assert saved[0].result["ai_review_status"] == "parse_error"
+    # 오염된 필드가 default 로 폴백돼 breakdown 카테고리 점수가 정상 범위(0~cap)여야 한다.
+    # The polluted field falls back to a default so the breakdown category stays in range (0~cap).
+    breakdown = saved[0].result["breakdown"]
+    assert 0 <= breakdown["commit_message"] <= COMMIT_MSG_MAX
+    assert 0 <= breakdown["ai_review"] <= AI_REVIEW_MAX
+    assert 0 <= breakdown["test_coverage"] <= TEST_COVERAGE_MAX
+
+
+def test_hook_result_none_score_value_returns_parse_error():
+    # 점수 필드 값이 None 이면 int(None) → TypeError 가 500 으로 새면 안 되고,
+    # default 폴백 + ai_review_status="parse_error" 로 graceful 처리되어 200 을 반환해야 한다.
+    # When a score field value is None, int(None) raises TypeError which must not leak as a 500;
+    # it must fall back to defaults, mark ai_review_status="parse_error", and return 200.
+    r, saved = _post_hook_non_numeric({**_AI_RESULT, "test_score": None})
+
+    # 핵심 단언: 현재 구현은 int(None) → TypeError → 500 (= Red). 가드 추가 후 200.
+    # Core assertion: current impl raises TypeError → 500 (= Red). After the guard, 200.
+    assert r.status_code == 200
+    assert len(saved) == 1
+    assert saved[0].result["ai_review_status"] == "parse_error"
+    breakdown = saved[0].result["breakdown"]
+    assert 0 <= breakdown["test_coverage"] <= TEST_COVERAGE_MAX

--- a/tests/unit/api/test_hook.py
+++ b/tests/unit/api/test_hook.py
@@ -612,17 +612,21 @@ def test_hook_result_none_score_value_returns_parse_error():
     assert 0 <= breakdown["test_coverage"] <= TEST_COVERAGE_MAX
 
 
-def test_hook_result_infinity_score_value_returns_parse_error():
-    # JSON 비표준 리터럴 Infinity 는 json.loads 가 float('inf') 로 파싱 → int(float('inf'))
-    # 는 OverflowError. (TypeError, ValueError) 만 잡으면 500 으로 샌다 — OverflowError 도
-    # 흡수해 default 폴백 + parse_error 로 200 을 반환해야 한다 (적대적 self-verify 발견).
-    # The non-standard JSON literal Infinity is parsed by json.loads to float('inf'); int(float('inf'))
-    # raises OverflowError. Catching only (TypeError, ValueError) would leak a 500 — OverflowError must
-    # also be absorbed (default fallback + parse_error, 200). Found by adversarial self-verify.
-    r, saved = _post_hook_non_numeric({**_AI_RESULT, "commit_message_score": float("inf")})
-
-    assert r.status_code == 200
-    assert len(saved) == 1
-    assert saved[0].result["ai_review_status"] == "parse_error"
-    breakdown = saved[0].result["breakdown"]
-    assert 0 <= breakdown["commit_message"] <= COMMIT_MSG_MAX
+def test_coerce_raw_score_absorbs_infinity_overflow():
+    # int(float('inf')) → OverflowError. 운영에서 JSON 비표준 리터럴 Infinity 는 json.loads 가
+    # float('inf') 로 파싱하므로 핸들러가 이를 만난다 (적대적 self-verify 발견). _coerce_raw_score 가
+    # OverflowError 를 흡수해 default 폴백 + ok=False 를 반환해야 한다 (parse_error 분류 → 200).
+    # 헬퍼를 직접 단위 검증한다 — TestClient json= 직렬화는 inf 를 환경에 따라 거부하므로
+    # (CI httpx: "Out of range float values are not JSON compliant") HTTP 경로 테스트는 fragile.
+    # int(float('inf')) raises OverflowError. In production json.loads parses the non-standard literal
+    # Infinity to float('inf'), so the handler hits it (found by adversarial self-verify). _coerce_raw_score
+    # must absorb the OverflowError → default fallback + ok=False (parse_error → 200). Verified at the helper
+    # level directly — TestClient json= serialization rejects inf env-dependently, so an HTTP-path test is fragile.
+    from src.api.hook import _coerce_raw_score  # pylint: disable=import-outside-toplevel
+    assert _coerce_raw_score(float("inf"), 20, 17) == (17, False)
+    assert _coerce_raw_score(float("-inf"), 10, 7) == (7, False)
+    # NaN 은 int(float('nan')) → ValueError 로 흡수됨 (기존 except 로 안전) / NaN absorbed via ValueError
+    assert _coerce_raw_score(float("nan"), 20, 17) == (17, False)
+    # 정상 정수·숫자문자열은 ok=True 로 통과 (동등성) / valid int & numeric string stay ok=True
+    assert _coerce_raw_score(18, 20, 17) == (18, True)
+    assert _coerce_raw_score("15", 20, 17) == (15, True)


### PR DESCRIPTION
## Summary

`POST /api/hook/result`가 `ai_result` 점수 필드를 `int(ar.get(...))`로 변환하는데, 키는 존재하나 값이 비숫자(문자열·None·list)이거나 `Infinity`이면 `int()`가 예외를 던져 **운영 500**. 기존 `parse_error` fallback은 키 존재만 검사하고 타입 유효성은 미검사 → 오작동·악성 CLI 입력이 500 유발. 안전 변환 + graceful `parse_error` 처리로 차단 (정합성 감사 area=gate P2 — api/hook.py:167).

## 변경 내용

- `_coerce_raw_score(raw, max_val, default) -> (int, bool)` — `int()` 변환을 `try/except (TypeError, ValueError, OverflowError)`로 흡수, 비정상 시 default 폴백 + `ok=False`
- `_coerce_ai_scores(ar) -> (commit, direction, test, status_ok)` — 3개 점수 응집 변환 + 'success' 적격(키 존재 AND 숫자) 판정 (R0914 회피용 헬퍼 추출 — testing.md 결정 트리)
- 핸들러: 비숫자/누락/Infinity → `ai_review_status='parse_error'` + default 점수, **200 반환**
- 유효 입력(정수·범위초과·음수·숫자문자열·bool·float) 동작 **무변경** — 기존 클램프 테스트 18건 무회귀

## 테스트

- `pytest tests/unit/api/test_hook.py` — **21 passed** (신규 3: 비숫자 문자열 / None / Infinity → 200 + parse_error)
- 전체 단위 `pytest tests/unit/` — **4631 passed, 1 skipped** (회귀 0)
- `pylint src/api/hook.py` 클린(R0914 해소) · `flake8` 0
- TDD Red→Green: 각 비정상 입력이 Red(500/예외) 후 가드로 Green 확인

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] (선택) 운영에서 pre-push 훅이 정상 점수 전송 시 동작 무변경(점수/등급 동일) 확인

## ⚠️ 자율 판단 보고 (정책 3)

- **다음 작업 자율 선정**: 사용자 "다음 작업 수행" 위임 → 잔여 area=gate 백로그 중 **api/hook.py:167(P2)** 자율 선정. 사유: P1-4(telegram retry 비대칭)는 gate 동작 변경 = High tier 설계 결정 필요(사용자 결정 대기), Task 9는 비용 승인 필요 → 자율 진행 가능 + 외부 입력 경로 방어 가치 높은 본 P2 선정.
- **헬퍼 추출 결정**: R0914(20/15) 해소를 위해 inline disable 대신 `_coerce_ai_scores` 응집 헬퍼 추출 선택 (testing.md R0914 결정 트리 — 응집 단위 보존 + 가독성↑).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) **Codex 토큰 만료로 검증 차단** — 본 세션 5+1연속 fallback 확정(exec 시 401). 정책 18 복구 강제 가드 — `codex login` 복구 필요.
- [x] **Claude 적대적 self-verify 대체**(사용자 standing 승인 — 본 세션 동일 codex-down 조건 fallback 승인 + "다음 작업 수행" 위임): 독립 skeptic 6렌즈 반증 → **렌즈 6에서 실재 결함 발견(NG)**: `_coerce_raw_score`가 `OverflowError` 미포착 → `Infinity`(json.loads→`float('inf')`) 입력 시 `int(float('inf'))` OverflowError → 500 (e2e 재현). **수정 반영**(커밋 2): `except`에 `OverflowError` 추가 + 회귀 테스트 1건. 재검증 후 6렌즈 전부 refuted. **적대적 self-verify ROI 양성 — 실 결함 1건 차단.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
