### PR TITLE
fix(pipeline): branch/tag 삭제 push(zero-SHA) 조기 종료 — GitHub 404 반복 차단 (정합성 감사 area=gate)

### DIFF
--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -541,7 +541,10 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
             # Branch/tag-delete push carries a zero-SHA (all-zeros) or empty SHA — no commit to analyze.
             # Without this guard, _collect_files queries a nonexistent SHA on GitHub → a 404 + exception log every time.
             if _is_blank_sha(commit_sha):
-                logger.info("Skipping %s — no analyzable commit SHA (branch/tag delete)", repo_log)
+                logger.info(
+                    "Skipping %s — no analyzable commit SHA (branch/tag delete or missing head)",
+                    repo_log,
+                )
                 return
 
             with SessionLocal() as db:

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -261,6 +261,18 @@ def _extract_event_metadata(event: str, data: dict) -> tuple[str, str, str, int 
     return repo_name, commit_sha, commit_message, pr_number
 
 
+def _is_blank_sha(sha: str) -> bool:
+    """SHA 가 비었거나 all-zeros 인지 판정 (브랜치/태그 삭제 push 의 GitHub zero-SHA).
+    True if the SHA is empty or all-zeros (GitHub's zero-SHA for branch/tag-delete pushes).
+
+    GitHub 는 브랜치/태그 삭제 시 after 를 40-zero SHA 로 보낸다 (예: src/github_client/repos.py
+    의 REMOTE_SHA 비교와 동일 컨벤션). 길이에 무관하게 all-zeros 를 포착하도록 set 비교 사용.
+    GitHub sends a 40-zero after-SHA on branch/tag deletion (same convention as the REMOTE_SHA
+    check in src/github_client/repos.py). Uses a set comparison to catch all-zeros of any length.
+    """
+    return not sha or set(sha) == {"0"}
+
+
 def _ensure_repo(db: Session, repo_name: str, commit_sha: str) -> tuple[Repository, str] | None:
     """리포를 조회·등록하고 owner token을 결정한다. SHA 중복이면 None을 반환한다."""
     owner_token: str = settings.github_token
@@ -523,6 +535,14 @@ async def run_analysis_pipeline(event: str, data: dict) -> None:  # pylint: disa
             # user-controlled webhook 입력이므로 로그 인젝션 방어 (CLAUDE.md 규약)
             repo_log = sanitize_for_log(repo_name)
             pr_head_ref = _extract_pr_head_ref(event, data)
+
+            # 브랜치/태그 삭제 push 는 zero-SHA(all-zeros) 또는 빈 SHA — 분석할 커밋이 없다.
+            # 가드 없이 진입하면 _collect_files 가 존재하지 않는 SHA 를 GitHub 에 조회 → 매번 404 + 예외 로그.
+            # Branch/tag-delete push carries a zero-SHA (all-zeros) or empty SHA — no commit to analyze.
+            # Without this guard, _collect_files queries a nonexistent SHA on GitHub → a 404 + exception log every time.
+            if _is_blank_sha(commit_sha):
+                logger.info("Skipping %s — no analyzable commit SHA (branch/tag delete)", repo_log)
+                return
 
             with SessionLocal() as db:
                 ensure_result = _ensure_repo(db, repo_name, commit_sha)

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -1243,3 +1243,25 @@ async def test_empty_sha_push_skips_pipeline(mock_deps):
     # Empty SHA also has no commit to analyze → neither repo lookup nor file fetch runs
     mock_deps["find_repo"].assert_not_called()
     mock_deps["push"].assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "sha,expected_blank",
+    [
+        ("0" * 40, True),    # GitHub zero-SHA (40-zero branch/tag delete) — blank
+        ("", True),          # 빈 SHA / empty SHA — blank
+        ("0" * 7, True),     # short-SHA all-zeros (길이 무관) — blank
+        ("abc123def456", False),               # 정상 SHA / normal SHA
+        ("0a1b2c3d4e5f60718293a4b5c6d7e8f901020304", False),  # 0 포함 실 40-hex — not blank
+        ("0000000a", False),                   # 한 글자만 비-0 → not blank
+    ],
+)
+def test_is_blank_sha_classifies_zero_and_empty(sha, expected_blank):
+    """_is_blank_sha 는 빈/all-zeros SHA 만 blank 로 판정하고 정상 hex SHA 는 통과시킨다.
+    _is_blank_sha flags only empty/all-zeros SHAs; any SHA with a non-zero char passes.
+
+    set(sha)=={"0"} 오탐(예: <= 로 잘못 수정) 회귀를 직접 봉인 (pipeline-reviewer P2-B).
+    Directly seals regressions in the set comparison (e.g. an accidental <= rewrite).
+    """
+    from src.worker.pipeline import _is_blank_sha  # pylint: disable=import-outside-toplevel
+    assert _is_blank_sha(sha) is expected_blank

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -1189,3 +1189,57 @@ async def test_race_recover_existing_skips_when_result_is_none():
 
     mock_gate.assert_not_called()
     assert result is mock_repo_config
