### PR TITLE
fix(webhook): Telegram 게이트 콜백 리플레이 가드(원자적 claim) + webhook 본문 파싱 robustness (Task9 P2 #11/#13)

### DIFF
--- a/src/repositories/gate_decision_repo.py
+++ b/src/repositories/gate_decision_repo.py
@@ -1,4 +1,5 @@
 """GateDecisionRepo — GateDecision ORM 쿼리·upsert 단일 출처."""
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.models.gate_decision import GateDecision
@@ -7,6 +8,41 @@ from src.models.gate_decision import GateDecision
 def find_by_analysis_id(db: Session, analysis_id: int) -> GateDecision | None:
     """analysis_id 로 조회."""
     return db.query(GateDecision).filter_by(analysis_id=analysis_id).first()
+
+
+def claim_decision(
+    db: Session,
+    analysis_id: int,
+    decision: str,
+    mode: str,
+    decided_by: str | None = None,
+) -> bool:
+    """결정을 원자적으로 INSERT 한다 (first-writer-wins) — 이미 있으면 False 반환.
+    Atomically INSERT the decision (first-writer-wins); return False if one already exists.
+
+    UNIQUE(analysis_id) 제약으로 동시·멀티프로세스 리플레이 중 한 번만 INSERT 가 성공한다.
+    리플레이 가드(handle_gate_callback)가 GitHub 리뷰·auto-merge 등 부수효과 전에 호출 —
+    패자(이미 결정됨 또는 동시 INSERT 충돌)는 IntegrityError 를 흡수하고 부수효과를 skip 한다.
+    upsert(save_gate_decision)와 달리 update 분기가 없어 결정 뒤집기를 원천 차단한다.
+    The UNIQUE(analysis_id) constraint lets only one caller win under concurrent/multi-process
+    replays; the replay guard calls this before side effects (GitHub review, auto-merge), so losers
+    skip them. Unlike the upsert (save_gate_decision) there is no update branch — decisions cannot flip.
+    (#780 save_new / #787 _ensure_repo 와 동일 race-safe 패턴 / same race-safe pattern.)
+    """
+    db.add(
+        GateDecision(
+            analysis_id=analysis_id,
+            decision=decision,
+            mode=mode,
+            decided_by=decided_by,
+        )
+    )
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        return False
+    return True
 
 
 def upsert(

--- a/src/webhook/providers/telegram.py
+++ b/src/webhook/providers/telegram.py
@@ -20,13 +20,17 @@ from src.config import settings
 from src.config_manager.manager import get_repo_config
 from src.database import SessionLocal
 from src.gate._common import ai_review_failed
-from src.gate.engine import save_gate_decision
 from src.gate.github_review import post_github_review
 from src.i18n.loader import get_text
 from src.notifier._language import resolve_notification_language
 from src.notifier.telegram import telegram_post_message
 from src.notifier.telegram_commands import handle_message_command, parse_cmd_callback
-from src.repositories import analysis_repo, repository_repo, user_repo
+from src.repositories import (
+    analysis_repo,
+    gate_decision_repo,
+    repository_repo,
+    user_repo,
+)
 from src.shared.secure_compare import secure_str_compare
 
 logger = logging.getLogger(__name__)
@@ -106,11 +110,6 @@ async def handle_gate_callback(  # pylint: disable=too-many-locals
                     telegram_user_id, repo.full_name, analysis_id,
                 )
                 return
-            github_token = (
-                repo.owner.plaintext_token
-                if repo.owner and repo.owner.plaintext_token
-                else settings.github_token
-            )
             if analysis.pr_number is None:
                 # push 이벤트로 생성된 Analysis는 pr_number=None — GitHub Review 불가
                 # Analysis created from push event has no pr_number — GitHub Review unavailable
@@ -119,6 +118,28 @@ async def handle_gate_callback(  # pylint: disable=too-many-locals
                     analysis_id,
                 )
                 return
+            # 🔴 리플레이 가드 (#11): 부수효과(GitHub 리뷰·결정 뒤집기·auto-merge) 전에 결정을
+            # 원자적으로 claim 한다 — UNIQUE(analysis_id) INSERT 로 first-writer-wins. 이미 결정됐거나
+            # 동시 리플레이(더블클릭/Telegram 재전송) 패자는 IntegrityError→False 로 부수효과를 skip.
+            # callback_data HMAC 은 gate:{analysis_id} 만 서명(nonce 무관)이라 동일 버튼이 무한 재사용
+            # 가능 → claim 이 단일 동기화 지점. save_gate_decision(upsert) 대신 insert-only claim 으로
+            # 결정 뒤집기까지 차단(#780 save_new / #787 _ensure_repo 동형 race-safe 패턴).
+            # Replay guard (#11): atomically claim the decision before any side effect. A UNIQUE
+            # (analysis_id) INSERT makes it first-writer-wins; an existing decision or a concurrent
+            # replay (double-click / Telegram retry) loses with IntegrityError→False and skips side
+            # effects. The HMAC signs only gate:{analysis_id} (no nonce), so the claim is the single
+            # synchronization point — insert-only (no flip), mirroring #780/#787 race-safe pattern.
+            if not gate_decision_repo.claim_decision(db, analysis_id, decision, "manual", decided_by):
+                logger.info(
+                    "handle_gate_callback: analysis %d already decided — skipping replay",
+                    analysis_id,
+                )
+                return
+            github_token = (
+                repo.owner.plaintext_token
+                if repo.owner and repo.owner.plaintext_token
+                else settings.github_token
+            )
             # GitHub PR Review body 는 리포 협업자 전체에게 영구 노출 — 발신 언어 i18n (사이클 154 P0)
             # The PR Review body is permanently visible to all collaborators — i18n it (Cycle 154 P0)
             config = get_repo_config(db, repo.full_name)
@@ -133,7 +154,8 @@ async def handle_gate_callback(  # pylint: disable=too-many-locals
                 github_token, repo.full_name,
                 analysis.pr_number, decision, body,
             )
-            save_gate_decision(db, analysis_id, decision, "manual", decided_by)
+            # 결정은 위 claim 단계에서 이미 원자적으로 기록됨 (save_gate_decision 중복 제거)
+            # The decision was already recorded atomically by the claim above (no save needed)
             result_dict = analysis.result if isinstance(analysis.result, dict) else {}
             score = result_dict.get("score", analysis.score or 0)
             # 반자동 auto-merge 를 자동 경로(engine._run_auto_merge)에 위임 — retry 큐잉·
@@ -211,7 +233,13 @@ def _handle_message(
     return {"status": "ok"}
 
 
-@router.post("/api/webhook/telegram", responses={401: {"description": "Invalid secret token"}})
+@router.post(
+    "/api/webhook/telegram",
+    responses={
+        400: {"description": "Invalid request body"},
+        401: {"description": "Invalid secret token"},
+    },
+)
 async def telegram_webhook(  # pylint: disable=too-many-locals
     # too-many-locals: 콜백 소유권 전달용 telegram_user_id 추가로 16/15 (inline disable + 사유)
     request: Request,
@@ -234,7 +262,19 @@ async def telegram_webhook(  # pylint: disable=too-many-locals
         logger.warning("Telegram webhook: invalid or missing secret token")
         raise HTTPException(status_code=401, detail="Invalid secret token")
 
-    payload = await request.json()
+    # 🔴 본문 파싱 robustness (#13): secret 통과 후 비정형/비-dict 본문이 미처리 500 을 내지
+    # 않도록 방어 — railway provider 와 대칭(잘못된 client 요청은 400). malformed JSON 은
+    # JSONDecodeError, 비-dict(array/scalar) 본문은 이어지는 payload.get 의 AttributeError 유발.
+    # Body-parse robustness (#13): after the secret check, guard against malformed/non-dict bodies
+    # that would otherwise raise an unhandled 500 — reject as 400 (symmetric with railway provider).
+    try:
+        payload = await request.json()
+    except Exception:  # pylint: disable=broad-except
+        logger.warning("Telegram webhook: malformed JSON body")
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from None
+    if not isinstance(payload, dict):
+        logger.warning("Telegram webhook: non-dict JSON body (%s)", type(payload).__name__)
+        raise HTTPException(status_code=400, detail="Invalid JSON body")
 
     # message.text 분기: 텍스트 명령 처리
     # message.text branch: handle text commands

--- a/tests/unit/repositories/test_gate_decision_repo.py
+++ b/tests/unit/repositories/test_gate_decision_repo.py
@@ -62,3 +62,32 @@ def test_upsert_updates_existing(db_session):
 
 def test_find_by_analysis_id_not_found(db_session):
     assert gate_decision_repo.find_by_analysis_id(db_session, 9999) is None
+
+
+def test_claim_decision_first_wins(db_session):
+    """claim_decision: 최초 claim 은 True 반환 + 결정 INSERT (#11 원자적 first-writer)."""
+    a = _seed_analysis(db_session)
+    won = gate_decision_repo.claim_decision(db_session, a.id, "approve", "manual", "alice")
+    assert won is True
+    rec = gate_decision_repo.find_by_analysis_id(db_session, a.id)
+    assert rec.decision == "approve"
+    assert rec.mode == "manual"
+    assert rec.decided_by == "alice"
+    assert db_session.query(GateDecision).count() == 1
+
+
+def test_claim_decision_duplicate_loses_no_flip(db_session):
+    """claim_decision: 동일 analysis_id 2차 claim 은 False(UNIQUE 위반 흡수) + 결정 뒤집기 차단.
+
+    리플레이/동시 패자가 부수효과를 skip 하도록 False 를 반환하며, 기존 결정은 변경되지 않는다.
+    """
+    a = _seed_analysis(db_session)
+    assert gate_decision_repo.claim_decision(db_session, a.id, "approve", "manual", "alice") is True
+    # 2차 claim (다른 결정으로 뒤집기 시도) — UNIQUE(analysis_id) 위반 → False
+    lost = gate_decision_repo.claim_decision(db_session, a.id, "reject", "manual", "mallory")
+    assert lost is False
+    # 중복 INSERT 없음 + 최초 결정 보존 (뒤집기 차단)
+    assert db_session.query(GateDecision).count() == 1
+    rec = gate_decision_repo.find_by_analysis_id(db_session, a.id)
+    assert rec.decision == "approve"
+    assert rec.decided_by == "alice"

--- a/tests/unit/test_gate_i18n_seam.py
+++ b/tests/unit/test_gate_i18n_seam.py
@@ -215,7 +215,7 @@ async def test_gate_callback_approve_threads_japanese_to_review_body():
     ), patch(
         "src.webhook.providers.telegram.resolve_notification_language", return_value="ja"
     ), patch(
-        "src.webhook.providers.telegram.save_gate_decision"
+        "src.webhook.providers.telegram.gate_decision_repo.claim_decision"
     ), patch(
         "src.webhook.providers.telegram.user_repo.find_by_telegram_user_id", return_value=MagicMock(id=1)
     ), patch(
@@ -246,7 +246,7 @@ async def test_gate_callback_reject_threads_english_no_korean():
     ), patch(
         "src.webhook.providers.telegram.resolve_notification_language", return_value="en"
     ), patch(
-        "src.webhook.providers.telegram.save_gate_decision"
+        "src.webhook.providers.telegram.gate_decision_repo.claim_decision"
     ), patch(
         "src.webhook.providers.telegram.user_repo.find_by_telegram_user_id", return_value=MagicMock(id=1)
     ), patch(
@@ -275,7 +275,7 @@ async def test_gate_callback_approve_threads_korean_default():
     ), patch(
         "src.webhook.providers.telegram.resolve_notification_language", return_value="ko"
     ), patch(
-        "src.webhook.providers.telegram.save_gate_decision"
+        "src.webhook.providers.telegram.gate_decision_repo.claim_decision"
     ), patch(
         "src.webhook.providers.telegram.user_repo.find_by_telegram_user_id", return_value=MagicMock(id=1)
     ), patch(

--- a/tests/unit/webhook/test_telegram_provider.py
+++ b/tests/unit/webhook/test_telegram_provider.py
@@ -62,6 +62,20 @@ def _authorize_gate_owner():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _gate_decision_claim_succeeds():
+    """기본적으로 게이트 결정 claim 이 성공(first-writer)하도록 패치 (#11 리플레이 가드).
+
+    handle_gate_callback 의 원자적 claim(gate_decision_repo.claim_decision)을 True 로 패치해
+    기존 테스트의 최초-결정 정상 경로를 보존한다. 리플레이/동시패자 케이스는 개별 테스트가 False 로 덮어쓴다.
+    Patch claim_decision → True by default so the first decision proceeds; replay/concurrent-loser
+    cases override this (return False) in individual tests.
+    """
+    with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision",
+               return_value=True):
+        yield
+
+
 def test_approve_returns_200():
     with patch("src.webhook.providers.telegram.handle_gate_callback", new_callable=AsyncMock):
         r = client.post("/api/webhook/telegram", json=APPROVE, headers=_TG_HEADERS)
@@ -106,6 +120,36 @@ def test_missing_secret_returns_401():
     assert r.status_code == 401
 
 
+# --- #13 webhook 본문 파싱 robustness (secret 통과 후 비정형/비-dict 본문 → 500 아닌 400) ---
+
+def test_telegram_webhook_malformed_body_returns_400():
+    """#13: secret 통과 후 비정형 JSON 본문은 500 이 아니라 400 을 반환 (railway 대칭)."""
+    r = client.post(
+        "/api/webhook/telegram",
+        content="{bad json",
+        headers={**_TG_HEADERS, "Content-Type": "application/json"},
+    )
+    assert r.status_code == 400
+
+
+def test_telegram_webhook_json_array_body_returns_400():
+    """#13: 유효 JSON 이지만 비-dict(array) 본문은 payload.get 전 400 차단."""
+    r = client.post("/api/webhook/telegram", json=[1, 2, 3], headers=_TG_HEADERS)
+    assert r.status_code == 400
+
+
+def test_telegram_webhook_json_scalar_body_returns_400():
+    """#13: JSON scalar(str) 본문도 .get 부재 → isinstance 가드로 400."""
+    r = client.post("/api/webhook/telegram", json="hello", headers=_TG_HEADERS)
+    assert r.status_code == 400
+
+
+def test_telegram_webhook_valid_dict_body_still_200():
+    """#13 회귀 가드: 정상 dict 본문은 기존대로 200 유지."""
+    r = client.post("/api/webhook/telegram", json={"update_id": 99}, headers=_TG_HEADERS)
+    assert r.status_code == 200
+
+
 # --- handle_gate_callback auto_merge 위임 테스트 (Q1 A: engine._run_auto_merge 로 자동/반자동 완전 대칭) ---
 
 async def test_handle_gate_callback_approve_with_auto_merge():
@@ -118,7 +162,7 @@ async def test_handle_gate_callback_approve_with_auto_merge():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
                         await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
@@ -133,6 +177,58 @@ async def test_handle_gate_callback_approve_with_auto_merge():
                         assert kw["analysis_id"] == 42
 
 
+# --- #11 리플레이 가드 테스트 (원자적 claim 패자 = 부수효과 skip) ---
+
+async def test_handle_gate_callback_replay_claim_lost_skips_side_effects():
+    """#11: claim_decision 이 False(이미 결정됨 또는 동시 리플레이 패자)면 부수효과 전부 skip.
+
+    동일 서명 버튼 재클릭·더블클릭·Telegram 재전송으로 GitHub 리뷰 재게시·결정 뒤집기·
+    auto-merge 재실행이 일어나지 않아야 한다 — first-writer-wins (원자적 claim).
+    """
+    from src.webhook.router import handle_gate_callback
+    mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85, result={"score": 85})
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
+    config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
+    with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
+        with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision",
+                   return_value=False) as mock_claim:  # 동시/순차 리플레이 패자
+            with patch("src.webhook.providers.telegram.post_github_review",
+                       new_callable=AsyncMock) as mock_review:
+                with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
+                    with patch("src.gate.engine._run_auto_merge",
+                               new_callable=AsyncMock) as mock_am:
+                        await handle_gate_callback(analysis_id=42, decision="approve",
+                                                   decided_by="john", telegram_user_id="1")
+    mock_claim.assert_called_once()      # 가드가 실제로 claim 을 시도했는가
+    mock_review.assert_not_called()      # GitHub 리뷰 미게시
+    mock_am.assert_not_called()          # auto-merge 미재실행
+
+
+async def test_handle_gate_callback_first_decision_applies():
+    """#11 정상 경로 회귀 가드: claim 성공(first-writer) → 최초 결정은 정상 적용."""
+    from src.webhook.router import handle_gate_callback
+    mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=85, result={"score": 85})
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
+    config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
+    with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
+        with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision",
+                   return_value=True) as mock_claim:
+            with patch("src.webhook.providers.telegram.post_github_review",
+                       new_callable=AsyncMock) as mock_review:
+                with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
+                    with patch("src.gate.engine._run_auto_merge",
+                               new_callable=AsyncMock) as mock_am:
+                        await handle_gate_callback(analysis_id=42, decision="approve",
+                                                   decided_by="john", telegram_user_id="1")
+    mock_claim.assert_called_once()      # 결정 claim (원자적 기록)
+    mock_review.assert_called_once()     # 최초 결정 — GitHub 리뷰 게시
+    mock_am.assert_called_once()         # auto-merge 위임
+
+
 async def test_handle_gate_callback_approve_without_auto_merge():
     # auto_merge=False → _run_auto_merge 미호출
     from src.webhook.router import handle_gate_callback
