### PR TITLE
fix(gate): AI 리뷰 실제 실패 시 auto-merge/auto-approve 차단 — fail-open 봉인 (Task9 P1 #8)

### DIFF
--- a/src/gate/_common.py
+++ b/src/gate/_common.py
@@ -3,6 +3,26 @@ from __future__ import annotations
 
 from src.scorer.calculator import ScoreResult
 
+# AI 리뷰가 실제로 실패(API 호출/JSON 파싱 오류)한 상태 — auto-merge/auto-approve 차단 대상.
+# 정상(success)·의도적 미수행(no_api_key/empty_diff)은 제외하여 기존 동작을 보존한다
+# (AI 미사용 리포가 영구히 자동 머지 불가가 되는 회귀 방지).
+# AI review statuses that mean a genuine failure (API/parse error) — block auto actions.
+# success and intentional skips (no_api_key/empty_diff) are excluded to preserve behavior
+# (so AI-disabled repos are not permanently blocked from auto-merge).
+AI_REVIEW_FAILED_STATUSES = frozenset({"api_error", "parse_error"})
+
+
+def ai_review_failed(result: dict) -> bool:
+    """result_dict 의 ai_review_status 가 genuine 실패면 True (auto 차단 판정).
+
+    static_analysis_incomplete 와 대칭 — AI 리뷰가 실제 실패했는데 중립-고점 기본값(44점)이
+    적용되면 점수가 인플레이션되어 미검증 코드가 auto-merge/auto-approve 될 수 있다(fail-open).
+    키 부재(구 레코드)·정상·의도적 미수행은 False 로 차단하지 않는다.
+    Return True when ai_review_status is a genuine failure — symmetric with
+    static_analysis_incomplete. Missing key, success, and intentional skips return False.
+    """
+    return result.get("ai_review_status") in AI_REVIEW_FAILED_STATUSES
+
 
 def score_from_result(result: dict) -> ScoreResult:
     """result dict 에서 최소한의 ScoreResult 를 재구성한다.

--- a/src/gate/actions/approve.py
+++ b/src/gate/actions/approve.py
@@ -10,6 +10,7 @@ import httpx
 
 from src.config import settings
 from src.database import SessionLocal
+from src.gate._common import ai_review_failed
 from src.gate._common import score_from_result as _score_from_result
 from src.gate.actions import GateAction, GateContext, register
 from src.gate.github_review import post_github_review
@@ -56,6 +57,17 @@ class ApproveAction(GateAction):
             logger.warning(
                 "static analysis incomplete — auto-approve skipped (repo=%s, pr=%s)",
                 ctx.repo_name, ctx.pr_number,
+            )
+            return
+        # AI 리뷰 실제 실패(api_error/parse_error) 시도 보류 — 중립-고점 기본값이 점수를
+        # 인플레이션하고, auto-approve 가 branch-protection "approval 시 자동머지" 를 간접
+        # 트리거할 수 있으므로 결정을 내리지 않는다 (#8, auto-merge 가드의 approve 경로 확장).
+        # Also hold auto-approve when the AI review genuinely failed — inflated defaults could
+        # indirectly trigger branch-protection "auto-merge on approval" (#8, extends the merge guard).
+        if ai_review_failed(ctx.result):
+            logger.warning(
+                "AI review failed (%s) — auto-approve skipped (repo=%s, pr=%s)",
+                ctx.result.get("ai_review_status"), ctx.repo_name, ctx.pr_number,
             )
             return
         # 알림 언어 결정 (3-layer fallback) — GitHub PR 댓글을 리포 소유자 언어로 게시

--- a/src/gate/actions/auto_merge.py
+++ b/src/gate/actions/auto_merge.py
@@ -7,6 +7,7 @@ Delegates to engine.py's _run_auto_merge(). Tests can patch engine namespace sym
 """
 import logging
 
+from src.gate._common import ai_review_failed
 from src.gate.actions import GateAction, GateContext, register
 
 logger = logging.getLogger(__name__)
@@ -47,6 +48,16 @@ class AutoMergeAction(GateAction):
             logger.warning(
                 "static analysis incomplete — auto-merge skipped (repo=%s, pr=%s)",
                 ctx.repo_name, ctx.pr_number,
+            )
+            return
+        # AI 리뷰 실제 실패(api_error/parse_error) 시도 차단 — 중립-고점 기본값(44점)이
+        # 점수를 인플레이션해 미검증 코드가 자동 머지되는 fail-open 방지 (#8, 정적분석 대칭).
+        # Also block when the AI review genuinely failed — its neutral-high defaults inflate
+        # the score, which would auto-merge unvetted code (#8, symmetric with static analysis).
+        if ai_review_failed(ctx.result):
+            logger.warning(
+                "AI review failed (%s) — auto-merge skipped (repo=%s, pr=%s)",
+                ctx.result.get("ai_review_status"), ctx.repo_name, ctx.pr_number,
             )
             return
         from src.gate import engine  # pylint: disable=import-outside-toplevel

--- a/src/webhook/providers/telegram.py
+++ b/src/webhook/providers/telegram.py
@@ -19,6 +19,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from src.config import settings
 from src.config_manager.manager import get_repo_config
 from src.database import SessionLocal
+from src.gate._common import ai_review_failed
 from src.gate.engine import save_gate_decision
 from src.gate.github_review import post_github_review
 from src.i18n.loader import get_text
@@ -139,15 +140,18 @@ async def handle_gate_callback(  # pylint: disable=too-many-locals
             # SHA 원자성 가드·CI 재판별·terminal/deferred 알림까지 자동/반자동 완전 대칭 (Q1 A).
             # _run_auto_merge 가 자체 SessionLocal 을 열고 auto_merge/threshold 가드를 내부 수행한다.
             # 가드는 자동 경로 AutoMergeAction 미러링: (1) 승인 결정만 머지(reject 시 금지),
-            # (2) auto_merge 활성, (3) 정적분석 불완전(타임아웃) 시 차단(#779/#783).
+            # (2) auto_merge 활성, (3) 정적분석 불완전(타임아웃) 시 차단(#779/#783),
+            # (4) AI 리뷰 실제 실패(api_error/parse_error) 시 차단(#8 — 인플레 점수 자동 머지 방지).
             # Delegate semi-auto merge to the automatic path for full parity (retry queue, SHA guard,
             # CI re-check, terminal/deferred notifications). _run_auto_merge opens its own session and
             # applies the auto_merge/threshold guard internally. Guards mirror AutoMergeAction:
-            # (1) merge only on approve, (2) auto_merge enabled, (3) skip on incomplete static analysis.
+            # (1) merge only on approve, (2) auto_merge enabled, (3) skip on incomplete static analysis,
+            # (4) skip on genuine AI review failure (#8).
             if (
                 decision == "approve"
                 and config.auto_merge
                 and not result_dict.get("static_analysis_incomplete")
+                and not ai_review_failed(result_dict)
             ):
                 from src.gate import engine  # pylint: disable=import-outside-toplevel
                 await engine._run_auto_merge(  # pylint: disable=protected-access

--- a/tests/unit/gate/test_common.py
+++ b/tests/unit/gate/test_common.py
@@ -1,0 +1,39 @@
+"""src/gate/_common.py 헬퍼 단위 테스트.
+Unit tests for the src/gate/_common.py helpers.
+"""
+import pytest
+
+from src.gate._common import AI_REVIEW_FAILED_STATUSES, ai_review_failed
+
+
+@pytest.mark.parametrize("status", ["api_error", "parse_error"])
+def test_ai_review_failed_true_for_genuine_failures(status):
+    """API 호출/JSON 파싱 오류는 genuine 실패 → True (auto-merge/approve 차단 대상).
+    API/parse errors are genuine failures → True (block auto actions).
+    """
+    assert ai_review_failed({"ai_review_status": status}) is True
+
+
+@pytest.mark.parametrize("status", ["success", "no_api_key", "empty_diff"])
+def test_ai_review_failed_false_for_success_and_intentional_skips(status):
+    """정상·의도적 미수행(no_api_key/empty_diff)은 차단 대상 아님 → False (기존 동작 보존).
+    Success and intentional skips are not failures → False (preserves existing behavior).
+    """
+    assert ai_review_failed({"ai_review_status": status}) is False
+
+
+def test_ai_review_failed_false_when_status_missing():
+    """ai_review_status 키 부재(구 레코드) 시 False — 안전 기본값(차단 안 함).
+    Missing key (legacy records) → False — safe default that does not block.
+    """
+    assert ai_review_failed({"score": 90}) is False
+
+
+def test_ai_failed_statuses_excludes_intentional_skips():
+    """상수 집합은 genuine 실패만 포함 — no_api_key/empty_diff/success 제외 (회귀 가드).
+    The status set contains only genuine failures — excludes intentional skips (regression guard).
+    """
+    assert AI_REVIEW_FAILED_STATUSES == frozenset({"api_error", "parse_error"})
+    assert "no_api_key" not in AI_REVIEW_FAILED_STATUSES
+    assert "empty_diff" not in AI_REVIEW_FAILED_STATUSES
+    assert "success" not in AI_REVIEW_FAILED_STATUSES

--- a/tests/unit/gate/test_gate_actions.py
+++ b/tests/unit/gate/test_gate_actions.py
@@ -192,6 +192,54 @@ async def test_approve_action_auto_skips_when_static_analysis_incomplete():
     mock_review.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_approve_action_auto_skips_when_ai_review_failed():
+    """AI 리뷰 실제 실패(api_error/parse_error) 시 score 충족이어도 auto-approve 보류.
+    Hold auto-approve when the AI review genuinely failed — neutral defaults inflate the score.
+
+    result["ai_review_status"]="api_error" → 미수행 AI 점수의 auto-approve 차단 (#8 fail-closed).
+    """
+    from src.gate.actions.approve import ApproveAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(approve_mode="auto")
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        # 90 >= threshold(70) 이나 AI 리뷰 실패 → 차단
+        result={"score": 90, "ai_review_status": "api_error"},
+        github_token="ghp_test", config=cfg, score=90,
+    )
+    with patch("src.gate.actions.approve.post_github_review", new=AsyncMock()) as mock_review, \
+         patch("src.gate.actions.approve.gate_decision_repo"), \
+         patch("src.gate.actions.approve.SessionLocal") as mock_sess:
+        mock_sess.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+        await ApproveAction().execute(ctx)
+    mock_review.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_approve_action_auto_proceeds_when_ai_no_api_key():
+    """AI 리뷰 의도적 미수행(no_api_key)은 실패가 아니므로 auto-approve 보존 (회귀 가드).
+    Intentional AI skip (no_api_key) is not a failure — auto-approve must still proceed.
+    """
+    from src.gate.actions.approve import ApproveAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(approve_mode="auto")
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        result={"score": 90, "ai_review_status": "no_api_key"},  # 의도적 미수행 — 차단 대상 아님
+        github_token="ghp_test", config=cfg, score=90,
+    )
+    with patch("src.gate.actions.approve.post_github_review", new=AsyncMock()) as mock_review, \
+         patch("src.gate.actions.approve.gate_decision_repo"), \
+         patch("src.gate.actions.approve.resolve_notification_language", return_value="en"), \
+         patch("src.gate.actions.approve.SessionLocal") as mock_sess:
+        mock_sess.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+        await ApproveAction().execute(ctx)
+    mock_review.assert_awaited_once()
+
+
 # ─── AutoMergeAction ─────────────────────────────────────────────────────────
 
 def test_auto_merge_action_is_applicable_when_enabled():
@@ -234,6 +282,41 @@ async def test_auto_merge_action_skips_when_static_analysis_incomplete():
     with patch("src.gate.engine._run_auto_merge", new=AsyncMock()) as mock_impl:
         await AutoMergeAction().execute(ctx)
     mock_impl.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_merge_action_skips_when_ai_review_failed():
+    """AI 리뷰 실제 실패(api_error/parse_error) 시 score 충족이어도 _run_auto_merge 미호출.
+
+    result["ai_review_status"]="parse_error" → 미수행 AI 점수의 자동 머지 차단 (#8 fail-closed).
+    """
+    from src.gate.actions.auto_merge import AutoMergeAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(auto_merge=True)
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        result={"score": 90, "ai_review_status": "parse_error"},  # 90 >= threshold 이나 AI 실패
+        github_token="ghp_test", config=cfg, score=90,
+    )
+    with patch("src.gate.engine._run_auto_merge", new=AsyncMock()) as mock_impl:
+        await AutoMergeAction().execute(ctx)
+    mock_impl.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_merge_action_proceeds_when_ai_no_api_key():
+    """AI 의도적 미수행(no_api_key)은 차단 대상 아님 — 자동 머지 보존 (회귀 가드)."""
+    from src.gate.actions.auto_merge import AutoMergeAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(auto_merge=True)
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        result={"score": 90, "ai_review_status": "no_api_key"},  # 의도적 미수행 — 차단 대상 아님
+        github_token="ghp_test", config=cfg, score=90,
+    )
+    with patch("src.gate.engine._run_auto_merge", new=AsyncMock()) as mock_impl:
+        await AutoMergeAction().execute(ctx)
+    mock_impl.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/webhook/test_telegram_provider.py
+++ b/tests/unit/webhook/test_telegram_provider.py
@@ -187,6 +187,42 @@ async def test_handle_gate_callback_incomplete_static_skips_merge():
                         mock_am.assert_not_called()
 
 
