### PR TITLE
fix(pipeline): 정적분석 파일 단위 격리 + 타임아웃 부분결과 보존 (정합성 감사 area=gate Q2+Q3)

### DIFF
--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -26,8 +26,10 @@ from src.repositories import repository_repo, analysis_repo
 
 logger = logging.getLogger(__name__)
 
-# 정적 분석 전체 타임아웃 단일 출처 (초) — 초과 시 빈 리스트 반환, AI 리뷰는 계속 진행
-# Single source of truth for the static-analysis timeout (seconds) — returns empty list on timeout; AI review continues
+# 정적 분석 전체 타임아웃(deadline) 단일 출처 (초) — 초과 시 완료된 파일 부분결과 보존 +
+# incomplete 신호 반환(auto-merge 차단), AI 리뷰는 계속 진행
+# Single source of truth for the static-analysis deadline (seconds) — on overrun keeps the
+# partial results of completed files and returns an incomplete flag (blocks auto-merge); AI review continues
 PIPELINE_ANALYSIS_TIMEOUT = 60
 
 
@@ -145,7 +147,12 @@ def _extract_pr_head_ref(event: str, data: dict) -> str | None:
 async def _run_static_analysis(
     files: list[ChangedFile], repo_config: object | None = None
 ) -> list[StaticAnalysisResult]:
-    """Run registered analyzers on all changed files; each Analyzer filters by language.
+    """Run registered analyzers on the given changed files in one worker thread.
+
+    _run_static_with_timeout 가 파일별로 호출하며, 파일 단위 격리·deadline·실패 집계는
+    호출측(_run_static_with_timeout)이 담당한다. 여기서는 동기 분석 루프만 to_thread 로 offload.
+    Called per-file by _run_static_with_timeout; per-file isolation, deadline, and failure
+    counting live in the caller. This only offloads the sync analysis loop to a thread.
 
     repo_config: RepoConfig 인스턴스 — disabled_tools 필터링에 사용.
     repo_config: RepoConfig instance — used for disabled_tools filtering.
