### PR TITLE
test(cycle164): 회고 발견 회귀 가드 3건 — incomplete 종단·_race_recover 대칭·semi-auto 임계 layer

### DIFF
--- a/tests/unit/webhook/test_telegram_provider.py
+++ b/tests/unit/webhook/test_telegram_provider.py
@@ -192,6 +192,30 @@ async def test_handle_gate_callback_merge_error_does_not_propagate():
                         await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john")
 
 
+async def test_handle_gate_callback_below_threshold_still_delegates_to_engine():
+    """score < merge_threshold 여도 telegram 은 _run_auto_merge 에 위임한다 (사이클 164 회고 P1 — layer 격리 봉인).
+
+    임계 가드(score>=merge_threshold)는 engine._run_auto_merge 단일 layer(engine.py:109)가 담당하고
+    telegram 위임은 무조건(approve+auto_merge+not incomplete)이다. telegram 이 임계를 잘못 추가하면
+    이 테스트가 회귀를 잡는다 — 실제 머지 차단은 engine layer 테스트(tests/unit/gate/)가 봉인.
+    """
+    from src.webhook.router import handle_gate_callback
+    mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85, result={"score": 85})
+    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
+    config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=90)  # 85 < 90
+    with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
+        with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
+            with patch("src.webhook.providers.telegram.save_gate_decision"):
+                with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
+                    with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
+                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john")
+                        mock_am.assert_called_once()
+                        # score 가 임계 미달이어도 그대로 engine 에 전달 — engine 이 차단 결정
+                        assert mock_am.call_args.args[4] == 85
+
+
 # --- 추가 테스트: HMAC 검증 실패·파트 형식 오류·analysis 미존재·내부 예외 ---
 
 INVALID_TOKEN_PAYLOAD = {

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -597,6 +597,25 @@ async def test_pipeline_marks_result_incomplete_on_static_timeout(mock_deps):
         "정적분석 타임아웃 시 result 에 static_analysis_incomplete=True 마커가 없음 — auto-merge 차단 불가"
 
 
+async def test_pipeline_persists_incomplete_marker_to_saved_analysis(mock_deps):
+    """정적분석 incomplete 시 DB 저장되는 Analysis.result 에도 마커가 영속돼야 한다 (사이클 164 회고 P1 종단 봉인).
+
+    기존 test 는 마커→run_gate_check 전파만 검증 — 본 테스트는 _save_and_gate 가 result_dict 에
+    마커를 심어 db.add 되는 Analysis.result 에 영속되는지(관측 마커 겸용) end-to-end 봉인.
+    """
+    from src.worker.pipeline import run_analysis_pipeline
+    from unittest.mock import AsyncMock, patch
+
+    with patch("src.worker.pipeline._run_static_with_timeout",
+               new=AsyncMock(return_value=([], True))):
+        with patch("src.worker.pipeline.run_gate_check", new_callable=AsyncMock):
+            await run_analysis_pipeline("pull_request", PR_DATA)
+
+    analysis_added = mock_deps["db"].add.call_args_list[-1][0][0]
+    assert analysis_added.result.get("static_analysis_incomplete") is True, \
+        "저장된 Analysis.result 에 incomplete 마커가 영속되지 않음 — 관측/재게이트 회귀 위험"
+
+
 async def test_pipeline_no_incomplete_marker_when_static_ok(mock_deps):
     """정적분석 정상 완료 시 result 에 static_analysis_incomplete 마커가 없어야 한다 (회귀 가드)."""
     from src.worker.pipeline import run_analysis_pipeline
@@ -1274,6 +1293,41 @@ async def test_race_recover_existing_skips_when_result_is_none():
             result = await _race_recover_existing(mock_db, params, mock_existing)
 
     mock_gate.assert_not_called()
+    assert result is mock_repo_config
+
+
+async def test_race_recover_existing_skips_when_pr_number_already_set():
+    """existing.pr_number 가 이미 다른 non-None 값이면 덮어쓰지 않고 run_gate_check 미호출 (first-writer-wins).
+
+    `_regate_pr_if_needed`(#794)와 대칭 — 동일 head SHA 를 두 PR 이 공유하는 race 경로에서도
+    잘못된 PR 에 gate 가 적용되는 것을 차단한다 (사이클 164 회고 P2 — 대칭 가드 봉인).
+    """
+    from src.worker.pipeline import _race_recover_existing  # pylint: disable=import-outside-toplevel
+    from src.worker.pipeline import _AnalysisSaveParams  # pylint: disable=import-outside-toplevel
+
+    mock_db = MagicMock()
+    # existing.pr_number=10 (이미 PR #10 으로 gate됨), 신규 params.pr_number=11
+    mock_existing = MagicMock(id=20, pr_number=10, result={"score": 80})
+    mock_repo_config = MagicMock()
+
+    params = _AnalysisSaveParams(
+        repo_name="owner/repo",
+        commit_sha="abc123",
+        commit_message="feat: test",
+        pr_number=11,
+        owner_token="tok",
+        analysis_results=[],
+        ai_review=MagicMock(),
+        score_result=MagicMock(),
+    )
+
+    with patch("src.worker.pipeline.get_repo_config", return_value=mock_repo_config):
+        with patch("src.worker.pipeline.run_gate_check", new_callable=AsyncMock) as mock_gate:
+            result = await _race_recover_existing(mock_db, params, mock_existing)
+
+    mock_gate.assert_not_called()
+    assert mock_existing.pr_number == 10, "pr_number 가 덮어써짐 — first-writer-wins 위반"
+    mock_db.commit.assert_not_called()
     assert result is mock_repo_config
 
 


### PR DESCRIPTION
## 요약
사이클 164 5+1 회고가 식별한 **회귀 가드 봉인 깊이 공백 3건** 보강 (src 무변경, 정책 4 — 단언과 회귀 가드 동봉).

## 변경 (test-only)
- **incomplete 종단 봉인** (회고 P1) — `test_pipeline_persists_incomplete_marker_to_saved_analysis`: 정적분석 타임아웃 시 마커가 run_gate_check 전파(기존 테스트)뿐 아니라 **DB 저장 Analysis.result 에도 영속**되는지 end-to-end 검증.
- **_race_recover 대칭** (회고 P2) — `test_race_recover_existing_skips_when_pr_number_already_set`: `existing.pr_number` 이미 non-None 시 덮어쓰지 않고 gate 미실행 (first-writer-wins, `_regate_pr_if_needed` #794 와 대칭 — 한쪽만 가드 테스트 보유하던 정책 4 미충족 해소).
- **semi-auto 임계 layer 격리** (회고 P1) — `test_handle_gate_callback_below_threshold_still_delegates_to_engine`: `score < merge_threshold` 여도 telegram 은 `engine._run_auto_merge` 에 위임(임계 가드 engine 단일 layer). telegram 이 임계를 잘못 추가하면 회귀 검출.

## 검증 (테스트 통과)
- 단위 **4652 passed, 1 skipped** (+3) / pylint·flake8 clean
- **✅ Codex mutual OK** — 3 테스트가 주장한 바를 정확히 단언하며 false-confidence 없음 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
✅ `codex exec` 검토 **CODEX OK** (test-only 회귀 가드).

## 🔍 사용자 검증 필요 (정책 2)
- test-only 변경 — 운영 영향 없음. 회고 발견 회귀 가드 봉인이 목적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
