### PR TITLE
fix(pipeline): 동일 SHA 멀티 PR regate first-writer-wins 통일 — 잘못된 PR auto-merge 차단 (정합성 감사 area=gate Q4)

### DIFF
--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -317,6 +317,21 @@ async def _regate_pr_if_needed(
     existing = analysis_repo.find_by_sha(db, commit_sha, repo.id)
     if existing is None or existing.pr_number == pr_number:
         return
+    if existing.pr_number is not None:
+        # 동일 SHA가 이미 다른 PR#로 gate된 경우 덮어쓰지 않는다 (first-writer-wins) —
+        # _race_recover_existing(existing.pr_number is not None → return)과 대칭.
+        # 동일 head SHA를 두 PR이 공유할 때 댓글/승인/auto-merge가 잘못된 PR에
+        # 적용되는 것을 차단한다.
+        # Don't overwrite when this SHA was already gated for a different PR
+        # (first-writer-wins), mirroring _race_recover_existing. Prevents gate
+        # actions (comment/approve/auto-merge) from hitting the wrong PR when the
+        # same head SHA is shared by multiple PRs.
+        logger.warning(
+            "_regate_pr_if_needed: sha=%s already gated for PR #%d, "
+            "skipping re-gate for PR #%d (first-writer-wins)",
+            commit_sha[:8], existing.pr_number, pr_number,
+        )
+        return
     try:
         existing.pr_number = pr_number
         db.commit()

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -319,18 +319,13 @@ async def _regate_pr_if_needed(
         return
     if existing.pr_number is not None:
         # 동일 SHA가 이미 다른 PR#로 gate된 경우 덮어쓰지 않는다 (first-writer-wins) —
-        # _race_recover_existing(existing.pr_number is not None → return)과 대칭.
-        # 동일 head SHA를 두 PR이 공유할 때 댓글/승인/auto-merge가 잘못된 PR에
-        # 적용되는 것을 차단한다.
-        # Don't overwrite when this SHA was already gated for a different PR
-        # (first-writer-wins), mirroring _race_recover_existing. Prevents gate
-        # actions (comment/approve/auto-merge) from hitting the wrong PR when the
-        # same head SHA is shared by multiple PRs.
-        # 단일 라인 유지 — codecov/patch 가 멀티라인 statement continuation 줄을 미커버로
-        # 오집계하는 것을 회피 (로직은 회귀 테스트 + SonarCloud New Code 100% 로 검증).
-        # Keep on one line — codecov/patch miscounts multi-line statement continuations as
-        # uncovered on small diffs (logic is covered by the regression test, SonarCloud 100%).
-        logger.warning("sha %s already gated for PR #%d (first-writer-wins)", commit_sha[:8], existing.pr_number)
+        # _race_recover_existing 과 대칭. 동일 head SHA 멀티 PR 시 잘못된 PR 에 gate 적용 차단.
+        # Don't overwrite when this SHA was already gated for a different PR (first-writer-wins),
+        # mirroring _race_recover_existing — prevents gate actions hitting the wrong PR.
+        logger.warning(
+            "_regate_pr_if_needed: sha=%s already gated for PR #%d, skip PR #%d (first-writer-wins)",
+            commit_sha[:8], existing.pr_number, pr_number,
+        )
         return
     try:
         existing.pr_number = pr_number

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -326,11 +326,11 @@ async def _regate_pr_if_needed(
         # (first-writer-wins), mirroring _race_recover_existing. Prevents gate
         # actions (comment/approve/auto-merge) from hitting the wrong PR when the
         # same head SHA is shared by multiple PRs.
-        logger.warning(
-            "_regate_pr_if_needed: sha=%s already gated for PR #%d, "
-            "skipping re-gate for PR #%d (first-writer-wins)",
-            commit_sha[:8], existing.pr_number, pr_number,
-        )
+        # 단일 라인 유지 — codecov/patch 가 멀티라인 statement continuation 줄을 미커버로
+        # 오집계하는 것을 회피 (로직은 회귀 테스트 + SonarCloud New Code 100% 로 검증).
+        # Keep on one line — codecov/patch miscounts multi-line statement continuations as
+        # uncovered on small diffs (logic is covered by the regression test, SonarCloud 100%).
+        logger.warning("sha %s already gated for PR #%d (first-writer-wins)", commit_sha[:8], existing.pr_number)
         return
     try:
         existing.pr_number = pr_number

--- a/tests/unit/worker/test_pipeline_pr_regate.py
+++ b/tests/unit/worker/test_pipeline_pr_regate.py
@@ -318,3 +318,49 @@ async def test_regate_pr_if_needed_rolls_back_on_commit_error(caplog):
     db.commit.assert_called_once()
     run_gate.assert_not_called()
     assert any("pr_number update failed" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# 시나리오 E: 동일 SHA가 이미 다른 non-None PR#로 gate됨 → first-writer-wins skip
+# Scenario E: same SHA already gated for a different non-None PR# → first-writer-wins skip
+# (area=gate 감사 P2 pipeline.py:288 — _regate_pr_if_needed last-writer-wins 비대칭 해소)
+# ---------------------------------------------------------------------------
+
+async def test_regate_does_not_overwrite_different_existing_pr_number(caplog):
+    """기존 Analysis가 이미 다른 PR#(=10)로 gate된 경우, 새 PR#(=11) 이벤트가 와도
+    pr_number를 덮어쓰지 않고 WARNING 후 조용히 return 해야 한다 (first-writer-wins).
+
+    _race_recover_existing(`existing.pr_number is not None → return`)과 대칭.
+    동일 head SHA를 두 PR이 공유할 때 댓글/승인/auto-merge가 잘못된 PR에
+    적용되는 것을 차단한다.
+    """
+    import logging
+    from src.worker import pipeline as pipeline_mod
+
+    db = MagicMock()
+
+    existing = MagicMock()
+    existing.pr_number = 10  # 이미 PR #10으로 gate됨 / already gated for PR #10
+    existing.id = 99
+    existing.result = {"score": 80}
+
+    repo = MagicMock()
+    repo.id = 1
+    repo.owner = None
+
+    with patch.object(pipeline_mod.repository_repo, "find_by_full_name", return_value=repo), \
+         patch.object(pipeline_mod.analysis_repo, "find_by_sha", return_value=existing), \
+         patch.object(pipeline_mod, "run_gate_check", new=AsyncMock()) as run_gate, \
+         caplog.at_level(logging.WARNING, logger="src.worker.pipeline"):
+        await pipeline_mod._regate_pr_if_needed(
+            db=db, repo_name="o/r", commit_sha="deadbeef", pr_number=11,
+        )
+
+    # Then: pr_number는 10 그대로 (덮어쓰기 안 됨) + commit 미호출 + gate 미실행
+    assert existing.pr_number == 10, f"pr_number가 덮어써졌습니다: {existing.pr_number}"
+    db.commit.assert_not_called()
+    run_gate.assert_not_called()
+    assert any(
+        "already gated for PR #10" in r.message and "first-writer-wins" in r.message
+        for r in caplog.records
+    ), "first-writer-wins skip WARNING 로그가 없습니다"


### PR DESCRIPTION
## 요약
area=gate 정합성 감사 P2(pipeline.py:288) — 사용자 **Q4=A** 결정 이행.

`_regate_pr_if_needed` 가 동일 head SHA를 두 PR이 공유할 때 `pr_number`를 무조건 덮어써(last-writer-wins) 댓글/승인/auto-merge가 **잘못된 PR**에 적용되던 결함을, `_race_recover_existing`(`existing.pr_number is not None → return`)과 대칭인 **first-writer-wins**로 통일.

## 변경
- `src/worker/pipeline.py::_regate_pr_if_needed` — 기존 `pr_number`가 다른 non-None이면 덮어쓰지 않고 `WARNING` + return (가드 1분기 추가)
- 정상 경로(push-먼저 `None`→set) + idempotent 동일 PR# 재수신(`== pr_number`) 보존
- 회귀 테스트 1건 추가 — `test_regate_does_not_overwrite_different_existing_pr_number` (시나리오 E: 기존 non-None ≠ 신규 non-None)

## 검증 (테스트 통과)
- 단위 **4648 passed, 1 skipped** (`pytest tests/unit/`)
- regate 테스트 5/5 통과 / pylint·flake8 clean
- pipeline-reviewer **APPROVE** (멱등성·정상경로·회귀·관측성·None순서·테스트 6항목)
- 적대적 self-verify 2렌즈(회귀 탐색 / 대칭성 반증) — **P0·P1 0건**

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
⚠️ **Codex exec 401 만료**(`refresh token already used`) — 이번 세션 mutual 검증 불가. 정책 18 standing 승인 하 **Claude 적대적 self-verify(pipeline-reviewer + 독립 skeptic 2렌즈) fallback** 적용 (전례 사이클 119/125/161/162/163). `codex login` 재인증 시 이후 PR부터 true mutual 복원.

## 🔍 사용자 검증 필요 (정책 2)
- 운영 동작 변경: 동일 head SHA를 **두 PR이 공유**하는 드문 케이스에서 두 번째 PR은 gate skip(WARNING 로그). auto_merge 활성 리포에서 의도 외 PR squash merge 차단이 목적.
- **자율 판단 보고 (정책 3)**: self-verify가 식별한 P2 2건은 본 PR 범위(Q4 A = WARNING+회귀가드) 밖으로 보류 — ① 멀티PR skip 사용자 가시성(PR 코멘트/대시보드, 새 발신=별도 High-tier 결정) ② 시나리오 E sqlite fixture 승격(현재 가드가 commit 이전 순수 분기라 MagicMock 충분). 이견 있으면 알려주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
