### PR TITLE
fix(config): merge_retry 백오프 config 검증자 추가 — 양수 + max>=initial 경계 (정합성 감사 area=gate)

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -95,12 +95,12 @@ Sentry 외 자동 로깅은 별도 환경변수 없이 동작:
 | 변수 | 설명 | 기본값 |
 |------|------|--------|
 | `MERGE_RETRY_ENABLED` | `false` 시 레거시 단일 시도 동작으로 fallback | `true` |
-| `MERGE_RETRY_MAX_ATTEMPTS` | 큐 행당 최대 재시도 횟수 | `30` |
-| `MERGE_RETRY_MAX_AGE_HOURS` | 큐 행 만료 시간 (시간) | `24` |
-| `MERGE_RETRY_INITIAL_BACKOFF_SECONDS` | 첫 재시도 백오프 (초) | `60` |
-| `MERGE_RETRY_MAX_BACKOFF_SECONDS` | 최대 백오프 (초) | `600` |
+| `MERGE_RETRY_MAX_ATTEMPTS` | 큐 행당 최대 재시도 횟수 (**>= 1** 제약 — `Field(ge=1)`) | `30` |
+| `MERGE_RETRY_MAX_AGE_HOURS` | 큐 행 만료 시간 (시간, **>= 1** 제약 — `Field(ge=1)`) | `24` |
+| `MERGE_RETRY_INITIAL_BACKOFF_SECONDS` | 첫 재시도 백오프 (초, **>= 1** 제약 — `Field(ge=1)`) | `60` |
+| `MERGE_RETRY_MAX_BACKOFF_SECONDS` | 최대 백오프 (초, **>= 1 AND >= INITIAL_BACKOFF** — `Field(ge=1)` + `model_validator` 경계 강제, max<initial 시 startup ValidationError) | `600` |
 | `MERGE_RETRY_CHECK_SUITE_WEBHOOK_ENABLED` | `check_suite.completed` 웹훅 즉각 트리거 활성화 | `true` |
-| `MERGE_RETRY_WORKER_BATCH_SIZE` | cron sweep 1회 처리 최대 행 수 | `50` |
+| `MERGE_RETRY_WORKER_BATCH_SIZE` | cron sweep 1회 처리 최대 행 수 (**>= 1** 제약 — `Field(ge=1)`) | `50` |
 | `MERGE_UNKNOWN_RETRY_LIMIT` | `mergeable_state=unknown` 상태 폴링 최대 재시도 횟수 (`config.py:60`) | `3` |
 | `MERGE_UNKNOWN_RETRY_DELAY` | `mergeable_state=unknown` 재시도 간격 (초, `config.py:61`) | `3.0` |
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,7 @@
 """Application settings loaded from environment variables via pydantic-settings."""
 import logging
 from pydantic_settings import BaseSettings
-from pydantic import field_validator
+from pydantic import Field, field_validator, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -76,18 +76,23 @@ class Settings(BaseSettings):
     # Phase 12: CI-aware Auto Merge retry configuration
     # False 시 레거시 단일 시도 동작 / False falls back to legacy single-attempt behavior
     merge_retry_enabled: bool = True
