### PR TITLE
fix(ui): settings.html JS 리터럴 i18n tojson 통일 (Task9 P2 #32)

### DIFF
--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -446,7 +446,7 @@
             border-left: 3px solid var(--accent); border-radius: 6px;">
     {{ 'settings_page.simple_only_hint' | i18n_args(locale | default('ko')) | safe }}
   </p>
-  
+
 
   <form id="settingsForm" method="post" action="/repos/{{ repo_name }}/settings">
     <input type="hidden" name="approve_mode" id="approveModeValue" value="{{ config.approve_mode }}">
@@ -1171,9 +1171,9 @@
     },
   };
   var PRESET_LABELS = {
-    minimal: '{{ 'settings.preset_minimal' | i18n_args(locale | default('ko')) }}',
-    standard: '{{ 'settings.preset_standard' | i18n_args(locale | default('ko')) }}',
-    strict: '{{ 'settings.preset_strict' | i18n_args(locale | default('ko')) }}',
+    minimal: {{ 'settings.preset_minimal' | i18n_args(locale | default('ko')) | tojson }},
+    standard: {{ 'settings.preset_standard' | i18n_args(locale | default('ko')) | tojson }},
+    strict: {{ 'settings.preset_strict' | i18n_args(locale | default('ko')) | tojson }},
   };
 
   // 아코디언 토글 — 펼치면 diff 미리보기(자동 적용 아님), 다른 카드는 닫힘
@@ -1193,15 +1193,15 @@
     if (!tbody) return;
 
     const labels = {
-      pr_review_comment: '{{ 'settings.field_pr_review_comment' | i18n_args(locale | default('ko')) }}',
-      commit_comment: '{{ 'settings.field_commit_comment' | i18n_args(locale | default('ko')) }}',
-      create_issue: '{{ 'settings.field_create_issue' | i18n_args(locale | default('ko')) }}',
-      railway_deploy_alerts: '{{ 'settings.field_railway_deploy_alerts' | i18n_args(locale | default('ko')) }}',
-      approve_mode: '{{ 'settings.field_approve_mode' | i18n_args(locale | default('ko')) }}',
-      auto_merge: '{{ 'settings.field_auto_merge' | i18n_args(locale | default('ko')) }}',
-      approve_threshold: '{{ 'settings.field_approve_threshold' | i18n_args(locale | default('ko')) }}',
-      reject_threshold: '{{ 'settings.field_reject_threshold' | i18n_args(locale | default('ko')) }}',
-      merge_threshold: '{{ 'settings.field_merge_threshold' | i18n_args(locale | default('ko')) }}',
+      pr_review_comment: {{ 'settings.field_pr_review_comment' | i18n_args(locale | default('ko')) | tojson }},
+      commit_comment: {{ 'settings.field_commit_comment' | i18n_args(locale | default('ko')) | tojson }},
+      create_issue: {{ 'settings.field_create_issue' | i18n_args(locale | default('ko')) | tojson }},
+      railway_deploy_alerts: {{ 'settings.field_railway_deploy_alerts' | i18n_args(locale | default('ko')) | tojson }},
+      approve_mode: {{ 'settings.field_approve_mode' | i18n_args(locale | default('ko')) | tojson }},
+      auto_merge: {{ 'settings.field_auto_merge' | i18n_args(locale | default('ko')) | tojson }},
+      approve_threshold: {{ 'settings.field_approve_threshold' | i18n_args(locale | default('ko')) | tojson }},
+      reject_threshold: {{ 'settings.field_reject_threshold' | i18n_args(locale | default('ko')) | tojson }},
+      merge_threshold: {{ 'settings.field_merge_threshold' | i18n_args(locale | default('ko')) | tojson }},
     };
 
     function curVal(key) {
@@ -1218,8 +1218,8 @@
       if (val === true) return '✅';
       if (val === false) return '⬜';
       if (val === 'disabled') return '🚫';
-      if (val === 'auto') return '{{ 'settings.mode_auto' | i18n_args(locale | default('ko')) }}';
-      if (val === 'semi-auto') return '{{ 'settings.mode_semi_auto' | i18n_args(locale | default('ko')) }}';
+      if (val === 'auto') return {{ 'settings.mode_auto' | i18n_args(locale | default('ko')) | tojson }};
+      if (val === 'semi-auto') return {{ 'settings.mode_semi_auto' | i18n_args(locale | default('ko')) | tojson }};
       return String(val);
     }
 
@@ -1350,7 +1350,7 @@
     toast.id = 'presetToast';
     toast.className = 'save-toast save-toast-ok';
     toast.innerHTML = '✅ <strong>' + label + '</strong> ' +
-      '{{ 'settings.preset_applied_suffix' | i18n_args(locale | default('ko')) }}';
+      {{ 'settings.preset_applied_suffix' | i18n_args(locale | default('ko')) | tojson }};
     toast.style.cursor = 'pointer';
     toast.addEventListener('click', () => toast.remove());
     document.body.appendChild(toast);