@@ -143,7 +239,7 @@ async def test_handle_gate_callback_approve_without_auto_merge():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=False)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
                         await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
@@ -161,7 +257,7 @@ async def test_handle_gate_callback_reject_does_not_merge():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
                         await handle_gate_callback(analysis_id=42, decision="reject", decided_by="john", telegram_user_id="1")
@@ -180,7 +276,7 @@ async def test_handle_gate_callback_incomplete_static_skips_merge():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision"):
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision"):
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
                         await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
@@ -198,7 +294,7 @@ async def test_handle_gate_callback_ai_review_failed_skips_merge():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision"):
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision"):
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
                         await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
@@ -216,7 +312,7 @@ async def test_handle_gate_callback_ai_no_api_key_still_merges():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision"):
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision"):
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
                         await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
@@ -233,7 +329,7 @@ async def test_handle_gate_callback_merge_error_does_not_propagate():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision"):
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision"):
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock,
                                side_effect=RuntimeError("merge boom")):
@@ -256,7 +352,7 @@ async def test_handle_gate_callback_below_threshold_still_delegates_to_engine():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=90)  # 85 < 90
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
-            with patch("src.webhook.providers.telegram.save_gate_decision"):
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision"):
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
                         await handle_gate_callback(analysis_id=42, decision="approve", decided_by="john", telegram_user_id="1")
