### PR TITLE
docs: Railway Python 핀 메커니즘 문서화 + #22 'Railway 핀없음' 정정 (#22 follow-up)

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -6,6 +6,7 @@ paths:
   - "requirements.txt"
   - "requirements-dev.txt"
   - ".env.example"
+  - ".python-version"
   - "alembic.ini"
   - "sonar-project.properties"
 ---
@@ -26,6 +27,7 @@ paths:
 - **gem/npm transitive 의존성 핀**: Ruby gem 또는 npm 패키지의 **직접 의존성만 버전 고정해도 transitive 의존성은 시간에 따라 바뀐다**. rubocop 1.57.2 는 pure Ruby 지만 transitive `rubocop-ast` 가 2024년 이후 prism 네이티브 확장을 필수로 요구하게 변경됨 → Railway 빌드 실패. 해결책은 `gem install rubocop-ast -v 1.36.2` (prism-free 마지막 버전) 를 rubocop 설치 **이전에** 명시 핀.
 - **requirements.txt 분리**: `requirements.txt`(프로덕션 — Railway 자동 감지)와 `requirements-dev.txt`(개발 — `-r requirements.txt` 포함 + pytest/playwright) 분리. `pytest`, `playwright`는 `requirements-dev.txt`에만 유지.
 - **FastAPI 버전 핀**: `requirements.txt` — `fastapi>=0.136.1` (CVE-2024-47874 / CVE-2025-54121 패치 버전). 다운그레이드 금지.
