### PR TITLE
chore: hx-boost 리스너 누적 차단 — add_repo pagehide + tweaks keydown (#35/#36)

### DIFF
--- a/src/static/js/tweaks.js
+++ b/src/static/js/tweaks.js
@@ -80,12 +80,19 @@
     }
 
     // Keyboard shortcut: T toggles tweaks
-    document.addEventListener("keydown", (e) => {
+    // 🔴 remove-before-add 단일 핸들러 — hx-boost body swap 시 document keydown 누적 차단 (#36)
+    // Single handler via remove-before-add: prevents document keydown pile-up across hx-boost body swaps.
+    if (document._tweaksKeydown) {
+      document.removeEventListener("keydown", document._tweaksKeydown);
+    }
+    document._tweaksKeydown = function (e) {
       if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
       if (e.key === "t" || e.key === "T") {
-        panel && panel.classList.toggle("is-collapsed");
+        const p = document.querySelector(".tweaks");
+        if (p) p.classList.toggle("is-collapsed");
       }
-    });
+    };
+    document.addEventListener("keydown", document._tweaksKeydown);
 
     apply();
   }

--- a/src/templates/add_repo.html
+++ b/src/templates/add_repo.html
@@ -212,7 +212,15 @@
   // 페이지 이탈 시 fetch abort 제어 — hx-boost 뒤로가기 freezing 방지
   // AbortController to cancel in-flight fetch on page leave — prevents stale DOM updates after hx-boost navigation
   var _repoCtrl = new AbortController();
-  window.addEventListener('pagehide', () => _repoCtrl.abort());
+  // 🔴 remove-before-add 단일 핸들러 — hx-boost 재방문 시 pagehide 리스너 누적 차단 (#35)
+  // Single handler via remove-before-add: prevents pagehide listener pile-up across hx-boost re-navigations.
+  // 저장은 document._ (effects.js _tabsResizeHandler 동일 패턴), pagehide 는 window 이벤트라 add/remove 만 window.
+  // Handler stored on document._ (same pattern as effects.js); pagehide is a window event so add/remove use window.
+  if (document._addRepoPagehide) {
+    window.removeEventListener('pagehide', document._addRepoPagehide);
+  }
+  document._addRepoPagehide = function () { _repoCtrl.abort(); };
+  window.addEventListener('pagehide', document._addRepoPagehide);
 
   async function loadRepos() {
     try {

--- a/tests/unit/ui/test_hx_boost_listener_guards.py
+++ b/tests/unit/ui/test_hx_boost_listener_guards.py
@@ -1,0 +1,45 @@
+"""hx-boost 리스너 누적 방지 정적 가드 (#35/#36).
+
+hx-boost listener accumulation regression guard (#35/#36).
+
+add_repo.html 의 pagehide 리스너와 tweaks.js 의 document keydown 리스너가
+remove-before-add 패턴(named handler + 선행 removeEventListener)을 유지하는지
+소스 정적 스캔으로 회귀 차단. hx-boost body swap 재실행 시 익명 리스너가
+window/document 에 누적되던 사고(#35/#36)를 봉인한다.
+
+Static source scan guard: ensures the pagehide (add_repo.html) and document keydown
+(tweaks.js) listeners keep the remove-before-add pattern so they do not pile up on
+hx-boost body-swap re-execution.
+"""
+import pathlib
+
+_ROOT = pathlib.Path(__file__).resolve().parents[3]
+
+
+def _read(rel: str) -> str:
+    return (_ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_add_repo_pagehide_uses_remove_before_add():
+    """add_repo.html pagehide 리스너는 named handler + remove-before-add (#35)."""
+    src = _read("src/templates/add_repo.html")
+    # named handler 저장 + 선행 removeEventListener 존재
+    # Named handler storage + preceding removeEventListener present
+    assert "document._addRepoPagehide" in src
+    assert "removeEventListener('pagehide', document._addRepoPagehide)" in src
+    assert "addEventListener('pagehide', document._addRepoPagehide)" in src
+    # 익명 화살표 리스너 회귀 차단 (제거 불가 → 누적)
+    # Block regression to an anonymous arrow listener (unremovable → pile-up)
+    assert "addEventListener('pagehide', () =>" not in src
+    assert "addEventListener('pagehide', ()=>" not in src
+
+
+def test_tweaks_keydown_uses_remove_before_add():
+    """tweaks.js document keydown 리스너는 named handler + remove-before-add (#36)."""
+    src = _read("src/static/js/tweaks.js")
+    assert "document._tweaksKeydown" in src
+    assert 'removeEventListener("keydown", document._tweaksKeydown)' in src
+    assert 'addEventListener("keydown", document._tweaksKeydown)' in src
+    # 익명 keydown 리스너 회귀 차단
+    # Block regression to an anonymous keydown listener
+    assert 'addEventListener("keydown", (e) =>' not in src


### PR DESCRIPTION
## 요약
정합성 감사 full 리포트(2026-06-08, Task9 골든) **P2 UI 2건(#35/#36)**. UI Medium 묶음 PR D. hx-boost body swap 재실행 시 익명 리스너가 window/document 에 무한 누적되던 메모리 누수를 remove-before-add 로 봉인.

## 변경 내역

### #35 — `add_repo.html` pagehide 리스너 remove-before-add
- 익명 화살표 `window.addEventListener('pagehide', () => _repoCtrl.abort())` 가 hx-boost 재방문마다 window 에 누적(익명이라 제거 불가).
- named handler `document._addRepoPagehide` + 선행 `removeEventListener` (effects.js `_tabsResizeHandler` **동일 검증 패턴** — 저장 `document._`, pagehide 는 window 이벤트라 add/remove 만 window).

### #36 — `tweaks.js` document keydown 리스너 remove-before-add
- 익명 keydown 리스너가 hx-boost body swap(`base.html:697` `<script src>` 재실행)마다 document 에 무한 누적.
- named handler `document._tweaksKeydown` + 선행 `removeEventListener` + 핸들러 내부 **live `.tweaks` lookup**(stale closure 제거).

## 회귀 가드
- `tests/unit/ui/test_hx_boost_listener_guards.py` 2건 — named handler + remove-before-add 정적 스캔 + 익명 리스너 회귀 차단(`addEventListener('pagehide', () =>` 부재 단언).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** ✅ — Codex가 (1) 양 파일 remove-before-add 패턴 + _repoCtrl abort 보존, (2) tweaks live lookup 무파손 + `node --check`, (3) 가드 테스트 실행(126 passed), (4) add_repo 폼 기능 무회귀를 적대적 실측 검증. true mutual (push 전).

## 🔍 사용자 검증 필요 (정책 11 — Claude 시각 검증 불가)
- ⚠️ **시각 변화 0 으로 예상** — 리스너 누적/메모리 누수 수정만, UI 동작·외관 동일. 4-테마 × 8 조합 시각 정합성은 Claude 확인 불가.
- [ ] (선택) `/repos/add` 페이지를 hx-boost 로 여러 번 재방문해도 정상 동작하는지 확인

## 테스트
- 가드 2 passed, `node --check` OK, add_repo 관련 24 passed, JS const 회귀 0. 단위 +2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)