### PR TITLE
fix(security): 반자동 Telegram gate 콜백 리포 소유권 검증 — broken access control 차단 (Task9 P1 #1)

### DIFF
--- a/src/webhook/providers/telegram.py
+++ b/src/webhook/providers/telegram.py
@@ -25,7 +25,7 @@ from src.i18n.loader import get_text
 from src.notifier._language import resolve_notification_language
 from src.notifier.telegram import telegram_post_message
 from src.notifier.telegram_commands import handle_message_command, parse_cmd_callback
-from src.repositories import analysis_repo, repository_repo
+from src.repositories import analysis_repo, repository_repo, user_repo
 
 logger = logging.getLogger(__name__)
 
@@ -69,10 +69,13 @@ def _parse_gate_callback(data: str) -> "tuple[str, int, str] | None":
     return decision, analysis_id, callback_token
 
 
-async def handle_gate_callback(
+async def handle_gate_callback(  # pylint: disable=too-many-locals
+    # too-many-locals: authz 검증(user) 추가로 16/15 — 함수 응집 단위 보호 위해 inline disable
+    # (testing.md R0914 결정 트리: 기존 함수 시그니처 확장 시 inline disable + 사유)
     analysis_id: int,
     decision: str,
     decided_by: str,
+    telegram_user_id: str | None = None,
 ) -> None:
     """Telegram 인라인 키보드 콜백을 처리해 GitHub Review 결정을 실행한다."""
     with SessionLocal() as db:
@@ -83,6 +86,23 @@ async def handle_gate_callback(
                 return
             repo = repository_repo.find_by_id(db, analysis.repo_id)
             if not repo:
+                return
+            # 🔴 authorization (보안): 콜백을 클릭한 Telegram 사용자가 해당 repo 소유자인지 검증.
+            # 텍스트 명령 경로(telegram_commands.py: repo.user_id != user.id)와 대칭 — HMAC 토큰은
+            # gate:{analysis_id} 만 서명(사용자 신원 무관)하므로, 이 검증이 없으면 버튼을 받은 임의
+            # 사용자가 PR 승인/머지를 실행할 수 있다 (broken access control). 미연동/비소유자는 차단.
+            # Authorization: verify the clicking Telegram user owns the repo (mirrors the
+            # text-command path). The HMAC token signs only gate:{analysis_id} (identity-agnostic),
+            # so without this any user who receives the button could approve/merge a PR.
+            user = (
+                user_repo.find_by_telegram_user_id(db, telegram_user_id)
+                if telegram_user_id else None
+            )
+            if user is None or repo.user_id != user.id:
+                logger.warning(
+                    "handle_gate_callback: unauthorized tg_user=%s for repo=%s (analysis %d) — skipping",
+                    telegram_user_id, repo.full_name, analysis_id,
+                )
                 return
             github_token = (
                 repo.owner.plaintext_token
@@ -187,7 +207,8 @@ def _handle_message(
 
 
 @router.post("/api/webhook/telegram", responses={401: {"description": "Invalid secret token"}})
-async def telegram_webhook(
+async def telegram_webhook(  # pylint: disable=too-many-locals
+    # too-many-locals: 콜백 소유권 전달용 telegram_user_id 추가로 16/15 (inline disable + 사유)
     request: Request,
     background_tasks: BackgroundTasks,
     x_telegram_bot_api_secret_token: Annotated[str | None, Header()] = None,
@@ -243,10 +264,14 @@ async def telegram_webhook(
     user_id = from_data.get("id", "unknown")
     username = from_data.get("username", "")
     decided_by = f"{username}(id:{user_id})" if username else f"id:{user_id}"
+    # 클릭 사용자 telegram_user_id 를 소유권 검증용으로 전달 (str 정규화, 부재 시 None → 차단)
+    # Pass the clicking user's telegram_user_id for the ownership check (None → blocked)
+    telegram_user_id = str(user_id) if user_id != "unknown" else None
     background_tasks.add_task(
         handle_gate_callback,
         analysis_id=analysis_id,
         decision=decision,
         decided_by=decided_by,
+        telegram_user_id=telegram_user_id,
     )
     return {"status": "ok"}

--- a/tests/unit/test_gate_i18n_seam.py
+++ b/tests/unit/test_gate_i18n_seam.py
@@ -191,6 +191,7 @@ def _make_gate_callback_mocks(*, decision: str):
     repo = MagicMock()
     repo.full_name = "owner/repo"
     repo.owner.plaintext_token = "ghp_x"
+    repo.user_id = 1  # authz: 콜백 소유권 검증용 (사이클 164 P1 #1)
     config = MagicMock()
     config.auto_merge = False  # 머지 분기 skip — body 생성만 검증
     return db_cm, analysis, repo, config
@@ -216,9 +217,11 @@ async def test_gate_callback_approve_threads_japanese_to_review_body():
     ), patch(
         "src.webhook.providers.telegram.save_gate_decision"
     ), patch(
+        "src.webhook.providers.telegram.user_repo.find_by_telegram_user_id", return_value=MagicMock(id=1)
+    ), patch(
         "src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock
     ) as mock_review:
-        await telegram.handle_gate_callback(1, "approve", "alice")
+        await telegram.handle_gate_callback(1, "approve", "alice", telegram_user_id="1")
 
     assert mock_review.await_count == 1
     # post_github_review(token, full_name, pr_number, decision, body) — body = 5번째 positional
@@ -245,9 +248,11 @@ async def test_gate_callback_reject_threads_english_no_korean():
     ), patch(
         "src.webhook.providers.telegram.save_gate_decision"
     ), patch(
+        "src.webhook.providers.telegram.user_repo.find_by_telegram_user_id", return_value=MagicMock(id=1)
+    ), patch(
         "src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock
     ) as mock_review:
-        await telegram.handle_gate_callback(1, "reject", "bob")
+        await telegram.handle_gate_callback(1, "reject", "bob", telegram_user_id="1")
 
     assert mock_review.await_count == 1
     body = mock_review.await_args.args[4]
@@ -272,9 +277,11 @@ async def test_gate_callback_approve_threads_korean_default():
     ), patch(
         "src.webhook.providers.telegram.save_gate_decision"
     ), patch(
+        "src.webhook.providers.telegram.user_repo.find_by_telegram_user_id", return_value=MagicMock(id=1)
+    ), patch(
         "src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock
     ) as mock_review:
-        await telegram.handle_gate_callback(1, "approve", "carol")
+        await telegram.handle_gate_callback(1, "approve", "carol", telegram_user_id="1")
 
     assert mock_review.await_count == 1
     body = mock_review.await_args.args[4]

--- a/tests/unit/webhook/test_telegram_provider.py
+++ b/tests/unit/webhook/test_telegram_provider.py
@@ -49,6 +49,19 @@ def _patch_tg_secret(monkeypatch):
     monkeypatch.setattr(_tg.settings, "telegram_webhook_secret", _TG_SECRET)
 
 
+@pytest.fixture(autouse=True)
+def _authorize_gate_owner():
+    """기본적으로 콜백 클릭 사용자를 repo 소유자(user_id=1)로 인가 (사이클 164 P1 #1 authz).
+
+    handle_gate_callback 의 소유권 검증을 통과시키기 위해 user_repo.find_by_telegram_user_id 가
+    id=1 사용자를 반환하도록 patch. 테스트는 mock_repo.user_id=1 + telegram_user_id 전달로 인가.
+    비인가 케이스는 개별 테스트에서 이 patch 를 덮어쓴다.
+    """
+    with patch("src.webhook.providers.telegram.user_repo.find_by_telegram_user_id",
+               return_value=MagicMock(id=1)):
+        yield
+
+
 def test_approve_returns_200():
     with patch("src.webhook.providers.telegram.handle_gate_callback", new_callable=AsyncMock):
         r = client.post("/api/webhook/telegram", json=APPROVE, headers=_TG_HEADERS)
@@ -99,7 +112,7 @@ async def test_handle_gate_callback_approve_with_auto_merge():
     # approve + auto_merge=True + score>=threshold → engine._run_auto_merge 에 위임
     from src.webhook.router import handle_gate_callback
     mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85, result={"score": 85})
-    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
     mock_db = MagicMock()
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
@@ -108,7 +121,7 @@ async def test_handle_gate_callback_approve_with_auto_merge():
             with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
-                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john")
+                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
                         mock_save.assert_called_once()
                         mock_am.assert_called_once()
                         args, kw = mock_am.call_args
@@ -124,7 +137,7 @@ async def test_handle_gate_callback_approve_without_auto_merge():
     # auto_merge=False → _run_auto_merge 미호출
     from src.webhook.router import handle_gate_callback
     mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85, result={"score": 85})
-    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
     mock_db = MagicMock()
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=False)
@@ -133,7 +146,7 @@ async def test_handle_gate_callback_approve_without_auto_merge():
             with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
-                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john")
+                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
                         mock_save.assert_called_once()
                         mock_am.assert_not_called()
 
@@ -142,7 +155,7 @@ async def test_handle_gate_callback_reject_does_not_merge():
     # reject 시 auto_merge=True + 높은 score(>=threshold) 여도 머지 금지 (decision 가드 — 잠재 버그 차단)
     from src.webhook.router import handle_gate_callback
     mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=90, result={"score": 90})
-    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
     mock_db = MagicMock()
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
@@ -151,7 +164,7 @@ async def test_handle_gate_callback_reject_does_not_merge():
             with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
-                        await handle_gate_callback(analysis_id=42, decision="reject", decided_by="john")
+                        await handle_gate_callback(analysis_id=42, decision="reject", decided_by="john", telegram_user_id="1")
                         mock_save.assert_called_once()
                         mock_am.assert_not_called()
 
@@ -161,7 +174,7 @@ async def test_handle_gate_callback_incomplete_static_skips_merge():
     from src.webhook.router import handle_gate_callback
     mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85,
                               result={"score": 85, "static_analysis_incomplete": True})