@@ -277,7 +373,7 @@ async def test_handle_gate_callback_unauthorized_non_owner_skips():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock) as mock_review:
-            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.webhook.providers.telegram.user_repo.find_by_telegram_user_id",
                                return_value=MagicMock(id=999)):  # 비소유자(id != 1)
@@ -299,7 +395,7 @@ async def test_handle_gate_callback_unlinked_user_skips():
     config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock) as mock_review:
-            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision") as mock_save:
                 with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
                     with patch("src.webhook.providers.telegram.user_repo.find_by_telegram_user_id",
                                return_value=None):  # 미연동
@@ -605,7 +701,7 @@ async def test_handle_gate_callback_skips_when_pr_number_is_none():
     with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
         with patch("src.webhook.providers.telegram.post_github_review",
                    new_callable=AsyncMock) as mock_review:
-            with patch("src.webhook.providers.telegram.save_gate_decision") as mock_save:
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision") as mock_save:
                 await handle_gate_callback(analysis_id=55, decision="approve", decided_by="john", telegram_user_id="1")
     # pr_number=None → post_github_review·save_gate_decision 모두 호출되지 않아야 한다
     mock_review.assert_not_called()


### PR DESCRIPTION
## 개요
Task9 골든 감사 P2 보안·파이프라인 하드닝 클러스터 1/N — Telegram webhook 입력 경로 하드닝 2건(응집 단위 1 PR).

