### PR TITLE
fix: i18n_args 이중 이스케이프 해소 — 수동 escape 제거, autoescape 위임 (#34)

### DIFF
--- a/src/i18n/filters.py
+++ b/src/i18n/filters.py
@@ -12,7 +12,6 @@ Used in Phase 2 PR-5~8 (UI multilingual) scope.
 from typing import Any
 
 from jinja2 import Environment
-from markupsafe import Markup, escape as _html_escape
 
 from src.i18n.loader import get_text
 
@@ -29,21 +28,21 @@ def i18n_filter(key: str, locale: str | None = None) -> str:
 
 
 def i18n_args_filter(key: str, locale: str | None = None, **kwargs: Any) -> str:
-    """Jinja2 필터 — 번역 + 변수 치환.
+    """Jinja2 필터 — 번역 + 변수 치환 (raw 치환만, escape 는 autoescape 가 수행).
 
-    XSS 방어: str kwargs에 html.escape 적용 — Markup 인스턴스(의도적 HTML)는 이스케이프 제외.
-    XSS defence: html.escape applied to str kwargs — Markup instances (intentional HTML) pass through.
+    이스케이프는 Jinja2 autoescape 가 렌더 시점에 1회 수행한다 — 필터는 raw 값을 치환만
+    하므로 이중 이스케이프(#34)가 발생하지 않는다. 자동이스케이프가 꺼진 `| safe` 컨텍스트
+    (개발자 의도 HTML 번역문)에서는 kwarg 가 escape 되지 않으므로 **사용자 입력을
+    `i18n_args(...) | safe` 로 넘기지 말 것** (회귀 가드: tests/unit/i18n/test_i18n_args_safe_contract.py).
+
+    Escaping happens once at Jinja2 render time (autoescape); the filter only substitutes raw
+    values, so the double-escape bug (#34) cannot occur. In `| safe` contexts (intentional-HTML
+    translations) kwargs are NOT escaped — never pass user input through `i18n_args(...) | safe`.
 
     Example:
         {{ "header.welcome" | i18n_args(locale, name=user.name) }}
     """
-    # str kwargs에 XSS 가드 적용 — Markup(의도적 HTML)은 그대로 통과
-    # Apply XSS guard to str kwargs — Markup (intentional HTML) passes through unchanged
-    safe_kwargs = {
-        k: v if not isinstance(v, str) or isinstance(v, Markup) else str(_html_escape(v))
-        for k, v in kwargs.items()
-    }
-    return get_text(key, locale, **safe_kwargs)
+    return get_text(key, locale, **kwargs)
 
 
 def register_i18n_filters(env: Environment) -> None:

--- a/tests/unit/i18n/test_filters.py
+++ b/tests/unit/i18n/test_filters.py
@@ -63,21 +63,33 @@ def test_filter_with_default_locale_none():
     assert result == "Dashboard"
 
 
-def test_i18n_args_filter_escapes_html_in_str_kwarg():
-    """str kwarg에 HTML 태그가 있으면 이스케이프됨 — XSS 방어.
-    HTML tags in str kwargs are escaped — XSS defence."""
-    result = i18n_args_filter("header.welcome", "en", name="<script>alert(1)</script>")
+def test_i18n_args_render_escapes_html_in_str_kwarg():
+    """autoescape 렌더 시 str kwarg 의 HTML 이 이스케이프됨 — XSS 방어 (Jinja2 autoescape).
+    Under autoescape, HTML in a str kwarg is escaped by Jinja2 at render — XSS defence."""
+    env = Environment(autoescape=select_autoescape(["html", "xml"]))
+    register_i18n_filters(env)
+    tmpl = env.from_string('{{ "header.welcome" | i18n_args("en", name=name) }}')
+    result = tmpl.render(name="<script>alert(1)</script>")
     assert "<script>" not in result
     assert "&lt;script&gt;" in result
 
 
-def test_i18n_args_filter_passes_markup_kwarg_unchanged():
-    """Markup 인스턴스는 의도적 HTML로 간주 — 이스케이프하지 않음.
-    Markup instances are treated as intentional HTML — not escaped."""
+def test_i18n_args_filter_passes_kwargs_raw_no_escape():
+    """필터는 kwarg 를 raw 치환만 — escape 안 함(Markup·일반 str 모두). escape 는 render 시 autoescape (#34).
+
+    The filter substitutes kwargs raw without escaping (Markup and plain str alike); escaping is
+    deferred to Jinja2 autoescape at render. `| safe` 컨텍스트의 의도적 HTML(Markup) 은 그대로 렌더된다.
+    """
     from markupsafe import Markup
-    result = i18n_args_filter("header.welcome", "en", name=Markup("<b>Alice</b>"))
-    assert "<b>Alice</b>" in result
-    assert "&lt;b&gt;" not in result
+    # Markup HTML 그대로 통과 (의도적 HTML — | safe 컨텍스트에서 렌더)
+    # Markup HTML passes through (intentional HTML — rendered in | safe contexts)
+    result_markup = i18n_args_filter("header.welcome", "en", name=Markup("<b>Alice</b>"))
+    assert "<b>Alice</b>" in result_markup
+    # 일반 str 도 raw — 필터는 escape 안 함 (autoescape 가 render 시 처리)
+    # Plain str is also raw — the filter does not escape (autoescape handles it at render)
+    result_str = i18n_args_filter("header.welcome", "en", name="<i>x</i>")
+    assert "<i>x</i>" in result_str
+    assert "&lt;" not in result_str
 
 
 def test_i18n_args_filter_normal_str_no_html():
@@ -85,3 +97,20 @@ def test_i18n_args_filter_normal_str_no_html():
     Plain str without HTML is substituted as-is — no escape side-effects."""
     result = i18n_args_filter("header.welcome", "en", name="World")
     assert "World" in result
+
+
+def test_i18n_args_render_no_double_escape():
+    """autoescape 렌더 시 str kwarg 는 1회만 이스케이프 — 이중 이스케이프 회귀 차단 (#34).
+
+    Under autoescape, a str kwarg is escaped exactly once — guards against the double-escape
+    bug (#34). 필터가 직접 escape 하면 Jinja2 가 재escape 해 'Tom & Jerry' → 'Tom &amp;amp; Jerry'
+    로 깨졌다. 필터는 raw 치환만 하고 escape 는 autoescape 가 1회 수행한다.
+    """
+    env = Environment(autoescape=select_autoescape(["html", "xml"]))
+    register_i18n_filters(env)
+    tmpl = env.from_string('{{ "header.welcome" | i18n_args("en", name=name) }}')
+    result = tmpl.render(name="Tom & Jerry")
+    # 1회 이스케이프: & → &amp; (정상 표시)
+    assert "Tom &amp; Jerry" in result
+    # 이중 이스케이프 부재: &amp;amp; 금지
+    assert "&amp;amp;" not in result

--- a/tests/unit/i18n/test_i18n_args_safe_contract.py
+++ b/tests/unit/i18n/test_i18n_args_safe_contract.py
@@ -1,0 +1,53 @@
+"""`i18n_args(...) | safe` 호출 계약 가드 (#34 Option A 방어선).
+
+`i18n_args(...) | safe` caller contract guard (#34 Option A defence line).
+
+#34 Option A 로 i18n_args 필터의 수동 escape 를 제거(이중 이스케이프 해소)한 뒤,
+autoescape 가 꺼진 `| safe` 컨텍스트에서 kwarg 는 더 이상 필터에서 escape 되지 않는다.
+따라서 `i18n_args(...kwargs...) | safe` 호출처에 **사용자 제어 문자열 kwarg** 가 추가되면
+XSS 우회가 된다. 본 가드는 그런 호출처를 vetted allowlist 로 고정해, 신규 위험 호출처가
+추가되면 CI fail 로 사람 검토를 강제한다.
+
+After #34 Option A removed the filter-level manual escape, a `| safe` caller passing a kwarg
+bypasses Jinja2 autoescape. This guard pins such callers to a vetted allowlist so a future
+user-data kwarg in a `| safe` context fails CI and forces review.
+"""
+import pathlib
+import re
+
+_TEMPLATES = pathlib.Path(__file__).resolve().parents[3] / "src" / "templates"
+
+# kwargs(=) + | safe 를 동반하는 i18n_args 호출의 검증된 안전 키.
+# Vetted-safe keys for i18n_args calls that carry kwargs AND | safe.
+#   - range_summary: approve/reject = config 정수(Field 검증) — 사용자 자유문자열 아님
+#   - telegram_otp_expires: remaining = 개발자 작성 Markup <span> — 의도적 HTML
+_SAFE_KWARG_ALLOWLIST = {
+    "settings_page.pr_rules.range_summary",
+    "settings_page.notify.telegram_otp_expires",
+}
+
+_KEY_RE = re.compile(r"'([^']+)'\s*\|\s*i18n_args")
+# i18n_args(...) 인자 안의 kwarg 패턴 (`, name=` 형태) — `default('ko')` 등 위치 인자 제외
+# kwarg pattern inside i18n_args(...) (`, name=`); excludes positional like default('ko')
+_KWARG_RE = re.compile(r",\s*\w+\s*=")
+
+
+def test_safe_i18n_args_callers_pass_only_vetted_kwargs():
+    """`i18n_args(...kwargs...) | safe` 호출처는 vetted allowlist 키만 허용 (#34 방어선)."""
+    offenders: dict[str, set[str]] = {}
+    for path in _TEMPLATES.rglob("*.html"):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if "i18n_args(" not in line or "| safe" not in line:
+                continue
+            seg = line[line.index("i18n_args("):]
+            if not _KWARG_RE.search(seg):
+                continue  # kwargs 없는 호출은 XSS 우회 위험 없음 (번역문은 신뢰)
+            match = _KEY_RE.search(line)
+            key = match.group(1) if match else line.strip()
+            if key not in _SAFE_KWARG_ALLOWLIST:
+                offenders.setdefault(path.name, set()).add(key)
+    assert not offenders, (
+        "i18n_args(...kwargs...) | safe 신규 호출처 발견 — autoescape 우회로 사용자 입력 XSS 위험. "
+        "kwarg 가 config 상수/Markup 등 안전값임을 확인 후 _SAFE_KWARG_ALLOWLIST 에 등재하라. "
+        f"미등재 호출처: {offenders}"
+    )


### PR DESCRIPTION
## 요약
정합성 감사 full 리포트(2026-06-08, Task9 골든) **P2 UI 1건(#34)**. UI Medium 묶음 PR E (마지막). 보안 민감 — 공유 i18n 필터 escape 계약 변경이라 사용자 **Option A 결정** + Codex mutual 검증.

## 문제
`i18n_args_filter` 가 kwargs 를 수동 `_html_escape` 한 뒤 plain str 반환 → Jinja2 autoescape 가 재escape → **이중 이스케이프**. 예: `name='Tom & Jerry'` → `Tom &amp;amp; Jerry` → 화면에 `Tom &amp; Jerry` 로 깨짐 (overview greeting·repo명).

## 수정 (Option A)
수동 escape 제거 → 필터는 raw 치환만, escape 는 **autoescape 가 렌더 시 1회** 수행 (표준 Jinja2 i18n 패턴). `markupsafe` import 제거.

## 🔴 안전성 검증 — 감사 원안의 함정 정정
| 검토 | 결과 |
|------|------|
| 감사 원안(escape 제거)의 XSS 우려 | 22건 `\|safe` 호출처 실측 → **사용자 자유문자열 kwarg 0건**(config 정수·Markup span·placeholder뿐) → 회귀 0 |
| literal `<` 번역문 (`reject_threshold_hint: "< → Reject"` @settings.html:716, non-safe) | 여전히 Jinja2 escape → **표시 회귀 0** |
| 대안 B′(Markup 전체 래핑) | literal-< 번역문(reject_threshold_hint·range_summary)을 깨뜨려 **기각** |

## 방어선 회귀 가드
`tests/unit/i18n/test_i18n_args_safe_contract.py` — `i18n_args(...kwargs...) \| safe` 호출처를 vetted allowlist(`range_summary`·`telegram_otp_expires`)로 고정. 미래에 사용자 입력 kwarg + `\| safe` 호출처가 추가되면 **CI fail** 로 검토 강제.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** ✅ — Codex가 (1) autoescape 단일 escape(XSS 안전·이중escape 부재), (2) `\|safe`+kwarg 호출처 = allowlist 2건뿐 확인, (3) literal-< 번역문 표시 회귀 0, (4) i18n 테스트 14 passed 를 적대적 실측 검증. true mutual (push 전).

## 🔍 사용자 검증 필요 (정책 11 — Claude 시각 검증 불가)
- [ ] 특수문자 포함 GitHub 표시명/리포명(예: `Tom & Jerry`) 계정으로 overview greeting 이 정상 표시되는지 (이중 `&amp;amp;` 부재)
- [ ] settings 페이지의 `| safe` 힌트(`<strong>`·`< → Reject` 등) 정상 렌더 확인

## 테스트
- i18n 29 + 템플릿/ui **306** + i18n smoke 13 passed. 단위 +2. pylint 10.00/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)