+
+
+# ---------------------------------------------------------------------------
+# branch/tag 삭제 push (zero-SHA) 조기 종료 회귀 테스트 (정합성 감사 area=gate P2)
+# Branch/tag-delete push (zero-SHA) early-termination regression tests
+#
+# GitHub 은 브랜치/태그 삭제 push 시 data["after"] 를 all-zeros SHA("0"*40, zero-SHA
+# 컨벤션)로, head_commit 을 None 으로 보낸다. 분석할 커밋이 없으므로 _ensure_repo
+# (repo 등록) + _collect_files (get_push_files API) 진입 전에 즉시 종료해야 한다.
+# 가드 부재 시 존재하지 않는 SHA 조회 → 매번 404 + 예외 로그 (pipeline.py:251).
+#
+# GitHub sends data["after"] as an all-zeros SHA ("0"*40, the zero-SHA convention)
+# and head_commit as None on a branch/tag-delete push. With no commit to analyze, the
+# pipeline must terminate before _ensure_repo / _collect_files. Without the guard it
+# queries a nonexistent SHA → 404 + exception log on every delete push.
+# ---------------------------------------------------------------------------
+
+
+async def test_branch_delete_zero_sha_push_skips_pipeline(mock_deps):
+    """all-zeros SHA(brach/tag 삭제 push)는 repo 등록·파일 수집 전에 조기 종료해야 한다.
+    An all-zeros SHA (branch/tag-delete push) must terminate before repo lookup / file collection.
+    """
+    zero_sha_data = {
+        "repository": {"full_name": "owner/repo"},
+        "after": "0" * 40,       # GitHub zero-SHA (branch/tag delete) / GitHub zero-SHA(브랜치·태그 삭제)
+        "head_commit": None,     # 삭제 push 는 head_commit None / delete push sends head_commit None
+        "commits": [],
+    }
+    from src.worker.pipeline import run_analysis_pipeline
+    await run_analysis_pipeline("push", zero_sha_data)
+
+    # 가드로 _ensure_repo / _collect_files 진입 전 return → repo 조회·파일 수집 모두 미호출
+    # Guard returns before _ensure_repo / _collect_files → neither repo lookup nor file fetch runs
+    mock_deps["find_repo"].assert_not_called()
+    mock_deps["push"].assert_not_called()
+
+
+async def test_empty_sha_push_skips_pipeline(mock_deps):
+    """빈 SHA("") push 도 동일하게 repo 등록·파일 수집 전에 조기 종료해야 한다.
+    An empty SHA ("") push must likewise terminate before repo lookup / file collection.
+    """
+    empty_sha_data = {
+        "repository": {"full_name": "owner/repo"},
+        "after": "",             # 빈 SHA — after 키 누락 시 _extract_event_metadata default
+        "head_commit": None,     # 삭제 push 는 head_commit None / delete push sends head_commit None
+        "commits": [],
+    }
+    from src.worker.pipeline import run_analysis_pipeline
+    await run_analysis_pipeline("push", empty_sha_data)
+
+    # 빈 SHA 도 분석 대상 커밋 없음 → repo 조회·파일 수집 모두 미호출
+    # Empty SHA also has no commit to analyze → neither repo lookup nor file fetch runs
+    mock_deps["find_repo"].assert_not_called()
+    mock_deps["push"].assert_not_called()


### PR DESCRIPTION
## Summary

GitHub는 브랜치/태그 삭제 push의 `after`를 all-zeros SHA(40-zero)로 보낸다. 가드 없이 `run_analysis_pipeline`이 이를 처리하면 `_ensure_repo`(repo 등록) + `_collect_files`(GitHub `get_push_files`)로 진입 → 존재하지 않는 SHA 조회 → **매번 404 + 예외 로그** (정합성 감사 area=gate P2 — pipeline.py:251).

## 변경 내용

- `_is_blank_sha(sha)` 헬퍼 — 빈 SHA 또는 all-zeros(`not sha or set(sha) == {"0"}`, 길이 무관) 판정
- `run_analysis_pipeline` 진입부(`_ensure_repo` 호출 전) 가드 — blank-SHA 시 `logger.info` + `return`
- 정상 push/PR(실 SHA)는 무영향 — branch-delete의 repo 등록·분석 진입만 차단

## 테스트

- `tests/unit/worker/test_pipeline.py` — **59 passed** (zero-SHA/empty-SHA push 조기종료 2 + `_is_blank_sha` 파라미터화 6케이스)
- 전체 단위 `pytest tests/unit/` — **4639 passed, 1 skipped** (회귀 0)
- `pylint src/worker/pipeline.py` **10.00** · `flake8` 0

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] (선택) 운영에서 브랜치 삭제 시 `Skipping ... no analyzable commit SHA` INFO 로그 + GitHub 404 예외 로그 소멸 확인

## ⚠️ 자율 판단 보고 (정책 3)

- **다음 작업 자율 선정**: "defensive pipeline P2 자율 진행" 위임 → pipeline.py:251(zero-SHA) 선정 (순수 방어, 동작 변경 X).
- **event 무관 가드**: PR 이벤트 blank head.sha도 skip — PR은 `opened/synchronize/reopened`만 진입(전부 실 SHA)이라 실무 영향 0, malformed PR도 안전 차단 (pipeline-reviewer 확인).

## 🔍 파이프라인 리뷰 (CLAUDE.md 의무)

- **pipeline-reviewer: APPROVE** (P0/P1 없음). force-push retry abandonment(`github.py:381` webhook 레이어, 파이프라인 독립)·멱등성·정상 push/PR 무영향 실측 확인. 선택 P2 2건(직접 단위 테스트 + 로그 메시지 정확화) **반영 완료**.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) Codex 토큰 만료 — 본 세션 지속 fallback. `codex login` 복구 필요.
- [x] **Claude 적대적 self-verify**(사용자 standing 승인): 독립 skeptic **6렌즈 전부 refuted (VERDICT OK)** — 오탐(0포함 실 SHA 통과)·누락·가드 위치 부작용(force-push/retry 무간섭)·PR 영향·테스트 봉인력·회귀 전부 무결. pipeline-reviewer와 2-layer 교차 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