| # | 결함 | 수정 |
|---|------|------|
| **#11** | Gate 콜백 리플레이 가드 부재 — 동일 서명 버튼 재클릭으로 결정 뒤집기·GitHub 리뷰 재게시·auto-merge 재실행 무한 반복 | `gate_decision_repo.claim_decision` 원자적 first-writer-wins(UNIQUE analysis_id INSERT, IntegrityError→False)를 부수효과 전에 배치 |
| **#13** | `telegram_webhook` 이 secret 통과 후 `request.json()` 무방비 — malformed/비-dict 본문 시 미처리 500 | `try/except`→400 + `isinstance(dict)` 가드→400 (railway provider 대칭) + responses 400 문서화 |

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**3-라운드 mutual 검증 완료 → 최종 CODEX_OK** (push 전 수행):
- **R1 NG**: 초기 `find_by_analysis_id` 가드는 check→side-effect 사이 `await` 구간에서 동시 콜백이 모두 통과하는 TOCTOU. → 사용자 결정(옵션 A)에 따라 **원자적 claim** 으로 재구성.
- **R2 NG**: 타 파일 `test_gate_i18n_seam.py` 의 `save_gate_decision` stale mock 3건 누락 발견(Codex 정확 지적). → `claim_decision` 로 전환, 전체 4840 passed.
- **R3 OK**: 원자적 claim TOCTOU 폐쇄 + 신규 회귀 0 확인.

