### PR TITLE
chore: ORM↔alembic 인덱스 정합 — merge_attempts state_repo + merge_retry 부분 유일 (#15/#16)

### DIFF
--- a/src/models/merge_attempt.py
+++ b/src/models/merge_attempt.py
@@ -31,6 +31,9 @@ class MergeAttempt(Base):
     # Phase H PR-4A — single index for Phase F.4 dashboard time-series queries.
     __table_args__ = (
         Index("ix_merge_attempts_attempted_at", "attempted_at"),
+        # (state, repo_name) 그룹 집계용 복합 인덱스 — alembic 0022 와 ORM 양쪽 선언 (ORM↔alembic 정합 #15)
+        # Composite index for (state, repo_name) aggregation — declared in both ORM and alembic 0022.
+        Index("ix_merge_attempts_state_repo", "state", "repo_name"),
     )
 
     id = Column(Integer, primary_key=True, index=True)

--- a/src/models/merge_retry.py
+++ b/src/models/merge_retry.py
@@ -11,7 +11,7 @@ When a merge fails because CI is still running, enqueue and retry.
 """
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String, Text, text
 
 from src.database import Base
 
@@ -120,4 +120,13 @@ class MergeRetryQueue(Base):
         # SHA 조회 인덱스 — 특정 커밋의 큐 상태 빠른 조회
         # SHA lookup index — fast lookup of queue status for a specific commit.
         Index("ix_merge_retry_queue_sha_lookup", "repo_full_name", "commit_sha", "status"),
+        # 부분 유일 인덱스 — status='pending' 활성 행 중복 방지. alembic 0020 raw DDL 과 ORM 양쪽 선언 (#16)
+        # Partial unique index — prevents duplicate active (pending) rows; declared in ORM + alembic 0020.
+        Index(
+            "uq_merge_retry_queue_active",
+            "repo_full_name", "pr_number", "commit_sha",
+            unique=True,
+            sqlite_where=text("status = 'pending'"),
+            postgresql_where=text("status = 'pending'"),
+        ),
     )

--- a/tests/unit/migrations/test_0023_composite_indexes.py
+++ b/tests/unit/migrations/test_0023_composite_indexes.py
@@ -65,12 +65,41 @@ def test_merge_attempts_has_attempted_at_index(engine):
     assert cols == ["attempted_at"]
 
 
+def test_merge_attempts_has_state_repo_index(engine):
+    """ix_merge_attempts_state_repo 복합 인덱스 ORM↔alembic 정합 (#15).
+
+    alembic 0022 전용이던 인덱스를 ORM __table_args__ 에도 선언 — create_all 정합.
+    """
+    cols = _index_columns(engine, "merge_attempts", "ix_merge_attempts_state_repo")
+    assert cols is not None, (
+        "ix_merge_attempts_state_repo 미존재 — ORM __table_args__ 미선언(alembic 0022 drift)"
+    )
+    assert cols == ["state", "repo_name"], f"인덱스 컬럼 순서 불일치: {cols}"
+
+
+def test_merge_retry_has_partial_unique_active_index(engine):
+    """uq_merge_retry_queue_active 부분 유일 인덱스 ORM↔alembic 정합 (#16).
+
+    status='pending' 활성 행 중복 방지 — ORM __table_args__(sqlite/postgresql_where) + alembic 0020 양쪽 선언.
+    """
+    inspector = inspect(engine)
+    indexes = {ix["name"]: ix for ix in inspector.get_indexes("merge_retry_queue")}
+    assert "uq_merge_retry_queue_active" in indexes, (
+        "uq_merge_retry_queue_active 미존재 — ORM __table_args__ 미선언(alembic 0020 drift)"
+    )
+    idx = indexes["uq_merge_retry_queue_active"]
+    assert idx["column_names"] == ["repo_full_name", "pr_number", "commit_sha"], (
+        f"인덱스 컬럼 불일치: {idx['column_names']}"
+    )
+    assert idx["unique"], "부분 유일 인덱스는 unique=True 여야 함"
+
+
 def test_existing_orm_indexes_preserved(engine):
     """기존 ORM 인덱스 회귀 가드 — Phase 2 추가 단일 인덱스 보존.
 
-    Note: 일부 인덱스(예: ix_merge_attempts_state_repo from 0022)는 마이그레이션
-    전용이라 ORM `Base.metadata.create_all` 에서 생성되지 않음. 본 테스트는
-    ORM 측 인덱스만 검증.
+    Note: 사이클 166 #15/#16 으로 ix_merge_attempts_state_repo(0022)·uq_merge_retry_queue_active(0020)
+    도 ORM __table_args__ 에 선언됨 — 각각 위 전용 테스트(state_repo/partial_unique)로 검증. 본 테스트는
+    그 외 ORM 측 단일 인덱스만 검증.
     """
     # 0021 — analyses.created_at 단일 인덱스 (ORM index=True 명시)
     assert _index_columns(engine, "analyses", "ix_analyses_created_at") == ["created_at"]


### PR DESCRIPTION
## 요약
정합성 감사 full 리포트(2026-06-08) **P2 DB 2건(#15/#16)**. 사이클 166 잔여 DB 묶음 — alembic 전용이던 인덱스를 ORM `__table_args__` 에 선언해 ORM↔alembic drift 해소. **운영 PG DDL 무변경**(인덱스는 이미 alembic 0020/0022 에 존재, 신규 마이그레이션 불필요).

## 변경 내역
### #15 — `merge_attempt.py` ix_merge_attempts_state_repo
- `Index("ix_merge_attempts_state_repo", "state", "repo_name")` ORM 선언 — alembic 0022 전용 → ORM `create_all` 정합 (대시보드 `(state, repo_name)` 그룹 집계용).

### #16 — `merge_retry.py` uq_merge_retry_queue_active
- 부분 유일 인덱스 `(repo_full_name, pr_number, commit_sha) WHERE status='pending'` ORM 선언 (`sqlite_where` + `postgresql_where`) — alembic 0020 raw DDL 전용 → ORM 선언. SQLite 단위 테스트에서도 활성(pending) 행 중복 방지 검증 가능.

> `db.md` 규칙 "🔴 DB 인덱스 정의 — ORM `__table_args__` + alembic 양쪽 의무" 정합.

## 회귀 가드
`test_0023_composite_indexes.py`: `test_merge_attempts_has_state_repo_index` + `test_merge_retry_has_partial_unique_active_index` (inspect 로 컬럼 + unique 검증) + 기존 stale NOTE(state_repo 마이그레이션 전용) 갱신.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** ✅ — Codex가 (1) ORM Index 정의 ↔ alembic 0020/0022 정확 일치, (2) 신규 마이그레이션 불필요(인덱스 이미 prod 존재), (3) 부분 유일 인덱스가 기존 merge_retry pending 행 삽입 테스트 무파손(merge_retry -k + test_0023 실행)을 적대적 검증. true mutual (push 전).

## 🔍 사용자 검증 필요 (정책 2)
- 운영 영향 없음 — 인덱스는 이미 운영 PG 에 존재, ORM 모델 선언만 추가(SQLite 테스트 정합 + drift 가드). DB 스키마 변경/마이그레이션 0.

## 테스트
- migrations 36 + repositories 133 + merge_retry 90 passed. 단위 +2. pylint 10.00, flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)