-    # 큐 행당 최대 재시도 횟수 / Maximum retry attempts per queue row
-    merge_retry_max_attempts: int = 30
-    # 큐 행 만료 시간 (시간) / Queue row expiry time (hours)
-    merge_retry_max_age_hours: int = 24
-    # 첫 재시도 백오프 (초) / Initial retry backoff (seconds)
-    merge_retry_initial_backoff_seconds: int = 60
-    # 최대 백오프 (초) / Maximum retry backoff (seconds)
-    merge_retry_max_backoff_seconds: int = 600
+    # 큐 행당 최대 재시도 횟수 (>= 1 — 0·음수 시 재시도 즉시 terminal)
+    # Maximum retry attempts per queue row (>= 1 — 0/negative makes retries immediately terminal)
+    merge_retry_max_attempts: int = Field(default=30, ge=1)
+    # 큐 행 만료 시간 (시간, >= 1 — 0 시 즉시 만료)
+    # Queue row expiry time in hours (>= 1 — 0 expires instantly)
+    merge_retry_max_age_hours: int = Field(default=24, ge=1)
+    # 첫 재시도 백오프 (초, >= 1 — 0·음수 시 백오프 소멸)
+    # Initial retry backoff in seconds (>= 1 — 0/negative removes backoff)
+    merge_retry_initial_backoff_seconds: int = Field(default=60, ge=1)
+    # 최대 백오프 (초, >= 1, initial 이상 — model_validator 로 경계 강제)
+    # Maximum retry backoff in seconds (>= 1, >= initial — enforced by model_validator)
+    merge_retry_max_backoff_seconds: int = Field(default=600, ge=1)
     # check_suite 웹훅 활성화 / Enable check_suite webhook
     merge_retry_check_suite_webhook_enabled: bool = True
-    # cron sweep 1회 처리 최대 행 수 / Max rows per cron sweep
-    merge_retry_worker_batch_size: int = 50
+    # cron sweep 1회 처리 최대 행 수 (>= 1 — 0 시 sweep 무처리)
+    # Max rows per cron sweep (>= 1 — 0 processes nothing)
+    merge_retry_worker_batch_size: int = Field(default=50, ge=1)
 
     # Phase 1 PR-1a (사이클 84 — 다국어 지원 i18n 인프라)
     # 다국어 지원 (영어/한국어/일본어) — 5 환경변수 + I18N_DISABLED kill-switch
@@ -171,6 +176,25 @@ class Settings(BaseSettings):
         if not v:
             return v
         return cls._normalize_pg_url(v)
+
+    @model_validator(mode="after")
+    def _validate_retry_backoff_bounds(self) -> "Settings":
+        """최대 백오프는 초기 백오프 이상이어야 한다 (지수 백오프 단조성 보장).
+        Max backoff must be >= initial backoff (preserves exponential backoff monotonicity).
+
+        max < initial 이면 compute_next_retry_at 의 min(initial*2^n, max) 가 항상 max 로
+        capped 되어 백오프 증가가 소멸한다 (retry_policy.py compute_next_retry_at 페어).
+        If max < initial, compute_next_retry_at's min(initial*2^n, max) is always capped at max,
+        so the intended growth disappears (paired with retry_policy.py compute_next_retry_at).
+        """
+        if self.merge_retry_max_backoff_seconds < self.merge_retry_initial_backoff_seconds:
+            raise ValueError(
+                "merge_retry_max_backoff_seconds "
+                f"({self.merge_retry_max_backoff_seconds}) must be >= "
+                "merge_retry_initial_backoff_seconds "
+                f"({self.merge_retry_initial_backoff_seconds})"
+            )
+        return self
 
     # Phase 1 PR-1a — i18n 환경변수 4 field_validator (사이클 84)
     # i18n env var validators (Cycle 84)

