### PR TITLE
fix(security): SSRF DNS-rebinding 가드 docstring 정직화 — validate-time 한계 명시 (Task9 P2 #12)

### DIFF
--- a/src/notifier/_http.py
+++ b/src/notifier/_http.py
@@ -21,8 +21,17 @@ async def validate_external_url(url: str) -> bool:
     Blocks:
     - Non-https schemes (http, ftp, file, …)
     - IP literals in private/loopback/link-local/reserved/multicast ranges
-    - Hostnames that DNS-resolve to any such address (DNS-rebinding defence)
+    - Hostnames whose DNS *currently* resolves to such an address
     - Empty or malformed URLs
+
+    🔴 한계 (정직화 — Task9 P2 #12): 이것은 validate 시점 1차 차단일 뿐 **완전한 DNS-rebinding
+    방어가 아니다**. httpx 는 connect 시점에 호스트명을 독립적으로 재해석하므로(이 함수의 getaddrinfo
+    와 별개), validate→connect 사이 DNS 가 내부 IP 로 rebind 되면 우회 가능한 TOCTOU 가 잔존한다.
+    완전 방어는 connect 시 검증된 IP 핀이 필요하나 httpx 가 native 미지원이라 미적용.
+    🔴 Limitation (Task9 P2 #12): only a validate-time first block, NOT a full DNS-rebinding defence.
+    httpx re-resolves the hostname independently at connect time, so a TOCTOU remains if DNS rebinds
+    to an internal IP between validate and connect. A full fix needs a connect-time pinned IP, which
+    httpx does not natively support.
 
     DNS 조회는 asyncio.to_thread 으로 실행 — 이벤트 루프 블로킹 방지.
     DNS lookup runs in asyncio.to_thread to avoid blocking the event loop.
@@ -79,5 +88,12 @@ def build_safe_client() -> httpx.AsyncClient:
 
     - timeout=10 seconds for all operations
     - follow_redirects=False to prevent redirect-based SSRF
+
+    🔴 한계 (Task9 P2 #12): 목적지 호스트는 connect 시 httpx 가 재해석하므로 validate_external_url
+    의 1차 IP 차단 이후의 DNS-rebinding TOCTOU 를 막지 못한다(검증된 IP 핀 미적용). 외부 webhook 은
+    재시도 금지 채널이고 follow_redirects=False 라 잔여 위험은 제한적.
+    🔴 Limitation (Task9 P2 #12): httpx re-resolves the destination host at connect time, so this does
+    NOT close the DNS-rebinding TOCTOU after validate_external_url's first block (no pinned IP).
+    External webhooks are non-retried and follow_redirects=False, so residual risk is limited.
     """
     return httpx.AsyncClient(timeout=HTTP_CLIENT_TIMEOUT, follow_redirects=False)

--- a/tests/unit/notifier/test_http.py
+++ b/tests/unit/notifier/test_http.py
@@ -154,3 +154,26 @@ async def test_validate_logs_warning_on_private_ip(caplog):
     assert result is False
     assert len(caplog.records) >= 1
     assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# #12 — SSRF docstring 정직화 회귀 가드 (DNS-rebinding 과대표현 재발 차단)
+# DNS-rebinding overclaim regression guard.
+# ---------------------------------------------------------------------------
+
+
+def test_validate_docstring_no_dns_rebinding_overclaim():
+    """#12: validate_external_url docstring 이 'DNS-rebinding defence' 를 방어 단언으로 과대표현하지
+    않고, validate 시점 한계(connect 재해석 TOCTOU)를 명시해야 한다 — 정직화 봉인."""
+    doc = validate_external_url.__doc__ or ""
+    assert "NOT a full DNS-rebinding defence" in doc  # 정직한 한계 명시
+    assert "validate-time" in doc
+    assert "connect time" in doc
+    assert "TOCTOU" in doc
+
+
+def test_build_safe_client_docstring_notes_toctou_limitation():
+    """#12: build_safe_client docstring 이 connect-time 재해석 TOCTOU 한계를 명시해야 한다."""
+    doc = build_safe_client.__doc__ or ""
+    assert "TOCTOU" in doc
+    assert "connect time" in doc


### PR DESCRIPTION
## 개요
Task9 골든 감사 P2 보안·파이프라인 하드닝 클러스터 3/N.

`validate_external_url` docstring 이 `(DNS-rebinding defence)` 로 완전 방어를 표방했으나, 실제로는
**validate 시점 1차 차단**일 뿐이다. httpx 가 connect 시점에 호스트명을 독립 재해석(이 함수의
getaddrinfo 와 별개)하므로, validate→connect 사이 DNS 가 내부 IP 로 rebind 되면 우회 가능한
**TOCTOU 가 잔존**한다.

## 수정 (옵션 B — 사용자 결정)
- **코드 로직 0줄 변경**. `validate_external_url` / `build_safe_client` docstring 을 정직화:
  - validate 시점 1차 차단임을 명시
  - connect 재해석 TOCTOU 한계 + 검증된 IP 핀 미적용(httpx native 미지원) 기록

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK**: 순수 docstring(동작 무변경) 확인 + 한계 표기 정확 + 테스트 false invariant 없음.

## 🤖 자율 판단 보고 (정책 3)
- **옵션 B 선택 = 사용자 결정**: 옵션 A(custom `AsyncHTTPTransport` IP 핀)는 httpx 내부 버전 의존 + https SNI/cert 검증 깨짐 위험 + 4채널 회귀 위험으로 정책17(안정성)·정책16(단순성) 위배. 사용자가 옵션 B(정직화) 선택.
- **근본 미해결 명시**: 정직한 한계 표기일 뿐 TOCTOU 자체는 미해결 — SaaS 전환 시 네트워크 계층 재설계에서 옵션 A 재검토 후보. follow_redirects=False + validate 1차 차단 + untrusted webhook 비재시도로 잔여 위험 제한적.

## 🔍 사용자 검증 필요 (정책 2)
- [ ] UI 무변경 — 시각 확인 불필요
- [ ] 운영 동작 무변경 (docstring 만) — smoke 불필요
- [ ] **인지 사항**: SSRF DNS-rebinding 은 1차 차단만 제공(완전 방어 아님)임을 운영 인지

## 테스트
- docstring 회귀 가드 2건 (과대표현 재발 차단 — `NOT a full DNS-rebinding defence` + validate-time/connect time/TOCTOU 키워드 존재)
- 기존 validate 차단 가드 18건 보존 / notifier 20 passed / pylint 10.00 / flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)