@@ -158,28 +165,83 @@ async def _run_static_analysis(
 async def _run_static_with_timeout(
     files: list[ChangedFile], repo_config: object | None = None
 ) -> tuple[list[StaticAnalysisResult], bool]:
-    """_run_static_analysis를 PIPELINE_ANALYSIS_TIMEOUT 초 상한으로 실행한다.
-    Run _run_static_analysis bounded by PIPELINE_ANALYSIS_TIMEOUT seconds.
+    """정적분석을 PIPELINE_ANALYSIS_TIMEOUT 초 deadline 으로 파일 단위 순차 실행한다.
+    Run static analysis file-by-file under a PIPELINE_ANALYSIS_TIMEOUT-second deadline.
+
+    각 파일을 독립 to_thread 로 순차 await 하므로 (1) subprocess 동시 폭주가 없고,
+    (2) deadline 초과 시 그때까지 완료된 파일의 부분결과를 보존하며,
+    (3) 타임아웃으로 고아가 되는 워커 스레드는 진행 중이던 단일 파일 1개로 한정된다
+    (파일당 도구 subprocess timeout=STATIC_ANALYSIS_TIMEOUT 합산으로 bounded — 자연 종료).
+    Each file runs in its own to_thread, awaited sequentially, so (1) there is no concurrent
+    subprocess blow-up, (2) partial results of completed files are preserved on deadline, and
+    (3) at most one in-flight file's worker thread can be orphaned on timeout (bounded by the
+    sum of that file's per-tool subprocess timeouts).
+
+    파일 단위 격리(Q2): 한 파일의 analyze_file 예외(디스크/encoding/tempfile 오류 등)는
+    빈 StaticAnalysisResult 로 격리하고 다음 파일을 계속 분석한다 (배치/AI리뷰 미중단).
+    Per-file isolation (Q2): a single file's analyze_file failure is isolated as an empty result
+    and the loop continues — it does not abort the batch or AI review.
 
     Returns:
-        (results, timed_out). 타임아웃 시 ([], True) — 빈 결과가 "이슈 없음"(만점)으로
-        오인되어 미분석 코드가 auto-merge 되는 것을 막기 위해 timed_out 신호를 함께 반환한다.
-        On timeout returns ([], True) — the bool flags incomplete analysis so the empty list
-        is not mistaken for "no issues" (perfect score) and auto-merging unanalyzed code.
-        AI 리뷰는 계속 진행 / AI review continues unaffected.
+        (results, incomplete). incomplete=True 는 (a) deadline 초과, 또는 (b) 비어있지 않은
+        배치의 모든 파일이 실패한 경우의 신호로, 부분/누락 분석이 "이슈 없음"(만점)으로 오인되어
+        미분석 코드가 auto-merge 되는 것을 막는다. 일부 파일만 실패(나머지 정상 분석)는 Q2=A
+        결정에 따라 incomplete 로 처리하지 않는다. AI 리뷰는 계속 진행.
+        incomplete=True flags (a) a deadline overrun or (b) every file in a non-empty batch
+        failing, so partial/missing analysis is not mistaken for "no issues" and auto-merged.
+        A partial failure (some files analyzed) is NOT incomplete per the Q2=A decision.
     """
-    try:
-        results = await asyncio.wait_for(
-            _run_static_analysis(files, repo_config=repo_config),
-            timeout=PIPELINE_ANALYSIS_TIMEOUT,
-        )
-        return results, False
-    except asyncio.TimeoutError:
+    results: list[StaticAnalysisResult] = []
+    incomplete = False
+    failed = 0
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + PIPELINE_ANALYSIS_TIMEOUT
+    for f in files:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            incomplete = True
+            logger.warning(
+                "static analysis deadline (%ss) reached — %d/%d files analyzed, "
+                "marking incomplete (auto-merge blocked, partial preserved)",
+                PIPELINE_ANALYSIS_TIMEOUT, len(results), len(files),
+            )
+            break
+        try:
+            part = await asyncio.wait_for(
+                _run_static_analysis([f], repo_config=repo_config),
+                timeout=remaining,
+            )
+            results.extend(part)
+        except asyncio.TimeoutError:
+            incomplete = True
+            logger.warning(
+                "static analysis deadline (%ss) reached during %s — %d/%d files analyzed, "
+                "marking incomplete (auto-merge blocked, partial preserved)",
+                PIPELINE_ANALYSIS_TIMEOUT, f.filename, len(results), len(files),
+            )
+            break
+        except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+            # 파일 단위 격리(Q2) — 실패 파일은 빈 결과(이슈0)로 처리하고 다음 파일 진행
+            # Per-file isolation (Q2) — failed file yields an empty result; loop continues
+            failed += 1
+            results.append(StaticAnalysisResult(filename=f.filename))
+            logger.warning(
+                "static analysis failed for %s — isolated as empty result",
+                f.filename, exc_info=True,
+            )
+    # 안전망: 비어있지 않은 배치의 모든 파일이 예외 실패 → 실 분석 0건 → 미분석 코드
+    # auto-merge 차단(fail-closed). 변경 전 동작(파일 예외 시 파이프라인 abort)이 Q2=A 격리로
+    # 바뀌며 생길 수 있는 전량-실패 fail-open 회귀를 막는다.
+    # Safety net: every file in a non-empty batch failed → zero real analysis → block auto-merge
+    # of unanalyzed code (fail-closed). Prevents the total-failure fail-open regression that Q2=A
+    # isolation could introduce versus the previous abort-on-exception behavior.
+    if files and failed == len(files):
+        incomplete = True
         logger.warning(
-            "static analysis timed out after %ss — marking incomplete (auto-merge blocked)",
-            PIPELINE_ANALYSIS_TIMEOUT,
+            "all %d files failed static analysis — marking incomplete (auto-merge blocked)",
+            len(files),
         )
-        return [], True
+    return results, incomplete
 
 
 def build_notification_tasks(  # pylint: disable=too-many-positional-arguments,too-many-arguments

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -1072,12 +1072,13 @@ async def test_collect_files_wrapped_in_asyncio_to_thread(mock_deps):
 
 @pytest.mark.asyncio
 async def test_run_static_with_timeout_returns_empty_on_timeout():
-    """분석이 PIPELINE_ANALYSIS_TIMEOUT 초과 시 (빈 리스트, timed_out=True) 를 반환해야 한다.
+    """완료된 파일이 하나도 없는 채 deadline 초과 시 (빈 리스트, incomplete=True) 반환.
 
-    timed_out=True 는 auto-merge 차단 신호 — 미분석 코드 자동 머지 방지.
+    incomplete=True 는 auto-merge 차단 신호 — 미분석 코드 자동 머지 방지.
     """
     import asyncio
     from src.worker.pipeline import _run_static_with_timeout
+    from src.github_client.diff import ChangedFile
 
     async def _slow(files, repo_config=None):          # 타임아웃보다 오래 걸리는 가짜 분석
         await asyncio.sleep(10)
@@ -1085,16 +1086,17 @@ async def test_run_static_with_timeout_returns_empty_on_timeout():
 
     with patch("src.worker.pipeline._run_static_analysis", side_effect=_slow):
         with patch("src.worker.pipeline.PIPELINE_ANALYSIS_TIMEOUT", 0.01):
-            result = await _run_static_with_timeout([])
+            result = await _run_static_with_timeout([ChangedFile("a.py", "x=1\n", "@@")])
 
     assert result == ([], True)
 
 
 @pytest.mark.asyncio
 async def test_run_static_with_timeout_returns_results_when_fast():
-    """분석이 타임아웃 내에 완료되면 (정상 결과, timed_out=False) 를 반환해야 한다."""
+    """분석이 타임아웃 내에 완료되면 (정상 결과, incomplete=False) 를 반환해야 한다."""
     from src.worker.pipeline import _run_static_with_timeout
     from src.analyzer.io.static import StaticAnalysisResult
+    from src.github_client.diff import ChangedFile
 
     fake_result = [StaticAnalysisResult(filename="app.py", issues=[])]
 
@@ -1102,9 +1104,93 @@ async def test_run_static_with_timeout_returns_results_when_fast():
         return fake_result
 
     with patch("src.worker.pipeline._run_static_analysis", side_effect=_fast):
-        result = await _run_static_with_timeout([])
+        result = await _run_static_with_timeout([ChangedFile("app.py", "x=1\n", "@@")])
 
     assert result == (fake_result, False)
+
+
+@pytest.mark.asyncio
+async def test_run_static_with_timeout_preserves_partial_results_on_deadline():
+    """배치 deadline 초과 시 그때까지 완료된 파일 결과를 보존하고 incomplete=True 반환 (Q3 B).
+
+    이전 동작은 타임아웃 시 전량 폐기 ([], True) 였으나, 부분결과 보존으로
+    완료된 파일 분석은 점수에 반영되고 incomplete 마커로 auto-merge 만 차단한다.
+    """
+    import asyncio
+    from src.worker.pipeline import _run_static_with_timeout
+    from src.analyzer.io.static import StaticAnalysisResult
+    from src.github_client.diff import ChangedFile
+
+    f1 = ChangedFile("a.py", "x=1\n", "@@")
+    f2 = ChangedFile("b.py", "y=2\n", "@@")
+    r1 = StaticAnalysisResult(filename="a.py", issues=[])
+
+    async def _per_file(files, repo_config=None):
+        # _run_static_with_timeout 는 파일별로 [f] 단일 리스트로 호출한다
+        f = files[0]
+        if f.filename == "a.py":
+            return [r1]
+        await asyncio.sleep(10)  # b.py: 느림 → deadline 초과
+        return [StaticAnalysisResult(filename="b.py", issues=[])]
+
+    with patch("src.worker.pipeline._run_static_analysis", side_effect=_per_file):
+        with patch("src.worker.pipeline.PIPELINE_ANALYSIS_TIMEOUT", 0.2):
+            results, incomplete = await _run_static_with_timeout([f1, f2])
+
+    assert incomplete is True            # deadline 초과 → auto-merge 차단 신호
+    assert results == [r1]               # a.py 부분 결과 보존, b.py 는 폐기 (deadline)
+
+
+@pytest.mark.asyncio
+async def test_run_static_with_timeout_isolates_single_file_exception():
+    """한 파일의 analyze_file 예외가 다른 파일 분석·AI리뷰를 막지 않고 빈 결과로 격리된다 (Q2 A).
+
+    이전 동작은 list comprehension 이라 한 파일 예외가 전체 배치를 중단시켰으나,
+    파일 단위 격리로 실패 파일은 빈 StaticAnalysisResult 가 되고 나머지는 정상 분석된다.
+    일부 파일만 실패하면 incomplete=False (Q2=A — 나머지 정상 분석 보존).
+    """
+    from src.worker.pipeline import _run_static_with_timeout
+    from src.analyzer.io.static import StaticAnalysisResult
+    from src.github_client.diff import ChangedFile
+
+    good = StaticAnalysisResult(filename="good.py", issues=[])
+
+    async def _per_file(files, repo_config=None):
+        f = files[0]
+        if f.filename == "bad.py":
+            raise OSError("disk full")
+        return [good]
+
+    files = [ChangedFile("bad.py", "x\n", "@@"), ChangedFile("good.py", "y\n", "@@")]
+    with patch("src.worker.pipeline._run_static_analysis", side_effect=_per_file):
+        results, incomplete = await _run_static_with_timeout(files)
+
+    assert len(results) == 2
+    assert results[0].filename == "bad.py" and results[0].issues == []  # 격리된 빈 결과
+    assert results[1] is good                                            # 정상 파일 보존
+    assert incomplete is False                                           # 일부 실패는 incomplete 아님
+
+
+@pytest.mark.asyncio
+async def test_run_static_with_timeout_marks_incomplete_when_all_files_fail():
+    """비어있지 않은 배치의 모든 파일이 analyze_file 예외로 실패하면 incomplete=True (안전망).
+
+    실 분석 0건이므로 빈 결과의 만점 인플레가 미분석 코드 auto-merge 로 이어지지 않도록
+    fail-closed 처리한다 (Q2=A 격리가 전량-실패 시 만들 수 있는 fail-open 회귀 방지).
+    """
+    from src.worker.pipeline import _run_static_with_timeout
+    from src.github_client.diff import ChangedFile
+
+    async def _all_fail(files, repo_config=None):
+        raise OSError("disk full")
+
+    files = [ChangedFile("a.py", "x\n", "@@"), ChangedFile("b.py", "y\n", "@@")]
+    with patch("src.worker.pipeline._run_static_analysis", side_effect=_all_fail):
+        results, incomplete = await _run_static_with_timeout(files)
+
+    assert len(results) == 2                       # 빈 결과 2개 보존 (관측용)
+    assert all(r.issues == [] for r in results)
+    assert incomplete is True                      # 전량 실패 → auto-merge 차단 신호
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 요약
area=gate 정합성 감사 — 사용자 **Q2=A + Q3=B** 결정 이행. 정적분석 코어(`_run_static_analysis` / `_run_static_with_timeout`) 재구성.

## 변경
- **Q2 A 파일 단위 격리**: 한 파일 `analyze_file` 예외(디스크/encoding/tempfile 오류)가 전체 배치+AI리뷰를 중단시키던 list comprehension → 파일별 격리로 전환. 실패 파일은 빈 `StaticAnalysisResult`, 나머지는 정상 분석.
- **Q3 B 부분결과 보존**: 타임아웃 시 전량 폐기(`[], True`) → `loop.time()` deadline 기반 파일별 순차 실행으로 **완료된 파일 부분결과 보존**(`partial, True`). 고아 스레드는 진행 중 단일 파일로 한정(subprocess timeout bounded — pipeline:164 완화).
- **안전망 (self-verify 발견 추가)**: 비어있지 않은 배치의 **모든 파일이 실패**하면 `incomplete=True`(fail-closed). Q2=A 격리가 변경 전 abort-on-exception 대비 만들 수 있는 **전량-실패 fail-open 회귀**를 차단.
- `incomplete` 마커 → auto-merge 차단(#779/#783) 경로 보존. 일부 파일만 실패는 `incomplete` 아님(Q2=A).

## 검증 (테스트 통과)
- 단위 **4650 passed, 1 skipped** (`pytest tests/unit/`) / 정적분석 테스트 5종(부분보존·격리·전량실패·타임아웃·정상) / pylint·flake8 clean
- pipeline-reviewer **APPROVE ×2** (재구성 + 안전망 보강 최종)
- 적대적 self-verify **3렌즈**(동시성/타임아웃 · Q2·Q3 의미·점수 · 안전망 엣지) — **P0·P1 0건**

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
⚠️ **Codex exec 401 만료**(`refresh token already used`) — 이번 세션 mutual 불가. 정책 18 standing 승인 하 **Claude 적대적 self-verify(pipeline-reviewer ×2 + 독립 skeptic 3렌즈) fallback** 적용. `codex login` 재인증 시 이후 PR 부터 true mutual 복원.

## 🔍 사용자 검증 필요 (정책 2)
- **운영 동작 변경**: ① 정적분석 타임아웃(60s) 시 이제 완료된 파일 점수가 보존됨(이전엔 전량 0) — auto-merge 는 여전히 차단. ② 단일 파일 분석 실패 시 전체 PR 분석이 살아남음(이전엔 abort).

## 🔍 자율 판단 보고 + follow-up 후보 (정책 3)
self-verify 가 식별한 잔여 항목 — 본 PR 범위(Q2=A+Q3=B) 밖이라 보류, 사용자 결정 영역:
1. **부분/만점 점수의 PR 코멘트·대시보드 무경고 노출** — `static_analysis_incomplete` 마커가 gate action 에서만 소비되고 review_comment/대시보드는 미체크. 이는 Q3 **옵션 A**(review_comment 경고문)의 영역으로, 사용자가 옵션 B 선택 → 별도 결정 필요(새 발신 = High tier).
2. **안전망 임계값 정책** — 현재 `failed == len(files)`(전량 실패만 차단). "9/10 실패 + 1 성공"은 incomplete 아님(점수 인플레 잔존). 비율 임계(예: 다수 실패 → incomplete) 도입은 새 정책 결정 + magic number(정책 16) → 보류. Q2=A "파일 1개 한정 위험 수용"의 다수-실패 확장 여부는 사용자 결정.
3. **incomplete→점수→gate 차단 end-to-end 통합 테스트** — 현재 레이어별(파이프라인/gate) 분리 검증, 마커 key 계약 단방향 변경 시 양 테스트 통과 위험. 통합 테스트/공유 상수 추출 후보(선택).

이견 있으면 알려주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
