### PR TITLE
fix(pipeline): _ensure_repo 동시 INSERT race(IntegrityError) 복구 — 워커 abort 차단 (정합성 감사 area=gate)

### DIFF
--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 
 import httpx
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from src.database import SessionLocal
@@ -278,10 +278,22 @@ def _ensure_repo(db: Session, repo_name: str, commit_sha: str) -> tuple[Reposito
     owner_token: str = settings.github_token
     repo = repository_repo.find_by_full_name(db, repo_name)
     if not repo:
-        repo = repository_repo.save_new(
-            db, Repository(full_name=repo_name, telegram_chat_id=settings.telegram_chat_id)
-        )
-        db.commit()
+        try:
+            repo = repository_repo.save_new(
+                db, Repository(full_name=repo_name, telegram_chat_id=settings.telegram_chat_id)
+            )
+            db.commit()
+        except IntegrityError:
+            # 동시 webhook race — 다른 워커가 같은 repo 를 먼저 INSERT (full_name unique 위반).
+            # rollback 후 재조회로 복구해 uncaught IntegrityError 의 워커 abort 를 방지한다.
+            # Concurrent webhook race — another worker INSERTed the same repo first (full_name unique).
+            # Recover via rollback + re-fetch to prevent an uncaught IntegrityError from aborting the worker.
+            db.rollback()
+            repo = repository_repo.find_by_full_name(db, repo_name)
+            if repo is None:
+                # 재조회도 None = unique-race 가 아닌 진짜 오류 → 전파 (복구로 삼키지 않음)
+                # Re-fetch is None too = a genuine error, not the unique-race → propagate (don't swallow)
+                raise
     if repo.owner and repo.owner.plaintext_token:
         owner_token = repo.owner.plaintext_token
     if analysis_repo.find_by_sha(db, commit_sha, repo.id):

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -1265,3 +1265,111 @@ def test_is_blank_sha_classifies_zero_and_empty(sha, expected_blank):
     """
     from src.worker.pipeline import _is_blank_sha  # pylint: disable=import-outside-toplevel
     assert _is_blank_sha(sha) is expected_blank
+
+
+# ---------------------------------------------------------------------------
+# _ensure_repo 동시 INSERT race (IntegrityError) 복구 회귀 테스트 (정합성 감사 area=gate P2)
+# _ensure_repo concurrent-INSERT race (IntegrityError) recovery regression tests
+# (integrity audit area=gate P2 — pipeline.py:263)
+#
+# 동시 webhook 2건이 같은 신규 repo 를 처리하면 둘 다 find_by_full_name → None →
+# save_new → db.commit() 시도 → Repository.full_name unique 제약으로 한 워커가
+# IntegrityError 를 맞는다. 곧 추가할 수정은 save_new+commit 을 try/except IntegrityError
+# 로 감싸 — IntegrityError 시 db.rollback() + find_by_full_name 재조회로 복구한다.
+# When two concurrent webhooks process the same new repo, both find_by_full_name → None →
+# save_new → db.commit(); one worker hits IntegrityError on the full_name unique constraint.
+# The upcoming fix wraps save_new+commit in try/except IntegrityError — on IntegrityError it
+# rolls back and re-queries find_by_full_name to recover the row another worker created.
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_repo_recovers_from_concurrent_insert_race():
+    """동시 INSERT race 로 commit 이 IntegrityError 면 rollback 후 재조회한 repo 로 복구해야 한다.
+    On a concurrent-INSERT IntegrityError at commit, must roll back and recover via re-fetch.
+
+    현재 구현(_ensure_repo 가 IntegrityError 를 잡지 않음)에서는 db.commit() 의
+    IntegrityError 가 그대로 전파되어 (mock_existing, "ghp_test") 반환 단언 도달 전에
+    호출 자체가 raise → 테스트가 에러로 실패 = Red.
+    With the current impl (no try/except), the commit IntegrityError propagates and the call
+    raises before the (mock_existing, "ghp_test") assertion is reached → test errors out = Red.
+    """
+    from src.worker.pipeline import _ensure_repo  # pylint: disable=import-outside-toplevel
+    from sqlalchemy.exc import IntegrityError  # pylint: disable=import-outside-toplevel
+
+    # db.commit() 이 unique 제약 위반으로 IntegrityError 를 던지도록 mock
+    # Mock db.commit() to raise IntegrityError on the unique-constraint violation
+    mock_db = MagicMock()
+    mock_db.commit.side_effect = IntegrityError(
+        "INSERT repositories", {}, Exception("duplicate key full_name")
+    )
+
+    # 다른 워커가 이미 만든 repo (재조회로 복구되는 대상)
+    # The repo another worker already created (recovered via re-fetch)
+    mock_existing = MagicMock(id=5)
+    mock_existing.owner = None  # owner_token 분기 skip → owner_token 은 "ghp_test" 유지
+    #                            # skip owner_token branch → owner_token stays "ghp_test"
+
+    with (
+        # 1차 None → save_new 진입 / 2차 mock_existing → race 복구 재조회
+        # 1st None → enters save_new / 2nd mock_existing → race-recovery re-fetch
+        patch(
+            "src.worker.pipeline.repository_repo.find_by_full_name",
+            side_effect=[None, mock_existing],
+        ) as mock_find_repo,
+        patch(
+            "src.worker.pipeline.repository_repo.save_new",
+            return_value=MagicMock(),
+        ),
+        # 중복 분석 없음 → None 반환 끝까지 진행
+        # No duplicate analysis → returns None, proceeds to the end
+        patch("src.worker.pipeline.analysis_repo.find_by_sha", return_value=None),
+        patch("src.worker.pipeline.settings") as mock_settings,
+    ):
+        mock_settings.github_token = "ghp_test"
+        mock_settings.telegram_chat_id = "-100"
+
+        # 핵심(Red): 예외 없이 (mock_existing, "ghp_test") 반환해야 한다
+        # Core (Red): must return (mock_existing, "ghp_test") without raising
+        result = _ensure_repo(mock_db, "owner/repo", "sha123")
+
+    assert result == (mock_existing, "ghp_test")
+    mock_db.rollback.assert_called_once()  # IntegrityError 시 정확히 1회 rollback
+    assert mock_find_repo.call_count == 2  # 최초 조회 + race 복구 재조회
+
+
+def test_ensure_repo_reraises_when_refetch_also_none():
+    """재조회도 None 이면 (unique race 가 아닌 진짜 오류) IntegrityError 를 그대로 전파해야 한다.
+    If the re-fetch is also None (a real error, not a unique race), must re-raise IntegrityError.
+
+    현재 구현도 commit 시점에서 IntegrityError 를 raise 하나, rollback 미호출 + 재조회 경로
+    부재 — 구현 후엔 rollback → 재조회 None → re-raise 경로가 핵심 검증 대상이다.
+    The current impl already raises at commit, but without rollback or the re-fetch path; after
+    the fix the rollback → re-fetch-None → re-raise path is the behavior under test.
+    """
+    from src.worker.pipeline import _ensure_repo  # pylint: disable=import-outside-toplevel
+    from sqlalchemy.exc import IntegrityError  # pylint: disable=import-outside-toplevel
+
+    mock_db = MagicMock()
+    mock_db.commit.side_effect = IntegrityError(
+        "INSERT repositories", {}, Exception("duplicate key full_name")
+    )
+
+    with (
+        # 1차 None → save_new 진입 / 2차도 None → unique race 아님 → 진짜 오류 전파
+        # 1st None → enters save_new / 2nd also None → not a unique race → propagate real error
+        patch(
+            "src.worker.pipeline.repository_repo.find_by_full_name",
+            side_effect=[None, None],
+        ),
+        patch(
+            "src.worker.pipeline.repository_repo.save_new",
+            return_value=MagicMock(),
+        ),
+        patch("src.worker.pipeline.analysis_repo.find_by_sha", return_value=None),
+        patch("src.worker.pipeline.settings") as mock_settings,
+    ):
+        mock_settings.github_token = "ghp_test"
+        mock_settings.telegram_chat_id = "-100"
+
+        with pytest.raises(IntegrityError):
+            _ensure_repo(mock_db, "owner/repo", "sha123")

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -1360,7 +1360,7 @@ def test_ensure_repo_reraises_when_refetch_also_none():
         patch(
             "src.worker.pipeline.repository_repo.find_by_full_name",
             side_effect=[None, None],
-        ),
+        ) as mock_find_repo,
         patch(
             "src.worker.pipeline.repository_repo.save_new",
             return_value=MagicMock(),
@@ -1373,3 +1373,8 @@ def test_ensure_repo_reraises_when_refetch_also_none():
 
         with pytest.raises(IntegrityError):
             _ensure_repo(mock_db, "owner/repo", "sha123")
+
+    # bare commit raise 와 구별되게 rollback → 재조회 → re-raise 경로를 봉인한다 (review 수렴 지적).
+    # Seal the rollback → re-fetch → re-raise path distinctly from a bare commit raise (converged review note).
+    mock_db.rollback.assert_called_once()
+    assert mock_find_repo.call_count == 2


### PR DESCRIPTION
## Summary

동시 webhook 2건이 같은 신규 repo를 처리하면 둘 다 `find_by_full_name`→None→`save_new`→`commit` 시도 → `Repository.full_name` unique 제약(model+alembic 확인)으로 한 워커가 **IntegrityError → uncaught → 워커 abort** (정합성 감사 area=gate P2 — pipeline.py:263).

## 변경 내용

- `_ensure_repo`의 `save_new`+`commit`을 `try/except IntegrityError`로 감쌈 — race 시 `db.rollback()` + `find_by_full_name` 재조회로 복구(다른 워커가 만든 repo 사용)
- 재조회도 None = unique-race 아닌 진짜 오류 → `raise`(복구로 삼키지 않음)
- `from sqlalchemy.exc import IntegrityError` 추가
- 정상 신규 repo 등록(예외 없음) 경로는 무변경

## 테스트

- `tests/unit/worker/test_pipeline.py` — race 복구(`(repo, token)` 반환 + rollback + 재조회 2회) / 재조회 None re-raise(rollback·재조회 경로 봉인) 2건
- 전체 단위 `pytest tests/unit/` — **4647 passed, 1 skipped** (회귀 0)
- `pylint src/worker/pipeline.py` **10.00** · `flake8` 0

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] (선택) 운영에서 신규 repo 첫 webhook 동시 도착 시 워커 abort 없이 한쪽이 복구 진행하는지 (드문 race — 로그상 IntegrityError 스택 트레이스 소멸)

## ⚠️ 자율 판단 보고 (정책 3)

- **다음 작업 자율 선정**: "defensive pipeline P2 2건" 위임의 2번째 — pipeline.py:263(IntegrityError race) 선정. 이로써 위임 2건(zero-SHA #786 + 본 건) 완료.
- **복구 위치 = caller**(pipeline-reviewer P1 반영): `repository_repo.save_new`는 add-only 계약 유지, race 복구는 의도적으로 `_ensure_repo`(commit 소유 유일 지점) 책임. `analysis_repo.save_new`(#780)의 `(obj, created)` 내장 패턴과 통일은 별도 PR 영역(70+ mock chain 회귀 트랩 — repository_repo.py:37-58).

## 🔍 파이프라인 리뷰 (CLAUDE.md 의무)

- **pipeline-reviewer: APPROVE** (P0 없음). 트랜잭션 정합(rollback 후 동일 세션 재조회 안전 — `_regate_pr_if_needed`/`_race_recover_existing`/#780 검증 패턴 일관)·복구 정확성(READ COMMITTED 가시성)·정상 경로 무변경·#780과 직교(repositories vs analyses 테이블) 실측 확인.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] (예외) Codex 토큰 만료 — 본 세션 지속 fallback. `codex login` 복구 필요.
- [x] **Claude 적대적 self-verify**(사용자 standing 승인): 독립 skeptic **7렌즈(6 refuted + 1 부분)** — rollback 세션 사용성·except 범위·re-raise 전파·정상 경로·race 직교·owner_token·회귀 무결. 렌즈 6(reraises 약한 seal) 지적 → **rollback·재조회 단언 추가로 강화 반영**(pipeline-reviewer P2와 수렴). pipeline-reviewer + adversarial 2-layer 교차 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
