### PR TITLE
test: 사이클 165 회고 (B) 테스트 갭 봉인 — claim_decision PG invariant·broad-absorb·seam 실DB (P1)

### DIFF
--- a/tests/integration/test_retry_concurrency_postgres.py
+++ b/tests/integration/test_retry_concurrency_postgres.py
@@ -387,4 +387,102 @@ def test_skip_locked_prevents_concurrent_double_claim():
         # 테스트 후 정리
         # Clean up after test.
         Base.metadata.drop_all(engine)
+
+
+def _seed_postgres_analysis(session, repo_name: str, sha: str) -> int:
+    """Postgres 세션에 Repository + Analysis 시드 — analysis.id 반환 (claim_decision race 용).
+    Seed a Repository + Analysis into the Postgres session; return analysis.id.
+    """
+    from src.models.analysis import Analysis
+    from src.models.repository import Repository
+
+    repo = session.query(Repository).filter_by(full_name=repo_name).first()
+    if repo is None:
+        repo = Repository(full_name=repo_name)
+        session.add(repo)
+        session.flush()
+    analysis = Analysis(
+        repo_id=repo.id, commit_sha=sha, score=80, grade="B", result={}, pr_number=1,
+    )
+    session.add(analysis)
+    session.commit()
+    return analysis.id
+
+
+@_requires_postgres
+def test_claim_decision_concurrent_first_writer_wins_invariant():
+    """claim_decision first-writer-wins **invariant** — 실 PG, barrier 동기화 동시 claim.
+    claim_decision first-writer-wins **invariant** on real PG under barrier-synchronized concurrent claims.
+
+    #11 게이트 콜백 리플레이 가드의 핵심 보장: 두 워커가 동일 analysis 를 동시에 claim 할 때 정확히
+    한 쪽만 True(승자), 다른 쪽은 IntegrityError→False(패자) — 중복행 0·crash 0.
+    barrier 로 진입을 동기화해 실 PG 에서 경합을 극대화하지만, 본 테스트가 증명하는 것은 **타이밍이
+    직렬화되든 겹치든 항상 성립해야 하는 invariant**(정확히 1 승자)이다. **직렬화 지점은 DB 의
+    UNIQUE(analysis_id) 인덱스** — 제약이 사라지면(2 행) 또는 IntegrityError 흡수가 깨지면(crash) 본
+    테스트가 fail 한다. 순차 SQLite 단위 테스트와 달리 실 PG + 동시 스레드 + 실제 IntegrityError 타입을
+    탄다 (사이클 165 회고 testing P1-1 / Codex mutual: 'in-flight 결정론 증명' 과장 표현 정직화).
+    What this guards is the INVARIANT (exactly one winner) that must hold whether timing serializes or
+    overlaps; the UNIQUE(analysis_id) index is the serialization point. A dropped constraint (2 rows) or a
+    broken IntegrityError absorb (crash) fails this — on real PG with the real IntegrityError type.
+    """
+    from src.database import Base
+    from src.models.gate_decision import GateDecision
+    from src.repositories import gate_decision_repo
+
+    engine = _make_engine()
+    try:
+        Base.metadata.drop_all(engine)
+        Base.metadata.create_all(engine)
+        Session = sessionmaker(bind=engine)
+
+        # 시드: GateDecision 미존재 analysis 1건 — 두 워커가 이 결정을 두고 경쟁.
+        # Seed: one analysis with no GateDecision yet — both workers race to claim its decision.
+        with Session() as seed_session:
+            analysis_id = _seed_postgres_analysis(seed_session, "owner/repo-claim", "sha_claim_race")
+
+        results: list = [None, None]
+        errors: list = []
+        # barrier — 두 세션이 동일 analysis_id claim 진입을 동기화해 실 PG 경합을 극대화한다.
+        # (직렬화 지점은 DB UNIQUE 인덱스 — barrier 는 invariant 검증을 위한 경합 최대화 수단이지
+        #  in-flight 겹침을 결정론적으로 강제하지는 못함, 본 테스트는 invariant 를 검증.)
+        # timeout=30 — deadlock guard (한 워커 조기 예외 시 무기한 block 방지).
+        barrier = threading.Barrier(2, timeout=30)
+
+        def worker(i: int) -> None:
+            """독립 세션으로 동일 analysis 의 결정을 claim 시도.
+            Attempt to claim the same analysis's decision in an independent session.
+            """
+            try:
+                with Session() as db:
+                    barrier.wait()  # 두 워커 동시 INSERT 강제 / force concurrent INSERT
+                    results[i] = gate_decision_repo.claim_decision(
+                        db, analysis_id, "approve", "manual", f"user{i}",
+                    )
+            except Exception as exc:  # pylint: disable=broad-except
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        # 크래시 없이 완료 — IntegrityError 는 claim_decision 내부에서 흡수되어 False 로 반환.
+        # Must complete without errors — IntegrityError is absorbed inside claim_decision as False.
+        assert not errors, f"Unexpected errors from worker threads: {errors}"
+
+        # invariant: 정확히 한 워커만 True(first-writer), 다른 워커 False(패자).
+        # invariant: exactly one True (first-writer) and one False (loser).
+        assert sorted([results[0], results[1]]) == [False, True], (
+            f"Expected exactly one True (first-writer-wins invariant), got {results}"
+        )
+
+        # invariant: GateDecision 행 정확히 1개 (UNIQUE 제약 누락 시 2 행 → fail).
+        # invariant: exactly one GateDecision row (a dropped UNIQUE constraint → 2 rows → fail).
+        with Session() as verify:
+            count = verify.query(GateDecision).filter_by(analysis_id=analysis_id).count()
+        assert count == 1, f"Expected exactly 1 GateDecision row, got {count}"
+
+    finally:
+        Base.metadata.drop_all(engine)
         engine.dispose()