+async def test_handle_gate_callback_ai_review_failed_skips_merge():
+    # approve + auto_merge=True 여도 AI 리뷰 실제 실패(api_error) 시 머지 차단 (자동 AutoMergeAction 대칭, #8)
+    from src.webhook.router import handle_gate_callback
+    mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85,
+                              result={"score": 85, "ai_review_status": "api_error"})
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
+    config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
+    with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
+        with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
+            with patch("src.webhook.providers.telegram.save_gate_decision"):
+                with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
+                    with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
+                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
+                        mock_am.assert_not_called()
+
+
+async def test_handle_gate_callback_ai_no_api_key_still_merges():
+    # AI 의도적 미수행(no_api_key)은 실패가 아니므로 반자동 머지 보존 (회귀 가드, #8)
+    from src.webhook.router import handle_gate_callback
+    mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85,
+                              result={"score": 85, "ai_review_status": "no_api_key"})
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
+    config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
+    with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
+        with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
+            with patch("src.webhook.providers.telegram.save_gate_decision"):
+                with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
+                    with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
+                        await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
+                        mock_am.assert_called_once()
+
+
 async def test_handle_gate_callback_merge_error_does_not_propagate():
     # _run_auto_merge 가 RuntimeError 누출 시에도 콜백이 격리되어 정상 완료 (except RuntimeError 보강)
     from src.webhook.router import handle_gate_callback


