### PR TITLE
fix(verifier+ci): 회고 P2 하드닝 — 검증자 fail-closed 엄격 파싱 + CI 가시성/복원력

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install --retries 5 --timeout 60 -r requirements-dev.txt
 
       - name: Run pytest with coverage (XML for Codecov + SonarCloud)
         env:
@@ -100,7 +100,7 @@ jobs:
             --cov-report=xml:coverage.xml \
             --cov-report=term-missing \
             --junitxml=pytest-results.xml \
-            -q
+            -rs -q
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -164,7 +164,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install --retries 5 --timeout 60 -r requirements-dev.txt
 
       - name: Run PG-only tests (SKIP LOCKED 동시성 + 마이그레이션 round-trip)
         # DATABASE_URL_TEST_POSTGRES 단일 env 가 필수 — DATABASE_URL 은 conftest.py 가 sqlite 로 덮어씀(무의미).

--- a/src/gate/merge_verifier.py
+++ b/src/gate/merge_verifier.py
@@ -116,7 +116,18 @@ def interpret_verdict(raw: object) -> VerifierVerdict:
     # Limit reasons to 3 — non-list (int/None etc.) → empty tuple (interpret_verdict never raises)
     reasons_raw = raw.get("reasons")
     reasons = tuple(str(r) for r in reasons_raw[:3]) if isinstance(reasons_raw, list) else ()
-    return VerifierVerdict(bool(raw["safe"]), bool(raw["manipulation_detected"]), reasons, VERIFIER_OK)
+    # fail-closed 엄격 파싱 — bool() truthy 함정 회피 (#859 회고 P2):
+    #   safe = 명시적 True 만 안전 (문자열 "false"/정수/None 등은 모두 unsafe 로 차단)
+    #   manipulation = 명시적 False 만 무조작 (그 외 전부 조작 의심으로 차단)
+    # 게이트(auto_merge.py)는 `not safe or manipulation` 으로 차단하므로 양쪽 모두 차단 쪽 fallback.
+    # Strict fail-closed parse — avoid bool() truthiness trap:
+    #   safe is True only when literally True; manipulation clear only when literally False.
+    return VerifierVerdict(
+        raw["safe"] is True,
+        raw["manipulation_detected"] is not False,
+        reasons,
+        VERIFIER_OK,
+    )
 
 
 async def verify_merge_safety(ctx) -> VerifierVerdict:

--- a/tests/unit/gate/test_merge_verifier.py
+++ b/tests/unit/gate/test_merge_verifier.py
@@ -1,3 +1,5 @@
+import pytest
+
 from src.gate import merge_reasons
 
 
@@ -40,6 +42,34 @@ def test_interpret_verdict_missing_keys_is_parse_error():
 def test_interpret_verdict_non_dict_is_parse_error():
     v = mv.interpret_verdict(["not", "a", "dict"])
     assert v.status == mv.VERIFIER_PARSE_ERROR and v.safe is False
+
+
+# fail-closed 엄격 파싱 회귀 가드 (#859 회고 P2) — bool() truthy 함정 차단
+# Strict fail-closed parse regression guards — block the bool() truthiness trap
+
+
+@pytest.mark.parametrize("bad_safe", ["false", "False", "true", 1, 0, None, "0"])
+def test_interpret_verdict_non_bool_safe_is_unsafe(bad_safe):
+    # 명시적 True 가 아닌 모든 safe 값(특히 문자열 "false")은 unsafe 로 차단해야 함(fail-closed)
+    # Any non-literal-True 'safe' (esp. string "false") must be treated unsafe (fail-closed)
+    v = mv.interpret_verdict({"safe": bad_safe, "manipulation_detected": False, "reasons": []})
+    assert v.safe is False
+    assert v.status == mv.VERIFIER_OK  # 키는 존재하므로 parse_error 아님 (값 해석만 보수적)
+
+
+@pytest.mark.parametrize("bad_manip", ["false", "true", 1, 0, None, "0"])
+def test_interpret_verdict_non_false_manipulation_blocks(bad_manip):
+    # 명시적 False 가 아닌 모든 manipulation 값은 조작 의심으로 차단해야 함(fail-closed)
+    # Any non-literal-False 'manipulation_detected' must be treated as detected (fail-closed)
+    v = mv.interpret_verdict({"safe": True, "manipulation_detected": bad_manip, "reasons": []})
+    assert v.manipulation_detected is True
+
+
+def test_interpret_verdict_literal_bools_unchanged():
+    # 정상 real-bool 경로는 회귀 없이 보존
+    # Real-bool happy path preserved (no regression)
+    ok = mv.interpret_verdict({"safe": True, "manipulation_detected": False, "reasons": []})
+    assert ok.safe is True and ok.manipulation_detected is False
 
 
 def test_build_verifier_prompt_wraps_diff_in_untrusted_boundary():

