### PR TITLE
fix(security): hook /result 빈/NULL 토큰 인증 우회 차단 (정합성 감사 P0)

### DIFF
--- a/src/api/hook.py
+++ b/src/api/hook.py
@@ -184,7 +184,20 @@ def save_hook_result(  # pylint: disable=unused-argument,too-many-locals
     with SessionLocal() as db:
         config = repo_config_repo.find_by_full_name(db, body.repo)
 
-        if config is None or not secure_str_compare(config.hook_token, body.token):
+        # 🔴 빈/NULL 토큰 인증 우회 차단 (보안 P0): secure_str_compare 는 None·"" 를 모두
+        # b"" 로 인코딩하므로 secure_str_compare(None, "") == True → hook_token 미설정(NULL)
+        # 행에 body.token="" 로 인증 통과 가능. verify 엔드포인트(L139 `if not effective_token`)
+        # 와 대칭으로, 제출 토큰 또는 저장된 hook_token 이 비면 비교 전에 거부한다.
+        # Block empty/NULL-token auth bypass (security P0): secure_str_compare encodes both None and
+        # "" to b"", so secure_str_compare(None, "") == True — a NULL-hook_token row would authenticate
+        # with body.token="". Mirroring the verify endpoint (L139), reject before the compare when
+        # either the submitted token or the stored hook_token is empty.
+        if (
+            not body.token
+            or config is None
+            or not config.hook_token
+            or not secure_str_compare(config.hook_token, body.token)
+        ):
             # locale 해소는 에러 시에만 (정상 경로 쿼리 순서 불변)
             # Resolve locale only on error (keep happy-path query order intact)
             locale = _resolve_hook_locale(db, body.repo)

--- a/tests/unit/api/test_hook.py
+++ b/tests/unit/api/test_hook.py
@@ -338,6 +338,78 @@ def test_hook_result_invalid_token():
     mock_db.add.assert_not_called()
 
 
+def test_hook_result_empty_token_with_null_config_token_rejected():
+    # 🔴 핵심 Red (P0 인증 우회 회귀 가드):
+    # config.hook_token=None 행 + body.token="" 빈 문자열 → secure_str_compare(None, "")
+    # 이 None/"" 둘 다 b"" 로 인코딩되어 b""==b"" True 를 반환 → 현재 코드는 인증 통과(200).
+    # fix 후엔 빈/NULL 토큰 가드가 403 + add 미호출을 보장해야 한다.
+    # CORE Red guard: a config row with hook_token=None plus an empty body.token bypasses auth
+    # because secure_str_compare(None, "") encodes both sides to b"" → b""==b"" is True (current
+    # code returns 200). After the fix the empty/NULL-token guard must reject with 403 + no add().
+    mock_db = MagicMock()
+    mock_config = MagicMock()
+    mock_config.hook_token = None
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_config
+
+    with patch("src.api.hook.SessionLocal", return_value=_make_session_mock(mock_db)):
+        r = client.post("/api/hook/result", json={
+            "repo": "owner/repo",
+            "token": "",
+            "commit_sha": "abc123",
+            "commit_message": "feat: 테스트",
+            "ai_result": _AI_RESULT,
+        })
+
+    assert r.status_code == 403
+    mock_db.add.assert_not_called()
+
+
+def test_hook_result_empty_token_with_set_config_token_rejected():
+    # 빈 제출 토큰 자체 차단 회귀 가드: config.hook_token="real-token" + body.token="" → 403.
+    # 현재도 secure_str_compare("real-token","")=False 라 이미 403(통과 OK) — 빈 토큰 거부 고정.
+    # Regression guard for empty submitted token: hook_token set + body.token="" → 403 (already
+    # passes today since secure_str_compare("real-token","") is False; pins empty-token rejection).
+    mock_db = MagicMock()
+    mock_config = MagicMock()
+    mock_config.hook_token = "real-token"
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_config
+
+    with patch("src.api.hook.SessionLocal", return_value=_make_session_mock(mock_db)):
+        r = client.post("/api/hook/result", json={
+            "repo": "owner/repo",
+            "token": "",
+            "commit_sha": "abc123",
+            "commit_message": "feat: 테스트",
+            "ai_result": _AI_RESULT,
+        })
+
+    assert r.status_code == 403
+    mock_db.add.assert_not_called()
+
+
+def test_hook_result_null_config_token_nonempty_token_rejected():
+    # NULL config 토큰은 어떤 제출 토큰도 거부 회귀 가드: hook_token=None + body.token="anything" → 403.
+    # 현재도 secure_str_compare(None,"anything")=False 라 이미 403(통과 OK) — NULL config 거부 고정.
+    # Regression guard: a NULL config token rejects any submitted token (None + "anything" → 403;
+    # already passes today since secure_str_compare(None,"anything") is False; pins NULL rejection).
+    mock_db = MagicMock()
+    mock_config = MagicMock()
+    mock_config.hook_token = None
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_config
+
+    with patch("src.api.hook.SessionLocal", return_value=_make_session_mock(mock_db)):
+        r = client.post("/api/hook/result", json={
+            "repo": "owner/repo",
+            "token": "anything",
+            "commit_sha": "abc123",
+            "commit_message": "feat: 테스트",
+            "ai_result": _AI_RESULT,
+        })
+
+    assert r.status_code == 403
+    mock_db.add.assert_not_called()
+
+
 def test_hook_result_missing_fields():
     # 필수 필드(token) 누락 → 422 Unprocessable Entity 반환
     r = client.post("/api/hook/result", json={


### PR DESCRIPTION
## 요약 (보안 P0 — 정합성 감사 발견)

`POST /api/hook/result`(`src/api/hook.py:187`)에서 **인증 우회**: `config.hook_token`이 NULL인 RepoConfig 행 + 공격자가 `body.token=""`(빈 문자열) 전송 시 `secure_str_compare(None, "")`가 **True**(None·"" 둘 다 `b""`로 인코딩 → `b""==b""`) → 인증 통과 → **위조 Analysis 저장 / 점수 오염** (자격증명 0).

- **NULL hook_token 도달 경로**: `upsert_repo_config`(`config_manager/manager.py:73`)가 `RepoConfigData` field_names만 kwargs로 생성(hook_token 미포함) → REST `api/repos`·settings 최초 생성 시 hook_token=NULL.
- **대조**: verify(GET) 엔드포인트(`hook.py:139`)는 `if not effective_token`으로 빈 토큰을 401 차단. POST /result는 그 가드 부재 = 비대칭 갭.

## 수정

`hook.py:195-200` — verify 엔드포인트와 대칭으로 비교 **전에** 거부:
```python
if (not body.token or config is None or not config.hook_token
        or not secure_str_compare(config.hook_token, body.token)):
    raise HTTPException(403, ...)
```

## 🔴 결함 클래스 전수 확인 (보안 수정 의무 — 사이클 166 학습)

`secure_str_compare` **8 호출처 전수 분석** → hook.py:187(result)만 취약. 나머지 7곳 안전:

| 호출처 | 상류 가드 |
|--------|----------|
| hook.py:147 (verify) | L139 `if not effective_token` → 빈토큰 401 |
| internal_cron.py:49 | L42 `if not expected` → 미설정 503 |
| auth.py:26 | 미설정 시 dev-mode allow(의도) / 설정 시 빈토큰 False |
| validator.py:18 | `expected` = computed HMAC (항상 non-empty) |
| telegram.py:73 (callback) | `expected` = computed HMAC[:32] (non-empty) |
| telegram.py:262 (webhook) | L259 미설정 401 |
| railway.py:48 | `config is not None` + NULL-lookup mismatch |

## 검증

- **TDD 회귀 +3**: 빈토큰+NULL config→403 (핵심 Red — fix 없이는 200 우회) · 빈토큰+설정토큰→403 · NULL config+토큰→403. 정상 인증 경로 회귀 0.
- api+webhook **272 pass** · pylint **10.00** · flake8 0 · 단위 4895→**4898**.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**OK** — fix 정확성(빈/NULL 가드 차단·정상 경로 보존)·8 호출처 전수(나머지 7곳 안전 분석 확인)·테스트 완전성(핵심 Red 200→403 봉인) 전부 확인.

## 🔍 사용자 검증 필요

- 🔴 **운영 영향**: hook_token이 NULL인 기존 RepoConfig 행이 운영 DB에 있으면(REST/settings로 생성된 repo), 그 repo의 pre-push 훅은 이제 403을 받습니다(정상 — hook_token을 설정해야 함). add_repo 플로우로 추가된 repo는 hook_token이 항상 설정돼 영향 없음.
- 운영 smoke: 정상 hook_token으로 `POST /api/hook/result` 200 + 빈 토큰 403 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