--- a/tests/unit/test_retry_config_validator.py
+++ b/tests/unit/test_retry_config_validator.py
@@ -1,0 +1,100 @@
+"""tests/unit/test_retry_config_validator.py
+
+TDD Red Phase: merge_retry_* 백오프 config 검증자 회귀 테스트.
+TDD Red Phase: regression tests for the merge_retry_* backoff config validators.
+
+검증 대상 / Validation target:
+  - src/config.py Settings 클래스 (pydantic v2 BaseSettings)
+  - merge_retry_max_attempts / merge_retry_max_age_hours /
+    merge_retry_initial_backoff_seconds / merge_retry_max_backoff_seconds /
+    merge_retry_worker_batch_size 에 대한 검증자 (정합성 감사 area=gate P2 — config.py:81)
+
+검증 규칙 / Validation rules:
+  1. 양수 제약 — 위 5개 필드는 >= 1 이어야 한다. 0·음수 시
+     gate/retry_policy.py::compute_next_retry_at 의 min(initial*2^n, max_backoff)
+     백오프가 소멸/단조성 깨짐, max_attempts=0 시 재시도 즉시 terminal 등.
+     Positive constraint — the 5 fields must be >= 1, otherwise the exponential
+     backoff in compute_next_retry_at degenerates / monotonicity breaks.
+  2. 백오프 경계 — merge_retry_max_backoff_seconds >= merge_retry_initial_backoff_seconds.
+     max < initial 이면 base 가 항상 max 로 capped → 단조 증가 소멸.
+     Backoff boundary — max must be >= initial, otherwise base is always capped to max.
+
+위반 시 pydantic 이 ValidationError 를 던져야 한다 (구현 예정).
+On violation pydantic must raise ValidationError (implementation pending).
+
+구현 전이므로 invalid 입력도 현재 통과(에러 없음)해 테스트가 실패해야 정상이다 (Red).
+Implementation is absent, so invalid inputs currently pass (no error) and the
+invalid-input tests must FAIL (Red) until the validators are added.
+
+conftest.py 가 환경변수를 주입하므로 추가 os.environ 설정 불필요 — test_failover.py 미러.
+conftest.py injects env vars, so no extra os.environ setup is needed (mirrors test_failover.py).
+"""
+import pytest
+from pydantic import ValidationError
+
+from src.config import Settings
+
+# Settings(...) 직접 구성에 필요한 필수 6개 kwargs (test_failover.py:232~270 미러).
+# The six required kwargs to construct Settings directly (mirrors test_failover.py:232~270).
+_REQUIRED_KWARGS = dict(
+    database_url="sqlite:///:memory:",
+    github_webhook_secret="x",
+    github_token="x",
+    telegram_bot_token="123:ABC",
+    telegram_chat_id="-100",
+)
+
+
+def test_valid_defaults_construct_ok():
+    # 회귀 가드 — merge_retry_* 미지정(기본값 30/24/60/600/50) 시 검증자가 정상 기본값을 거부하면 안 된다
+    # Regression guard — when merge_retry_* is unspecified (defaults), the validators must NOT reject valid defaults
+    s = Settings(**_REQUIRED_KWARGS)
+    assert s.merge_retry_max_attempts == 30
+    assert s.merge_retry_max_age_hours == 24
+    assert s.merge_retry_initial_backoff_seconds == 60
+    assert s.merge_retry_max_backoff_seconds == 600
+    assert s.merge_retry_worker_batch_size == 50
+
+
+def test_max_backoff_less_than_initial_raises():
+    # max_backoff(10) < initial_backoff(60) → 경계 위반 → ValidationError (단조 증가 소멸 방지)
+    # max_backoff(10) < initial_backoff(60) → boundary violation → ValidationError (prevents monotonicity loss)
+    with pytest.raises(ValidationError):
+        Settings(
+            **_REQUIRED_KWARGS,
+            merge_retry_max_backoff_seconds=10,
+            merge_retry_initial_backoff_seconds=60,
+        )
+
+
+def test_zero_initial_backoff_raises():
+    # initial_backoff=0 → 양수 제약 위반 → ValidationError (백오프 0 으로 소멸)
+    # initial_backoff=0 → positive-constraint violation → ValidationError (backoff degenerates to 0)
+    with pytest.raises(ValidationError):
+        Settings(**_REQUIRED_KWARGS, merge_retry_initial_backoff_seconds=0)
+
+
+def test_negative_max_attempts_raises():
+    # max_attempts=-1 → 양수 제약 위반 → ValidationError (음수 시 재시도 로직 비정상)
+    # max_attempts=-1 → positive-constraint violation → ValidationError (negative breaks retry logic)
+    with pytest.raises(ValidationError):
+        Settings(**_REQUIRED_KWARGS, merge_retry_max_attempts=-1)
+
+
+def test_zero_worker_batch_size_raises():
+    # worker_batch_size=0 → 양수 제약 위반 → ValidationError (cron sweep 0행 처리로 무한 정체)
+    # worker_batch_size=0 → positive-constraint violation → ValidationError (cron sweep processes 0 rows, stalls forever)
+    with pytest.raises(ValidationError):
+        Settings(**_REQUIRED_KWARGS, merge_retry_worker_batch_size=0)
+
+
+def test_max_backoff_equal_initial_ok():
+    # 경계 포함 — max_backoff == initial_backoff(60==60) 동일값은 허용(>= 경계) → 예외 없음
+    # Boundary inclusive — equal values (60==60) are allowed (>= boundary) → no exception
+    s = Settings(
+        **_REQUIRED_KWARGS,
+        merge_retry_max_backoff_seconds=60,
+        merge_retry_initial_backoff_seconds=60,
+    )
+    assert s.merge_retry_max_backoff_seconds == 60
+    assert s.merge_retry_initial_backoff_seconds == 60


