### PR TITLE
fix(admin): rls-audit 에 FORCE RLS 미설정 owner-bypass 경고 가시화 (Task9 P1 #2-D 갭 가시화)

### DIFF
--- a/alembic/versions/0026_supabase_rls_policies.py
+++ b/alembic/versions/0026_supabase_rls_policies.py
@@ -15,13 +15,23 @@ SCAManager 는 Supabase Auth 미사용 (GitHub OAuth) — auth.uid() 미적용.
 
 SQLite (단위 테스트) 분기: op.execute 모두 skip — RLS 미지원 환경 호환.
 앱 레벨 filter (`src/services/dashboard_service.py::_apply_*_user_filter`) 가 1차 안전망.
-본 RLS policy 는 운영 환경 (Supabase) 의 2차 안전망 (DB 레벨 격리 — 앱 버그 시에도 데이터 누출 차단).
+본 RLS policy 는 운영 환경 (Supabase) 의 2차 안전망 (DB 레벨 격리).
+
+⚠️ owner-bypass 주의 (Task9 P1 #2): 본 마이그레이션은 RLS 를 ENABLE 만 하고 FORCE ROW LEVEL
+SECURITY 를 적용하지 않는다. 앱 연결 role 이 테이블 owner 면 PostgreSQL 이 owner 에 대해 RLS 를
+기본 우회하므로, '앱 버그 시에도 데이터 누출 차단' 은 owner 연결에서 실제로 보장되지 않을 수 있다.
+2차 안전망을 실효화하려면 FORCE 도입 + background 경로(app.user_id 미설정) 차단 회피 설계가 선행돼야
+한다(High-tier — 설계 검토: docs/reports/2026-06-08-integrity-audit-full.md #2). admin /admin/rls-audit
+페이지가 FORCE 미설정을 경고 표기한다.
+⚠️ owner-bypass caveat (#2): this migration only ENABLEs RLS (no FORCE), so an owner connection may
+bypass it — the 2nd safety layer is not guaranteed for the owner role until FORCE is introduced.
 
 회귀 가드: tests/unit/migrations/test_0026_rls_policies.py (3 테스트).
 """
 # Phase 3 PR 5 — Supabase RLS permission model (PostgreSQL only)
 # Provides DB-level isolation as a 2nd safety layer; app-level filter
 # (src/services/dashboard_service.py::_apply_*_user_filter) is the 1st layer.
+# NOTE (#2): ENABLE-only without FORCE — owner connections may bypass RLS.
 from alembic import op
 
 from src.shared.alembic_dialect import is_postgresql

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -622,8 +622,10 @@
       "info_li1": "<strong>RLS applied</strong> = PostgreSQL only (SQLite unit tests auto-skip)",
       "info_li2": "Runtime activation middleware = `src/middleware/rls_session.py` (Cycle 66 #228)",
       "info_li3": "contextvars bridge = `src/shared/rls_context.py` + DB event listener (`SET LOCAL app.user_id`)",
-      "info_li4": "2-layer safety = (1) app-level filter (`_apply_*_user_filter`) + (2) DB RLS policy (PG/Supabase)",
-      "info_li5": "Backfill diagnostic = `docs/runbooks/saas-phase0-backfill-readiness.md` (Cycle 78 PR 3 — null=0 confirmed)"
+      "info_li4": "2-layer safety = (1) app-level filter (`_apply_*_user_filter`) + (2) DB RLS policy (PG/Supabase) — ⚠️ without FORCE, an owner connection can bypass (2)",
+      "info_li5": "Backfill diagnostic = `docs/runbooks/saas-phase0-backfill-readiness.md` (Cycle 78 PR 3 — null=0 confirmed)",
+      "force_warning_title": "⚠️ FORCE ROW LEVEL SECURITY not set — 2nd safety layer may be bypassed",
+      "force_warning_body": "No alembic migration applies FORCE ROW LEVEL SECURITY. If the app connection role owns the tables, PostgreSQL bypasses RLS for the owner, so despite the 'applied' matrix above the DB-level 2nd safety layer may not actually take effect. Verify whether the runtime connection role owns the tables on the operational DB (pg_class.relowner / relforcerowsecurity)."
     },
     "operations": {
       "title_prefix": "Operations",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -622,8 +622,10 @@
       "info_li1": "<strong>RLS 適用</strong> = PostgreSQL のみ (SQLite 単体テストは自動 skip)",
       "info_li2": "ランタイム有効化ミドルウェア = `src/middleware/rls_session.py` (サイクル 66 #228)",
       "info_li3": "contextvars bridge = `src/shared/rls_context.py` + DB event listener (`SET LOCAL app.user_id`)",
-      "info_li4": "2-layer 安全網 = (1) アプリレベルフィルタ (`_apply_*_user_filter`) + (2) DB RLS policy (PG/Supabase)",
-      "info_li5": "backfill 診断 = `docs/runbooks/saas-phase0-backfill-readiness.md` (サイクル 78 PR 3 — null=0 確認)"
+      "info_li4": "2-layer 安全網 = (1) アプリレベルフィルタ (`_apply_*_user_filter`) + (2) DB RLS policy (PG/Supabase) — ⚠️ FORCE 未設定なら owner 接続は (2) を回避可能",
+      "info_li5": "backfill 診断 = `docs/runbooks/saas-phase0-backfill-readiness.md` (サイクル 78 PR 3 — null=0 確認)",
+      "force_warning_title": "⚠️ FORCE ROW LEVEL SECURITY 未設定 — 2次安全網が回避される可能性",
+      "force_warning_body": "いずれの alembic マイグレーションも FORCE ROW LEVEL SECURITY を適用していません。アプリ接続 role がテーブル owner の場合、PostgreSQL は owner に対して RLS を回避するため、上記「適用」マトリクスにもかかわらず DB レベルの 2次安全網が実際には回避される可能性があります。運用 DB で connection role の owner 状態(pg_class.relowner / relforcerowsecurity)の確認を推奨します。"
     },
     "operations": {
       "title_prefix": "Operations",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -622,8 +622,10 @@
       "info_li1": "<strong>RLS 적용</strong> = PostgreSQL 만 (SQLite 단위 테스트 자동 skip)",
       "info_li2": "운영 활성화 미들웨어 = `src/middleware/rls_session.py` (사이클 66 #228)",
       "info_li3": "contextvars bridge = `src/shared/rls_context.py` + DB event listener (`SET LOCAL app.user_id`)",
-      "info_li4": "2-layer 안전망 = (1) 앱 레벨 filter (`_apply_*_user_filter`) + (2) DB RLS policy (PG/Supabase)",
-      "info_li5": "backfill 진단 = `docs/runbooks/saas-phase0-backfill-readiness.md` (사이클 78 PR 3 — null=0 확인)"
+      "info_li4": "2-layer 안전망 = (1) 앱 레벨 filter (`_apply_*_user_filter`) + (2) DB RLS policy (PG/Supabase) — ⚠️ FORCE 미설정 시 owner 연결은 (2) 우회 가능",
+      "info_li5": "backfill 진단 = `docs/runbooks/saas-phase0-backfill-readiness.md` (사이클 78 PR 3 — null=0 확인)",
+      "force_warning_title": "⚠️ FORCE ROW LEVEL SECURITY 미설정 — 2차 안전망 우회 가능",
+      "force_warning_body": "어느 alembic 마이그레이션도 FORCE ROW LEVEL SECURITY 를 적용하지 않습니다. 앱 연결 role 이 테이블 owner 이면 PostgreSQL 이 RLS 를 owner-bypass 하므로, 위 '적용' 매트릭스에도 불구하고 DB 레벨 2차 안전망이 실제로는 우회될 수 있습니다. 운영 DB 에서 connection role 의 owner 여부(pg_class.relowner / relforcerowsecurity) 확인을 권장합니다."
     },
     "operations": {
       "title_prefix": "Operations",

--- a/src/services/saas_service.py
+++ b/src/services/saas_service.py
@@ -147,10 +147,17 @@ def rls_audit_matrix() -> list[dict[str, str]]:
     return list(_RLS_MATRIX)
 
 
-def rls_coverage_summary() -> dict[str, int]:
-    """RLS 적용 vs 미적용 카운트 요약.
+def rls_coverage_summary() -> dict[str, int | bool]:
+    """RLS 적용 vs 미적용 카운트 요약 + FORCE 상태 경고 플래그.
+    RLS applied vs missing summary, plus a FORCE-status warning flag.
 
-    RLS applied vs missing summary.
+    force_applied: 어느 alembic 마이그레이션도 FORCE ROW LEVEL SECURITY 를 적용하지 않으므로
+    정적 False. 앱 연결 role 이 테이블 owner 면 PostgreSQL 이 RLS USING 절을 owner-bypass 하여
+    2차 안전망(DB RLS)이 실제로는 우회될 수 있다(Task9 P1 #2 — false-confidence 갭 가시화).
+    FORCE 마이그레이션 도입 시 True 로 갱신 + test_summary_reports_force_not_applied 가드 갱신.
+    force_applied: no migration applies FORCE ROW LEVEL SECURITY, so this is statically False —
+    an owner connection may bypass RLS, leaving the 2nd safety layer ineffective (Task9 P1 #2).
+    Flip to True when a FORCE migration lands (and update the guard test).
     """
     matrix = rls_audit_matrix()
     applied = sum(1 for m in matrix if m["status"] == "applied")
@@ -158,4 +165,5 @@ def rls_coverage_summary() -> dict[str, int]:
         "total": len(matrix),
         "applied": applied,
         "missing": len(matrix) - applied,
+        "force_applied": False,
     }

--- a/src/templates/admin_rls_audit.html
+++ b/src/templates/admin_rls_audit.html
@@ -27,6 +27,15 @@
     <a href="/admin/tenants" class="admin-link">{{ 'admin.rls_audit.tenants_link' | i18n_args(locale | default('ko')) }}</a>
   </div>
 
+  {% if not summary.force_applied %}
+  {# FORCE ROW LEVEL SECURITY 미설정 경고 — owner 연결 시 2차 안전망 우회 가능 (Task9 P1 #2) #}
+  {# Warn that FORCE RLS is unset — an owner connection may bypass the 2nd safety layer (Task9 P1 #2) #}
+  <div class="admin-info-card reveal" style="border-left: 4px solid var(--warning); margin-bottom: 16px;">
+    <strong>{{ 'admin.rls_audit.force_warning_title' | i18n_args(locale | default('ko')) }}</strong>
+    <p style="margin: 6px 0 0; font-size: 13px; line-height: 1.5;">{{ 'admin.rls_audit.force_warning_body' | i18n_args(locale | default('ko')) }}</p>
+  </div>
+  {% endif %}
+
   <div class="admin-table-wrap">
     <table class="admin-table tbl">
       <thead>

--- a/tests/unit/services/test_saas_service.py
+++ b/tests/unit/services/test_saas_service.py
@@ -123,3 +123,12 @@ class TestRlsCoverageSummary:
         assert summary["total"] == 11
         assert summary["applied"] == 11
         assert summary["missing"] == 0
+
+    def test_summary_reports_force_not_applied(self):
+        """어느 마이그레이션도 FORCE ROW LEVEL SECURITY 를 적용하지 않으므로 force_applied=False.
+
+        owner-bypass 경고(rls-audit) 의 단일 출처 — owner 연결 시 2차 안전망 우회 가능성 가시화
+        (Task9 P1 #2 false-confidence 갭). FORCE 마이그레이션 도입 시 True 로 갱신 + 본 가드 갱신.
+        """
+        summary = saas_service.rls_coverage_summary()
+        assert summary["force_applied"] is False

--- a/tests/unit/templates/test_admin_settings_i18n_render.py
+++ b/tests/unit/templates/test_admin_settings_i18n_render.py
@@ -90,7 +90,7 @@ def _rls_ctx(**overrides) -> dict:
             {"table": "repositories", "pattern": "user_id", "since": "0026", "status": "applied"},
             {"table": "missing_table", "pattern": "tenant_id", "since": "TBD", "status": "missing"},
         ],
-        "summary": {"total": 2, "applied": 1, "missing": 1},
+        "summary": {"total": 2, "applied": 1, "missing": 1, "force_applied": False},
     }
     base.update(overrides)
     return base
@@ -105,6 +105,8 @@ def test_admin_rls_audit_renders_korean():
     assert ">테이블</th>" in out
     assert ">격리 패턴</th>" in out
     assert "💡 RLS 운영 안내" in out
+    # FORCE 미설정 경고 배너 (Task9 P1 #2 — owner-bypass 가시화)
+    assert "FORCE ROW LEVEL SECURITY 미설정" in out
 
 
 def test_admin_rls_audit_renders_english():
@@ -115,6 +117,7 @@ def test_admin_rls_audit_renders_english():
     assert "❌ Missing 1" in out
     assert ">Table</th>" in out
     assert ">Isolation pattern</th>" in out
+    assert "FORCE ROW LEVEL SECURITY not set" in out
 
 
 def test_admin_rls_audit_renders_japanese():
@@ -123,6 +126,16 @@ def test_admin_rls_audit_renders_japanese():
     assert "総テーブル数" in out
     assert "✅ 適用 1件" in out
     assert ">分離パターン</th>" in out
+    assert "FORCE ROW LEVEL SECURITY 未設定" in out
+
+
+def test_admin_rls_audit_hides_force_warning_when_applied():
+    """force_applied=True 면 경고 배너 미표시 — FORCE 마이그레이션 도입 시 회귀 가드 (#2)."""
+    out = _render(
+        "admin_rls_audit.html", locale="ko",
+        **_rls_ctx(summary={"total": 2, "applied": 2, "missing": 0, "force_applied": True}),
+    )
+    assert "FORCE ROW LEVEL SECURITY 미설정" not in out
 
 
 # ── admin_operations.html ───────────────────────────────────────────────────


### PR DESCRIPTION
## 🖼️ 정책 11 — Claude 시각 검증 불가 (사용자 확인 의무)
admin_rls_audit.html 경고 배너 추가는 **정적 코드만 검증** 가능. 4-테마(dark/light/pastel/catppuccin) × 모바일/데스크탑 8 조합 시각 정합성은 사용자 확인 필요:
- [ ] dark / 데스크탑 · 모바일
- [ ] light / 데스크탑 · 모바일
- [ ] pastel / 데스크탑 · 모바일
- [ ] catppuccin / 데스크탑 · 모바일

경고 배너는 기존 `.admin-info-card` 클래스 재사용 + `border-left: 4px solid var(--warning)` (시맨틱 토큰). 4-테마 `--warning` 정의 존재 가정 — 시각 확인 권장.

## 요약
Task 9 정합성 감사 **P1 #2** — 5+1 다중 에이전트 설계 검토 후 사용자가 **옵션 D(갭 가시화 + 실측)** 선택. 그 1단계: `/admin/rls-audit` 의 false-confidence 갭을 경고로 가시화 (**코드 동작 무변경**).

### 설계 검토 결론 (별도 보고)
- **#2는 실재 결함이나 본체 P1**: RLS 11테이블이 `ENABLE` 만 하고 `FORCE ROW LEVEL SECURITY` 미적용 → 앱 연결 role 이 테이블 owner 면 owner-bypass 로 2차 안전망 무력 가능.
- **🔴 FORCE 단순 도입 = P0 운영 붕괴**: user 컨텍스트 없는 background 경로(webhook 파이프라인/cron/merge_retry)가 전부 `app.user_id` 없이 RLS 테이블을 쿼리 → FORCE 시 0행/차단. → 지금은 **FORCE 미도입**, 갭 가시화 + 운영 DB 실측으로 전환.

### 문제 (false confidence)
`_RLS_MATRIX` 가 11테이블 전부 `applied` 보고 + `rls_coverage_summary` missing=0 → rls-audit '11/11 녹색'. FORCE 미설정(owner-bypass 가능)을 운영자가 인지 못 함.

### 수정 (관측/문서만 — RLS/DDL/쿼리 동작 0)
- `rls_coverage_summary` 에 `force_applied: False` (정적 — FORCE 마이그레이션 도입 시 True 갱신).
- `admin_rls_audit.html`: `force_applied=False` 시 owner-bypass 경고 배너.
- i18n 3언어(ko/en/ja): `force_warning_title/body` + `info_li4` caveat.
- `0026` docstring: owner-bypass caveat (DDL 무변경 — 이력 마이그레이션 보호).

### 테스트
- `force_applied=False` 단일 출처 가드 + render-parity(3언어 경고 출현) + 숨김 회귀가드(`force_applied=True`).
- 전체 **4684 단위 통과**, pylint 10.00/10, flake8 clean, 0026 round-trip 통과.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** — push 전 mutual 검증 완료.
- 판정 1 (동작 무변경): **OK** — 정적 플래그 + 조건부 배너 + i18n + docstring만
- 판정 2 (i18n 3언어 정합): **OK** — en 포함 동시 추가, fallback 안전
- 판정 3 (경고 정확성): **OK** — 조건부 'owner 연결 시' 표현, 과장 단정 아님
- 판정 4 (render-parity): **OK** — 3언어 경고 텍스트 출현 assert

## 🔍 사용자 검증 필요 (#2-D 2단계 — 실측)
다음 단계로 **운영 DB pg_class 실측**(owner-bypass 실재 확인)을 준비 중입니다. 실행 방식(Supabase MCP / psql / 사용자 직접)을 별도로 확인드리겠습니다. 실측 결과에 따라 옵션 B(role 분리 + FORCE) 승격 여부 재결정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