--- a/tests/unit/repositories/test_gate_decision_repo.py
+++ b/tests/unit/repositories/test_gate_decision_repo.py
@@ -91,3 +91,17 @@ def test_claim_decision_duplicate_loses_no_flip(db_session):
     rec = gate_decision_repo.find_by_analysis_id(db_session, a.id)
     assert rec.decision == "approve"
     assert rec.decided_by == "alice"
+
+
+def test_claim_decision_absorbs_non_unique_integrity_error(db_session):
+    """correctness 회귀 가드: claim_decision 의 broad `except IntegrityError` 는 UNIQUE 외
+    NOT NULL/FK 위반도 흡수해 graceful False 를 반환한다(크래시 아님). 호출자는 호출 전
+    analysis 존재를 보장할 책임이 있다(docstring 명시). 사이클 165 회고 correctness P1-1.
+
+    analysis_id=None → NOT NULL(nullable=False) 위반 → IntegrityError → 흡수 → False.
+    (UNIQUE 충돌이 아닌 IntegrityError 도 동일 경로로 흡수됨을 봉인.)
+    """
+    won = gate_decision_repo.claim_decision(db_session, None, "approve", "manual", "alice")
+    assert won is False
+    # 아무 행도 영속되지 않아야 한다 (rollback)
+    assert db_session.query(GateDecision).count() == 0

