### PR TITLE
fix(db): analyses/insight_cache 부분 인덱스 ORM 선언 — drift ③④' 정합 (#18)

### DIFF
--- a/src/models/analysis.py
+++ b/src/models/analysis.py
@@ -1,7 +1,7 @@
 """Analysis ORM 모델 — 분석 이력(정적 분석 + AI 리뷰 점수) 저장."""
 from datetime import datetime, timezone
 from sqlalchemy import (
-    Column, Integer, String, JSON, DateTime, ForeignKey, UniqueConstraint, Index,
+    Column, Integer, String, JSON, DateTime, ForeignKey, UniqueConstraint, Index, text,
 )
 from sqlalchemy.orm import relationship
 from src.database import Base
@@ -22,6 +22,15 @@ class Analysis(Base):
         UniqueConstraint("repo_id", "commit_sha", name="uq_analyses_repo_sha"),
         Index("ix_analyses_repo_id_created_at", "repo_id", "created_at"),
         Index("ix_analyses_repo_id_author_login", "repo_id", "author_login"),
+        # 0032: 월별 토큰 합산 쿼리용 부분 인덱스 (input_tokens IS NOT NULL).
+        # ORM↔alembic 정합 (#18 drift ③) — postgresql/sqlite 양 방언 부분 인덱스 선언.
+        # 0032: partial index for monthly token aggregation; declared for ORM↔alembic parity.
+        Index(
+            "ix_analyses_repo_id_created_at_tokens",
+            "repo_id", "created_at",
+            postgresql_where=text("input_tokens IS NOT NULL"),
+            sqlite_where=text("input_tokens IS NOT NULL"),
+        ),
     )
 
     id = Column(Integer, primary_key=True, index=True)