-    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
     mock_db = MagicMock()
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
@@ -170,7 +183,7 @@ async def test_handle_gate_callback_incomplete_static_skips_merge():
             with patch("src.webhook.providers.telegram.save_gate_decision"):
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
-                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john")
+                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
                         mock_am.assert_not_called()
 
 
@@ -178,7 +191,7 @@ async def test_handle_gate_callback_merge_error_does_not_propagate():
     # _run_auto_merge 가 RuntimeError 누출 시에도 콜백이 격리되어 정상 완료 (except RuntimeError 보강)
     from src.webhook.router import handle_gate_callback
     mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=90, result={"score": 90})
-    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
     mock_db = MagicMock()
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
@@ -189,7 +202,7 @@ async def test_handle_gate_callback_merge_error_does_not_propagate():
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock,
                                side_effect=RuntimeError("merge boom")):
                         # 예외가 전파되지 않아야 한다 (handle_gate_callback except 격리)
-                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john")
+                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
 
 
 async def test_handle_gate_callback_below_threshold_still_delegates_to_engine():
@@ -201,7 +214,7 @@ async def test_handle_gate_callback_below_threshold_still_delegates_to_engine():
     """
     from src.webhook.router import handle_gate_callback
     mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85, result={"score": 85})
-    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
     mock_db = MagicMock()
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=90)  # 85 < 90
@@ -210,10 +223,54 @@ async def test_handle_gate_callback_below_threshold_still_delegates_to_engine():
             with patch("src.webhook.providers.telegram.save_gate_decision"):
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
-                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john")
+                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
                         mock_am.assert_called_once()
                         # score 가 임계 미달이어도 그대로 engine 에 전달 — engine 이 차단 결정
                         assert mock_am.call_args.args[4] == 85
+
+
+# --- handle_gate_callback authorization 테스트 (사이클 164 P1 #1 — 콜백 소유권 검증) ---
+
+async def test_handle_gate_callback_unauthorized_non_owner_skips():
+    """콜백 클릭 사용자가 repo 소유자가 아니면(user.id != repo.user_id) gate 액션 전부 미실행."""
+    from src.webhook.router import handle_gate_callback
+    mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85, result={"score": 85})
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)  # 소유자 user_id=1
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
+    config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
+    with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
+        with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock) as mock_review:
+            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
+                with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
+                    with patch("src.webhook.providers.telegram.user_repo.find_by_telegram_user_id",
+                               return_value=MagicMock(id=999)):  # 비소유자(id != 1)
+                        with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
+                            await handle_gate_callback(analysis_id=42, decision="approve",
+                                                       decided_by="attacker", telegram_user_id="999")
+                            mock_review.assert_not_called()
+                            mock_save.assert_not_called()
+                            mock_am.assert_not_called()
+
+
+async def test_handle_gate_callback_unlinked_user_skips():
+    """미연동(find_by_telegram_user_id None) 또는 telegram_user_id 부재 시 gate 액션 미실행."""
+    from src.webhook.router import handle_gate_callback
+    mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85, result={"score": 85})
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
+    config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
+    with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
+        with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock) as mock_review:
+            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
+                with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
+                    with patch("src.webhook.providers.telegram.user_repo.find_by_telegram_user_id",
+                               return_value=None):  # 미연동
+                        await handle_gate_callback(analysis_id=42, decision="approve",
+                                                   decided_by="ghost", telegram_user_id="555")
+                        mock_review.assert_not_called()
+                        mock_save.assert_not_called()
 
 
 # --- 추가 테스트: HMAC 검증 실패·파트 형식 오류·analysis 미존재·내부 예외 ---
@@ -308,7 +365,7 @@ async def test_handle_gate_callback_exception_does_not_propagate():
     # post_github_review가 예외를 던져도 handle_gate_callback이 정상 종료되어야 한다
     from src.webhook.router import handle_gate_callback
     mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, result={"score": 85})
-    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
     mock_db = MagicMock()
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [
         mock_analysis, mock_repo
@@ -318,9 +375,11 @@ async def test_handle_gate_callback_exception_does_not_propagate():
         with patch("src.webhook.providers.telegram.post_github_review",
                    new_callable=AsyncMock, side_effect=httpx.ConnectError("GitHub API down")):
             with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
-                # 예외가 전파되지 않아야 한다
-                # The exception must not propagate.
-                await handle_gate_callback(analysis_id=42, decision="approve", decided_by="user")
+                # 예외가 전파되지 않아야 한다 (authz 통과 후 post_github_review 예외 경로 검증)
+                # The exception must not propagate (authorized → reaches post_github_review).
+                await handle_gate_callback(
+                    analysis_id=42, decision="approve", decided_by="user", telegram_user_id="1",
+                )
 
 
 # --- Phase F.2 관측 테스트 — Q1 A 이후 engine._run_auto_merge 로 이관됨 ---
@@ -502,7 +561,7 @@ async def test_handle_gate_callback_skips_when_pr_number_is_none():
     from src.webhook.router import handle_gate_callback  # pylint: disable=import-outside-toplevel
     # push Analysis — pr_number 없음
     mock_analysis = MagicMock(id=55, repo_id=1, pr_number=None, result={"score": 80})
-    mock_repo = MagicMock(id=1, full_name="owner/repo")
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
     mock_db = MagicMock()
     mock_db.query.return_value.filter_by.return_value.first.side_effect = [
         mock_analysis, mock_repo
@@ -511,7 +570,7 @@ async def test_handle_gate_callback_skips_when_pr_number_is_none():
         with patch("src.webhook.providers.telegram.post_github_review",
                    new_callable=AsyncMock) as mock_review:
             with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
-                await handle_gate_callback(analysis_id=55, decision="approve", decided_by="john")
+                await handle_gate_callback(analysis_id=55, decision="approve", decided_by="john", telegram_user_id="1")
     # pr_number=None → post_github_review·save_gate_decision 모두 호출되지 않아야 한다
     mock_review.assert_not_called()
     mock_save.assert_not_called()


### PR DESCRIPTION
## 요약
Task 9 full 감사 **P1 #1 (보안 — broken access control)**. 반자동 Telegram gate 콜백이 클릭 사용자의 repo 소유권을 검증하지 않아 **임의 사용자가 PR 승인/머지** 가능하던 갭 차단.

## 배경
`handle_gate_callback` 은 클릭 사용자(from.id)를 `decided_by` 로 기록만 할 뿐 소유권 미검증. HMAC 토큰은 `gate:{analysis_id}` 만 서명(사용자 신원 무관). 반면 텍스트 명령 경로(telegram_commands.py)는 `repo.user_id != user.id` 를 엄격 검증 — **대칭 깨진 authz 갭**.

## 변경
- repo 조회 직후 `user_repo.find_by_telegram_user_id(db, telegram_user_id)` → `user.id == repo.user_id` 검증. 미연동/비소유자/`telegram_user_id` 부재 시 gate 액션 전부 skip (post_github_review·save_gate_decision·auto-merge 미실행).
- dispatch site 가 클릭 사용자 telegram_user_id 를 콜백에 전달.
- 회귀 가드 2건(비소유자 차단·미연동 차단) + 기존 위임/i18n seam 테스트 인가 갱신.

## 검증 (테스트 통과)
- 단위 **4656 passed** / telegram+i18n seam 37 통과 / pylint·flake8 clean (R0914 inline disable)
- **✅ Codex mutual OK** (security review — authz 배치·우회 불가·None 차단·dispatch 확인)

## 🔍 사용자 검증 필요 (정책 2)
- 운영: 본인(repo 소유자) telegram 계정으로 승인 버튼 클릭 시 정상 동작 + 미연동/타인 클릭 시 무시(로그 WARNING) 확인 권장. **telegram_user_id 연동(/connect)된 소유자만 승인 가능** — 미연동 소유자는 먼저 연동 필요.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
✅ Codex CODEX OK (재인증 복구 후 mutual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)