@@ -1380,8 +1380,8 @@
     input.type = isHidden ? 'text' : 'password';
     btn.textContent = isHidden ? '🙈' : '👁️';
     btn.setAttribute('aria-label', isHidden
-      ? '{{ 'settings.hide_value' | i18n_args(locale | default('ko')) }}'
-      : '{{ 'settings.show_value' | i18n_args(locale | default('ko')) }}');
+      ? {{ 'settings.hide_value' | i18n_args(locale | default('ko')) | tojson }}
+      : {{ 'settings.show_value' | i18n_args(locale | default('ko')) | tojson }});
   }
 
   function toggleMergeIssueOption(show) {

--- a/tests/unit/templates/test_admin_settings_i18n_render.py
+++ b/tests/unit/templates/test_admin_settings_i18n_render.py
@@ -11,11 +11,14 @@ Phase 2 PR-8 regression guards — settings + admin 3 templates multilingual ren
 """
 from __future__ import annotations
 
+import json
 from datetime import datetime
+from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from src.i18n.filters import register_i18n_filters
+from src.i18n.loader import get_text
 
 
 def _render(template_name: str, **context) -> str:
@@ -26,6 +29,15 @@ def _render(template_name: str, **context) -> str:
     register_i18n_filters(env)
     tmpl = env.get_template(template_name)
     return tmpl.render(**context)
+
+
+def _js(key: str, locale: str) -> str:
+    """렌더된 JS 출력에서 기대되는 `| tojson` 직렬화 문자열 (#32 — JS 리터럴 안전 주입).
+
+    Expected tojson-serialized string in rendered JS output (#32 — JS-literal safe injection).
+    Jinja `| tojson` == json.dumps(ensure_ascii=True) — 라벨 문자열에 <>&' 없어 동치.
+    """
+    return json.dumps(get_text(key, locale))
 
 
 class _FakeUser:
@@ -462,18 +474,18 @@ def test_settings_renders_korean_settings_namespace_keys():
     assert "AI 코드리뷰 모델" in out
     assert "전역 기본값 사용" in out
     assert "리포별 AI 리뷰 모델을 선택합니다" in out  # model_hint
-    # JS 인라인 PRESET_LABELS (settings.html:1174~1176) — 렌더 출력에 문자열로 포함
-    # JS inline PRESET_LABELS appear as literal strings in rendered output
-    assert "minimal: '최소'" in out
-    assert "standard: '표준'" in out
-    assert "strict: '엄격'" in out
+    # JS 인라인 PRESET_LABELS (settings.html:1174~1176) — #32 이후 `| tojson` 직렬화(JS-안전)
+    # JS inline PRESET_LABELS — tojson-serialized after #32 (ensure_ascii escaped, JS-safe)
+    assert f"minimal: {_js('settings.preset_minimal', 'ko')}" in out
+    assert f"standard: {_js('settings.preset_standard', 'ko')}" in out
+    assert f"strict: {_js('settings.preset_strict', 'ko')}" in out
     # JS 인라인 field 라벨 (settings.html:1196~1204)
-    assert "pr_review_comment: 'PR 코드리뷰 댓글'" in out
-    assert "approve_threshold: '승인 기준점'" in out
-    assert "merge_threshold: 'Merge 임계값'" in out
-    # mode 라벨 (settings.html:1221~1222)
-    assert "⚡ 자동" in out
-    assert "📱 반자동" in out
+    assert f"pr_review_comment: {_js('settings.field_pr_review_comment', 'ko')}" in out
+    assert f"approve_threshold: {_js('settings.field_approve_threshold', 'ko')}" in out
+    assert f"merge_threshold: {_js('settings.field_merge_threshold', 'ko')}" in out
+    # mode 라벨 (settings.html:1221~1222) — tojson 직렬화
+    assert _js('settings.mode_auto', 'ko') in out
+    assert _js('settings.mode_semi_auto', 'ko') in out
 
 
 def test_settings_renders_english_settings_namespace_keys():
@@ -481,9 +493,9 @@ def test_settings_renders_english_settings_namespace_keys():
     out = _render("settings.html", locale="en", **_settings_ctx_146())
     assert "AI Code Review Model" in out
     assert "Use global default" in out
-    assert "minimal: 'Minimal'" in out
-    assert "standard: 'Standard'" in out
-    assert "strict: 'Strict'" in out
+    assert f"minimal: {_js('settings.preset_minimal', 'en')}" in out
+    assert f"standard: {_js('settings.preset_standard', 'en')}" in out
+    assert f"strict: {_js('settings.preset_strict', 'en')}" in out
 
 
 def test_settings_renders_japanese_settings_namespace_keys():
@@ -491,7 +503,7 @@ def test_settings_renders_japanese_settings_namespace_keys():
     out = _render("settings.html", locale="ja", **_settings_ctx_146())
     assert "AIコードレビューモデル" in out
     assert "グローバルデフォルトを使用" in out
-    assert "minimal: '最小'" in out
+    assert f"minimal: {_js('settings.preset_minimal', 'ja')}" in out
 
 
 def test_settings_renders_save_toast_ok_when_saved():
@@ -537,3 +549,24 @@ def test_settings_no_raw_settings_namespace_keys_leak():
 
     leaks = re.findall(r"(?<![\w-])settings\.[a-z_]+", out)
     assert not leaks, f"raw settings 키 노출: {leaks}"
+
+
+# ── #32 회귀 가드 — JS 리터럴 i18n 은 tojson 직렬화 의무 ─────────────────────
+# Cycle 166 'resolved' 위양성(cycle-history.md:83) → 적대 재검증 후 실제 수정.
+
+
+def test_settings_js_literals_use_tojson_not_html_escape():
+    """#32 회귀 가드 — settings.html <script> 의 i18n_args 가 JS 문자열 리터럴에
+    HTML-escape(autoescape)로 주입되지 않고 `| tojson` 으로 JS-안전 직렬화되는지 검증.
+
+    #32 regression guard — i18n_args inside settings.html JS string literals must use
+    `| tojson` (JS-safe), NOT single-quote HTML-escape wrapping.
+    `i18n_args` 는 raw + HTML autoescape(JS-escape 아님)라 JS 리터럴 컨텍스트 부정합 —
+    번역문에 따옴표/백슬래시 유입 시 JS 깨짐·주입 위험. tojson 이 JS-안전 직렬화.
+    """
+    src = Path("src/templates/settings.html").read_text(encoding="utf-8")
+    # 안티패턴: '{{ 'settings.<key>' | i18n_args(...) }}' (단일 따옴표 래핑 = HTML-escape)
+    assert "'{{ 'settings." not in src, (
+        "JS 문자열 리터럴 i18n 은 `| tojson` 직렬화 의무 (#32) — "
+        "'{{ ... | i18n_args(...) }}' 단일따옴표 래핑(HTML-escape) 금지"
+    )


### PR DESCRIPTION
> ♻️ **본문 복원 (2026-06-10)** — `gh pr create` 본문 인자 결함(리터럴 `@-` 저장)으로 소실된 본문을 squash 머지 커밋 메시지에서 복원. 전 PR Codex mutual OK 기록은 `docs/STATE.md` 사이클 166 항 참조.

fix(ui): settings.html JS 리터럴 i18n 을 tojson 직렬화로 통일 (Task9 P2 #32) (#839)

사이클166 정합성 감사 골든 #32 — settings.html <script> 의 i18n_args 출력이
JS 문자열 리터럴('...')에 HTML-escape(autoescape)로 주입돼 JS 컨텍스트 부정합.
i18n_args 는 raw + HTML autoescape(JS-escape 아님)라 번역문에 따옴표/백슬래시
유입 시 JS 깨짐·주입 위험. confirm() 라인(1114/1130)이 이미 쓰는 | tojson
패턴으로 17개 JS-리터럴 사이트 통일 (JS-안전 직렬화).

⚠️ #32 는 사이클166 검증이 'resolved(이미 tojson)' 으로 오판한 위양성 —
적대 재검증(wf_688dd1f2)이 confirm() 라인 tojson 을 PRESET_LABELS JS-리터럴로
오인한 것 확인 → 실제 미해소였고 본 PR 로 해소 (PR #838 docs 정정 페어).

변경:
- settings.html 17곳: '{{ KEY | i18n_args(...) }}' → {{ KEY | i18n_args(...) | tojson }}
  (PRESET_LABELS 3 + labels 객체 9 + mode 2 + preset_applied_suffix 1 + hide/show 2)
- 기존 render-parity 단언 12건: 단일따옴표 패턴 → _js() tojson 직렬화 형식
  (Jinja tojson == json.dumps(ensure_ascii=True), 한국어 \uXXXX 브라우저 정상 복원)
- 신규 #32 회귀 정적 가드: 안티패턴 '{{ 'settings. 0건 강제

라이브 XSS 無(현 번역문에 따옴표/백슬래시 없음)·구조적 비일관 해소. 코드 동작
불변(브라우저 렌더 동일). templates+i18n 145 + ui 193 통과, 단위 +1(정적 가드).

Co-authored-by: xzawed <xzawed31@gmail.com>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---

## 🎨 사용자 검증 필요 — 정책 11 (본문 복원 시 회복)

본 PR 은 `src/templates/settings.html` 17곳 JS-리터럴 → `| tojson` 변경 — **Claude 시각 검증 불가**.
4-테마(dark/light/pastel/catppuccin) × 모바일/데스크탑 **8조합**에서 settings 페이지의 프리셋 라벨·모드 문구·hide/show 토글·preset_applied 토스트가 정상 렌더(한국어 \uXXXX 브라우저 복원 포함)되는지 확인 필요.