--- a/src/models/insight_narrative_cache.py
+++ b/src/models/insight_narrative_cache.py
@@ -9,7 +9,7 @@ InsightNarrativeCache ORM — Insight mode Claude AI narrative 1h TTL cache.
 """
 from datetime import datetime, timezone
 
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Integer, String
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, Index, Integer, String, text
 
 from src.database import Base
 
@@ -25,13 +25,29 @@ class InsightNarrativeCache(Base):
     __table_args__ = (
         # 0031: old (user_id, days) UniqueConstraint removed — repo_id 추가로 다중 행 허용.
         # 0031: old (user_id, days) UniqueConstraint removed — multiple rows allowed with repo_id.
-        # Partial uniqueness enforced by migration 0031 partial indexes (PG only).
         Index(
             "ix_insight_cache_user_days_language",
             "user_id", "days", "language",
         ),
         Index("ix_insight_cache_repo_id", "repo_id"),
         Index("ix_insight_cache_last_error_at", "last_error_at"),
+        # 0031: 전역(repo_id IS NULL) / 리포별(repo_id IS NOT NULL) 부분 유니크 인덱스.
+        # ORM↔alembic 정합 (#18 drift ④') — postgresql/sqlite 양 방언 선언으로 전역+리포 공존 보장.
+        # 0031: partial UNIQUE indexes — global (repo_id IS NULL) vs repo-specific; declared for parity.
+        Index(
+            "uq_insight_cache_global",
+            "user_id", "days", "language",
+            unique=True,
+            postgresql_where=text("repo_id IS NULL"),
+            sqlite_where=text("repo_id IS NULL"),
+        ),
+        Index(
+            "uq_insight_cache_repo",
+            "user_id", "days", "language", "repo_id",
+            unique=True,
+            postgresql_where=text("repo_id IS NOT NULL"),
+            sqlite_where=text("repo_id IS NOT NULL"),
+        ),
     )
 
     id = Column(Integer, primary_key=True, index=True)

--- a/tests/unit/migrations/test_orm_alembic_parity.py
+++ b/tests/unit/migrations/test_orm_alembic_parity.py
@@ -66,16 +66,12 @@ _ALLOWLIST_PATTERNS = (
     #    기능 동등(둘 다 email 유일성) — 표현 FP. (ORM/마이그레이션 표현 통일 차기 후보)
     ("remove_index", "ix_users_email"),
     ("add_constraint", "users", "email"),
-    # ③ analyses 보조 복합 인덱스 — 0032 가 ix_analyses_repo_id_created_at_tokens 생성, ORM __table_args__ 미선언
-    #    (#15-class, alembic 전용). (ORM 선언 차기 후보)
-    ("remove_index", "ix_analyses_repo_id_created_at_tokens"),
-    # ④ insight_narrative_cache 부분 유일 인덱스 — 0031 raw DDL(WHERE 절), ORM 미선언 (#16-class).
-    #    (ORM postgresql_where 선언 차기 후보 — WHERE 정규화 FP 주의)
-    ("remove_index", "uq_insight_cache_global"),
-    ("remove_index", "uq_insight_cache_repo"),
+    # ③④' analyses 토큰 인덱스 + insight_cache 부분 유일 인덱스 — **해소(ORM postgresql_where+sqlite_where 선언)**:
+    #    0032 ix_analyses_repo_id_created_at_tokens + 0031 uq_insight_cache_global/repo 를 ORM __table_args__ 에
+    #    양 방언 partial 로 선언 → compare_metadata 정합. allowlist 불요(제거). 잔존 시 가드가 누락(회귀)을 잡도록 미등재.
     # ⑤ repositories.user_id FK — **해소(alembic 0039, ondelete=SET NULL)**: 0005 가 컬럼만 추가했던
     #    DB FK 부재를 0039 가 추가(고아 정리 선행). ORM↔DB 정합 → allowlist 불요(제거). 잔존 시 가드가
-    #    실제 FK 누락(회귀)을 잡도록 의도적 미등재. (#14-class 데이터 무결성 영향분 — ③④' 부분인덱스만 잔존)
+    #    실제 FK 누락(회귀)을 잡도록 의도적 미등재. (잔존 allowlist = ② email 유일성 표현 FP 뿐)
 )
 
 
@@ -186,11 +182,11 @@ def test_structural_diffs_filter_logic():
     t_pk = Table("merge_attempts", md, Column("id", Integer, primary_key=True))
     assert _structural_diffs([("add_index", Index("ix_merge_attempts_id", t_pk.c.id))]) == []
 
-    # 2) allowlist 사전 존재 항목(인덱스명 repr) 제외 — ③ analyses tokens 부분인덱스(잔존 allowlist).
-    #    (① users 인덱스명·⑤ FK 는 0040/0039 로 해소돼 allowlist 제거 — 잔존 항목으로 fixture 교체)
-    t_idx_fx = Table("idx_fixture_tbl", md, Column("created_at", Integer))
+    # 2) allowlist 사전 존재 항목(인덱스명 repr) 제외 — ② email 유일성 표현 FP (유일 잔존 allowlist).
+    #    (①⑤ 0040/0039 · ③④' ORM postgresql_where 선언으로 해소돼 제거 — ② 만 잔존)
+    t_email_fx = Table("users_email_fx", md, Column("email", Integer))
     assert _structural_diffs(
-        [("remove_index", Index("ix_analyses_repo_id_created_at_tokens", t_idx_fx.c.created_at))]
+        [("remove_index", Index("ix_users_email", t_email_fx.c.email))]
     ) == []
 
     # 3) 신규(non-allowlisted, non-PK) 인덱스 drift 는 포착 → fail 신호

--- a/tests/unit/migrations/test_orm_partial_indexes.py
+++ b/tests/unit/migrations/test_orm_partial_indexes.py
@@ -1,0 +1,68 @@
+"""정합성 감사 #18 drift ③④' — ORM 부분 인덱스 선언 회귀 가드.
+
+정합성 감사 full(2026-06-08) #18 가드 발견 drift ③④' — alembic 이 생성한 부분 인덱스를
+ORM `__table_args__` 가 미선언 → ORM↔alembic compare_metadata drift.
+- ③ analyses `ix_analyses_repo_id_created_at_tokens` (0032, WHERE input_tokens IS NOT NULL)
+- ④' insight_cache `uq_insight_cache_global`/`uq_insight_cache_repo` (0031, 부분 UNIQUE)
+
+본 테스트는 ORM 측 선언(부분 WHERE + 양 방언)이 유지되는지 검증 (compare_metadata PG 가드 페어).
+WHERE 절 누락 시 SQLite 가 전체 유니크 인덱스를 만들어 전역+리포 캐시 공존이 깨진다.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test-secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+# pylint: disable=wrong-import-position
+from src.models.analysis import Analysis
+from src.models.insight_narrative_cache import InsightNarrativeCache
+
+
+def _index(table, name):
+    for ix in table.indexes:
+        if ix.name == name:
+            return ix
+    return None
+
+
+def _where_str(ix, dialect):
+    """Index 의 방언별 부분 WHERE 술어 문자열 반환 (미설정 시 None).
+
+    text() 로 선언한 WHERE 는 str() 가 원문 술어를 그대로 반환 — 술어 정확 비교로
+    술어 뒤바뀜/오타(예: global↔repo NULL 술어 swap)를 차단 (Codex mutual 강화).
+    """
+    where = ix.dialect_options[dialect].get("where")
+    return None if where is None else str(where)
+
+
+def test_analyses_tokens_partial_index_declared():
+    """analyses ix_analyses_repo_id_created_at_tokens 부분 인덱스 ORM 선언 (#18 drift ③)."""
+    ix = _index(Analysis.__table__, "ix_analyses_repo_id_created_at_tokens")
+    assert ix is not None, "ix_analyses_repo_id_created_at_tokens ORM 미선언 (#18 drift ③ 회귀)"
+    assert [c.name for c in ix.columns] == ["repo_id", "created_at"]
+    # 부분 WHERE 술어 정확 비교 — 양 방언 (PG compare_metadata 정합 + SQLite 부분 인덱스)
+    assert _where_str(ix, "postgresql") == "input_tokens IS NOT NULL", "postgresql_where 술어 불일치"
+    assert _where_str(ix, "sqlite") == "input_tokens IS NOT NULL", "sqlite_where 술어 불일치"
+
+
+def test_insight_cache_partial_unique_indexes_declared():
+    """insight_cache uq_insight_cache_global/repo 부분 유니크 인덱스 ORM 선언 (#18 drift ④')."""
+    tbl = InsightNarrativeCache.__table__
+    glob = _index(tbl, "uq_insight_cache_global")
+    repo = _index(tbl, "uq_insight_cache_repo")
+    assert glob is not None and repo is not None, "부분 유니크 인덱스 ORM 미선언 (#18 drift ④' 회귀)"
+    # 유니크 + 부분 WHERE 술어 정확 비교 — 전역(repo_id IS NULL) / 리포별(repo_id IS NOT NULL).
+    # 술어 정확 비교로 global↔repo NULL 술어 뒤바뀜 차단 (Codex mutual 강화).
+    assert glob.unique and repo.unique, "부분 인덱스가 unique 가 아님 — 캐시 키 무결성 위반"
+    assert [c.name for c in glob.columns] == ["user_id", "days", "language"]
+    assert [c.name for c in repo.columns] == ["user_id", "days", "language", "repo_id"]
+    for dialect in ("postgresql", "sqlite"):
+        assert _where_str(glob, dialect) == "repo_id IS NULL", (
+            f"uq_insight_cache_global {dialect}_where 술어 불일치 (전역=repo_id IS NULL)"
+        )
+        assert _where_str(repo, dialect) == "repo_id IS NOT NULL", (
+            f"uq_insight_cache_repo {dialect}_where 술어 불일치 (리포별=repo_id IS NOT NULL)"
+        )


