### PR TITLE
fix(pipeline): AI 리뷰 점수 per-field 안전 변환 — 단일 비숫자/Infinity 리뷰 붕괴 차단 (Task9 P2 #24)

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -20,7 +20,7 @@ import anthropic
 from src.analyzer.pure.review_prompt import build_review_prompt, get_system_prompt
 from src.config import settings
 from src.constants import (
-    AI_DEFAULT_COMMIT_RAW, AI_DEFAULT_DIRECTION_RAW,
+    AI_DEFAULT_COMMIT_RAW, AI_DEFAULT_DIRECTION_RAW, AI_DEFAULT_TEST_RAW,
     AI_RAW_COMMIT_MAX, AI_RAW_DIRECTION_MAX, AI_RAW_TEST_MAX,
 )
 from src.shared.anthropic_caching import build_cached_system_param
@@ -151,11 +151,34 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
         await aclose_anthropic_client(client)
 
 
-def _extract_test_score(data: dict) -> int:
-    """test_score 추출. 구 포맷(has_tests boolean) 하위 호환."""
+def _coerce_score(raw: object, max_val: int, default: int) -> "tuple[int, bool]":
+    """raw 점수를 [0, max_val] 정수로 안전 클램프 — 비숫자/Infinity 시 default 폴백 + ok=False.
+    Safely clamp a raw score to [0, max_val]; fall back to default on non-numeric/Infinity (ok=False).
+
+    🔴 PARITY GUARD: src/api/hook.py::_coerce_raw_score 와 행동 동등(반환 (int, ok)). 둘 중 하나
+    변경 시 양쪽 동시 수정 + parity 회귀 가드(test_ai_review_errors.py) 갱신 의무 (testing.md
+    의도적 중복 패턴 — 사용처 2곳이라 공유 추출 대신 인라인+가드, 정책16 최소 추상화).
+    int(raw) 가 TypeError/ValueError(float-string)/OverflowError(Infinity)를 던지면 default·ok=False.
+    🔴 PARITY GUARD with src/api/hook.py::_coerce_raw_score — keep behaviour identical; update both
+    plus the parity regression test together when changing either.
+    """
+    try:
+        value = int(raw)
+    except (TypeError, ValueError, OverflowError):
+        return max(0, min(max_val, default)), False
+    return max(0, min(max_val, value)), True
+
+
+def _coerce_test_score(data: dict) -> "tuple[int, bool]":
+    """test_score 안전 추출 (int, ok). 구 포맷(has_tests boolean) 하위 호환 — 키 부재는 ok=True."""
     if "test_score" in data:
-        return max(0, min(AI_RAW_TEST_MAX, int(data["test_score"])))
-    return AI_RAW_TEST_MAX if data.get("has_tests", False) else 0
+        return _coerce_score(data["test_score"], AI_RAW_TEST_MAX, AI_DEFAULT_TEST_RAW)
+    return (AI_RAW_TEST_MAX if data.get("has_tests", False) else 0), True
+
+
+def _extract_test_score(data: dict) -> int:
+    """test_score 추출(int) — 하위 호환 wrapper. 안전 변환·ok 플래그는 _coerce_test_score 사용."""
+    return _coerce_test_score(data)[0]
 
 
 def _extract_json_payload(text: str) -> str:
@@ -183,22 +206,49 @@ def _extract_json_payload(text: str) -> str:
 def _parse_response(text: str) -> AiReviewResult:
     try:
         data = json.loads(_extract_json_payload(text))
-        return AiReviewResult(
-            commit_score=max(0, min(AI_RAW_COMMIT_MAX, int(data.get("commit_message_score", AI_DEFAULT_COMMIT_RAW)))),
-            ai_score=max(0, min(AI_RAW_DIRECTION_MAX, int(data.get("direction_score", AI_DEFAULT_DIRECTION_RAW)))),
-            test_score=_extract_test_score(data),
-            summary=str(data.get("summary", "")),
-            suggestions=[str(s) for s in data.get("suggestions", [])],
-            commit_message_feedback=str(data.get("commit_message_feedback", "")),
-            code_quality_feedback=str(data.get("code_quality_feedback", "")),
-            security_feedback=str(data.get("security_feedback", "")),
-            direction_feedback=str(data.get("direction_feedback", "")),
-            test_feedback=str(data.get("test_feedback", "")),
-            file_feedbacks=list(data.get("file_feedbacks", [])),
-        )
-    except (json.JSONDecodeError, ValueError, KeyError):
+    except json.JSONDecodeError:
+        # 진짜 구조 붕괴(JSON 파싱 실패)만 전량 parse_error — 점수 필드 문제는 아래서 per-field 흡수.
+        # Only genuine structural failure (JSON decode) collapses to parse_error; score-field issues
+        # are absorbed per-field below.
         logger.warning("Failed to parse AI review response: %s", text[:200])
         return _default_result("parse_error")
+    if not isinstance(data, dict):
+        # JSON array/scalar 등 비-dict 페이로드 — data.get 불가 → parse_error
+        # Non-dict payload (array/scalar) — data.get unavailable → parse_error
+        logger.warning("AI review response is not a JSON object: %s", text[:200])
+        return _default_result("parse_error")
+    # 🔴 #24: 점수 필드 per-field 안전 변환 — 단일 필드 float-string("88.0")/Infinity 가 리뷰 전체
+    # (복구 가능한 점수 + 모든 feedback 텍스트)를 붕괴시키지 않도록 한다. hook.py _coerce_raw_score
+    # 하드닝(#784)과 대칭(PARITY GUARD).
+    # #24: per-field score coercion so one bad numeric field (float-string/Infinity) doesn't collapse
+    # the whole review (recoverable scores + all feedback text); mirrors hook.py _coerce_raw_score.
+    commit, commit_ok = _coerce_score(
+        data.get("commit_message_score", AI_DEFAULT_COMMIT_RAW), AI_RAW_COMMIT_MAX, AI_DEFAULT_COMMIT_RAW)
+    direction, direction_ok = _coerce_score(
+        data.get("direction_score", AI_DEFAULT_DIRECTION_RAW), AI_RAW_DIRECTION_MAX, AI_DEFAULT_DIRECTION_RAW)
+    test, test_ok = _coerce_test_score(data)
+    result = AiReviewResult(
+        commit_score=commit,
+        ai_score=direction,
+        test_score=test,
+        summary=str(data.get("summary", "")),
+        suggestions=[str(s) for s in data.get("suggestions", [])],
+        commit_message_feedback=str(data.get("commit_message_feedback", "")),
+        code_quality_feedback=str(data.get("code_quality_feedback", "")),
+        security_feedback=str(data.get("security_feedback", "")),
+        direction_feedback=str(data.get("direction_feedback", "")),
+        test_feedback=str(data.get("test_feedback", "")),
+        file_feedbacks=list(data.get("file_feedbacks", [])),
+    )
+    if not (commit_ok and direction_ok and test_ok):
+        # 점수 필드 비숫자/Infinity — feedback·복구가능 점수는 보존하되 parse_error 로 표시해
+        # #804(#8) ai_review_failed 게이트의 fail-closed(auto-merge/approve 차단)를 유지한다.
+        # (이전: 전량 _default_result 로 feedback 까지 폐기. 게이트 동작은 동일, 데이터만 보존.)
+        # Non-numeric/Infinity score field: keep feedback/recoverable scores but mark parse_error so
+        # the #804 gate stays fail-closed (was: total discard via _default_result; gate behaviour
+        # unchanged, only the data is preserved).
+        result.status = "parse_error"
+    return result
 
 
 def _default_result(reason: str = "no_api_key") -> AiReviewResult:

--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -28,6 +28,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 
 from src.analyzer.io.ai_review import (
+    _coerce_score,
     _default_result,
     _extract_json_payload,
     _parse_response,
@@ -251,6 +252,77 @@ def test_parse_response_clamps_out_of_range_scores():
     assert result.commit_score == 20  # clamped to max
     assert result.ai_score == 0       # clamped to min
     assert result.test_score == 10    # clamped to test max
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #24 — 점수 필드 per-field 안전 변환 (단일 비숫자/Infinity 가 리뷰 전체를 붕괴시키지 않음)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_coerce_score_parity_with_hook_coerce_raw_score():
+    """🔴 PARITY GUARD: ai_review._coerce_score 가 hook._coerce_raw_score 와 행동 동등 (#24/#784).
+
+    의도적 중복(인라인, 정책16 사용처 2곳) 두 구현이 drift 하지 않도록 입력 배터리로 (int, ok)
+    동등성을 봉인한다. 한쪽 변경 시 본 테스트가 fail → 양쪽 동시 수정 강제.
+    """
+    from src.api.hook import _coerce_raw_score  # pylint: disable=import-outside-toplevel
+    battery = [
+        ("88.0", 20, 17),        # float-string → ValueError → default
+        (float("inf"), 20, 17),  # Infinity → OverflowError → default
+        (float("nan"), 20, 17),  # NaN → ValueError → default
+        ("abc", 20, 17),         # 비숫자 문자열 → ValueError → default
+        (None, 20, 17),          # None → TypeError → default
+        (18, 20, 17),            # 정상 → 18
+        (99, 20, 17),            # 범위 초과 → clamp 20
+        (-5, 20, 17),            # 음수 → clamp 0
+        (3.9, 20, 17),           # float → int 절단 3
+        (10, 10, 7),             # test 범위
+    ]
+    for raw, mx, default in battery:
+        assert _coerce_score(raw, mx, default) == _coerce_raw_score(raw, mx, default), \
+            f"parity drift for raw={raw!r}"
+
+
+def test_parse_response_preserves_feedback_on_nonnumeric_score():
+    """#24: 단일 점수 필드 float-string 이어도 리뷰 전체를 폐기하지 않고 feedback·정상 점수 보존.
+
+    상태는 parse_error 로 표시(#804 게이트 fail-closed 유지)하되, 이전처럼 _default_result 로
+    feedback 까지 폐기하지 않는다.
+    """
+    text = json.dumps({
+        "commit_message_score": "88.0",  # float-string → ValueError → default + parse_error
+        "direction_score": 18,
+        "test_score": 9,
+        "summary": "great review",
+        "security_feedback": "no issues",
+        "suggestions": ["add tests"],
+    })
+    result = _parse_response(text)
+    assert result.status == "parse_error"          # 비숫자 필드 → 게이트 fail-closed 유지
+    assert result.commit_score == 17               # 복구 불가 필드는 default
+    assert result.ai_score == 18                   # 정상 필드 보존 (전량 폐기 아님)
+    assert result.test_score == 9                  # 정상 필드 보존
+    assert result.summary == "great review"        # 🔴 feedback 보존 (이전엔 _default_result 로 폐기)
+    assert result.security_feedback == "no issues"
+    assert "add tests" in result.suggestions
+
+
+def test_parse_response_infinity_marked_parse_error_preserves():
+    """#24: direction_score=Infinity(int(inf) OverflowError) → 전량 폐기/api_error 아닌 parse_error + 보존."""
+    text = '{"commit_message_score": 18, "direction_score": Infinity, "test_score": 9, "summary": "ok"}'
+    result = _parse_response(text)
+    assert result.status == "parse_error"
+    assert result.commit_score == 18    # 보존
+    assert result.ai_score == 17        # Infinity → default
+    assert result.test_score == 9       # 보존
+    assert result.summary == "ok"       # feedback 보존
+
+
+def test_parse_response_non_dict_payload_returns_parse_error():
+    """#24: JSON 이 유효해도 비-dict(array/scalar) 페이로드는 parse_error (data.get AttributeError 방어)."""
+    # _extract_json_payload 는 {} 구간을 찾지만, 중괄호 없는 순수 배열/스칼라는 그대로 통과 가능
+    assert _parse_response("[1, 2, 3]").status == "parse_error"
+    assert _parse_response("42").status == "parse_error"
 
 
 # ──────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 개요
Task9 골든 감사 P2 보안·파이프라인 하드닝 클러스터 2/N.

`_parse_response` 가 commit/direction/test 점수를 bare `int()` 로 변환해, 단일 필드가
float-string(`"88.0"`→ValueError) 또는 Infinity(`int(float('inf'))`→OverflowError)면 try 블록
전체가 except 로 떨어져 `_default_result("parse_error")` 반환 — **복구 가능한 점수 + 모든 feedback
텍스트까지 전량 폐기**했다. hook.py `_coerce_raw_score` 하드닝(#784)과 비대칭.

## 수정
- `_coerce_score(raw, max, default) -> (int, ok)` 인라인 추가 — `hook._coerce_raw_score` 와 **PARITY GUARD** (정책16 사용처 2곳 → 공유 추출 대신 인라인+가드).
- `_parse_response`: `json.JSONDecodeError` 만 분리 catch(진짜 구조 붕괴) + 비-dict 페이로드 가드 + 점수 3필드 per-field 안전 변환.
- 비숫자/Infinity 필드 시 **feedback·정상 점수는 보존**하되 `status='parse_error'` 표시 → #804(#8) `ai_review_failed` 게이트 **fail-closed(auto-merge/approve 차단) 그대로 유지**.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** (1라운드): "no gate weakening found; nonnumeric/Infinity score fields preserve feedback but set parse_error so auto-merge/approve stays blocked, _coerce_score matches hook._coerce_raw_score, valid/invalid/clamping paths pass."

## 🤖 자율 판단 보고 (정책 3)
- **보수적 안 채택**: 설계 에이전트는 'success 복구'(점수 정상화 후 통과)를 제안했으나, 전부-garbage AI 응답이 89/B 로 auto-merge 가능해지는 **fail-open 위험**이 있어, fail-open 봉인 클러스터 정합상 **parse_error 신호 유지 + feedback 보존**의 보수적 안 채택. 게이트 동작은 불변, 데이터(feedback)만 보존.
- **#807 독립**: 인라인 PARITY 방식이라 hook.py 미접촉 → 머지 대기 #807 과 충돌 없음.
- 부수: S5713(중복 except `json.JSONDecodeError`⊂`ValueError`) 해소.

## 🔍 사용자 검증 필요 (정책 2)
- [ ] UI 무변경 (백엔드 파싱 로직) — 시각 확인 불필요
- [ ] 운영: AI 리뷰가 비정형 점수를 반환하던 PR 에서 이제 feedback 이 보존되며 parse_error 배너가 뜨는지(대시보드) — 해당 케이스 발생 시 확인
- [ ] 운영 사고 보고: 해당 없음

## 테스트
- **PARITY 가드**: `_coerce_score` ≡ `hook._coerce_raw_score` 입력 배터리 10건 (float-string/Infinity/NaN/None/clamp)
- feedback 보존(float-string commit) / Infinity→parse_error 보존 / 비-dict→parse_error
- 기존 51 + 신규 4 = 55, **전체 4836 passed / pylint 10.00 / flake8 clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)