### PR TITLE
fix(notifier): PR 코멘트에 정적분석 incomplete 경고 배너 — 인플레 점수 무경고 노출 차단 (사이클 164 follow-up #5)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -726,6 +726,7 @@
     },
     "github_pr_comment": {
       "title": "## {emoji} SCAManager Analysis Result",
+      "static_incomplete_warning": "> ⚠️ **Static analysis incomplete (timeout or error)** — the score below may be inflated and is not reliable. Review manually before merging.",
       "total_line": "**Total: {score}/100** (Grade {grade})",
       "breakdown_header": "### Score Breakdown",
       "table_header": "| Item | Score | Max |",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -726,6 +726,7 @@
     },
     "github_pr_comment": {
       "title": "## {emoji} SCAManager 分析結果",
+      "static_incomplete_warning": "> ⚠️ **静的解析が未完了 (タイムアウトまたはエラー)** — 以下のスコアは過大評価され信頼できない可能性があります。マージ前に手動で確認してください。",
       "total_line": "**合計: {score}/100** (グレード {grade})",
       "breakdown_header": "### スコア詳細",
       "table_header": "| 項目 | スコア | 満点 |",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -726,6 +726,7 @@
     },
     "github_pr_comment": {
       "title": "## {emoji} SCAManager 분석 결과",
+      "static_incomplete_warning": "> ⚠️ **정적분석 미완료 (타임아웃 또는 오류)** — 아래 점수는 인플레이션되었을 수 있어 신뢰할 수 없습니다. 머지 전 수동 검토하세요.",
       "total_line": "**총점: {score}/100** (등급 {grade})",
       "breakdown_header": "### 점수 상세",
       "table_header": "| 항목 | 점수 | 만점 |",

--- a/src/notifier/github_comment.py
+++ b/src/notifier/github_comment.py
@@ -154,10 +154,25 @@ def _static_issues_lines(result: dict, language: str = "en") -> list[str]:
     return lines
 
 
+def _incomplete_warning_lines(result: dict, language: str = "en") -> list[str]:
+    """정적분석 불완전(타임아웃/전량실패) 시 점수 신뢰 불가 경고 배너 (사이클 164 follow-up #5).
+    Warning banner when static analysis is incomplete — the score may be inflated/unreliable.
+
+    `static_analysis_incomplete` 마커는 auto-merge/auto-approve 만 차단(#779/#783)할 뿐
+    PR 코멘트 점수에는 무경고 노출돼 사람 수동 머지 시 오판 위험 → 점수 위에 배너 삽입.
+    The marker only blocks auto-merge/approve; surface it in the PR comment so manual
+    reviewers do not trust an inflated score.
+    """
+    if not result.get("static_analysis_incomplete"):
+        return []
+    return [get_text("notifier.github_pr_comment.static_incomplete_warning", language), ""]
+
+
 def _build_comment_from_result(result: dict, language: str = "en") -> str:
     """Build a formatted PR comment body from a stored analysis result dict (Phase 3 PR-11 — i18n)."""
     return "\n".join(
-        _header_lines(result, language)
+        _incomplete_warning_lines(result, language)
+        + _header_lines(result, language)
         + _ai_summary_lines(result, language)
         + _category_feedback_lines(result, language)
         + _file_feedback_lines(result, language)

--- a/tests/unit/notifier/test_github_comment.py
+++ b/tests/unit/notifier/test_github_comment.py
@@ -234,6 +234,36 @@ def test_build_comment_from_result_grade_f():
     assert "🔴" in body  # GRADE_EMOJI["F"]
 
 
+# ── 정적분석 incomplete 경고 배너 (사이클 164 follow-up #5) ─────────────────
+
+def _has_incomplete_warning(body: str) -> bool:
+    """경고 배너가 en/ko/ja 중 하나로 노출됐는지 (default locale=en)."""
+    return (
+        "Static analysis incomplete" in body
+        or "정적분석 미완료" in body
+        or "静的解析が未完了" in body
+    )
+
+
+def test_build_comment_shows_incomplete_warning_when_marked():
+    """static_analysis_incomplete=True 시 점수 위에 신뢰 불가 경고 배너가 노출돼야 한다.
+
+    타임아웃/전량실패로 인플레된 점수가 PR 코멘트에 무경고 노출되면 사람이 수동 머지 시
+    오판할 수 있으므로(사이클 164 회고 P1 — 운영 가시성), 경고 배너로 차단한다.
+    """
+    body = _build_comment_from_result(_make_result(score=45, static_analysis_incomplete=True))
+    assert _has_incomplete_warning(body), "incomplete 경고 배너가 없습니다"
+    assert "⚠️" in body
+    # 배너는 점수 위에 위치해야 한다 — 사람이 점수를 읽기 전 신뢰 불가를 먼저 인지 (Codex 제안)
+    assert body.index("⚠️") < body.index("45/100"), "경고 배너가 점수보다 아래에 있습니다"
+
+
+def test_build_comment_no_incomplete_warning_when_complete():
+    """정상(마커 없음) 분석은 경고 배너를 노출하지 않아야 한다 (false 경고 방지)."""
+    body = _build_comment_from_result(_make_result(score=80))
+    assert not _has_incomplete_warning(body), "정상 분석에 incomplete 경고가 잘못 노출됨"
+
+
 # ── post_pr_comment_from_result 테스트 (164-172 커버) ───────────────────────
 
 async def test_post_pr_comment_from_result_calls_api():


### PR DESCRIPTION
## 요약
사이클 164 회고 P1 (운영 가시성 **최우선**) follow-up. 정적분석 incomplete 시 PR 코멘트 점수에 신뢰 불가 경고 배너 추가.

## 배경
`static_analysis_incomplete` 마커(타임아웃/전량실패)는 **auto-merge/auto-approve 만 차단**(#779/#783)하고, PR 코멘트 점수에는 무경고로 노출됐습니다. → **사람이 수동 머지 시 인플레된 점수를 신뢰할 위험** (회고 운영안전 P1).

## 변경
- `_incomplete_warning_lines()` — 마커 True 시 경고 배너 라인, 아니면 빈 리스트 (정상 분석 무영향)
- `_build_comment_from_result` **최상단 prepend** — 점수보다 위에 배너 (사람이 점수 읽기 전 신뢰 불가 인지)
- i18n 키 `notifier.github_pr_comment.static_incomplete_warning` **3 언어(en/ko/ja) 동시 추가** (i18n.md 규칙)
- 회귀 가드 2건 — present+**ordering**(배너가 점수 위) / absent. render-parity 가드 겸용

## 검증 (테스트 통과)
- 단위 **4651 passed, 1 skipped** / github_comment 24 + i18n smoke·no-hardcoded-korean 16 통과 / pylint·flake8 clean
- **✅ Codex mutual OK** (재인증 후 첫 검증) — 정확성·배치·i18n 일관성·회귀 확인 + ordering assertion 제안 반영

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
✅ Codex 재인증 복구(2026-06-08) → `codex exec` 검토 **CODEX OK**. push 전 mutual 검증 정상 흐름 복원.

## 🔍 사용자 검증 필요 (정책 2)
- 운영 확인: 정적분석 타임아웃/전량실패 발생 시 실제 PR 코멘트 상단에 ⚠️ 배너가 점수 위에 노출되는지 (3 언어 중 repo 소유자 언어).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
