### PR TITLE
fix(gate): check_suite.completed 즉시 재시도가 백오프 우회하도록 — only_ids force-due (Task9 P1 #4)

### DIFF
--- a/src/repositories/merge_retry_repo.py
+++ b/src/repositories/merge_retry_repo.py
@@ -236,10 +236,15 @@ def claim_batch(
     클레임 대상 조건:
     Claimable condition:
       - status = 'pending'
-      - next_retry_at <= now (재시도 예정 시각 도달)
-      - next_retry_at <= now (retry due time reached)
+      - next_retry_at <= now (재시도 예정 시각 도달) — 단, only_ids 지정 시 우회(force-due, #4)
+      - next_retry_at <= now (retry due) — bypassed when only_ids is given (force-due, #4)
       - claimed_at IS NULL  OR  claimed_at < now - stale_after_seconds (stale 클레임 재획득)
       - claimed_at IS NULL  OR  claimed_at < now - stale_after_seconds (reclaim stale)
+
+    only_ids: check_suite.completed 이벤트 트리거가 CI 완료 직후 특정 행을 즉시 재시도할 때 전달.
+    next_retry_at 백오프를 우회하되 claimed_at(in-flight) 가드는 유지한다. cron sweep 은 미지정.
+    only_ids: passed by the check_suite.completed trigger to retry named rows immediately once CI
+    finished — bypasses the next_retry_at backoff but keeps the claimed_at guard. Cron sweep omits it.
 
     클레임 처리: claimed_at=now, claim_token=uuid, attempts_count+=1, last_attempt_at=now
     Claim action: claimed_at=now, claim_token=uuid, attempts_count+=1, last_attempt_at=now
@@ -254,7 +259,6 @@ def claim_batch(
     # Query claimable rows.
     query = db.query(MergeRetryQueue).filter(
         MergeRetryQueue.status == "pending",
-        MergeRetryQueue.next_retry_at <= _now,
         # claimed_at IS NULL 또는 stale 기준 초과
         # claimed_at IS NULL or exceeds stale threshold.
         (
@@ -263,7 +267,18 @@ def claim_batch(
         ),
     )
     if only_ids:
+        # check_suite.completed 이벤트 트리거 — CI 완료 직후 명시 행을 즉시 재시도(force-due).
+        # 백오프(next_retry_at) 게이트를 우회한다(#4). 백오프는 CI 진행 중 과도한 폴링을 막기
+        # 위함이고, CI 완료 시점엔 불필요하므로 즉시 클레임이 맞다. claimed_at(in-flight) 가드는
+        # 유지돼 중복 재시도/타이트 루프를 방지한다. cron sweep(only_ids 없음)은 게이트 적용.
+        # check_suite.completed trigger — retry the named rows immediately once CI finished
+        # (force-due, #4). The backoff guards against polling while CI runs and is unneeded once
+        # CI completes; the claimed_at (in-flight) guard still prevents duplicate/tight-loop retries.
         query = query.filter(MergeRetryQueue.id.in_(only_ids))
+    else:
+        # cron sweep / overdue fallback — next_retry_at 백오프 게이트 적용.
+        # cron sweep / overdue fallback — apply the next_retry_at backoff gate.
+        query = query.filter(MergeRetryQueue.next_retry_at <= _now)
 
     # PostgreSQL: FOR UPDATE SKIP LOCKED로 동시 실행 클레임 방지 (SQLite: 단일 연결로 자동 원자적)
     # PostgreSQL: FOR UPDATE SKIP LOCKED prevents concurrent duplicate claims (SQLite: atomic under single conn)

--- a/tests/unit/repositories/test_merge_retry_repo.py
+++ b/tests/unit/repositories/test_merge_retry_repo.py
@@ -332,6 +332,59 @@ def test_claim_batch_skips_recently_claimed_rows(db_session):
     assert claimed == []
 
 
+def test_claim_batch_only_ids_bypasses_backoff(db_session):
+    """only_ids(check_suite.completed 이벤트 트리거)는 next_retry_at 백오프를 우회해
+    미래 예정(백오프 윈도우 내) 행도 즉시 클레임한다 (#4 force-due — CI 완료 직후 즉시 머지).
+
+    수정 전: only_ids 가 next_retry_at<=now AND 조건에 추가될 뿐 게이트를 우회 못 해 미클레임.
+    """
+    analysis = _seed_analysis(db_session, commit_sha="sha_force")
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    future = now + timedelta(seconds=55)  # 백오프 윈도우 내 (next_retry_at 미도달)
+    row = _make_queue_row(
+        db_session, analysis_id=analysis.id, commit_sha="sha_force", next_retry_at=future,
+    )
+
+    claimed = merge_retry_repo.claim_batch(db_session, now=now, only_ids=[row.id])
+
+    assert len(claimed) == 1
+    assert claimed[0].id == row.id
+
+
+def test_claim_batch_cron_sweep_still_respects_backoff(db_session):
+    """only_ids 없는 cron sweep 은 next_retry_at 백오프 게이트를 유지한다 (회귀 가드, #4)."""
+    analysis = _seed_analysis(db_session, commit_sha="sha_sweep")
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    future = now + timedelta(seconds=55)
+    _make_queue_row(
+        db_session, analysis_id=analysis.id, commit_sha="sha_sweep", next_retry_at=future,
+    )
+
+    claimed = merge_retry_repo.claim_batch(db_session, now=now)  # only_ids 없음
+
+    assert claimed == []
+
+
+def test_claim_batch_only_ids_still_skips_recently_claimed(db_session):
+    """only_ids force-due 여도 최근 claimed_at(stale 미달) 행은 재클레임하지 않는다 —
+    in-flight 재시도 중복/타이트 루프 방지 (claimed_at 가드 보존, #4)."""
+    analysis = _seed_analysis(db_session, commit_sha="sha_inprog")
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    future = now + timedelta(seconds=55)
+    row = _make_queue_row(
+        db_session, analysis_id=analysis.id, commit_sha="sha_inprog",
+        next_retry_at=future,
+        claimed_at=now - timedelta(seconds=30),  # 30초 전 — stale(300s) 미만
+        claim_token="inflight",
+    )
+
+    claimed = merge_retry_repo.claim_batch(
+        db_session, now=now, only_ids=[row.id], stale_after_seconds=300,
+    )
+
+    assert claimed == []
+
+
 def test_claim_batch_reclaims_stale_claims(db_session):
     """stale 기준 초과한 오래된 클레임은 재클레임한다.
     claim_batch() reclaims rows whose claimed_at is older than stale threshold.


### PR DESCRIPTION
## 요약
Task 9 정합성 감사 **P1 #4** 수정 — `check_suite.completed` 웹훅의 "CI 완료 즉시 머지" 목적이 백오프 윈도우 동안 무력화되는 결함 봉인.

### 문제
`_trigger_retry_for_sha`(`check_suite.completed` 핸들러)가 `find_pending_by_sha` 로 찾은 행 id 를 `only_ids` 로 `claim_batch` 에 넘겨 **즉시 재시도**를 의도하지만, `claim_batch` 는 `only_ids` 분기와 무관하게 `status=='pending' AND next_retry_at <= now` 를 **항상 강제**했다. `enqueue_or_bump` 는 신규 행 `next_retry_at = now + 60s`(`initial_next_retry_seconds` 기본)로 설정하므로, **CI 가 60초 미만에 완료**되어 `check_suite.completed` 가 도착해도 해당 SHA 행은 `next_retry_at` 가 미래라 claim 되지 않았다. 즉 check_suite 웹훅의 핵심 목적(CI 완료 즉시 머지)이 백오프 동안 동작하지 않고 **1분 cron sweep 을 기다려야** 했다.

### 수정
`claim_batch` 에서 `next_retry_at <= now` 백오프 게이트를 **`only_ids` 부재(cron sweep)일 때만** 적용:
- `only_ids` 지정(`check_suite.completed` 이벤트 트리거) → 백오프 **우회(force-due)** → 즉시 claim. 백오프는 CI 진행 중 과도 폴링 방지용이고 CI 완료 시점엔 불필요하므로 즉시 재시도가 맞다.
- `claimed_at`(in-flight) 가드는 **유지** → 중복 재시도/타이트 루프 방지. `attempts_count` 선증가 + `max_attempts` abandon 으로 무한 재시도 차단.
- `cron sweep`(`only_ids=None`)은 게이트 유지 (회귀 0). `FOR UPDATE SKIP LOCKED`·order·limit 보존.

### 테스트
- 3건 추가: `only_ids` force-due(미래 next_retry 행 즉시 claim) / cron sweep 백오프 유지(회귀 가드) / `only_ids` 여도 in-flight `claimed_at` 가드 보존.
- TDD Red→Green. 전체 **4666 단위 통과**, pylint 10.00/10, flake8 clean.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** — push 전 mutual 검증 완료 (Codex 파일 직접 확인, line 인용).
- 판정 1 (정확성): **OK** — only_ids 시 게이트 생략, cron(None)은 유지
- 판정 2 (타이트 루프 방지): **OK** — claimed_at 가드 + attempts_count/max_attempts abandon 유지
- 판정 3 (회귀 0): **OK** — cron 경로·SKIP LOCKED·order·limit 보존
- 판정 4 (only_ids 출처): **OK** — `_trigger_retry_for_sha` 만 전달, cron/sweep 은 인자 없음

## 🔍 사용자 검증 필요
1. **운영 동작**: CI 가 60초 미만에 완료되는 PR 에서 `check_suite.completed` 수신 즉시 머지가 트리거되는지(이전: 최대 1분 cron 지연) 확인.
2. **회귀 없음**: cron sweep 의 백오프(점진 재시도) 동작은 그대로 — 과도 폴링 없음 확인.

## 후속
잔여 P1: #3(docs architecture gate/actions 누락 — 다음). DB 스키마(#2/#14~18 High-tier)는 사용자 확인 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
