### PR TITLE
docs: Python 버전 SSOT 3.12 정렬 — 3.14 미검증 선언 정정 (#22)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -4,7 +4,7 @@
 
 **GitHub Push / PR 이벤트 기반 자동 코드 품질 분석 · AI 리뷰 · Gate 서비스**
 
-[![Python](https://img.shields.io/badge/Python-3.14-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.12-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.136-009688?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-SQLAlchemy_2-336791?style=flat-square&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 [![Claude AI](https://img.shields.io/badge/Claude_AI-Sonnet_4.6_(default)-CC6600?style=flat-square&logo=anthropic&logoColor=white)](https://www.anthropic.com/)
@@ -362,7 +362,7 @@ git push origin main
 
 | 분류 | 기술 |
 |------|------|
-| **언어** | Python 3.14 |
+| **언어** | Python 3.12 |
 | **웹 프레임워크** | FastAPI + Uvicorn |
 | **인증** | GitHub OAuth2 (authlib) + Starlette SessionMiddleware |
 | **데이터베이스** | PostgreSQL · SQLAlchemy 2 · Alembic · FailoverSessionFactory |
@@ -381,7 +381,7 @@ git push origin main
 
 ### 📋 요구사항
 
-- Python **3.14** 이상
+- Python **3.12** 이상
 - PostgreSQL
 - GitHub OAuth App (Client ID / Client Secret)
 - (선택) Telegram Bot Token · SMTP 서버 · ANTHROPIC_API_KEY

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Automated Code Quality Analysis · AI Review · PR Gate Service for GitHub**
 
-[![Python](https://img.shields.io/badge/Python-3.14-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![Python](https://img.shields.io/badge/Python-3.12-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.136-009688?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-SQLAlchemy_2-336791?style=flat-square&logo=postgresql&logoColor=white)](https://www.postgresql.org/)
 [![Claude AI](https://img.shields.io/badge/Claude_AI-Sonnet_4.6_(default)-CC6600?style=flat-square&logo=anthropic&logoColor=white)](https://www.anthropic.com/)
@@ -303,7 +303,7 @@ git push origin main
 
 | Category | Technology |
 |----------|------------|
-| **Language** | Python 3.14 |
+| **Language** | Python 3.12 |
 | **Web Framework** | FastAPI + Uvicorn |
 | **Auth** | GitHub OAuth2 (authlib) + Starlette SessionMiddleware |
 | **Database** | PostgreSQL · SQLAlchemy 2 · Alembic · FailoverSessionFactory |
@@ -322,7 +322,7 @@ git push origin main
 
 ### 📋 Requirements
 
-- Python **3.14** or later
+- Python **3.12** or later
 - PostgreSQL
 - GitHub OAuth App (Client ID / Client Secret)
 - (Optional) Telegram Bot Token · SMTP server · ANTHROPIC_API_KEY

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -16,12 +16,12 @@
 | SonarCloud BLOCKER / CRITICAL | **0 / 0** | Phase Q.7 완료 — 5건 Cognitive Complexity 전부 해소 |
 | pylint | **10.00/10** | `python -m pylint src/` — #415 잔여 21건 전체 해소 (C0415 17 lazy import inline disable + C0301 1 + R0913/R0917 3 + W0718/W0613 2 + E0401 1). **10.00 달성** |
 | 커버리지 | **Python 95% / JS: E2E 커버** | Python: `make test-cov` (`--cov=src` — 6970줄 중 318 미커버, 95%). JS: E2E pageerror 트랩(PR #605) + 정적 스캐너(PR #606) + ESLint(PR #607)으로 보완. `src/templates/*.html` 인라인 JS는 Python 커버리지 미측정 — 언어별 분리 보고 의무 (사이클 127 P0 학습). |
-| bandit HIGH | **0개** | bandit 1.9.4 (Python 3.14 대응) |
+| bandit HIGH | **0개** | bandit 1.9.4 (Python 3.12+ 대응) |
 | flake8 | **0건** (E501 16건 soft-pass — `|| true` 가드, CI 차단 없음) | `flake8 src/` |
 | 지원 언어 (AI 리뷰) | **50개** | language.py — Tier1/2/3 가이드 |
 | 지원 언어 (정적분석) | **52개+** | Semgrep 22 + ESLint/tsc 2 + ShellCheck 1 + cppcheck 1 + slither 1 + rubocop 1 + golangci-lint 1 + Python 3 + **신규 15**: Dockerfile(hadolint)·Kotlin(ktlint)·HCL(tflint)·SQL(sqlfluff)·YAML(yamllint)·PHP(phpstan)·Swift(swiftlint)·CSS(stylelint)·SCSS(stylelint)·HTML(htmlhint)·Protobuf(buf_lint)·Dart(dart_analyze)·PowerShell(psscriptanalyzer)·C#(dotnet_format)·Rust(clippy) |
 | Tier1 정적분석 도구 | **25종** | pylint·flake8·bandit·semgrep·eslint·shellcheck·cppcheck·slither·rubocop·golangci-lint·**hadolint**·**ktlint**·**tflint**·**tsc**·**sqlfluff**·**yamllint**·**phpstan**·**swiftlint**·**stylelint**·**htmlhint**·**buf_lint**·**dart_analyze**·**psscriptanalyzer**·**dotnet_format**·**clippy** |
-| pytest-asyncio | **1.3.0** | Python 3.14 DeprecationWarning 제거 완료 |
+| pytest-asyncio | **1.3.0** | Python 3.12+ DeprecationWarning 제거 완료 · SSOT=Python 3.12 (CI 기준, `.github/workflows/ci.yml` python-version) — 3.14 미검증 선언 정정 (#22) |
 | CodeQL | **✅ pass** | `.github/workflows/codeql.yml` — 주 1회 실행. 본 README 배지 (L15) 와 페어 |
 
 ## 주요 파일 역할 (빠른 참조)


### PR DESCRIPTION
## 요약
정합성 감사 full 리포트(2026-06-08) **P2 #22** (사용자 결정: **3.12 정렬, CI 기준**). README/STATE 가 Python **3.14** 를 선언했으나 **어느 환경도 3.14 미실행**:

| 환경 | Python |
|------|--------|
| CI (모든 PR gate, 권위) | **3.12** |
| 로컬 dev | 3.13.11 |
| Railway (nixpacks) | 핀 없음 (default) |
| pyproject `requires-python` | 부재 |

CI(권위)에 맞춰 **SSOT=3.12** 정렬.

## 변경 내역
- `README.md` / `README.ko.md`: 배지·기술스택 표·Requirements `3.14` → `3.12`
- `docs/STATE.md`: bandit/pytest-asyncio 노트 `3.14` → `3.12+` + SSOT=3.12(CI 기준) 결정 노트

## 🔴 자율 판단 보고 (정책 3)
- **README.ko.md 도 동일 3.14 선언** 보유 → 함께 정정(영문/한글 정합, 메모리 'README.ko 누락' 반복 지적 영역).
- **nixpacks Railway Python 핀은 별도 follow-up** — 올바른 메커니즘(`.python-version`/`NIXPACKS_PYTHON_VERSION`) + 정책 13 배포 smoke check 동반 필요. #22 범위는 docs SSOT 정렬로 한정.
- 역사 design plan(cycle-143)·audit 리포트의 3.14 는 **archival 보존**.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** ✅ — Codex가 README/README.ko/STATE 3.12 정렬 + CI(3.12) 정합 + docs-only(코드/CI/테스트 무변경) 확인. true mutual (push 전).

## 테스트
docs-only. 코드/CI/테스트 변경 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)