### PR DESCRIPTION
## 요약
Task 9 정합성 감사 **P1 #8** 수정 — AI 리뷰가 실제 실패했을 때 인플레이션된 점수로 미검증 코드가 auto-merge/auto-approve 되는 **fail-open** 봉인.

### 문제
`ai_review.status != "success"` 시 calculator 가 중립-고점 기본값(commit 13 + direction 21 + test 10 = **44**)을 적용한다. 정적분석 clean(code_quality 25 + security 20 = 45)이면 총점 **89/B** 로 `approve_threshold`/`merge_threshold` 를 초과할 수 있다. 정적분석 불완전은 `static_analysis_incomplete` 마커로 차단되지만 **AI 리뷰 실패에는 동등한 차단이 없어** 실제 리뷰가 수행되지 않은 PR 이 자동 승인/머지될 수 있었다.

### 수정
- `src/gate/_common.py`: `ai_review_failed(result)` + `AI_REVIEW_FAILED_STATUSES = frozenset({"api_error","parse_error"})` 헬퍼 추가.
- `build_analysis_result_dict` 가 이미 저장하는 `result["ai_review_status"]` 를 게이트가 읽어 **genuine 실패만 차단**.
- 3개 소비처에 `static_analysis_incomplete` 와 **대칭** 적용:
  - `AutoMergeAction.execute` (자동 머지)
  - `ApproveAction._run_auto` (자동 approve)
  - `telegram handle_gate_callback` 반자동 머지 위임 가드 (#796 완전 대칭 보존)

### 🔍 설계 결정 (자율 판단 보고 — 정책 3)
가능한 AI status 5종 중 `no_api_key`/`empty_diff`(**의도적 미수행**)·`success` 는 **차단 제외**. 의도적으로 AI 리뷰를 쓰지 않는 리포가 영구히 자동 머지 불가가 되는 회귀를 막기 위함. 회귀 가드 테스트 동반 (`no_api_key` → 정상 머지 유지 검증).

### 테스트
- 11건 추가: gate 액션 4 (auto_merge/approve × 차단·회귀가드) + telegram 반자동 2 + 헬퍼 5.
- TDD Red→Green. 전체 **4675 단위 통과**, 1 skip(PG 전용). pylint 10.00/10, flake8 clean.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** — push 전 mutual 검증 완료.
- 판정 1 (genuine 실패만 차단·의도적 skip 보존 정확성): **OK** — `no_api_key`/`empty_diff`/`success` 제외 확인
- 판정 2 (3 소비처 대칭 적용 완전성): **OK** — auto_merge/approve/telegram 동일 헬퍼 적용
- 판정 3 (fail-open 봉인 충분성): **OK** — `build_analysis_result_dict`→`ctx.result` 데이터 흐름상 우회 경로 없음, frozenset in-check false-safe

## 🔍 사용자 검증 필요
1. **동작 결정 확인**: AI 리뷰 실패(api_error/parse_error) 시 auto-merge/auto-approve 보류가 의도와 맞는지 — 특히 반자동(Telegram)에서 human이 approve해도 auto-merge만 차단되는 동작.
2. **의도적 skip 보존**: `ANTHROPIC_API_KEY` 미설정 리포(no_api_key)·비-코드 변경(empty_diff)은 기존대로 자동 머지 유지 — 회귀 없음 확인.

## 후속
잔여 Task 9 감사 P1 pipeline fail-open: #6 (content-fetch 실패) / #7 (per-tool 타임아웃) 별도 PR 예정. DB 스키마 항목(#2/#14~18)은 사용자 확인 후 진행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
