### PR TITLE
fix(ui): base.html KPI count-up 핸들러 htmx:historyRestore 등록 (뒤로가기 재초기화)

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -1031,9 +1031,13 @@
     _initKpiCountup();
     if (document._kpiCountupHandler) {
       document.removeEventListener('htmx:afterSettle', document._kpiCountupHandler);
+      document.removeEventListener('htmx:historyRestore', document._kpiCountupHandler);
     }
     document._kpiCountupHandler = _initKpiCountup;
     document.addEventListener('htmx:afterSettle', document._kpiCountupHandler);
+    // 뒤로가기(historyRestore) 시에도 KPI count-up 재초기화 — 다른 핸들러(_initReveal 등 #766)와 대칭.
+    // Re-init KPI count-up on back-nav (historyRestore) too — symmetry with other handlers (#766).
+    document.addEventListener('htmx:historyRestore', document._kpiCountupHandler);
 
     // 네비게이션 로딩 피드백 / Navigation loading feedback
     // fake progress 0→70% → hx-boost afterSettle / beforeunload 100% → pageshow reset

--- a/tests/unit/templates/test_base_kpi_handler.py
+++ b/tests/unit/templates/test_base_kpi_handler.py
@@ -1,0 +1,27 @@
+"""base.html KPI count-up hx-boost 핸들러 정적 가드.
+
+`_kpiCountupHandler` 가 htmx:afterSettle + htmx:historyRestore **양쪽**에 remove-before-add 로
+등록되는지 검증 — 뒤로가기(historyRestore) 시에도 count-up 재초기화 (다른 핸들러 _initReveal 등 #766 대칭).
+정적 소스 검사이므로 브라우저 불필요 (hx-boost SyntaxError 클래스는 기존 e2e #605 가 커버).
+Static guard: the KPI count-up handler must register on BOTH htmx:afterSettle and htmx:historyRestore
+with remove-before-add (back-nav re-init symmetry). Source-level check — no browser needed.
+"""
+from pathlib import Path
+
+_BASE_HTML = (
+    Path(__file__).resolve().parents[3] / "src" / "templates" / "base.html"
+).read_text(encoding="utf-8")
+
+
+def test_kpi_countup_registers_on_both_hx_boost_events():
+    # afterSettle(전진 네비) + historyRestore(뒤로가기) 양쪽 등록 의무
+    # Must register on both afterSettle (forward nav) and historyRestore (back nav)
+    assert "addEventListener('htmx:afterSettle', document._kpiCountupHandler)" in _BASE_HTML
+    assert "addEventListener('htmx:historyRestore', document._kpiCountupHandler)" in _BASE_HTML
+
+
+def test_kpi_countup_uses_remove_before_add():
+    # 등록 전 remove (양쪽) — hx-boost 재방문 시 핸들러 누적 차단 (ui.md remove-before-add 규칙)
+    # remove before add (both events) — prevents handler accumulation across hx-boost re-visits
+    assert "removeEventListener('htmx:afterSettle', document._kpiCountupHandler)" in _BASE_HTML
+    assert "removeEventListener('htmx:historyRestore', document._kpiCountupHandler)" in _BASE_HTML


### PR DESCRIPTION
## 요약

정합성 감사(`integrity-audit full`) 발견 — **ui 핸들러 대칭** (검토 후속 PR ④, P2). `base.html` 의 `_kpiCountupHandler` 가 `htmx:afterSettle` 에만 등록되고 **`htmx:historyRestore` 누락** → hx-boost 뒤로가기 시 KPI count-up 애니메이션이 재초기화되지 않습니다. 다른 핸들러(`_initReveal` #766, `_initSaveBar` #473)는 양쪽 등록하는데 이 핸들러만 비대칭이었습니다.

→ `afterSettle` + `historyRestore` 양쪽에 **remove-before-add** 등록 (ui.md #473 규칙 준수). additive event listener 라 hx-boost SyntaxError 클래스 위험 없음.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**Codex mutual = OK (4/4)** — 패턴 정합(#766/#473 대칭) · 회귀 위험 없음(historyRestore 재실행 idempotent) · const/let SyntaxError 0 · 정적 가드 적정 전부 OK.

## 🔍 사용자 검증 필요

- [ ] 대시보드에서 다른 페이지로 이동 후 **브라우저 뒤로가기** → KPI count-up 숫자 애니메이션이 다시 재생되는지 (이전: 정적 표시).
- [ ] 4-테마(dark/light/pastel/catppuccin) × 모바일/데스크탑에서 KPI 카드 정상 표시 (시각 회귀 없음 — 정책 11: Claude 정적 코드만 검증 가능).

## 자율 판단 보고 (정책 3)

- **테스트 전략**: hx-boost SyntaxError 클래스는 기존 E2E `test_nav_handler_survives_hx_boost_renavigation`(#605, 3회 재방문)이 CI 에서 커버. 본 변경은 additive 라 SyntaxError 위험 0 → **정적 가드 2건**(소스에서 양쪽 이벤트 add/remove 존재 검증)으로 배선 회귀 봉인(브라우저 불필요). 신규 E2E 미추가 사유 = additive + 기존 #605 커버.
- **수치/배지 보류**: STATE/README 테스트 수치는 **fix 묶음 종료 후 단일 sync PR** 에서 일괄 반영(병렬 PR count-cell 충돌 회피).

## 검증

- 전체 `pytest tests/` = **4975 passed / 7 skipped** (단위 4826→4828 **+2**: 정적 가드) · `flake8` 0.

## 변경 파일

- `src/templates/base.html`(historyRestore 등록 2줄) · `tests/unit/templates/test_base_kpi_handler.py`(정적 가드 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