## 🤖 자율 판단 보고 (정책 3)
- **#11 원자성 = 사용자 옵션 A 결정**: Codex R1 NG(비원자성) 후 AskUserQuestion 으로 옵션 A(원자적 claim) vs B(단일워커 최소) 제시 → 사용자 A 선택. claim 후 GitHub 리뷰 일시 실패 시 재시도 억제는 옵션 A 수용 트레이드오프(신뢰 GitHub API 5xx 자동 재시도가 transient 보완 — api.md / replay-안전 우선).
- **#11+#13 통합 PR**: 같은 telegram.py(다른 함수)라 self-conflict 회피 위해 1 PR(응집 단위, 정책 7). 1 커밋으로 정리(telegram.py hunk 혼재).
- **save_gate_decision 제거**: 수동 경로(telegram)에서만 사용되던 upsert 를 insert-only claim 으로 대체(결정 뒤집기까지 차단). 자동 경로(engine)는 무영향.
- **#24/#25 별도 진행**: 본 클러스터 잔여(#12 SSRF docstring·#24 ai_review·#25 hook 점수)는 후속 PR. #25 는 머지 대기 #807(hook.py 동일 함수) 머지 후.

## 🔍 사용자 검증 필요 (정책 2)
- [ ] **운영 시각 확인 불필요** (백엔드 로직 — UI 무변경)
- [ ] **반자동 Telegram gate 실사용 확인**: 인라인 버튼 클릭 1회 정상 동작 + **재클릭 시 무반응(리플레이 차단)** 확인 (Railway 배포 후)
- [ ] 운영 사고 보고: 해당 없음

## 테스트
- `gate_decision_repo`: claim 최초 성공 / 중복 패자(뒤집기 차단) 원자성 +2
- `telegram`: 리플레이 claim-패자 skip / 최초 결정 정상 적용 / #13 malformed·array·scalar→400 + 정상 dict→200 회귀
- 기존 콜백 테스트 16건(test_telegram_provider 13 + test_gate_i18n_seam 3) `save_gate_decision`→`claim_decision` patch 전환 + claim→True autouse 로 보존
- **전체 4840 passed, 4 skipped / pylint 10.00 / flake8 clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)