### PR TITLE
fix(db): users 인덱스명 ix_users_google_id→github_id 리네임 (정합성 감사 #18 drift ①)

### DIFF
--- a/alembic/versions/0040_rename_users_github_id_index.py
+++ b/alembic/versions/0040_rename_users_github_id_index.py
@@ -1,0 +1,49 @@
+"""rename ix_users_google_id → ix_users_github_id (정합성 감사 #18 drift ①)
+
+정합성 감사 full(2026-06-08) #18 가드가 발견한 사전존재 drift ① — 0005 가 `google_id`
+컬럼에 unique 인덱스 `ix_users_google_id` 를 생성했고, 0006 이 컬럼을 `github_id` 로
+리네임(`alter_column new_column_name`)했으나 **인덱스명은 리네임하지 않음**. 결과적으로
+운영 PG 에는 `ix_users_google_id` 인덱스가 잔존하나 ORM(user.py:19 `index=True`)은
+자동명 `ix_users_github_id` 를 선언 → ORM↔DB 인덱스명 drift.
+
+운영 무해(둘 다 동일 `github_id` 컬럼의 unique 인덱스 — 기능 동등, 명칭만 stale)이나
+ORM↔DB 정합을 위해 인덱스명 리네임. ALTER INDEX RENAME 은 unique·컬럼 등 속성 보존.
+
+PostgreSQL: `ALTER INDEX ... RENAME TO ...`.
+SQLite: 컬럼 리네임 이력(0006)이 batch_alter_table 재생성으로 ORM 자동명을 이미 사용 +
+단위 테스트는 ORM create_all 로 `ix_users_github_id` 생성 → rename 무의미·skip.
+
+rename ix_users_google_id → ix_users_github_id (index name only; PG ALTER INDEX RENAME).
+The column was renamed google_id→github_id in 0006 but the index name was not. PG-only.
+
+Revision ID: 0040
+Revises: 0039
+Create Date: 2026-06-09
+"""
+from alembic import op
+
+from src.shared.alembic_dialect import is_postgresql
+
+
+revision = "0040"
+down_revision = "0039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 운영 DB(Postgres)만 — SQLite 는 ORM create_all 로 이미 ix_users_github_id 사용.
+    # Only Postgres; SQLite already uses ix_users_github_id via ORM create_all.
+    bind = op.get_bind()
+    if not is_postgresql(bind):
+        return
+
+    op.execute("ALTER INDEX ix_users_google_id RENAME TO ix_users_github_id")
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if not is_postgresql(bind):
+        return
+
+    op.execute("ALTER INDEX ix_users_github_id RENAME TO ix_users_google_id")

--- a/tests/unit/migrations/test_0040_rename_users_github_id_index.py
+++ b/tests/unit/migrations/test_0040_rename_users_github_id_index.py
@@ -1,0 +1,33 @@
+"""정합성 감사 #18 drift ① — users github_id 인덱스명 회귀 가드.
+
+정합성 감사 full(2026-06-08) #18 가드 발견 drift ① — 0005 가 `ix_users_google_id`
+생성, 0006 이 컬럼 google_id→github_id 리네임했으나 인덱스명 미반영. ORM 은
+자동명 `ix_users_github_id` 선언. alembic 0040 가 운영 PG 인덱스명 리네임.
+
+본 테스트는 ORM 측 인덱스명이 `ix_users_github_id`(legacy 'google' 아님)인지 검증.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+# pylint: disable=wrong-import-position
+from src.models.user import User
+
+
+def test_users_github_id_index_name_not_legacy_google():
+    """User.github_id 인덱스명이 ix_users_github_id (legacy ix_users_google_id 아님) (#18 drift ①).
+
+    0006 컬럼 리네임 후 인덱스명 stale → ORM↔DB drift. alembic 0040 가 운영 PG 정합.
+    ORM `index=True` 자동명이 컬럼명(github_id) 기반인지 회귀 검증.
+    """
+    index_names = {ix.name for ix in User.__table__.indexes}
+    assert "ix_users_github_id" in index_names, (
+        f"users 인덱스에 ix_users_github_id 없음 — {index_names} (#18 drift ① 회귀)"
+    )
+    assert "ix_users_google_id" not in index_names, (
+        "legacy ix_users_google_id 가 ORM 에 잔존 — github_id 컬럼명 정합 위반"
+    )

--- a/tests/unit/migrations/test_orm_alembic_parity.py
+++ b/tests/unit/migrations/test_orm_alembic_parity.py
@@ -59,10 +59,9 @@ _IGNORED_OPS = frozenset({
 # Pre-existing ORM↔alembic structural diffs (legacy/representation), harmless and tracked as separate
 # fix candidates. This guard blocks NEW drift; pre-existing items below are allowlisted by repr substrings.
 _ALLOWLIST_PATTERNS = (
-    # ① users 인덱스 legacy 명 — 0005 가 google_id 컬럼에 ix_users_google_id 생성, 이후 컬럼이 github_id 로
-    #    리네임됐으나 인덱스명 미반영. ORM 은 ix_users_github_id 선언. (인덱스 리네임 마이그레이션 차기 후보)
-    ("remove_index", "ix_users_google_id"),
-    ("add_index", "ix_users_github_id"),
+    # ① users 인덱스 legacy 명 — **해소(alembic 0040, ALTER INDEX RENAME)**: 0005 ix_users_google_id →
+    #    0006 컬럼 리네임 시 인덱스명 미반영 → 0040 이 ix_users_github_id 로 리네임(ORM 자동명 정합).
+    #    allowlist 불요(제거) — 잔존 시 가드가 회귀를 잡도록 미등재.
     # ② email 유일성 표현 차이 — ORM unique=True(UniqueConstraint) ↔ DB unique INDEX ix_users_email(0005).
     #    기능 동등(둘 다 email 유일성) — 표현 FP. (ORM/마이그레이션 표현 통일 차기 후보)
     ("remove_index", "ix_users_email"),
@@ -76,7 +75,7 @@ _ALLOWLIST_PATTERNS = (
     ("remove_index", "uq_insight_cache_repo"),
     # ⑤ repositories.user_id FK — **해소(alembic 0039, ondelete=SET NULL)**: 0005 가 컬럼만 추가했던
     #    DB FK 부재를 0039 가 추가(고아 정리 선행). ORM↔DB 정합 → allowlist 불요(제거). 잔존 시 가드가
-    #    실제 FK 누락(회귀)을 잡도록 의도적 미등재. (#14-class 중 데이터 무결성 영향분 — drift ①③④ 는 잔존)
+    #    실제 FK 누락(회귀)을 잡도록 의도적 미등재. (#14-class 데이터 무결성 영향분 — ③④' 부분인덱스만 잔존)
 )
 
 
@@ -187,9 +186,12 @@ def test_structural_diffs_filter_logic():
     t_pk = Table("merge_attempts", md, Column("id", Integer, primary_key=True))
     assert _structural_diffs([("add_index", Index("ix_merge_attempts_id", t_pk.c.id))]) == []
 
-    # 2) allowlist 사전 존재 항목(인덱스명 repr) 제외
-    t_users = Table("users", md, Column("github_id", Integer))
-    assert _structural_diffs([("add_index", Index("ix_users_github_id", t_users.c.github_id))]) == []
+    # 2) allowlist 사전 존재 항목(인덱스명 repr) 제외 — ③ analyses tokens 부분인덱스(잔존 allowlist).
+    #    (① users 인덱스명·⑤ FK 는 0040/0039 로 해소돼 allowlist 제거 — 잔존 항목으로 fixture 교체)
+    t_idx_fx = Table("idx_fixture_tbl", md, Column("created_at", Integer))
+    assert _structural_diffs(
+        [("remove_index", Index("ix_analyses_repo_id_created_at_tokens", t_idx_fx.c.created_at))]
+    ) == []
 
     # 3) 신규(non-allowlisted, non-PK) 인덱스 drift 는 포착 → fail 신호
     t_an = Table("analyses", md, Column("score", Integer))


### PR DESCRIPTION
> ♻️ **본문 복원 (2026-06-10)** — `gh pr create` 본문 인자 결함(리터럴 `@-` 저장)으로 소실된 본문을 squash 머지 커밋 메시지에서 복원. 전 PR Codex mutual OK 기록은 `docs/STATE.md` 사이클 166 항 참조.

fix(db): users 인덱스명 ix_users_google_id→ix_users_github_id 리네임 (정합성 감사 #18 drift ①) (#841)

#18 compare_metadata 가드 발견 drift ① — 0005 가 google_id 컬럼에 unique 인덱스
ix_users_google_id 생성, 0006 이 컬럼을 github_id 로 리네임했으나 인덱스명 미반영.
운영 PG 에는 ix_users_google_id 잔존, ORM(user.py:19 index=True)은 자동명
ix_users_github_id 선언 → ORM↔DB 인덱스명 drift. 운영 무해(기능 동등)나 정합 위해 리네임.

수정 (사용자 결정 A — ①만 처리, ③④' 부분인덱스는 WHERE-FP 리스크로 allowlist 유지):
- alembic 0040: ALTER INDEX ix_users_google_id RENAME TO ix_users_github_id (PG-only,
  속성 보존). SQLite 는 ORM create_all 로 이미 자동명 사용 → skip.
- test_orm_alembic_parity allowlist ① 제거 — 0040 리네임으로 compare_metadata 정합.
- 필터 로직 테스트 fixture 를 잔존 allowlist(③ analyses tokens)로 교체 (① 제거 반영,
  table 명 충돌 회피).
- 회귀 가드 test_0040(ORM 인덱스명 ix_users_github_id, legacy google 아님).

🔴 PR3a(#840, 0039 FK)에 스택 — 0040 down_revision=0039 (선형 체인). **머지 순서:
#840 → 본 PR**. drift ③④'(부분인덱스, 운영무해)은 allowlist '문서화된 무해' 유지.
마이그레이션 40 통과, alembic head 단일(0040).

Co-authored-by: xzawed <xzawed31@gmail.com>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
