### PR TITLE
test(gate): CodeQL #506 — 미사용 pytest import 제거 (#865 follow-up)

### DIFF
--- a/tests/unit/gate/test_engine_verifier_guard.py
+++ b/tests/unit/gate/test_engine_verifier_guard.py
@@ -21,7 +21,6 @@ os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
 os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
 os.environ.setdefault("ANTHROPIC_API_KEY", "")
 
-import pytest
 from unittest.mock import AsyncMock, patch
 
 from src.gate.engine import _run_auto_merge


### PR DESCRIPTION
## 요약

#865(검증자 봉인 P1-1)에서 추가한 `tests/unit/gate/test_engine_verifier_guard.py`의 `import pytest`가 사용처 0(asyncio_mode=auto라 `@pytest.mark` 데코레이터 불필요) → CodeQL `py/unused-import` **신규 alert #506**(2026-06-12). 정책 14에 따라 즉시 fix.

- `import pytest` 1줄 제거 (실제 위반 — category a)

## 검증

- 6개 async 테스트 통과(asyncio_mode=auto로 `@pytest.mark` 없이 정상) · flake8 F401 0
- diff = 1줄 삭제만 (src/로직 변경 0)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**OK** — diff 1줄 삭제만 + pytest 사용처 0 + asyncio_mode=auto 확인(4항).

## 🔍 사용자 검증 필요

- 테스트 전용 미사용 import 제거 — 시각/운영 영향 0. 머지 후 CodeQL 재스캔 시 alert #506 자동 close 예상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
