### PR TITLE
chore: db/migration 정합 — insight_cache 유령 인덱스 제거 + test_0029 dead-branch (#17/#31)

### DIFF
--- a/src/models/insight_narrative_cache.py
+++ b/src/models/insight_narrative_cache.py
@@ -43,9 +43,13 @@ class InsightNarrativeCache(Base):
     language = Column(String(5), nullable=False, default="en", server_default="en")
     # 0031 — repo-specific cache key (NULL = global dashboard narrative)
     # 0031 — 리포별 캐시 키 (NULL = 전체 대시보드 내러티브)
+    # repo_id 인덱스는 위 __table_args__ 의 명시 Index("ix_insight_cache_repo_id") + alembic 0031:62 로 정합.
+    # index=True 를 쓰지 않음 — 자동명 ix_insight_narrative_cache_repo_id 중복/유령 인덱스(운영 PG 미존재) 방지 (#17).
+    # repo_id is indexed via the explicit Index above + alembic 0031; index=True omitted to avoid a
+    # duplicate auto-named ghost index that never exists in production PG (#17).
     repo_id = Column(
         Integer, ForeignKey("repositories.id", ondelete="CASCADE"),
-        nullable=True, index=True,
+        nullable=True,
     )
     response_json = Column(JSON, nullable=False)
     created_at = Column(

--- a/tests/unit/migrations/test_0029_rls_5_missing_tables.py
+++ b/tests/unit/migrations/test_0029_rls_5_missing_tables.py
@@ -161,12 +161,16 @@ def test_alembic_0029_analysis_feedbacks_direct_isolation():
 def test_alembic_0029_users_self_rls():
     """C.6 — users 가 self-RLS (id 직접 비교)."""
     captured = _capture_pg_upgrade_sql()
+    # 0029 가 users 에 ALTER TABLE users ENABLE ROW LEVEL SECURITY 를 발화하는지 검증
+    # Verify 0029 emits ALTER TABLE users ENABLE ROW LEVEL SECURITY
+    # (구 `or "ON users" in s.lower()` 서브분기 제거: s.lower() 라 대문자 "ON users" 절대 미매칭 dead-branch #31)
     users_sql = next(
-        (s for s in captured if "ALTER TABLE users" in s or "ON users" in s.lower()),
+        (s for s in captured if "ALTER TABLE users" in s),
         None,
     )
-    # 5 SQL 중 첫 번째가 users
-    assert users_sql is not None or "users" in " ".join(captured).lower()
+    # users RLS SQL 이 반드시 존재해야 함 (구 dead `or` fallback 제거 — 가드 강화 #31)
+    # The users RLS statement must be present (removed the dead `or` fallback)
+    assert users_sql is not None, "users RLS (ALTER TABLE users) SQL 누락"
     joined = " ".join(captured).upper()
     # users.id = current_setting (self-RLS)
     assert "ID = NULLIF" in joined, (

--- a/tests/unit/migrations/test_0031_repo_insights_cache.py
+++ b/tests/unit/migrations/test_0031_repo_insights_cache.py
@@ -50,6 +50,32 @@ def test_repo_id_is_nullable(engine):
     assert col["nullable"] is True
 
 
+def test_repo_id_no_duplicate_ghost_index(engine):
+    """repo_id 인덱스는 명시 ix_insight_cache_repo_id 단일 — 중복/유령 인덱스 부재 (#17).
+
+    repo_id index is the single explicit ix_insight_cache_repo_id — no duplicate ghost (#17).
+
+    과거 `Column(..., index=True)` 가 자동명 ix_insight_narrative_cache_repo_id 를 추가 생성해
+    SQLite create_all 에만 존재하고 운영 PG(alembic 0031)에는 없는 유령/중복 인덱스가 됐다.
+    index=True 제거로 명시 Index 만 남겨 ORM↔alembic 정합을 회복했음을 회귀 가드한다.
+    Previously `Column(..., index=True)` created an auto-named ghost index absent from production PG.
+    """
+    insp = inspect(engine)
+    indexes = insp.get_indexes("insight_narrative_cache")
+    repo_id_indexes = [ix for ix in indexes if ix["column_names"] == ["repo_id"]]
+    # repo_id 단일 컬럼 인덱스는 정확히 1개 (명시 ix_insight_cache_repo_id)
+    # Exactly one single-column repo_id index (the explicit ix_insight_cache_repo_id)
+    assert len(repo_id_indexes) == 1, (
+        f"repo_id 단일 컬럼 인덱스가 {len(repo_id_indexes)}개 — "
+        "중복/유령 인덱스(index=True 재도입?) 의심"
+    )
+    assert repo_id_indexes[0]["name"] == "ix_insight_cache_repo_id"
+    # 자동명 유령 인덱스가 부재해야 함
+    # The auto-named ghost index must be absent
+    names = {ix["name"] for ix in indexes}
+    assert "ix_insight_narrative_cache_repo_id" not in names
+
+
 def test_global_and_repo_rows_coexist(engine):
     """같은 (user_id, days) 에 repo_id=NULL 과 repo_id=N 행이 공존 가능하다."""
     from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
## 요약
정합성 감사 full 리포트(2026-06-08, Task9 골든) **P2 코드 정합 2건**. 빠른 정합 묶음 클러스터 PR B (코드 영역). 잔여 백로그 검증 워크플로우(wf_d1e440d5) 코드 grep 실측 후 정정.

## 변경 내역

### #17 — `src/models/insight_narrative_cache.py` repo_id `index=True` 제거
- repo_id 인덱스는 `__table_args__` 의 명시 `Index("ix_insight_cache_repo_id", "repo_id")` + `alembic/0031:62 op.create_index` 로 **이미 ORM↔alembic 양쪽 정합** 제공.
- `index=True` 는 자동명 `ix_insight_narrative_cache_repo_id` **중복/유령 인덱스**를 추가 생성 — SQLite `create_all` 전용, 운영 PG(alembic)에는 애초에 미존재.
- **🔴 신규 마이그레이션 불필요**: ghost 인덱스는 운영 PG 에 존재한 적이 없으므로 DDL 변경 0. (index 손실 아님 — 명시 인덱스가 repo_id 커버 유지)
- 회귀 가드 `test_repo_id_no_duplicate_ghost_index`: `inspect()` 로 repo_id 단일 인덱스 + ghost 부재 단언. **Red(2개)→Green(1개) TDD 검증** 완료.

### #31 — `tests/unit/migrations/test_0029_rls_5_missing_tables.py` dead-branch 제거
- 구 `or "ON users" in s.lower()` 서브분기: `s.lower()` 라 대문자 `"ON users"` 절대 미매칭 (**dead**).
- 구 `assert users_sql is not None or "users" in ...` fallback: 첫 조건 `"ALTER TABLE users"` 가 항상 매칭(0029:41)이라 unreachable (**dead**).
- 두 dead 제거 → users RLS SQL 존재를 명확히 단언 (**가드 강화**, functional 동작 동일).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** ✅ — Codex가 (1) alembic 0031 의 `ix_insight_cache_repo_id` create_index 존재 + ghost 인덱스의 alembic 부재(마이그레이션 불필요) 확인, (2) 가드 테스트 직접 실행(2 passed), (3) test_0029 두 분기 dead 여부(0029:41 ALTER TABLE users 항상 매칭)를 적대적 실측 검증. true mutual (push 전).

## 🔍 사용자 검증 필요 (정책 2)
- 운영 영향 없음 — repo_id 인덱스는 명시 인덱스로 유지(쿼리 성능 동일), 제거된 것은 SQLite 테스트 전용 ghost 뿐.
- DB 스키마(운영 PG) 무변경 — 마이그레이션 파일 추가 0.

## 테스트
- `tests/unit/migrations/` 34 passed (1 skip) + insight_narrative_cache 참조 11파일 89 passed.
- pylint **10.00/10**, flake8 clean. 단위 +1 (4718→4719, 가드 테스트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)