### PR TITLE
chore: effects.js 죽은 셀렉터 dead-code 제거 — setupTabs/setupNavMagnet (#33)

### DIFF
--- a/src/static/js/effects.js
+++ b/src/static/js/effects.js
@@ -5,8 +5,6 @@
    - Count-up animation for KPI numbers
    - Score-bar / frequency-bar grow-in
    - SVG chart line draw + donut segment grow
-   - Tabs sliding indicator
-   - Nav active pill slide
    - Smooth in-page scroll
    All effects respect [data-motion="still"] and prefers-reduced-motion.
    ========================================================================== */
@@ -258,94 +256,7 @@
     });
   }
 
-  /* ----- 7. Tabs sliding indicator --------------------------------------- */
-  // 모든 탭 인디케이터를 활성 탭 위치로 재배치 (resize 단일 전역 핸들러용)
-  // Reposition every tab indicator onto its active tab (used by the single resize handler).
-  function repositionAllTabIndicators() {
-    document.querySelectorAll(".tabs").forEach((group) => {
-      const ind = group.querySelector(".tabs__indicator");
-      const active = group.querySelector(".tabs__tab.is-active");
-      if (!ind || !active) return;
-      const groupRect = group.getBoundingClientRect();
-      const r = active.getBoundingClientRect();
-      ind.style.transition = "none";
-      ind.style.width = `${r.width}px`;
-      ind.style.transform = `translateX(${r.left - groupRect.left}px)`;
-    });
-  }
-
-  function setupTabs() {
-    document.querySelectorAll(".tabs").forEach((group) => {
-      let ind = group.querySelector(".tabs__indicator");
-      if (!ind) {
-        ind = document.createElement("span");
-        ind.className = "tabs__indicator";
-        group.prepend(ind);
-      }
-      function position(tab, animated = true) {
-        if (!tab) return;
-        const groupRect = group.getBoundingClientRect();
-        const r = tab.getBoundingClientRect();
-        ind.style.transition = animated
-          ? "transform var(--dur-base) var(--ease-spring), width var(--dur-base) var(--ease-spring)"
-          : "none";
-        ind.style.width = `${r.width}px`;
-        ind.style.transform = `translateX(${r.left - groupRect.left}px)`;
-      }
-      const active = group.querySelector(".tabs__tab.is-active");
-      position(active, false);
-      group.querySelectorAll(".tabs__tab").forEach((t) => {
-        t.addEventListener("click", () => {
-          group.querySelectorAll(".tabs__tab").forEach((x) => x.classList.remove("is-active"));
-          t.classList.add("is-active");
-          position(t);
-        });
-      });
-    });
-
-    // re-measure on layout shift — remove-before-add 단일 전역 핸들러 (hx-boost 재방문 시 누적 차단)
-    // Single global resize handler via remove-before-add: prevents listener pile-up across hx-boost re-navigations.
-    if (document._tabsResizeHandler) {
-      window.removeEventListener("resize", document._tabsResizeHandler);
-    }
-    document._tabsResizeHandler = repositionAllTabIndicators;
-    window.addEventListener("resize", document._tabsResizeHandler);
-  }
-
-  /* ----- 8. Nav sliding active indicator --------------------------------- */
-  function setupNavMagnet() {
-    document.querySelectorAll(".nav__links").forEach((group) => {
-      let ind = group.querySelector(".nav__indicator");
-      if (!ind) {
-        ind = document.createElement("span");
-        ind.className = "nav__indicator";
-        group.appendChild(ind);
-      }
-      function position(link, animated = true) {
-        if (!link) return;
-        const groupRect = group.getBoundingClientRect();
-        const r = link.getBoundingClientRect();
-        ind.style.transition = animated
-          ? "transform var(--dur-base) var(--ease-spring), width var(--dur-base) var(--ease-spring), opacity var(--dur-base) ease"
-          : "none";
-        ind.style.width = `${r.width}px`;
-        ind.style.transform = `translateX(${r.left - groupRect.left}px)`;
-        ind.style.opacity = "1";
-      }
-      const active = group.querySelector(".nav__link.is-active");
-      position(active, false);
-      group.querySelectorAll(".nav__link").forEach((l) => {
-        l.addEventListener("click", (e) => {
-          e.preventDefault();
-          group.querySelectorAll(".nav__link").forEach((x) => x.classList.remove("is-active"));
-          l.classList.add("is-active");
-          position(l);
-        });
-      });
-    });
-  }
-
-  /* ----- 9. Smooth scroll for in-page anchors ---------------------------- */
+  /* ----- 7. Smooth scroll for in-page anchors ---------------------------- */
   function setupSmoothScroll() {
     document.querySelectorAll('a[href^="#"]').forEach((a) => {
       a.addEventListener("click", (e) => {
@@ -361,7 +272,7 @@
     });
   }
 
-  /* ----- 10. Subtle magnetic hover on cards ----------------------------- */
+  /* ----- 8. Subtle magnetic hover on cards ------------------------------- */
   function setupMagnetic() {
     if (reduced()) return;
     const targets = document.querySelectorAll(".kpi, .repo-card, .principle");
@@ -387,8 +298,6 @@
   }
 
   function init() {
-    setupTabs();
-    setupNavMagnet();
     setupEntryAnimations();
     setupCountUp();
     setupScoreBars();


### PR DESCRIPTION
## 요약
정합성 감사 full 리포트(2026-06-08, Task9 골든) **P2 UI dead-code 1건(#33)**. 빠른 정합 묶음 클러스터 PR C (마지막). `effects.js` 의 setupTabs/setupNavMagnet/repositionAllTabIndicators 3 함수를 제거 — 코드 −91줄.

## 변경 내역 (#33)
- `.tabs` `.tabs__tab` `.tabs__indicator` `.nav__links` `.nav__link` `.nav__indicator` **BEM 셀렉터는 `src/templates/**` 사용 0** (grep 실측 — 템플릿은 별개 `issue-reg-tabs` 클래스). 함수들이 `querySelectorAll` 에서 항상 빈 NodeList 반환 → 핸들러 바인딩 0 = **완전 dead code**.
- `setupNavMagnet` 의 `.nav__link` click `preventDefault` **잠재 함정 제거** — 향후 `.nav__link` 부착 시 모든 네비 링크가 preventDefault 되어 hx-boost 네비 마비될 위험을 사전 차단.
- #777(사이클 162)이 remove-before-add 가드한 `_tabsResizeHandler` 도 함께 제거 — **핸들러 자체가 사라져** hx-boost 재방문 리스너 누적 우려가 완전 해소(가드보다 강한 해결).
- `init()` 호출 2건 제거 + 섹션 주석 renumber.

## 🔴 자율 판단 보고 (정책 3) — 고아 CSS follow-up 분리
`components.css` 의 `.tabs`/`.tabs__*`/`.nav__*` 정의(485-500/712-725/839-884)도 이제 고아입니다. 단 (1) 라이브 스타일과 산재 인접, (2) CSS 제거 = 시각 검증 비대칭(정책 11) 이라 **본 PR은 JS-only 로 한정**하고 CSS 정리는 별도 follow-up 으로 분리했습니다(정책 17 안정성 우선). 고아 CSS 는 참조 0 = inert(무해).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** ✅ — Codex가 (1) `components.css`/`src/templates` 셀렉터 사용처(템플릿 0), (2) effects.js 잔존 참조 0, (3) `node --check` 구문, (4) 테스트 부재를 적대적 실측 검증. true mutual (push 전).

## 🔍 사용자 검증 필요 (정책 11 — Claude 시각 검증 불가)
- ⚠️ **정적 코드만 검증 가능** — 4-테마(dark/light/pastel/catppuccin) × 모바일/데스크탑 8 조합 시각 정합성은 Claude 가 확인 불가.
- 단, 제거 대상은 **실행된 적 없는 dead code**(셀렉터가 어떤 템플릿에도 없음)이므로 **시각 변화 0 으로 예상**. 탭/네비 인디케이터 슬라이딩 애니메이션은 현 UI 에 존재하지 않음(이미 미사용).
- [ ] (선택) 임의 페이지 네비게이션·탭 동작이 평소와 동일한지 확인

## 테스트
- `node --check` 구문 OK, `test_template_js_const` passed, 잔존 참조 0.
- 코드 −91줄(dead), 테스트 카운트 불변.

🤖 Generated with [Claude Code](https://claude.com/claude-code)