### PR TITLE
fix(pipeline): CLI hook parse_error 시 인플레 점수 DB 미저장 + overview 등급 NULL 처리 (Task9 P2 #25)

### DIFF
--- a/src/api/hook.py
+++ b/src/api/hook.py
@@ -237,13 +237,25 @@ def save_hook_result(  # pylint: disable=unused-argument,too-many-locals
         # CLI 훅은 정적 분석 없음 → 빈 리스트 (code_quality=25, security=20 만점)
         score_result = calculate_score([], ai_review=ai_review)
 
+        # 🔴 #25: parse_error(비숫자/누락 점수) 시 인플레 fallback 점수(89/B)를 score/grade 컬럼에
+        # 저장하지 않는다(NULL). score/grade 는 nullable 이고 모든 집계(_kpi_avg·func.avg·leaderboard)
+        # 가 NULL 을 자연 제외하므로, NULL 저장만으로 대시보드/리더보드 오염을 차단한다(쿼리 변경 0).
+        # result dict 의 breakdown·ai_review_status='parse_error' 는 보존 → 대시보드 fallback 배너·
+        # 정성 정보 유지(컬럼=집계용 NULL / result=진단용 보존, 의도적 비대칭).
+        # #25: on parse_error don't persist the inflated fallback score (89/B) — store NULL. score/grade
+        # are nullable and every aggregation already excludes NULL, so NULL alone stops dashboard/
+        # leaderboard pollution (0 query change). The result dict keeps breakdown + ai_review_status for
+        # the fallback banner (column = NULL for aggregation / result = preserved for diagnostics).
+        persisted_score = score_result.total if scores_ok else None
+        persisted_grade = score_result.grade if scores_ok else None
+
         analysis = Analysis(
             repo_id=repo.id,
             commit_sha=body.commit_sha,
             commit_message=body.commit_message,
             pr_number=None,
-            score=score_result.total,
-            grade=score_result.grade,
+            score=persisted_score,
+            grade=persisted_grade,
             result=build_analysis_result_dict(ai_review, score_result, [], "cli"),
         )
 
@@ -269,15 +281,15 @@ def save_hook_result(  # pylint: disable=unused-argument,too-many-locals
         # NOSONAR 이유: SonarCloud taint analysis 가 str.replace 기반 커스텀
         # sanitizer 를 인식하지 못함 — log_safety 모듈에서 실제 방어 완료.
         logger.info(  # NOSONAR python:S5145 — sanitized via log_safety
-            "CLI hook result saved: repo=%s sha=%s score=%d",
+            "CLI hook result saved: repo=%s sha=%s score=%s",  # %s — parse_error 시 None 안전
             sanitize_for_log(body.repo),
             sanitize_for_log(body.commit_sha),
-            score_result.total,
+            persisted_score,
         )
 
         return {
             "status": "saved",
-            "score": score_result.total,
-            "grade": score_result.grade,
+            "score": persisted_score,
+            "grade": persisted_grade,
             "analysis_id": analysis.id,
         }

--- a/src/ui/routes/overview.py
+++ b/src/ui/routes/overview.py
@@ -67,12 +67,19 @@ def overview(
 
             for r in repos:
                 count = count_map.get(r.id, 0)
-                avg = round(avg_map.get(r.id) or 0)
+                # 🔴 #25: avg_map 은 func.avg(Analysis.score) — SQL AVG 가 NULL(parse_error) 을 자동
+                # 제외하므로 score 가 전부 NULL 인 리포는 avg=None. 반면 count 는 parse_error 를 포함한다.
+                # grade 를 count(>0) 가 아닌 '실제 평균 존재(avg_raw is not None)' 기준으로 판정해야
+                # parse_error-only 리포가 calculate_grade(0)=F 로 오분류되지 않는다(#25 NULL 저장 회귀 차단).
+                # avg_map is func.avg (auto-excludes NULL); a parse_error-only repo yields None while count
+                # still includes it. Gate the grade on an actual average, not the count, to avoid an F.
+                avg_raw = avg_map.get(r.id)
+                avg = round(avg_raw) if avg_raw is not None else 0
                 repo_data.append({
                     "full_name": r.full_name,
                     "analysis_count": count,
                     "avg_score": avg,
-                    "avg_grade": calculate_grade(avg) if count > 0 else None,
+                    "avg_grade": calculate_grade(avg) if avg_raw is not None else None,
                 })
 
         # Phase E.3-d — AI 점수 정합도 지표 (전역)

--- a/tests/unit/api/test_hook.py
+++ b/tests/unit/api/test_hook.py
@@ -691,3 +691,52 @@ def test_coerce_raw_score_absorbs_infinity_overflow():
     # 정상 정수·숫자문자열은 ok=True 로 통과 (동등성) / valid int & numeric string stay ok=True
     assert _coerce_raw_score(18, 20, 17) == (18, True)
     assert _coerce_raw_score("15", 20, 17) == (15, True)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# #25 — parse_error 시 인플레 fallback 점수를 DB 에 저장하지 않음 (집계 오염 차단)
+# Don't persist the inflated fallback score on parse_error (no aggregation pollution).
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_hook_result_parse_error_stores_null_score():
+    """#25: 비숫자 점수(parse_error)면 인플레 fallback(89/B)을 저장하지 않고 score/grade NULL 저장."""
+    r, saved = _post_hook_non_numeric({**_AI_RESULT, "commit_message_score": "abc"})
+    assert r.status_code == 200
+    assert len(saved) == 1
+    assert saved[0].score is None    # 인플레 점수 미저장 → 대시보드/리더보드 집계 오염 차단
+    assert saved[0].grade is None
+
+
+def test_hook_result_empty_ai_result_stores_null_score():
+    """#25: 빈 ai_result(parse_error)도 score/grade NULL 저장."""
+    saved = _post_hook_capturing({})
+    assert len(saved) == 1
+    assert saved[0].score is None
+    assert saved[0].grade is None
+
+
+def test_hook_result_parse_error_response_score_none():
+    """#25: parse_error 시 HTTP 응답 body 의 score/grade 도 None (훅 CLI 가 인플레 점수 표시 안 함)."""
+    r, saved = _post_hook_non_numeric({**_AI_RESULT, "commit_message_score": "abc"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["score"] is None
+    assert body["grade"] is None
+
+
+def test_hook_result_parse_error_preserves_result_dict():
+    """#25: score 컬럼은 NULL 이지만 result dict 의 ai_review_status·breakdown 은 보존(대시보드 배너)."""
+    r, saved = _post_hook_non_numeric({**_AI_RESULT, "commit_message_score": "abc"})
+    assert r.status_code == 200
+    assert saved[0].score is None                               # 컬럼 NULL (집계 제외)
+    assert saved[0].result["ai_review_status"] == "parse_error"  # 정성 정보 보존
+    assert "breakdown" in saved[0].result                        # 배너용 breakdown 보존
+
+
+def test_hook_result_valid_score_persists_non_null():
+    """#25 회귀 가드: 정상(success) 점수는 NULL 화 영향 없이 그대로 저장."""
+    saved = _post_hook_capturing(_AI_RESULT)
+    assert len(saved) == 1
+    assert saved[0].score is not None
+    assert saved[0].grade is not None

--- a/tests/unit/ui/test_router.py
+++ b/tests/unit/ui/test_router.py
@@ -1732,6 +1732,31 @@ def test_overview_grade_derived_from_avg_score():
     assert '<span class="grade grade--a">' in r.text
 
 
+def test_overview_parse_error_only_repo_shows_no_grade_not_f():
+    """#25 회귀 가드: 점수가 전부 NULL(parse_error)인 리포는 등급 F 로 오분류되지 않고 등급 없음.
+
+    count_map 은 parse_error 분석을 포함(count=1)하지만 avg_map 은 func.avg(NULL 제외)로 avg=None.
+    grade 를 count 가 아닌 avg_raw(실제 평균 존재) 기준으로 판정 → calculate_grade(0)=F 미발생.
+    Codex mutual 검토가 적발한 #25 NULL 저장 회귀(overview avg_grade=F 오분류) 봉인.
+    """
+    mock_db = MagicMock()
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1, created_at="2026-01-01")
+    mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [mock_repo]
+    # count_map 은 parse_error 분석 1건 포함, avg_map 은 func.avg(NULL 제외) → avg=None
+    mock_db.query.return_value.filter.return_value.group_by.return_value.all.side_effect = [
+        [(1, 1)],       # count_map: [(repo_id, count)] — parse_error 분석 카운트됨
+        [(1, None)],    # avg_map: [(repo_id, avg)] — 모든 score NULL → func.avg=None
+    ]
+    mock_db.query.return_value.filter.return_value.all.return_value = []
+
+    with patch("src.ui.routes.overview.SessionLocal", return_value=_ctx(mock_db)):
+        r = client.get("/")
+    assert r.status_code == 200
+    # F 등급 뱃지가 렌더되면 안 된다 (점수 없음 → 등급 미표시)
+    # No F-grade badge must render (no valid score → no grade)
+    assert '<span class="grade grade--f">' not in r.text
+
+
 # ── Settings 페이지 재설계 스모크 테스트 (2026-04-21) ──────────────────────────
 
 def test_settings_form_fields_preserved():


### PR DESCRIPTION
## 개요
Task9 골든 감사 P2 보안·파이프라인 하드닝 클러스터 **마지막(5/5)**. (#807 머지 후 진행)

`save_hook_result` 가 비숫자/누락 점수(parse_error)에도 `calculate_score` 의 인플레 fallback
점수(AI 중립 44 + 정적분석 부재 만점 45 = **89/B**)를 `Analysis.score/grade` 컬럼에 저장했다.
모든 집계가 score 컬럼을 읽으므로 parse_error 89점이 평균·순위·이동평균을 오염시켰다.

## 수정
1. **hook**: `scores_ok` False(parse_error)면 `score/grade` 를 **NULL 저장**. 컬럼 이미 nullable +
   집계가 이미 NULL 제외 → 쿼리 변경 0. 응답·로그도 None 반영. result dict 의 breakdown·
   ai_review_status='parse_error' 보존(컬럼=집계용 / result=진단용).
2. **overview** (Codex 적발 회귀): NULL 도입 후 `overview.py` 가 count(parse_error 포함)와
   func.avg(NULL 제외) 불일치로 score-전부-NULL 리포를 **grade=F 오분류**. → grade 를 count 가
   아닌 avg_raw(실제 평균 존재) 기준으로 판정.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**2-라운드 mutual → CODEX_OK**:
- **R1 NG**: Codex 가 overview.py 의 F-오분류 회귀를 적발(NULL 도입의 read-path 영향).
- **R2 OK**: overview 수정 + 전 read-path 감사(analytics/dashboard 안전 확인) + 회귀 테스트 확인.

## 🤖 자율 판단 보고 (정책 3)
- **NULL 저장 방식**: 신규 status 컬럼/마이그레이션 대신 기존 nullable + NULL-제외 집계 재사용(정책16 쿼리 0줄). 단, NULL 도입이 모든 read-path에 영향 → **전수 감사**로 overview(유일 미처리) 발견·수정.
- **정책 4 적용**: NULL 저장(단언) + overview 회귀 가드를 동일 PR에 묶음.
- **result dict score 보존**: 컬럼은 NULL이나 result['score']는 calculate_score total 유지(대시보드 진단 배너용) — 의도적 비대칭.

## 🔍 사용자 검증 필요 (정책 2)
- [ ] **운영 시각 확인**: 대시보드/overview에서 parse_error 분석만 있는 리포가 **F 등급이 아닌 '등급 없음'**으로 표시되는지 (Railway 배포 후)
- [ ] CLI hook이 비정상 점수 제출 시 대시보드 평균/리더보드가 오염되지 않는지
- [ ] 운영 사고 보고: 해당 없음

## 테스트
- hook: parse_error/빈 ai_result → score/grade NULL + 응답 None + result dict 보존 + 정상 회귀 (28)
- overview: parse_error-only 리포 F 미표시 회귀 가드 (+1)
- **전체 4862 passed / pylint 10.00 / flake8 clean**

🤖 Generated with [Claude Code](https://claude.com/claude-code)