--- a/tests/unit/verifier/test_openai_client.py
+++ b/tests/unit/verifier/test_openai_client.py
@@ -121,7 +121,10 @@ async def test_call_openai_verifier_falls_back_to_http_when_sdk_absent(monkeypat
 
     class _FakeHttpClient:
         async def post(self, url, **kwargs):
-            assert "openai.com" in url
+            # 정확한 엔드포인트 URL 비교 — 부분 문자열 검사(`"openai.com" in url`)는
+            # CodeQL py/incomplete-url-substring-sanitization(우회 가능) 이라 정확 비교 사용
+            # Exact endpoint comparison — substring checks trip CodeQL's URL sanitization rule
+            assert url == openai_client._OPENAI_CHAT_URL
             assert kwargs["json"]["response_format"] == {"type": "json_object"}
             assert kwargs["headers"]["Authorization"] == "Bearer k"
             return _FakeHttpResp(payload)

--- a/tests/unit/verifier/test_openai_client.py
+++ b/tests/unit/verifier/test_openai_client.py
@@ -87,3 +87,62 @@ async def test_call_openai_verifier_raises_on_api_error(monkeypatch):
     with pytest.raises(RuntimeError):
         await openai_client.call_openai_verifier(
             "SYS", "USER", api_key="k", model="gpt-5-mini", timeout=5.0)
+
+
+# httpx fallback 경로 (#859 회고 P2) — openai SDK 미설치 시 _call_via_http 강제
+# httpx fallback path — force ImportError so _call_via_http is exercised (SDK-less env)
+
+
+class _FakeHttpResp:
+    def __init__(self, payload, *, boom=False):
+        self._payload = payload
+        self._boom = boom
+
+    def raise_for_status(self):
+        if self._boom:
+            raise RuntimeError("http 500")
+
+    def json(self):
+        return self._payload
+
+
+def _force_sdk_absent(monkeypatch):
+    import sys
+    # sys.modules["openai"] = None → `import openai` 가 ImportError 발생 (SDK 미설치 모사)
+    # None in sys.modules makes `import openai` raise ImportError (simulates SDK absence)
+    monkeypatch.setitem(sys.modules, "openai", None)
+
+
+@pytest.mark.asyncio
+async def test_call_openai_verifier_falls_back_to_http_when_sdk_absent(monkeypatch):
+    _force_sdk_absent(monkeypatch)
+    payload = {"choices": [{"message": {"content": json.dumps({"safe": True})}}],
+               "usage": {"prompt_tokens": 11, "completion_tokens": 3}}
+
+    class _FakeHttpClient:
+        async def post(self, url, **kwargs):
+            assert "openai.com" in url
+            assert kwargs["json"]["response_format"] == {"type": "json_object"}
+            assert kwargs["headers"]["Authorization"] == "Bearer k"
+            return _FakeHttpResp(payload)
+
+    monkeypatch.setattr(openai_client, "get_http_client", lambda: _FakeHttpClient())
+    text = await openai_client.call_openai_verifier(
+        "SYS", "USER", api_key="k", model="gpt-5-mini", timeout=5.0)
+    assert json.loads(text)["safe"] is True
+
+
+@pytest.mark.asyncio
+async def test_http_fallback_reraises_on_api_error_fail_closed(monkeypatch):
+    # fallback 경로도 API 오류를 re-raise 해야 호출자가 fail-closed 처리 가능
+    # The fallback path must also re-raise so the caller can fail closed
+    _force_sdk_absent(monkeypatch)
+
+    class _BoomHttpClient:
+        async def post(self, url, **kwargs):
+            return _FakeHttpResp({}, boom=True)
+
+    monkeypatch.setattr(openai_client, "get_http_client", lambda: _BoomHttpClient())
+    with pytest.raises(RuntimeError):
+        await openai_client.call_openai_verifier(
+            "SYS", "USER", api_key="k", model="gpt-5-mini", timeout=5.0)


### PR DESCRIPTION
## 개요

사이클 166~#859 회고 cross-verify 가 confirmed 한 **P2 하드닝** (Claude 자율 영역). 검증자(#859)는 사용자 결정에 따라 **INACTIVE 유지** — 본 변경은 런타임 동작 무영향, 향후 활성화 대비 fail-closed 강화 + CI 가시성/복원력.

**gate+verifier 284 passed, 회귀 0. src 변경 = `merge_verifier.py` 의미 1줄 강화.**

## 🛡️ 검증자 fail-closed 엄격 파싱 (`src/gate/merge_verifier.py`)

`interpret_verdict` 의 `bool()` truthy 함정 차단:

| 필드 | 변경 | 이유 |
|------|------|------|
| `safe` | `bool(raw["safe"])` → `raw["safe"] is True` | 모델이 JSON 문자열 `"false"` 반환 시 `bool("false")=True` → safe 오판 → 자동머지 **fail-OPEN** 차단. 명시적 `True`만 안전 |
| `manipulation_detected` | `bool(...)` → `raw[...] is not False` | 명시적 `False`만 무조작 — `"true"`/`None`/정수는 조작 의심 차단 |

> 🔴 회고 권장은 `manipulation_detected`도 `is True`였으나, 그러면 문자열 `"true"`→`False`→무조작 **fail-OPEN 회귀**가 되어 `is not False`로 정정(게이트 `auto_merge.py:74 not safe or manipulation`와 정합 — 양쪽 차단 fallback).

회귀 가드 **+16**: 비-bool `safe` 7 / 비-`False` `manipulation` 6 / real-bool 보존 1 / fallback 2.

## 🧪 httpx fallback 테스트 (`tests/unit/verifier/test_openai_client.py`)

`_call_via_http`(openai SDK 미설치 분기)가 미테스트였음 — 검증자 fail-closed에 직결되는 coverage 갭. `sys.modules["openai"]=None`으로 ImportError 강제 → fallback 성공 파싱 + API 오류 re-raise(fail-closed) 검증.

## ⚙️ CI 가시성/복원력 (`.github/workflows/ci.yml`)

- main 잡 pytest `-q` → `-rs -q`: PG-gated skip 대상/사유 로그 노출 (pg-concurrency job 미실행/node-id drift 회귀 감지 단서 — 메인 잡 침묵 방지)
- 양 잡 `pip install --retries 5 --timeout 60`: PyPI 일시 timeout flaky 복원력 (#859 transitive 추가 대응, 실 사례: `httpcore` flake)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

✅ **CODEX_OK** (커밋 `dd3a6e0`, 284 passed 재현 + 정적 분석) — fail-closed 완전 보존(literal True/False만 통과·fail-OPEN 회귀 0) / 회귀 가드 16건 정확 / fallback ImportError 강제+re-raise 정상 / ci.yml YAML 문법 정합.

## 🔍 사용자 검증 필요 (정책 2)

- [ ] 검증자는 INACTIVE 유지 결정 — 본 PR은 활성화하지 않으며 동작 변화 0 (OPENAI_API_KEY 미설정 시 검증자 미진입)

## 자율 판단 보고 (정책 3)

- 회고 권장 `manipulation_detected is True`는 fail-OPEN 회귀라 `is not False`로 **정정 적용** (게이트 차단 로직 정합 분석 근거).
- 회고 P2 중 **reasons sanitize**(auto_merge.py)·**claim_decision 주석**(telegram.py)은 응집 단위(정책 7) 상 본 PR에서 제외 — 백로그 유지. 활성화 시 봉인 P1 3건(반자동 parity·diff cap)도 INACTIVE 유지 결정에 따라 백로그.
