### PR TITLE
fix(api): CLI hook 결과 저장 동시 SHA insert race 안전화 — IntegrityError 500 차단 (Task9 P1 #5)

### DIFF
--- a/src/api/hook.py
+++ b/src/api/hook.py
@@ -17,7 +17,7 @@ from src.shared.log_safety import sanitize_for_log
 from src.models.analysis import Analysis
 from src.models.repository import Repository
 from src.models.user import User
-from src.repositories import repo_config_repo
+from src.repositories import repo_config_repo, analysis_repo
 from src.analyzer.io.ai_review import AiReviewResult
 from src.scorer.calculator import calculate_score
 from src.worker.pipeline import build_analysis_result_dict
@@ -166,7 +166,14 @@ class HookResultRequest(BaseModel):
 
 @router.post("/result")
 @limiter.limit(RATE_LIMIT_API)
-def save_hook_result(request: Request, body: HookResultRequest):  # pylint: disable=unused-argument
+def save_hook_result(  # pylint: disable=unused-argument,too-many-locals
+    request: Request, body: HookResultRequest,
+):
+    # too-many-locals: race-safe save_new 도입(#5)으로 created 지역변수 1개 추가(16/15).
+    # 함수 응집 단위(토큰검증→파싱→점수→저장)를 깨지 않기 위해 헬퍼 추출 대신 inline disable
+    # (testing.md R0914 결정 트리 — 기존 함수 시그니처 확장 경로).
+    # too-many-locals: +1 local (created) from the race-safe save_new (#5); inline-disabled per the
+    # testing.md R0914 tree (existing-function expansion) to keep the function cohesive.
     """pre-push 훅이 코드리뷰 결과를 전송하는 엔드포인트.
 
     토큰 검증 후 Analysis 레코드를 저장하고 점수를 반환한다.
@@ -240,9 +247,23 @@ def save_hook_result(request: Request, body: HookResultRequest):  # pylint: disa
             result=build_analysis_result_dict(ai_review, score_result, [], "cli"),
         )
 
-        db.add(analysis)
-        db.commit()
-        db.refresh(analysis)
+        # 동시 동일 SHA insert race 안전 저장 — 두 hook 이 위 existing 체크(멱등성)를 동시에
+        # 통과한 뒤 DB unique 제약(uq_analyses_repo_sha)에 막히는 TOCTOU 를 흡수한다(#5).
+        # save_new 가 IntegrityError 를 rollback+재조회로 처리해 500 대신 기존 레코드를 반환.
+        # Race-safe save — absorbs the TOCTOU where two hooks pass the idempotency check and then
+        # collide on the unique constraint; save_new returns the existing row instead of a 500 (#5).
+        analysis, created = analysis_repo.save_new(db, analysis)
+        if not created:
+            logger.info(
+                "CLI hook concurrent insert blocked — returning existing (repo=%s sha=%s)",
+                sanitize_for_log(body.repo), sanitize_for_log(body.commit_sha),
+            )
+            return {
+                "status": "duplicate",
+                "score": analysis.score,
+                "grade": analysis.grade,
+                "analysis_id": analysis.id,
+            }
 
         # 로그 인젝션 방지: sanitize_for_log() 로 사용자 입력 정제
         # NOSONAR 이유: SonarCloud taint analysis 가 str.replace 기반 커스텀

--- a/tests/unit/api/test_hook.py
+++ b/tests/unit/api/test_hook.py
@@ -198,6 +198,50 @@ def test_hook_result_calculates_score():
     assert analysis_obj.grade == "A"
 
 
+def test_hook_result_concurrent_insert_race_returns_duplicate_not_500():
+    """동시 동일 SHA hook 이 existing 체크(L197)를 통과한 뒤 DB unique 제약(uq_analyses_repo_sha)에
+    막히면, 500 대신 duplicate 응답을 반환해야 한다 (#5 멱등성 — analysis_repo.save_new race-safe).
+
+    수정 전: db.add+db.commit() 가 IntegrityError 를 미처리로 전파 → 500.
+    수정 후: save_new 가 rollback+재조회로 흡수 → (existing, created=False) → duplicate 응답.
+    """
+    from sqlalchemy.exc import IntegrityError
+    mock_db = MagicMock()
+    mock_config = MagicMock(); mock_config.hook_token = "race-token"
+    mock_repo = MagicMock(); mock_repo.id = 9
+
+    call_count = {"n": 0}
+
+    def _first_side_effect():
+        idx = call_count["n"]; call_count["n"] += 1
+        return {0: mock_config, 1: mock_repo}.get(idx)
+
+    mock_db.query.return_value.filter.return_value.first.side_effect = _first_side_effect
+    # filter_by().first(): (1) L197 existing 체크 → None, (2) save_new find_by_sha(race 후) → existing
+    existing = MagicMock(id=555, score=88, grade="B")
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [None, existing]
+    mock_db.add = MagicMock()
+    mock_db.commit = MagicMock(side_effect=IntegrityError("INSERT", {}, Exception("duplicate key")))
+    mock_db.rollback = MagicMock()
+    mock_db.refresh = MagicMock()
+
+    with patch("src.api.hook.SessionLocal", return_value=_make_session_mock(mock_db)):
+        r = client.post("/api/hook/result", json={
+            "repo": "owner/repo",
+            "token": "race-token",
+            "commit_sha": "raceSHA123",
+            "commit_message": "feat: race",
+            "ai_result": _AI_RESULT,
+        })
+
+    assert r.status_code == 200, f"동시 insert race 가 500 을 유발하면 안 됨: {r.status_code}"
+    body = r.json()
+    assert body["status"] == "duplicate"
+    assert body["analysis_id"] == 555
+    assert body["score"] == 88
+    mock_db.rollback.assert_called_once()
+
+
 # ------------------------------------------------------------------
 # AI 점수 클램핑 회귀 가드 — CLI hook 의 raw 점수가 범위(0~MAX)를 벗어나면
 # breakdown 카테고리 점수가 cap 을 초과/미만해 정합성이 깨지는 결함 방지.


### PR DESCRIPTION
## 요약
Task 9 정합성 감사 **P1 #5** 수정 — CLI hook 결과 저장(`POST /api/hook/result`)이 동시 동일 SHA insert race 시 `IntegrityError` 500 을 유발하는 멱등성 결함 봉인.

### 문제
`save_hook_result` 가 existing 체크(`hook.py:197`) 후 raw `db.add(analysis); db.commit()` 를 **IntegrityError 처리 없이** 수행한다. `analyses` 에 `UniqueConstraint('repo_id','commit_sha', uq_analyses_repo_sha)` 가 있어, 동시 pre-push hook 2개가 동일 `commit_sha` 로 POST 하면 둘 다 existing 체크(L197)를 통과한 뒤 둘 다 insert → 한쪽이 `IntegrityError` 를 던지고 **uncaught 로 전파 → 500**. pipeline 경로(`_save_and_gate`)는 `analysis_repo.save_new` 로 이미 방어하던 비대칭 결함.

### 수정
raw `db.add+commit` 을 pipeline 과 **동일한 race-safe `analysis_repo.save_new(db, analysis)`** 로 교체:
- `save_new` 가 `IntegrityError` 를 `rollback`+재조회(`find_by_sha`)로 흡수 → `(existing, created=False)` 반환.
- `created=False` 시 **500 대신 `duplicate` 응답**(L200 기존 existing-체크 경로와 동일 형식).
- `created=True` 정상 경로는 기존 `saved` 응답 유지.

기존 hook 테스트는 `save_new` 가 동일 `db.add/commit` 을 호출하므로 **회귀 0**.

### 테스트
- 1건 추가: 동시 insert race(`IntegrityError` side_effect) → **200 `duplicate`** + `rollback` 호출 검증.
- TDD Red(500)→Green. 전체 **4663 단위 통과**, pylint 10.00/10 (R0914 +1 local = inline disable, `testing.md` 결정 트리), flake8 clean.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** — push 전 mutual 검증 완료.
- 판정 1 (race-safe TOCTOU 봉인): **PASS** — UniqueConstraint 를 DB 레이어에서 포착, check-then-insert 창 완전 봉인
- 판정 2 (회귀 0): **PASS** — `save_new` 내부 `db.add/commit` 으로 기존 mock chain 호환, 23 통과
- 판정 3 (duplicate 응답 일관성): **PASS** — 기존 idempotency 경로와 동일 형식, 호출자 contract 불변
- 판정 4 (rollback 후 재조회 안전성): **PASS** — 정상 SQLAlchemy 복구 패턴, 세션 오염 없음

## 🔍 사용자 검증 필요
1. **운영 동작**: 동일 SHA 로 pre-push hook 이 동시 실행될 때(드물지만 가능) 500 대신 `duplicate` 응답 정상 수신 확인.
2. **회귀 없음**: 단일 hook 정상 저장(`saved`)·기존 중복(`duplicate`) 동작 보존.

## 후속
잔여 P1: #4(gate check_suite 재시도 백오프), #3(docs architecture). DB 스키마(#2/#14~18)는 사용자 확인 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