+- 🔴 **Python 버전 핀 — `.python-version` (Railway nixpacks + pyenv, SSOT)**: 루트 `.python-version`(현재 `3.12`)이 **Railway nixpacks Python provider 의 빌드 버전을 핀**한다. nixpacks 는 `NIXPACKS_PYTHON_VERSION` env → `.python-version` → `runtime.txt` → `.tool-versions` 순으로 읽으며 **미지정 시 default 3.11**(nixpacks 공식 — 지원 2.7/3.8~3.13). **SSOT 의무(사이클 166 #22)**: CI(`.github/workflows/ci.yml` `python-version`) · `.python-version` · docs(README/README.ko/STATE 배지·표·Requirements) 3종을 동일 버전 유지. 버전 변경 시 3종 동시 갱신 + nixpacks 지원 범위 확인 + Railway 빌드 로그 직접 검증(`git push` ≠ 빌드 성공). 로컬 dev 는 pyenv 가 `.python-version` 적용(미설치 시 system python fallback — 3.12+ 호환). ⚠️ `.python-version` 미확인으로 'Railway 핀 없음' 오판 금지(#22 정정 학습 — Railway 는 핀 없음이 아니라 `.python-version`=3.12 로 이미 핀).
 - **SMTP_PORT 빈 문자열**: Railway 환경에서 `SMTP_PORT=""`로 설정해도 `config.py`의 `coerce_smtp_port` field_validator가 587로 자동 변환 (크래시 없음). 다만 Railway Variables에서 빈 값 대신 명시적 숫자 설정 권장.
 - **postgres:// URL**: Railway PostgreSQL이 `postgres://`로 제공하는 경우 `config.py`에서 `postgresql://`로 자동 변환.
 - **SonarCloud CPD 제외 (`sonar.cpd.exclusions`)**: 신규 기능 PR 에 테스트 파일(반복 패치 블록)과 Jinja2 HTML 템플릿(구조적 반복)이 포함될 경우 `sonar.cpd.exclusions=tests/**,src/templates/**` 가 이미 설정되어 있음. 서비스/API 계층 내 중복 블록(≥10 토큰)은 추출 헬퍼로 제거 의무. 사이클 129 학습: 13줄 TTL 동기화 중복이 `get_analysis_issue_status`·`get_repo_issue_summary` 양쪽에 존재 → CPD 4.8% → `_sync_state_if_stale` 헬퍼 추출로 0.0% 해소. **체크포인트**: 신규 서비스 함수 2개 이상이 동일 로직 블록을 공유하면 PR 완성 전 헬퍼 추출.

--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -21,7 +21,7 @@
 | 지원 언어 (AI 리뷰) | **50개** | language.py — Tier1/2/3 가이드 |
 | 지원 언어 (정적분석) | **52개+** | Semgrep 22 + ESLint/tsc 2 + ShellCheck 1 + cppcheck 1 + slither 1 + rubocop 1 + golangci-lint 1 + Python 3 + **신규 15**: Dockerfile(hadolint)·Kotlin(ktlint)·HCL(tflint)·SQL(sqlfluff)·YAML(yamllint)·PHP(phpstan)·Swift(swiftlint)·CSS(stylelint)·SCSS(stylelint)·HTML(htmlhint)·Protobuf(buf_lint)·Dart(dart_analyze)·PowerShell(psscriptanalyzer)·C#(dotnet_format)·Rust(clippy) |
 | Tier1 정적분석 도구 | **25종** | pylint·flake8·bandit·semgrep·eslint·shellcheck·cppcheck·slither·rubocop·golangci-lint·**hadolint**·**ktlint**·**tflint**·**tsc**·**sqlfluff**·**yamllint**·**phpstan**·**swiftlint**·**stylelint**·**htmlhint**·**buf_lint**·**dart_analyze**·**psscriptanalyzer**·**dotnet_format**·**clippy** |
-| pytest-asyncio | **1.3.0** | Python 3.12+ DeprecationWarning 제거 완료 · SSOT=Python 3.12 (CI 기준, `.github/workflows/ci.yml` python-version) — 3.14 미검증 선언 정정 (#22) |
+| pytest-asyncio | **1.3.0** | Python 3.12+ DeprecationWarning 제거 완료 · **SSOT=Python 3.12** — CI(`.github/workflows/ci.yml` python-version) + Railway(`.python-version`=3.12, nixpacks 핀; default 3.11) + docs 동일 (로컬 dev 3.13 = 3.12+ 호환). 3.14 미검증 선언 정정 (#22) |
 | CodeQL | **✅ pass** | `.github/workflows/codeql.yml` — 주 1회 실행. 본 README 배지 (L15) 와 페어 |
 
 ## 주요 파일 역할 (빠른 참조)

--- a/docs/cycle-history.md
+++ b/docs/cycle-history.md
@@ -103,7 +103,7 @@
 전 PR Codex true mutual OK·CI green. 단위 4723→4726.
 
 **결정 영역 처리 (사용자 순차 결정, #830~#831)**:
-- **#830 (#22)**: Python 버전 SSOT 3.12 정렬 — README/README.ko/STATE 의 3.14 미검증 선언 → CI(3.12) 기준. 4환경 불일치(CI 3.12·로컬 3.13·Railway nixpacks 핀없음·docs 3.14) 중 CI 권위. docs-only. nixpacks Railway 핀은 별도 follow-up.
+- **#830 (#22)**: Python 버전 SSOT 3.12 정렬 — README/README.ko/STATE 의 3.14 미검증 선언 → CI(3.12) 기준. docs-only. ⚠️ **#830 후속 정정(#22 부정확)**: 당시 'Railway nixpacks 핀없음'으로 기술했으나 **부정확** — 루트 `.python-version`=`3.12` 가 nixpacks Python provider 를 **이미 핀**(nixpacks 는 `.python-version`/`runtime.txt` 등을 읽음, 미지정 시 default 3.11; context7 nixpacks 공식 확인). #830/Codex 둘 다 `.python-version` 미확인 → 'follow-up nixpacks 핀'은 실제로 **이미 완료 상태**였고, 후속 PR 은 핀 추가가 아니라 **deploy.md 핀 메커니즘 문서화 + 본 정정**으로 종결. 즉 Railway·CI·docs 3종 모두 3.12 정합.
 - **#831 (#23)**: gate retry `'passed'` 의도 설계 명시 — 사용자 결정 **A(현 설계 유지, 코드 동작 0)**. `should_retry(UNSTABLE_CI,'passed')=True` 는 merge API lag / 다중 check suite pending 대비 의도적·bounded(감사 '영구 재시도' 표현 부정확). docstring + 회귀 가드. 🔴 **Codex mutual 적발(2-layer ROI)**: 초안이 예산을 `is_expired(max_age/max_attempts)` 로 오기 → 실측 is_expired=max_age 만, max_attempts=process_pending_retries(abandoned) 별도 → 정정 후 OK.
 
 단위 4726→4727.


### PR DESCRIPTION
## 요약
#22 follow-up("nixpacks Railway Python 핀") 조사 결과 — **루트 `.python-version`=`3.12` 가 이미 Railway nixpacks Python 을 핀**하고 있음을 확인. 즉 #22 PR 의 *'Railway nixpacks 핀없음'* 기술이 **부정확**했고, follow-up 으로 추가하려던 핀은 **이미 완료 상태**였습니다. → 핀 추가 대신 **정정 + 문서화**.

## 권위 근거 (context7 nixpacks 공식)
> nixpacks Python provider 는 `NIXPACKS_PYTHON_VERSION` → `.python-version` → `runtime.txt` → `.tool-versions` 순으로 버전을 핀하며, **미지정 시 default 3.11** (지원 2.7/3.8~3.13).

→ `.python-version`=3.12(git-tracked) 이므로 **Railway = 3.12**, CI = 3.12, docs = 3.12 **3종 정합**.

## 변경 내역 (코드/배포 설정 변경 0 — `.python-version` 불변)
- `.claude/rules/deploy.md`: `.python-version` Railway/nixpacks Python 핀 메커니즘 규칙 신설 + `paths` 등재 + **'Railway 핀없음 오판 금지'** 학습(#22 정정)
- `docs/STATE.md`: SSOT 노트 = CI + Railway(`.python-version`) + docs 3종 3.12 정합 명시
- `docs/cycle-history.md`: #830 'Railway 핀없음' 부정확 정정

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** ✅ — Codex가 (1) `.python-version`=3.12, (2) nixpacks 가 `.python-version` 핀(default 3.11)·#22 부정확, (3) diff docs-only(`.python-version`/배포 설정 무변경), (4) deploy.md 규칙 정확성 확인.

## 🔍 사용자 검증 (정책 13)
- 배포 설정 변경 0 — Railway 빌드 영향 없음(`.python-version` 기존 그대로). 다음 Railway 배포 빌드 로그에서 Python 3.12 사용 확인 시 SSOT 정합 최종 확정(선택).

## 테스트
docs/rule only. 테스트 영향 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)