### PR TITLE
docs: _coerce_score 정수 변환 의미 문서화 + 절삭 가드 (사이클166 회고 follow-up)

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -159,6 +159,8 @@ def _coerce_score(raw: object, max_val: int, default: int) -> "tuple[int, bool]"
     변경 시 양쪽 동시 수정 + parity 회귀 가드(test_ai_review_errors.py) 갱신 의무 (testing.md
     의도적 중복 패턴 — 사용처 2곳이라 공유 추출 대신 인라인+가드, 정책16 최소 추상화).
     int(raw) 가 TypeError/ValueError(float-string)/OverflowError(Infinity)를 던지면 default·ok=False.
+    유효한 float(예: 8.9)은 int() 가 0 방향 절삭(양수=floor, 반올림 X) → 8 — 점수 보수적 하향(인플레 방지), ok=True.
+    A valid float (e.g. 8.9) is truncated toward zero by int() (floor for positives, no rounding) → 8 (ok=True).
     🔴 PARITY GUARD with src/api/hook.py::_coerce_raw_score — keep behaviour identical; update both
     plus the parity regression test together when changing either.
     """

--- a/src/api/hook.py
+++ b/src/api/hook.py
@@ -70,6 +70,9 @@ def _coerce_raw_score(raw: Any, max_val: int, default: int) -> tuple[int, bool]:
 
     반환 (clamped, ok) — ok=False 시 호출자가 ai_review_status='parse_error' 로 분류.
     Returns (clamped, ok) — ok=False signals the caller to mark ai_review_status='parse_error'.
+
+    유효한 float(예: 8.9)은 int() 가 0 방향 절삭(양수=floor, 반올림 X) → 8 — 점수 보수적 하향(인플레 방지), ok=True.
+    A valid float (e.g. 8.9) is truncated toward zero by int() (floor for positives, no rounding) → 8 (ok=True).
     """
     try:
         value = int(raw)

--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -283,6 +283,22 @@ def test_coerce_score_parity_with_hook_coerce_raw_score():
             f"parity drift for raw={raw!r}"
 
 
+def test_coerce_score_truncates_valid_float_toward_zero():
+    """유효한 float 은 int() 0방향 절삭(반올림 X) — docstring 정수 의미 가드 (사이클166 follow-up).
+
+    문서화한 '정수 변환 의미'(8.9 → 8, 반올림이면 9)를 값으로 명시 봉인. int()→round() 같은
+    무심코 변경 시 본 가드가 fail. PARITY 대상이라 양쪽 동일 단언.
+    Valid floats are truncated toward zero (no rounding) — guards the documented int() semantics.
+    """
+    from src.api.hook import _coerce_raw_score  # pylint: disable=import-outside-toplevel
+    # 8.9 → 8 (절삭; 반올림이면 9), 유효 숫자라 ok=True
+    assert _coerce_score(8.9, 20, 17) == (8, True)
+    assert _coerce_raw_score(8.9, 20, 17) == (8, True)
+    # 음수 float 은 0 방향 절삭(-2.9 → -2) 후 [0,max] clamp → 0
+    assert _coerce_score(-2.9, 20, 17) == (0, True)
+    assert _coerce_raw_score(-2.9, 20, 17) == (0, True)
+
+
 def test_parse_response_preserves_feedback_on_nonnumeric_score():
     """#24: 단일 점수 필드 float-string 이어도 리뷰 전체를 폐기하지 않고 feedback·정상 점수 보존.
 


### PR DESCRIPTION
## 요약
사이클165 회고 completeness gap **'_coerce_score 정수 의미 모호'** 해소. `ai_review._coerce_score` / `hook._coerce_raw_score`(PARITY GUARD) docstring 이 비숫자/Infinity 거부는 명시했으나 **유효 float 의 `int()` 절삭 의미(8.9→8, 0방향 절삭/반올림 X)는 미문서화** → 양쪽 1줄씩 보강.

## 변경 내역 (코드 동작 변경 0)
- `src/analyzer/io/ai_review.py` / `src/api/hook.py`: docstring 에 "`int()` 0방향 절삭(반올림 X) → 점수 보수적 하향(인플레 방지), ok=True" 명시 (PARITY 양쪽 동일)
- 회귀 가드 `test_coerce_score_truncates_valid_float_toward_zero`: `8.9→(8,True)` · `-2.9→(0,True)`(clamp) 값 명시 단언 — `int()→round()` 무심코 변경 차단

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**CODEX_OK** ✅ — Codex가 (1) `int(8.9)==8`(절삭, not 9)·`int(-2.9)==-2` 정확성, (2) 반환값 `(8,True)`/`(0,True)` clamp 정합, (3) diff docstring-only(로직 불변), (4) 테스트 실행 확인.

## 🔴 자율 판단 보고 (정책 7 위반 회복)
초안을 실수로 main 에 직접 commit → 즉시 회복: 커밋을 본 브랜치로 보존 + `git reset --hard origin/main` 으로 main 복원 후 정상 PR 흐름. (push 전 발견, 원격 영향 0.)

## 잔여 (사이클166 회고 follow-up 분류)
- **#795** 안전망 비율화 = 사이클164 Q2=A 사용자 결정(부분실패≠incomplete)으로 코드+pipeline.md 봉인 → **무작업(재결정 영역)**
- **background task UX silent** = 전 background task 가 webhook 콜백(사용자 버튼 무관), 버튼 액션은 동기+에러 UX 보유 → **구체 지점 미발견**
- **#18**(compare_metadata 가드)·**#2**(RLS·SaaS) = 미착수/보류

## 테스트
docstring + test. `_coerce` 31 passed, ai_review/hook 340 passed, pylint 10.00, flake8 clean. 단위 +1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)