### PR TITLE
chore: 고아 CSS 제거 — components.css dead .nav/.nav__*/.tabs/.tabs__* (#33 follow-up)

### DIFF
--- a/src/static/css/components.css
+++ b/src/static/css/components.css
@@ -448,80 +448,6 @@ button { font-family: inherit; }
 .input--mono { font-family: var(--font-mono); font-size: var(--fs-xs); }
 
 /* ==========================================================================
-   NAV — top app bar
-   ========================================================================== */
-.nav {
-  position: sticky;
-  top: 0;
-  z-index: 50;
-  background: var(--bg-nav);
-  backdrop-filter: saturate(140%) blur(14px);
-  -webkit-backdrop-filter: saturate(140%) blur(14px);
-  border-bottom: 1px solid var(--border-subtle);
-  height: 56px;
-  display: flex;
-  align-items: center;
-  padding: 0 var(--space-6);
-  gap: var(--space-6);
-}
-.nav__brand {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  font-weight: 700;
-  font-size: var(--fs-md);
-  letter-spacing: var(--ls-tight);
-}
-.nav__mark {
-  width: 28px; height: 28px;
-  border-radius: var(--radius-md);
-  background: var(--accent-grad);
-  display: grid;
-  place-items: center;
-  box-shadow: var(--elev-1);
-  color: white;
-  font-size: 14px;
-}
-.nav__links {
-  display: flex;
-  align-items: center;
-  gap: 2px;
-  margin-left: var(--space-3);
-}
-.nav__link {
-  padding: 6px var(--space-3);
-  font-size: var(--fs-sm);
-  color: var(--text-2);
-  border-radius: var(--radius-sm);
-  text-decoration: none;
-  transition: all var(--dur-fast) var(--ease-out);
-}
-.nav__link:hover { color: var(--text-1); background: var(--bg-mute); }
-.nav__link.is-active {
-  color: var(--text-1);
-  background: var(--bg-mute);
-  font-weight: 580;
-}
-.nav__spacer { flex: 1 1 auto; }
-.nav__chip {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 4px 10px;
-  font-size: var(--fs-xs);
-  background: var(--bg-mute);
-  border-radius: var(--radius-pill);
-  color: var(--text-2);
-  border: 1px solid var(--border-subtle);
-}
-.nav__avatar {
-  width: 28px; height: 28px;
-  border-radius: 50%;
-  background: var(--accent-grad);
-  color: white;
-  display: grid; place-items: center;
-  font-size: var(--fs-xs); font-weight: 700;
-}
-
-/* ==========================================================================
    KPI CARD
    ========================================================================== */
 .kpi {
@@ -700,35 +626,6 @@ button { font-family: inherit; }
 }
 
 /* ==========================================================================
-   TAB BAR
-   ========================================================================== */
-.tabs {
-  display: inline-flex;
-  background: var(--bg-mute);
-  border-radius: var(--radius-md);
-  padding: 3px;
-  gap: 2px;
-}
-.tabs__tab {
-  padding: 6px var(--space-3);
-  font-size: var(--fs-xs);
-  font-weight: 540;
-  color: var(--text-2);
-  border-radius: var(--radius-sm);
-  cursor: pointer;
-  transition: all var(--dur-fast) var(--ease-out);
-  border: 0;
-  background: transparent;
-  display: inline-flex; align-items: center; gap: 6px;
-}
-.tabs__tab:hover { color: var(--text-1); }
-.tabs__tab.is-active {
-  background: var(--bg-card-hi);
-  color: var(--text-1);
-  box-shadow: var(--elev-1);
-}
-
-/* ==========================================================================
    KBD
    ========================================================================== */
 .kbd {
@@ -832,58 +729,6 @@ body.fx-ready .fx-enter.is-in-view {
 
 /* press feedback */
 .btn:active { transition-duration: 60ms; transform: scale(0.96); }
-
-/* ==========================================================================
-   TABS — sliding indicator
-   ========================================================================== */
-.tabs {
-  position: relative;
-  z-index: 0;
-}
-.tabs__indicator {
-  position: absolute;
-  top: 3px;
-  left: 0;
-  height: calc(100% - 6px);
-  background: var(--bg-card-hi);
-  border-radius: var(--radius-sm);
-  box-shadow: var(--elev-1);
-  z-index: 0;
-  pointer-events: none;
-  transition: transform var(--dur-base) var(--ease-spring),
-              width var(--dur-base) var(--ease-spring);
-}
-.tabs__tab { position: relative; z-index: 1; }
-.tabs__tab.is-active {
-  background: transparent !important;
-  box-shadow: none !important;
-}
-
-/* ==========================================================================
-   NAV — sliding active pill
-   ========================================================================== */
-.nav__links {
-  position: relative;
-}
-.nav__indicator {
-  position: absolute;
-  top: 50%;
-  left: 0;
-  height: calc(100% - 16px);
-  transform: translate(0, -50%);
-  background: var(--bg-mute);
-  border-radius: var(--radius-sm);
-  z-index: 0;
-  pointer-events: none;
-  opacity: 0;
-  transition: transform var(--dur-base) var(--ease-spring),
-              width var(--dur-base) var(--ease-spring),
-              opacity var(--dur-base) ease;
-}
-.nav__link { position: relative; z-index: 1; }
-.nav__link.is-active {
-  background: transparent !important;
-}
 
 /* ==========================================================================
    CARDS — hover lift + subtle tilt (driven by JS --tilt-x/y)
@@ -1038,4 +883,3 @@ body.fx-ready .fx-enter.is-in-view {
   font-size: 11px;
   color: var(--text-3);
 }
-


### PR DESCRIPTION
## 요약
#822(effects.js dead-code) **follow-up (F1)**. effects.js 가 참조하던 `.nav__*`/`.tabs__*` 셀렉터 제거 후 `components.css` 에 남은 **고아 CSS 156줄 제거**. 사이클 166 잔여.

## 변경 내역 — 제거 대상 (전부 0 element match, 교체된 옛 mockup 잔재)
| 섹션 | 셀렉터 |
|------|--------|
| NAV — top app bar | `.nav`(class) + `.nav__brand/mark/links/link/spacer/chip/avatar` |
| TAB BAR | `.tabs` + `.tabs__tab` |
| TABS — sliding indicator | `.tabs` + `.tabs__indicator` + `.tabs__tab` |
| NAV — sliding active pill | `.nav__links` + `.nav__indicator` + `.nav__link` |

🔴 **실제 nav 는 무관**: base.html 인라인 `<style>` 의 `nav {` element selector + 하이픈 `.nav-logo`/`.nav-link` 클래스(L76~122)로 스타일링됨. components.css 의 `.nav`/`.nav__*`(BEM 더블언더스코어)는 교체된 옛 디자인. `src/templates`·`src/static/js`·`tests`·`e2e` 전수 grep **0 참조**.

부수 효과: SonarCloud **S4666 중복 셀렉터**(`.tabs`/`.tabs__tab` 2중 정의) 해소. brace balance 199/199 유지.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** ✅ — Codex가 (1) 제거 셀렉터 전수 0 참조, (2) 실제 nav 의 base.html 독립 스타일링(BEM 무관), (3) brace balance + dangling rule 부재, (4) 테스트 무참조를 적대적 실측 검증. true mutual (push 전).

## 🔍 사용자 검증 필요 (정책 11 — Claude 시각 검증 불가)
- ⚠️ **정적 검증만 가능** — 4-테마 × 8 조합 시각 정합은 Claude 확인 불가.
- 단, 제거 셀렉터는 **0 element match**(어떤 요소도 매칭 안 됨)이므로 **시각 변화 0 으로 예상**. 실제 상단 네비게이션·탭은 base.html 인라인 스타일로 그대로 동작.
- [ ] (선택) 상단 네비게이션 바 정상 표시 확인

## 테스트
- CSS-only, 테스트 영향 0. brace balance 199/199. 코드 −156줄.

🤖 Generated with [Claude Code](https://claude.com/claude-code)