### PR TITLE
fix(db): repositories.user_id DB FK 추가 (SET NULL) (정합성 감사 #18 drift ④)

### DIFF
--- a/alembic/versions/0039_repositories_user_id_fk.py
+++ b/alembic/versions/0039_repositories_user_id_fk.py
@@ -1,0 +1,76 @@
+"""add DB-level FK on repositories.user_id → users.id (정합성 감사 P2 #18 drift ④)
+
+정합성 감사 full(2026-06-08) #18 가드가 발견한 사전존재 drift ④ —
+`repositories.user_id` 는 ORM 에 `ForeignKey("users.id")` 로 선언됐으나 0005 가
+컬럼+인덱스만 추가하고 **DB 레벨 FK 제약은 생성하지 않았다**. referential integrity
+미강제로 고아 user_id(users 미존재 id) 가능. ORM↔DB 정합(#14류) + 무결성 1차 안전망.
+
+repositories.user_id 는 nullable 이므로 **ondelete=SET NULL** (user 삭제 시 repo 는
+보존하되 소유자만 해제 — ui.md: user_id=NULL repo 는 전 로그인 사용자에게 노출됨).
+analyses(0038, NOT NULL→CASCADE) 와 대비되는 nullable 컬럼의 자연스러운 정책.
+
+🔴 FK 추가 전 **고아 정리 선행** (사용자 결정 A): users.id 에 없는 user_id 를 NULL 로
+정리해야 FK 생성이 기존 행 검증에서 실패하지 않는다.
+
+repositories.user_id has no DB-level FK (0005 added only the column+index). Add the FK
+with ondelete=SET NULL (nullable column). Orphan user_ids (no matching users.id) are set
+to NULL first so the FK can be created without failing on existing rows.
+
+PostgreSQL: orphan cleanup + CREATE CONSTRAINT (FK 없던 상태 → DROP 불요).
+SQLite: ALTER 로 FK 추가 불가 — 운영 DB(Postgres)만 처리.
+단위 테스트는 ORM Base.metadata.create_all 로 신규 ondelete='SET NULL' 자동 적용.
+
+add DB-level FK on repositories.user_id — see 0038 (analyses) for the ALTER pattern.
+user_id is nullable so SET NULL fits; orphans are nulled before the FK is created.
+
+Revision ID: 0039
+Revises: 0038
+Create Date: 2026-06-09
+"""
+from alembic import op
+
+from src.shared.alembic_dialect import is_postgresql
+
+
+revision = "0039"
+down_revision = "0038"
+branch_labels = None
+depends_on = None
+
+# Postgres 기본 FK 명명 규칙 (table_column_fkey) — compare_metadata 는 이름이 아닌
+# (컬럼·참조·ondelete) 시그니처로 대조하므로 ORM unnamed FK 와 정합.
+# Default Postgres FK name convention; compare_metadata matches by signature, not name.
+_FK_NAME = "repositories_user_id_fkey"
+
+
+def upgrade() -> None:
+    # SQLite 는 ALTER 로 FK 추가 불가 — 운영 DB(Postgres)만 처리.
+    # 단위 테스트는 ORM Base.metadata.create_all 로 신규 ondelete='SET NULL' 적용.
+    # SQLite cannot ALTER-add FKs — only Postgres; tests get the FK via ORM create_all.
+    bind = op.get_bind()
+    if not is_postgresql(bind):
+        return
+
+    # 고아 user_id 정리 (users.id 미존재) → NULL — FK 생성 전 기존 행 검증 통과 보장.
+    # Null out orphan user_ids (no matching users.id) before adding the FK.
+    op.execute(
+        "UPDATE repositories SET user_id = NULL "
+        "WHERE user_id IS NOT NULL "
+        "AND user_id NOT IN (SELECT id FROM users)"
+    )
+    op.create_foreign_key(
+        _FK_NAME,
+        "repositories",
+        "users",
+        ["user_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not is_postgresql(bind):
+        return
+
+    op.drop_constraint(_FK_NAME, "repositories", type_="foreignkey")

--- a/src/models/repository.py
+++ b/src/models/repository.py
@@ -15,7 +15,7 @@ class Repository(Base):
     full_name      = Column(String, unique=True, nullable=False, index=True)
     telegram_chat_id = Column(String, nullable=True)
     created_at     = Column(DateTime, default=lambda: datetime.now(timezone.utc))
-    user_id        = Column(Integer, ForeignKey("users.id"), nullable=True, index=True)
+    user_id        = Column(Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True)
     webhook_secret = Column(String, nullable=True)
     webhook_id     = Column(Integer, nullable=True)
 

--- a/tests/unit/migrations/test_0039_repositories_user_id_fk.py
+++ b/tests/unit/migrations/test_0039_repositories_user_id_fk.py
@@ -1,0 +1,35 @@
+"""정합성 감사 #18 drift ④ — repositories.user_id → users.id FK 회귀 가드.
+
+정합성 감사 full(2026-06-08) #18 가드 발견 drift ④ — `repositories.user_id` 가 ORM 에는
+`ForeignKey("users.id")` 로 선언됐으나 0005 가 DB FK 제약을 생성하지 않음(컬럼+인덱스만).
+referential integrity 미강제 → 고아 user_id 가능. alembic 0039 가 DB FK(SET NULL) 추가.
+
+본 테스트는 ORM 정의 측 `ondelete="SET NULL"` 가 유지되는지 검증 (alembic 0039 페어).
+nullable 컬럼이라 SET NULL (analyses 0038 의 NOT NULL→CASCADE 와 대비).
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+# pylint: disable=wrong-import-position
+from src.models.repository import Repository
+
+
+def test_repositories_user_id_fk_has_set_null_delete():
+    """Repository.user_id FK 의 ondelete 가 SET NULL 인지 검증 (#18 drift ④).
+
+    user 삭제 시 소유 repo 는 보존(소유자만 해제) — nullable 컬럼 정합. 미설정 시
+    DB 레벨 referential integrity 부재(고아 user_id 가능). alembic 0039 가 DB FK 추가.
+    """
+    fks = list(Repository.__table__.c.user_id.foreign_keys)
+    assert len(fks) == 1, "user_id 에 FK 가 정확히 1개 있어야 함"
+    fk = fks[0]
+    assert fk.column.table.name == "users", "user_id FK 는 users 테이블 참조"
+    assert fk.ondelete == "SET NULL", (
+        f"repositories.user_id FK ondelete='{fk.ondelete}' — "
+        "'SET NULL' 이어야 함 (#18 drift ④ 회귀, nullable 컬럼)"
+    )

--- a/tests/unit/migrations/test_orm_alembic_parity.py
+++ b/tests/unit/migrations/test_orm_alembic_parity.py
@@ -74,9 +74,9 @@ _ALLOWLIST_PATTERNS = (
     #    (ORM postgresql_where 선언 차기 후보 — WHERE 정규화 FP 주의)
     ("remove_index", "uq_insight_cache_global"),
     ("remove_index", "uq_insight_cache_repo"),
-    # ⑤ repositories.user_id FK — 0005 가 컬럼만 추가(DB FK 제약 미생성), ORM 은 ForeignKey('users.id') 선언
-    #    (#14-class, DB 레벨 FK 부재). (신규 마이그레이션 FK 추가 차기 후보 — 고아 user_id 검증 필요)
-    ("add_fk", "repositories", "user_id", "users.id"),
+    # ⑤ repositories.user_id FK — **해소(alembic 0039, ondelete=SET NULL)**: 0005 가 컬럼만 추가했던
+    #    DB FK 부재를 0039 가 추가(고아 정리 선행). ORM↔DB 정합 → allowlist 불요(제거). 잔존 시 가드가
+    #    실제 FK 누락(회귀)을 잡도록 의도적 미등재. (#14-class 중 데이터 무결성 영향분 — drift ①③④ 는 잔존)
 )
 
 


### PR DESCRIPTION
> ♻️ **본문 복원 (2026-06-10)** — `gh pr create` 본문 인자 결함(리터럴 `@-` 저장)으로 소실된 본문을 squash 머지 커밋 메시지에서 복원. 전 PR Codex mutual OK 기록은 `docs/STATE.md` 사이클 166 항 참조.

fix(db): repositories.user_id → users.id DB FK 추가 (SET NULL) (정합성 감사 #18 drift ④) (#840)

#18 compare_metadata 가드가 발견한 사전존재 drift ④ — repositories.user_id 가 ORM 에는
ForeignKey("users.id") 로 선언됐으나 0005 가 컬럼+인덱스만 추가하고 DB 레벨 FK 제약을
생성하지 않음. referential integrity 미강제로 고아 user_id(users 미존재 id) 가능 —
drift 4종 중 유일한 데이터 무결성 영향.

수정 (사용자 결정 A — SET NULL + 고아→NULL 정리):
- alembic 0039: 고아 user_id 정리(UPDATE ... SET NULL WHERE NOT IN users) 선행 후
  create_foreign_key ondelete=SET NULL (PG-only, 0038 ALTER 패턴 차용). user_id 가
  nullable 이라 SET NULL — user 삭제 시 repo 보존·소유자만 해제(ui.md: NULL=전 사용자 노출).
- ORM repository.py: ForeignKey 에 ondelete="SET NULL" 추가 (DB↔ORM 정합).
- test_orm_alembic_parity allowlist ⑤(add_fk) 제거 — 0039 가 FK 추가로 compare_metadata
  정합 → 잔존 시 가드가 실제 FK 누락(회귀)을 잡도록 의도적 미등재.
- 회귀 가드 test_0039(ORM ondelete=SET NULL 검증).

PG-only round-trip CI(pg-concurrency job)가 실 마이그레이션·고아 정리·FK 동작 검증.
drift ①③④(users 인덱스명·analyses _tokens·insight_cache 부분유일, 운영 무해)는 별도
cosmetic PR(PR3b). 마이그레이션 39 + repositories 133 통과, alembic head 단일(0039).

Co-authored-by: xzawed <xzawed31@gmail.com>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