### PR DESCRIPTION
## Summary

`merge_retry` 백오프/재시도 정수 설정에 검증자가 없어 `0`·음수·`max<initial` 같은 misconfig가 `compute_next_retry_at`의 지수 백오프 단조성을 깨뜨릴 수 있었다 (정합성 감사 area=gate P2 — config.py:81). `Field(ge=1)` 양수 제약 + `model_validator` 경계 제약으로 startup fail-fast.

## 변경 내용

- 5개 필드(`merge_retry_max_attempts`/`max_age_hours`/`initial_backoff_seconds`/`max_backoff_seconds`/`worker_batch_size`)에 `Field(ge=1)` — 0·음수 시 startup `ValidationError`
- `@model_validator(mode="after")` — `max_backoff >= initial_backoff` 경계 강제 (max<initial 시 `min(initial*2^n, max)`가 항상 max로 capped → 백오프 증가 소멸 차단)
- `docs/reference/env-vars.md` MERGE_RETRY_* 제약 동기화 (CLAUDE.md config validator sync 의무)

## 테스트

- `tests/unit/test_retry_config_validator.py` — **6건** (valid 2: 기본값/max==initial 경계 / invalid 4: max<initial·initial=0·max_attempts=-1·batch=0 → ValidationError)
- 전체 단위 `pytest tests/unit/` — **4637 passed, 1 skipped** (회귀 0) · retry integration 5 passed
- `pylint src/config.py` **10.00** · `flake8` 0
- 기본값(30/24/60/600/50) 전부 제약 충족 → startup 무영향, 기존 mock 기반 retry 테스트 무충돌

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] (선택) 운영 env에 `MERGE_RETRY_*`를 0·음수·max<initial로 오버라이드한 곳이 없는지 확인 (있으면 startup ValidationError — self-verify가 .env.example/railway/nixpacks/CI 전수 grep으로 위험 입력 부재 확인했으나 비공개 운영 env는 사용자 영역)

## ⚠️ 자율 판단 보고 (정책 3)

- **다음 작업 자율 선정**: "잔여 P2 계속 자율 진행" 위임 → config.py:81 선정 (pure config 검증, 파이프라인 flow 무관 → pipeline-reviewer 불요, 자기완결적).
- **구현 방식**: 양수 제약은 `Field(ge=1)`(Pydantic-idiomatic, 정책 16 단순화), 경계는 `model_validator`(필드 간 비교 — field_validator 단독 불가).
- **범위 한정**: `merge_unknown_retry_limit/delay`는 별개 retry 경로(github_review.py 동기 in-loop, 소비처 `max(1,...)`/`max(0.0,...)` self-clamp 보유)라 의도적 제외.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) **Codex 토큰 만료로 검증 차단** — 본 세션 지속 fallback. `codex login` 복구 필요.
- [x] **Claude 적대적 self-verify 대체**(사용자 standing 승인): 독립 skeptic **7렌즈 전부 refuted (VERDICT OK)** — startup 회귀/배포 crash 위험(운영 config 전수 grep), env 문자열 파싱+ge 호환, model_validator 상호작용, 경계 정확성(max==initial 허용), 소비처 정합(dead 분기 0), 테스트 봉인력, merge_unknown 의도적 제외. 실 결함 0건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
