### PR TITLE
fix(pipeline): transient content-fetch 실패 시 정적분석 incomplete 처리 — fail-open 봉인 (Task9 P1 #6)

### DIFF
--- a/src/github_client/diff.py
+++ b/src/github_client/diff.py
@@ -31,17 +31,34 @@ def get_push_files(github_token: str, repo_name: str, commit_sha: str) -> list[C
 
 
 def _collect_changed_files(repo, files, ref: str) -> list[ChangedFile]:
-    """Collect file content and patch for each changed file in the given ref."""
+    """Collect file content and patch for each changed file in the given ref.
+
+    transient fetch 실패(403 rate-limit/5xx)는 fetch_failed=True 로 표시해 호출 파이프라인이
+    미분석 코드를 incomplete 로 fail-closed 처리하게 한다. 404(삭제 파일)·UnicodeDecodeError
+    (바이너리/비-UTF8)는 정상 케이스이므로 content='' + fetch_failed=False.
+    Transient fetch failures (403 rate-limit/5xx) set fetch_failed=True so the pipeline can
+    fail-closed; 404 (deleted) and decode errors are legitimate (fetch_failed=False).
+    """
     result = []
     for f in files:
+        fetch_failed = False
         try:
             content = repo.get_contents(f.filename, ref=ref).decoded_content.decode("utf-8")
-        except (GithubException, UnicodeDecodeError) as exc:
-            logger.debug("파일 내용 로드 실패 %s@%s: %s", sanitize_for_log(f.filename), sanitize_for_log(ref), exc)
+        except GithubException as exc:
+            # 404 = 삭제된 파일(정상). 그 외(403 secondary rate-limit·5xx)는 transient → fail-closed.
+            # 404 = deleted file (legitimate); others (403 rate-limit, 5xx) are transient.
             content = ""
+            fetch_failed = getattr(exc, "status", None) != 404
+            logger.debug("파일 내용 로드 실패 %s@%s: %s", sanitize_for_log(f.filename), sanitize_for_log(ref), exc)
+        except UnicodeDecodeError as exc:
+            # 바이너리/비-UTF8 파일 — 분석 불가하나 fetch 자체는 성공 (정상)
+            # Binary/non-UTF8 file — not analyzable but the fetch itself succeeded (legitimate)
+            content = ""
+            logger.debug("파일 디코드 실패 %s@%s: %s", sanitize_for_log(f.filename), sanitize_for_log(ref), exc)
         result.append(ChangedFile(
             filename=f.filename,
             content=content,
             patch=f.patch or "",
+            fetch_failed=fetch_failed,
         ))
     return result

--- a/src/github_client/models.py
+++ b/src/github_client/models.py
@@ -9,3 +9,10 @@ class ChangedFile:
     filename: str
     content: str
     patch: str
+    # 콘텐츠 fetch 가 transient 오류(403 rate-limit/5xx)로 실패했는지 여부.
+    # True 면 content='' 가 '미분석'을 의미하므로 파이프라인이 incomplete 로 fail-closed 처리한다
+    # (404 삭제 파일·바이너리 decode 실패는 정상 — False).
+    # Whether content fetch failed transiently (403 rate-limit/5xx). When True, empty content
+    # means 'unanalyzed' so the pipeline marks the analysis incomplete (fail-closed). 404 deletes
+    # and binary decode failures are legitimate — False.
+    fetch_failed: bool = False

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -241,6 +241,18 @@ async def _run_static_with_timeout(
             "all %d files failed static analysis — marking incomplete (auto-merge blocked)",
             len(files),
         )
+    # 콘텐츠 fetch 가 transient(403 rate-limit/5xx)로 실패한 파일이 있으면 미분석 코드다 —
+    # 빈 content 는 이슈0=만점 인플레로 이어지므로 incomplete 로 fail-closed 처리(#6).
+    # AutoMergeAction/ApproveAction(#779/#783)이 이 마커로 자동 머지/승인을 차단한다.
+    # Files whose content fetch failed transiently are unanalyzed — empty content inflates the
+    # score, so mark incomplete (fail-closed, #6) to block auto-merge/approve.
+    fetch_failed_count = sum(1 for f in files if getattr(f, "fetch_failed", False))
+    if fetch_failed_count:
+        incomplete = True
+        logger.warning(
+            "%d/%d files had transient content-fetch failures — marking incomplete (auto-merge blocked)",
+            fetch_failed_count, len(files),
+        )
     return results, incomplete
 
 

--- a/tests/unit/github_client/test_diff.py
+++ b/tests/unit/github_client/test_diff.py
@@ -66,6 +66,67 @@ def test_get_pr_files_handles_content_error():
     assert result[0].content == ""
 
 
+def test_collect_changed_files_marks_fetch_failed_on_transient_403():
+    """transient 403(rate-limit) fetch 실패 시 fetch_failed=True (content='' 인플레 방어, #6).
+    Transient 403 (rate limit) marks fetch_failed=True so the pipeline can fail-closed (#6)."""
+    from github import GithubException
+    from src.github_client.diff import _collect_changed_files
+    mock_repo = MagicMock()
+    mock_repo.get_contents.side_effect = GithubException(403, "rate limit")
+    f = MagicMock(); f.filename = "src/app.py"; f.patch = "@@"
+    result = _collect_changed_files(mock_repo, [f], "abc123")
+    assert result[0].content == ""
+    assert result[0].fetch_failed is True
+
+
+def test_collect_changed_files_marks_fetch_failed_on_5xx():
+    """transient 5xx fetch 실패 시 fetch_failed=True (#6)."""
+    from github import GithubException
+    from src.github_client.diff import _collect_changed_files
+    mock_repo = MagicMock()
+    mock_repo.get_contents.side_effect = GithubException(502, "bad gateway")
+    f = MagicMock(); f.filename = "src/app.py"; f.patch = "@@"
+    result = _collect_changed_files(mock_repo, [f], "abc123")
+    assert result[0].fetch_failed is True
+
+
+def test_collect_changed_files_404_not_fetch_failed():
+    """404(삭제 파일)는 정상 — fetch_failed=False (content='' 적절, 인플레 아님, #6).
+    404 (deleted file) is legitimate — fetch_failed=False (empty content is correct, #6)."""
+    from github import GithubException
+    from src.github_client.diff import _collect_changed_files
+    mock_repo = MagicMock()
+    mock_repo.get_contents.side_effect = GithubException(404, "Not found")
+    f = MagicMock(); f.filename = "deleted.py"; f.patch = "@@"
+    result = _collect_changed_files(mock_repo, [f], "abc123")
+    assert result[0].content == ""
+    assert result[0].fetch_failed is False
+
+
+def test_collect_changed_files_unicode_decode_not_fetch_failed():
+    """바이너리/비-UTF8 파일 decode 실패는 정상(분석 불가) — fetch_failed=False (#6)."""
+    from src.github_client.diff import _collect_changed_files
+    mock_repo = MagicMock()
+    contents = MagicMock(); contents.decoded_content = b"\xff\xff"  # UTF-8 decode 실패
+    mock_repo.get_contents.return_value = contents
+    f = MagicMock(); f.filename = "bin.dat"; f.patch = "@@"
+    result = _collect_changed_files(mock_repo, [f], "abc123")
+    assert result[0].content == ""
+    assert result[0].fetch_failed is False
+
+
+def test_collect_changed_files_success_not_fetch_failed():
+    """정상 fetch 시 fetch_failed=False (#6)."""
+    from src.github_client.diff import _collect_changed_files
+    mock_repo = MagicMock()
+    contents = MagicMock(); contents.decoded_content = b"import os\n"
+    mock_repo.get_contents.return_value = contents
+    f = MagicMock(); f.filename = "src/app.py"; f.patch = "@@"
+    result = _collect_changed_files(mock_repo, [f], "abc123")
+    assert result[0].content == "import os\n"
+    assert result[0].fetch_failed is False
+
+
 def test_collect_changed_files_log_sanitizes_filename_and_ref(caplog):
     """파일 로드 실패 debug 로그가 filename·ref 를 sanitize 해 CR/LF 로그 인젝션을 차단한다.
     The file-load-failure log sanitizes filename/ref so CR/LF cannot inject fake log lines."""

--- a/tests/unit/worker/test_pipeline.py
+++ b/tests/unit/worker/test_pipeline.py
@@ -643,6 +643,28 @@ async def test_pipeline_no_incomplete_marker_when_static_ok(mock_deps):
         "정상 완료인데 static_analysis_incomplete 마커가 잘못 설정됨"
 
 
+async def test_run_static_with_timeout_incomplete_when_content_fetch_failed():
+    """content fetch 실패(transient 403/5xx) 파일이 있으면 incomplete=True 여야 한다 (#6 fail-closed).
+
+    빈 content 는 이슈0 → 만점 인플레로 이어지므로, fetch 실패를 incomplete 로 전파해
+    AutoMergeAction/ApproveAction(#779/#783)이 미분석 코드 자동 머지를 차단하게 한다.
+    """
+    from src.worker.pipeline import _run_static_with_timeout
+    from src.github_client.diff import ChangedFile
+    f = ChangedFile(filename="src/app.py", content="", patch="@@", fetch_failed=True)
+    _results, incomplete = await _run_static_with_timeout([f])
+    assert incomplete is True
+
+
+async def test_run_static_with_timeout_complete_when_fetch_ok():
+    """정상 fetch 파일만 있으면 incomplete=False 여야 한다 (회귀 가드, #6)."""
+    from src.worker.pipeline import _run_static_with_timeout
+    from src.github_client.diff import ChangedFile
+    f = ChangedFile(filename="README.md", content="# hi\n", patch="@@", fetch_failed=False)
+    _results, incomplete = await _run_static_with_timeout([f])
+    assert incomplete is False
+
+
 # ---------------------------------------------------------------------------
 # Task 1 — SHA 중복 체크 이동 및 result dict ai_review_status 필드 테스트
 # (Red 단계: SHA 중복 체크가 아직 review_code 이전으로 이동하지 않음)


### PR DESCRIPTION
## 요약
Task 9 정합성 감사 **P1 #6** 수정 — GitHub 파일 콘텐츠 fetch 가 transient 오류(403 rate-limit/5xx)로 실패했을 때 미분석 코드가 인플레 만점으로 auto-merge 되는 **fail-open** 봉인.

### 문제
`_collect_changed_files` 가 **모든** `GithubException`(404 삭제뿐 아니라 403 secondary rate-limit·5xx 등 transient 포함)을 `content=""` 로 폴백한다. 빈 content 는 `analyze_file` 이 빈 결과를 반환 → `code_quality 25 + security 20` 만점으로 환산되나 **예외를 raise 하지 않아** `_run_static_with_timeout` 의 incomplete 판정(deadline / 전량 실패)에 걸리지 않는다 → `static_analysis_incomplete` 마커 미설정 → #779/#783 auto-merge 가드 우회. 즉 transient GitHub 오류 시 미분석(추가/수정) 코드가 **인플레 만점으로 auto-merge** 될 수 있었다.

### 수정
- `ChangedFile` 에 `fetch_failed: bool = False` 필드 추가 (dataclass 마지막 — 기존 생성부 무영향).
- `_collect_changed_files`: `GithubException.status != 404`(403/5xx transient) → `fetch_failed=True`. **404(삭제 파일)·`UnicodeDecodeError`(바이너리/비-UTF8)는 정상** → `fetch_failed=False` (회귀 없음). status 불명확 시 보수적 차단(`True`).
- `_run_static_with_timeout`: `any(f.fetch_failed)` 시 `incomplete=True` 전파 → `static_analysis_incomplete` 마커 → AutoMergeAction/ApproveAction 이 미분석 코드 자동 머지/승인 차단 (fail-closed).

**데이터 흐름**: `ChangedFile.fetch_failed` → `_run_static_with_timeout incomplete` → `static_timed_out` → `static_analysis_incomplete` 마커 → 게이트 차단.

### #795 와의 관계
#795 "일부 파일 도구 실패는 incomplete 아님"(만점 인플레 미세 위험 수용)과 **카테고리가 다름** — 이 케이스는 도구 실패가 아니라 **원본 content 확보 실패로 파일이 실제 미분석**된 상태라 인플레 가능성이 직접 존재. 따라서 한 파일이라도 fetch 실패 시 fail-closed 가 맞다.

### 테스트
- 7건 추가: diff fetch_failed 분류 5 (403/5xx→True, 404·UnicodeDecodeError·success→False) + `_run_static_with_timeout` 전파 2.
- TDD Red→Green. 전체 **4682 단위 통과**, 1 skip(PG 전용). pylint 10.00/10, flake8 clean.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** — push 전 mutual 검증 완료.
- 판정 1 (transient vs 정상 분류 정확성): **OK** — 403/5xx→True, 404·decode→False, PyGithub status 기반 확인
- 판정 2 (회귀 없음): **OK** — fetch_failed 마지막 필드·기존 폴백/sanitize 보존
- 판정 3 (fail-closed 충분성): **OK** — status 불명확 시 보수적 차단 안전
- 판정 4 (과도성 없음): **OK** — content-fetch 실패는 #795 도구 실패와 다른 카테고리, fail-closed 타당

## 🔍 사용자 검증 필요
1. **운영 동작**: GitHub rate-limit(403)/5xx 일시 발생 시 해당 분석이 auto-merge/auto-approve 보류되는 동작 확인 — PR 코멘트의 incomplete 경고 배너(#798)로 사용자에게 노출됨.
2. **회귀 없음**: 정상 PR·삭제 파일(404)·바이너리 파일 변경은 기존대로 처리 — 과차단 없음 확인.

## 후속
잔여 Task 9 P1 pipeline fail-open: #7 (per-tool subprocess 타임아웃) 별도 PR 예정. #8(AI 실패)은 PR #804. DB 스키마(#2/#14~18)는 사용자 확인 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