--- a/tests/unit/webhook/test_gate_callback_seam_realdb.py
+++ b/tests/unit/webhook/test_gate_callback_seam_realdb.py
@@ -1,0 +1,109 @@
+"""handle_gate_callback seam 실DB 테스트 (사이클 165 회고 testing P1-2).
+
+claim_decision 을 patch 하지 않고 **실 in-memory DB**(StaticPool 공유 연결)로 콜백을 실행해,
+호출 심볼 리네임(save_gate_decision→claim_decision 류) 시 fail-fast 를 보장한다. MagicMock DB 가
+아닌 실 세션을 쓰므로 patch-target staleness 에 면역 — 콜백 seam 의 결정 claim 이 실제로 영속되는지
+(첫 호출)와 리플레이 skip(둘째 호출, 결정 뒤집기 차단)을 검증한다.
+
+real-DB test using a shared StaticPool in-memory engine so the callback runs the REAL claim_decision —
+immune to stale patch targets; a symbol rename breaks the import and fails this test fast.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+os.environ.setdefault("ANTHROPIC_API_KEY", "")
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from src.config_manager.manager import RepoConfigData
+from src.database import Base
+from src.models.analysis import Analysis  # noqa: F401 — create_all 테이블 등록
+from src.models.gate_decision import GateDecision  # noqa: F401
+from src.models.repository import Repository  # noqa: F401
+from src.models.user import User  # noqa: F401
+
+
+@pytest.fixture
+def real_session_factory():
+    """공유 연결(StaticPool) in-memory SQLite — 여러 세션이 동일 DB 를 본다.
+
+    handle_gate_callback 이 자체 `with SessionLocal() as db:` 로 새 세션을 열기 때문에,
+    기본 in-memory(연결별 별도 DB) 대신 StaticPool 로 단일 연결을 공유해야 seed 가 보인다.
+    """
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine)
+    try:
+        yield factory
+    finally:
+        engine.dispose()
+
+
+def _seed(factory) -> int:
+    """User(telegram 연동) + Repository(소유자=User) + Analysis(pr_number 有) 시드 — analysis.id 반환."""
+    with factory() as db:
+        user = User(
+            github_id="gh999", email="seam@test.com", display_name="Seam Tester",
+            telegram_user_id="999", preferred_language="en",
+        )
+        db.add(user)
+        db.flush()
+        repo = Repository(full_name="owner/seam", user_id=user.id)
+        db.add(repo)
+        db.flush()
+        analysis = Analysis(
+            repo_id=repo.id, commit_sha="seamsha", pr_number=5,
+            score=85, grade="B", result={"score": 85},
+        )
+        db.add(analysis)
+        db.commit()
+        return analysis.id
+
+
+async def test_handle_gate_callback_real_db_claims_then_replay_skips(real_session_factory):
+    """첫 콜백 = claim 실제 실행 → GateDecision 영속 + 리뷰 게시 / 둘째(리플레이) = claim False → skip.
+
+    claim_decision 을 patch 하지 않으므로(실 DB 실행), 콜백 seam 이 claim_decision 을 실제로 호출·
+    영속하는지 검증한다 — 심볼 리네임 시 import/실행 단계에서 즉시 fail.
+    """
+    from src.webhook.router import handle_gate_callback  # pylint: disable=import-outside-toplevel
+
+    analysis_id = _seed(real_session_factory)
+    config = RepoConfigData(repo_full_name="owner/seam", auto_merge=False)
+
+    with patch("src.webhook.providers.telegram.SessionLocal", real_session_factory), \
+         patch("src.webhook.providers.telegram.get_repo_config", return_value=config), \
+         patch("src.webhook.providers.telegram.post_github_review",
+               new_callable=AsyncMock) as mock_review:
+        # 1차: claim 성공(first-writer) → 리뷰 게시 + GateDecision 실제 영속
+        await handle_gate_callback(
+            analysis_id=analysis_id, decision="approve",
+            decided_by="tester", telegram_user_id="999",
+        )
+        assert mock_review.await_count == 1
+        with real_session_factory() as db:
+            assert db.query(GateDecision).filter_by(analysis_id=analysis_id).count() == 1
+
+        # 2차(리플레이, 다른 결정으로 뒤집기 시도): claim False → 부수효과 skip
+        await handle_gate_callback(
+            analysis_id=analysis_id, decision="reject",
+            decided_by="tester", telegram_user_id="999",
+        )
+        assert mock_review.await_count == 1  # 재게시 없음 (리플레이 차단)
+        with real_session_factory() as db:
+            rows = db.query(GateDecision).filter_by(analysis_id=analysis_id).all()
+            assert len(rows) == 1                    # 중복 INSERT 없음
+            assert rows[0].decision == "approve"     # 최초 결정 보존 (뒤집기 차단)


### PR DESCRIPTION
## 개요
사이클 165 5+1 회고가 식별한 **테스트 갭 P1 3건**을 회귀 가드로 봉인. **src 무변경 (테스트만).** follow-up (B).

| 회고 finding | 테스트 |
|--------------|--------|
| testing P1-1 | `test_retry_concurrency_postgres.py` — claim_decision **first-writer-wins invariant** (실 PG + `threading.Barrier(2)` 동시 claim, 1 True/1 False + 1행, pg-concurrency CI job) |
| correctness P1-1 | `test_gate_decision_repo.py` — claim_decision **broad IntegrityError 흡수**(NOT NULL→False) |
| testing P1-2 | `test_gate_callback_seam_realdb.py` 신규 — **seam 실DB**(StaticPool, claim_decision 미patch 실행) → 심볼 리네임 fail-fast |

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**2-라운드 mutual → CODEX_OK**:
- **R1 NG**: Codex 가 PG 테스트의 'in-flight race 결정론 증명' **claim 과장** 적발 — atomic INSERT+commit 은 barrier 후 직렬화 가능.
- **R2 OK**: claim 을 **invariant**(직렬화/겹침 무관 항상 성립할 1-승자 불변식)로 정직화. UNIQUE 인덱스가 직렬화 지점 — 제약 누락(2행)·absorb 깨짐(crash) 시 fail. 테스트 검증력은 보존, 표현만 정확화.

## 🤖 자율 판단 보고 (정책 3)
- **invariant 정직화 = 단일정답 표현 수정**(정책18 §3 2-tier: 객관적 과장 표현 정정) — 테스트를 약화하지 않고 claim 을 실제 보장 수준으로 scoping. 대안(in-flight 강제: A flush-비commit → B blocking INSERT → A commit)은 sleep 의존 flakiness 위험으로 보류.
- 회고 신규 P2(claim rollback 세션 영향·_regate source 오염)·completeness gap(background task UX 등)은 본 PR 제외 — 별도 결정 영역.

## 🔍 사용자 검증 필요 (정책 2)
- [ ] 운영/시각 영향 없음 (테스트 추가만)
- [ ] PG invariant 테스트는 로컬 skip → **CI `PG-only tests` job 에서 통과 확인** (codecov/patch tiny-diff 가능, non-blocking)

## 테스트
- 전체 **4864 passed, 5 skipped**(PG invariant = pg-concurrency CI job) / flake8 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)