### PR TITLE
feat: analyses.repo_id FK ON DELETE CASCADE — DB 레벨 안전망 (#14)

### DIFF
--- a/alembic/versions/0038_analyses_repo_id_cascade.py
+++ b/alembic/versions/0038_analyses_repo_id_cascade.py
@@ -1,0 +1,71 @@
+"""add ON DELETE CASCADE to analyses.repo_id FK (정합성 감사 P2 #14)
+
+정합성 감사 full(2026-06-08) P2 #14 — `analyses.repo_id` → repositories.id FK 가
+ondelete 미설정. repositories → analyses 삭제 사슬에 DB 레벨 안전망 부재.
+analyses 의 child 4종(MergeAttempt/MergeRetryQueue/AnalysisFeedback/GateDecision)은
+모두 CASCADE — parent 사슬도 일관성 확보. application-level delete_repo_cascade
+우회 경로 보완 (DB 레벨이 1차 안전망).
+
+repo_id 는 NOT NULL 이라 SET NULL 불가, RESTRICT 는 delete_repo_cascade 와 충돌 →
+CASCADE (db.md FK ondelete 일관성 매트릭스 정합, 사용자 confirm).
+
+PostgreSQL: DROP CONSTRAINT + CREATE CONSTRAINT (online, lock 최소화).
+SQLite: FK enforcement 가 PRAGMA foreign_keys 의존이라 ALTER 무의미 —
+운영 DB 는 Postgres 기준이므로 SQLite 분기에서 skip (단위 테스트는 ORM
+Base.metadata.create_all 로 신규 ondelete='CASCADE' 자동 적용).
+
+add ON DELETE CASCADE to analyses.repo_id FK — see 0024 (gate_decisions) for the
+identical pattern. repo_id is NOT NULL so SET NULL is impossible; CASCADE matches
+the db.md FK matrix and the user decision.
+
+Revision ID: 0038
+Revises: 0037
+Create Date: 2026-06-09
+"""
+from alembic import op
+
+from src.shared.alembic_dialect import is_postgresql
+
+
+revision = "0038"
+down_revision = "0037"
+branch_labels = None
+depends_on = None
+
+# 3b8216565fed 가 생성한 FK 이름 — Postgres 기본 명명 규칙 (table_column_fkey)
+# Default Postgres FK name from 3b8216565fed (table_column_fkey convention)
+_FK_NAME = "analyses_repo_id_fkey"
+
+
+def upgrade() -> None:
+    # SQLite 는 ALTER TABLE 로 FK 변경 불가 — 운영 DB(Postgres)만 처리.
+    # 단위 테스트는 ORM Base.metadata.create_all 로 신규 ondelete='CASCADE' 적용.
+    # SQLite cannot ALTER FKs — only act on Postgres; tests get CASCADE via ORM.
+    bind = op.get_bind()
+    if not is_postgresql(bind):
+        return
+
+    op.drop_constraint(_FK_NAME, "analyses", type_="foreignkey")
+    op.create_foreign_key(
+        _FK_NAME,
+        "analyses",
+        "repositories",
+        ["repo_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not is_postgresql(bind):
+        return
+
+    op.drop_constraint(_FK_NAME, "analyses", type_="foreignkey")
+    op.create_foreign_key(
+        _FK_NAME,
+        "analyses",
+        "repositories",
+        ["repo_id"],
+        ["id"],
+    )

--- a/src/models/analysis.py
+++ b/src/models/analysis.py
@@ -25,7 +25,13 @@ class Analysis(Base):
     )
 
     id = Column(Integer, primary_key=True, index=True)
-    repo_id = Column(Integer, ForeignKey("repositories.id"), nullable=False)
+    # repo_id FK — ondelete=CASCADE: repositories 삭제 시 analyses(+child 4종 CASCADE) 동반 삭제 (#14)
+    # repo_id FK — CASCADE: deleting a repository cascades to analyses (+ its 4 CASCADE children).
+    repo_id = Column(
+        Integer,
+        ForeignKey("repositories.id", ondelete="CASCADE"),
+        nullable=False,
+    )
     commit_sha = Column(String, nullable=False, index=True)
     commit_message = Column(String, nullable=True)
     pr_number = Column(Integer, nullable=True)

--- a/tests/unit/migrations/test_0038_analyses_repo_id_cascade.py
+++ b/tests/unit/migrations/test_0038_analyses_repo_id_cascade.py
@@ -1,0 +1,34 @@
+"""정합성 감사 P2 #14 — analyses.repo_id ON DELETE CASCADE 회귀 가드.
+
+정합성 감사 full(2026-06-08) P2 #14 — `analyses.repo_id` → repositories.id FK 가
+ondelete 미설정. repositories → analyses 삭제 사슬에 DB 레벨 안전망 부재.
+repo_id 는 NOT NULL 이라 CASCADE (SET NULL 불가) — db.md FK 매트릭스 정합.
+
+본 테스트는 ORM 정의 측 `ondelete="CASCADE"` 가 유지되는지 검증 (alembic 0038 페어).
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+# pylint: disable=wrong-import-position
+from src.models.analysis import Analysis
+
+
+def test_analyses_repo_id_fk_has_cascade_delete():
+    """Analysis.repo_id FK 의 ondelete 가 CASCADE 인지 검증 (#14).
+
+    repositories → analyses 삭제 사슬 DB 레벨 안전망. 미설정 시 repo 삭제 →
+    FK violation 또는 고아 행 (application delete_repo_cascade 우회 경로 보완).
+    Child 4종(MergeAttempt/MergeRetryQueue/AnalysisFeedback/GateDecision) CASCADE 와 일관.
+    """
+    fk_columns = list(Analysis.__table__.c.repo_id.foreign_keys)
+    assert len(fk_columns) == 1, "repo_id 에 FK 가 정확히 1개 있어야 함"
+    fk = fk_columns[0]
+    assert fk.ondelete == "CASCADE", (
+        f"analyses.repo_id FK ondelete='{fk.ondelete}' — "
+        "'CASCADE' 이어야 함 (#14 회귀)"
+    )


### PR DESCRIPTION
## 요약
정합성 감사 full 리포트(2026-06-08) **P2 #14** (사용자 confirm: **CASCADE**). `analyses.repo_id` → repositories.id FK 가 ondelete 미설정 → `repositories→analyses` 삭제 사슬에 **DB 레벨 안전망 부재**. analyses 의 child 4종(MergeAttempt/MergeRetryQueue/AnalysisFeedback/GateDecision)은 모두 CASCADE — parent 사슬도 일관성 확보.

## 선택 근거 (옵션 분석)
| 옵션 | 가부 |
|------|------|
| **CASCADE** ★ | repo 삭제 → analyses(+children) 동반 삭제. app `delete_repo_cascade` + db.md 매트릭스 정합 |
| SET NULL | ❌ `repo_id NOT NULL` 위반 |
| RESTRICT | ❌ `delete_repo_cascade`(analyses 먼저 삭제)와 충돌 |

## 변경 내역
- `src/models/analysis.py`: `ForeignKey("repositories.id", ondelete="CASCADE")`
- `alembic/0038_analyses_repo_id_cascade.py`: DROP+CREATE FK constraint (**PG only**, SQLite skip) — **0024(gate_decisions) 동일 패턴**. FK 이름 `analyses_repo_id_fkey` (3b8216565fed unnamed FK → PG 기본 `table_column_fkey` 규칙).
- 회귀 가드 `test_0038`: ORM `ondelete=CASCADE` 검증 (test_0024 미러).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** ✅ — Codex가 (1) FK 이름 `analyses_repo_id_fkey` 정확성(0024 선례 + naming_convention 부재), (2) CASCADE 적정성(NOT NULL), (3) 0024 패턴 정합·reversible, (4) 단일 head 0038→0037, (5) ORM 일치 + round-trip 테스트(3 passed)를 적대적 검증. true mutual (push 전).

## 🔍 사용자 검증 필요 (정책 2 — 운영 DB)
- ⚠️ **운영 PG 마이그레이션** — Railway/Supabase 배포 시 0038 적용 시 `analyses_repo_id_fkey` 제약 DROP+CREATE 수행. FK 기본 이름 가정(0024 동일 선례로 검증됨). 로컬 SQLite 는 분기 skip(ORM CASCADE 만 적용).
- [ ] 배포 후 repo 삭제 시 analyses 동반 삭제 동작 확인 (또는 PG-only CI round-trip green 으로 갈음)

## 테스트
- test_0038 + migrations 37 passed(체인 valid, 단일 head) + analysis/repo 342 passed. analysis.py pylint 10.00, flake8 clean. 단위 +1. **PG-only CI round-trip job 이 실 마이그레이션 검증**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)