### PR DESCRIPTION
> ♻️ **본문 복원 (2026-06-10)** — `gh pr create` 본문 인자 결함(리터럴 `@-` 저장)으로 소실된 본문을 squash 머지 커밋 메시지에서 복원. 전 PR Codex mutual OK 기록은 `docs/STATE.md` 사이클 166 항 참조.

fix(db): analyses/insight_cache 부분 인덱스 ORM 선언 — drift ③④' 정합 (정합성 감사 #18) (#843)

#18 compare_metadata 가드 발견 drift ③④' — alembic 이 생성한 부분 인덱스를 ORM
__table_args__ 가 미선언해 ORM↔alembic 구조 drift(allowlist 문서화 상태):
- ③ analyses ix_analyses_repo_id_created_at_tokens (0032, WHERE input_tokens IS NOT NULL)
- ④' insight_cache uq_insight_cache_global/repo (0031, 부분 UNIQUE, WHERE repo_id IS NULL/NOT NULL)

수정 (사용자 결정 C — ③④' 정합):
- analysis.py / insight_narrative_cache.py __table_args__ 에 Index 선언.
  🔴 **postgresql_where + sqlite_where 양 방언**: postgresql_where 만 쓰면 SQLite
  create_all 이 부분 WHERE 를 무시하고 전체 유니크 인덱스를 만들어 전역+리포 캐시 공존이
  깨짐 → 양 방언 partial 선언으로 SQLite 도 올바른 부분 인덱스(실측 sqlite_master 확인).
- test_orm_alembic_parity allowlist ③④ 제거 — ORM 선언으로 compare_metadata 정합.
  필터 로직 fixture 를 잔존 ②(email)로 교체. 잔존 allowlist = ② email 표현 FP 뿐.
- 신규 가드 test_orm_partial_indexes(ORM 부분 인덱스 선언+양 방언 WHERE 검증, +2).

🔴 WHERE 정규화 FP 리스크: compare_metadata(PG)가 ORM WHERE vs 반영된 PG WHERE 를
대조 — pg-concurrency CI 가 권위 검증(로컬 PG 없음). FP 발생 시 후속 조정.
전체 단위 4733→4735, 회귀 0(insight/analyses 157 + 전체 4733 passed).

Co-authored-by: xzawed <xzawed31@gmail.com>
Co-authored-by: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
