### PR TITLE
fix(security): dashboard security 모드 cross-tenant 노출 차단 (정합성 감사 U0)

### DIFF
--- a/src/repositories/security_alert_log_repo.py
+++ b/src/repositories/security_alert_log_repo.py
@@ -7,7 +7,26 @@ from datetime import datetime, timezone
 
 from sqlalchemy.orm import Session
 
+from src.models.repository import Repository
 from src.models.security_alert_log import SecurityAlertProcessLog
+
+
+def _apply_owner_filter(query, user_id: int | None):
+    """🔴 user_id 기반 repo 소유권 격리 (1차 앱 필터 — cross-tenant 노출 차단, U0).
+    Apply repo-ownership isolation by user_id (app-level 1st layer — blocks cross-tenant exposure).
+
+    user_id None → 미적용(admin/legacy). 명시 → repo 소유자 == user_id OR repo 소유자 NULL(legacy 호환).
+    dashboard_service._apply_analysis_user_filter 와 동일 의미론. alert 의 user_id 컬럼은
+    pending 시 NULL(record_user_decision 에서만 설정)이라 repo_id→Repository.user_id 로 격리한다.
+    user_id None → no-op (admin/legacy). Otherwise repo owner == user_id OR owner NULL (legacy compat).
+    Mirrors _apply_analysis_user_filter; the alert.user_id column is NULL while pending, so isolate via
+    repo_id → Repository.user_id.
+    """
+    if user_id is None:
+        return query
+    return query.join(Repository, SecurityAlertProcessLog.repo_id == Repository.id).filter(
+        (Repository.user_id == user_id) | (Repository.user_id.is_(None))
+    )
 
 
 def upsert_alert_log(  # pylint: disable=too-many-arguments
@@ -88,12 +107,16 @@ def record_user_decision(
     return log
 
 
-def list_pending(db: Session, *, repo_id: int | None = None, limit: int = 50) -> list[SecurityAlertProcessLog]:
+def list_pending(
+    db: Session, *, user_id: int | None = None, repo_id: int | None = None, limit: int = 50,
+) -> list[SecurityAlertProcessLog]:
     """user_decision IS NULL 인 pending alert 목록 (dashboard 진입 시 표시).
 
     List pending alerts (user_decision IS NULL) for dashboard display.
+    user_id 명시 시 repo 소유권으로 cross-tenant 격리 (U0).
     """
     q = db.query(SecurityAlertProcessLog).filter(SecurityAlertProcessLog.user_decision.is_(None))
+    q = _apply_owner_filter(q, user_id)
     if repo_id is not None:
         q = q.filter(SecurityAlertProcessLog.repo_id == repo_id)
     return q.order_by(SecurityAlertProcessLog.processed_at.desc()).limit(limit).all()
@@ -102,14 +125,17 @@ def list_pending(db: Session, *, repo_id: int | None = None, limit: int = 50) ->
 def count_by_classification(
     db: Session,
     *,
+    user_id: int | None = None,
     repo_id: int | None = None,
 ) -> dict[str, int]:
     """분류별 alert 카운트 (dashboard baseline 측정 카드).
 
     Count alerts by classification (dashboard baseline measurement card).
     Returns: {classification: count, "total": N, "pending": M}.
+    user_id 명시 시 repo 소유권으로 cross-tenant 격리 (U0).
     """
     q = db.query(SecurityAlertProcessLog)
+    q = _apply_owner_filter(q, user_id)
     if repo_id is not None:
         q = q.filter(SecurityAlertProcessLog.repo_id == repo_id)
     rows = q.all()

--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -931,7 +931,7 @@ async def insight_narrative(  # pylint: disable=too-many-locals
 
 # ── Cycle 73 F2 — Security Mode (Code Scanning + Secret Scanning audit) ──
 # Cycle 73 F2 — Security mode: Code Scanning + Secret Scanning audit overview.
-def dashboard_security(  # pylint: disable=unused-argument
+def dashboard_security(
     db: Session, *, user_id: int | None = None,
 ) -> dict[str, Any]:
     """`/dashboard?mode=security` 카드 데이터 — F2 Phase 1 MVP (read-only).
@@ -943,10 +943,13 @@ def dashboard_security(  # pylint: disable=unused-argument
     # Inline import — keeps top-level import surface minimal (policy 16 default).
     from src.repositories import security_alert_log_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
 
-    # 사용자별 격리: pending list 만 user_id 별 (audit 카운트는 전체 — admin 영역)
-    # Per-user isolation: pending list filtered by user_id (counts admin-wide for audit).
-    pending = security_alert_log_repo.list_pending(db, limit=5)
-    counts = security_alert_log_repo.count_by_classification(db)
+    # 🔴 사용자별 격리 (1차 앱 필터 — U0 cross-tenant 노출 차단): pending list·audit 카운트 모두
+    # user_id(repo 소유권)로 필터. user_id None(admin/legacy) 시 전체. 라우트는 require_login +
+    # current_user.id 전달 — 이전엔 미전달돼 모든 로그인 사용자가 타 테넌트 알림 노출했다.
+    # Per-user isolation (app-level 1st layer — blocks U0 cross-tenant exposure): both the pending list
+    # and audit counts are filtered by user_id (repo ownership). None → admin/legacy = all.
+    pending = security_alert_log_repo.list_pending(db, user_id=user_id, limit=5)
+    counts = security_alert_log_repo.count_by_classification(db, user_id=user_id)
 
     # AI 분류 분포 정규화 (4 카테고리 — false_positive / used_in_tests / actual_violation / deferred)
     classification_keys = ("false_positive", "used_in_tests", "actual_violation", "deferred", "unclassified")

--- a/tests/unit/services/test_dashboard_security.py
+++ b/tests/unit/services/test_dashboard_security.py
@@ -68,6 +68,42 @@ def test_dashboard_security_with_pending(db, repo):
     assert row["ai_classification"] == "false_positive"
 
 
+def test_dashboard_security_isolates_by_repo_owner(db):
+    """🔴 U0 cross-tenant 격리: user_id 명시 시 본인 소유 repo 알림만 노출 (타 테넌트 차단).
+
+    이전 결함: dashboard_security 가 user_id 를 무시하고 list_pending/count_by_classification
+    을 전체 조회 → 모든 로그인 사용자가 타 테넌트 보안 알림 노출 (1차 앱 필터 부재).
+    """
+    repo_a = Repository(full_name="alice/repo", user_id=1)
+    repo_b = Repository(full_name="bob/repo", user_id=2)
+    db.add_all([repo_a, repo_b])
+    db.commit()
+    db.refresh(repo_a)
+    db.refresh(repo_b)
+    security_alert_log_repo.upsert_alert_log(
+        db, repo_id=repo_a.id, alert_type="code_scanning", alert_number=1,
+        severity="high", rule_id="alice-rule",
+        ai_classification="actual_violation", ai_confidence=0.9,
+    )
+    security_alert_log_repo.upsert_alert_log(
+        db, repo_id=repo_b.id, alert_type="code_scanning", alert_number=2,
+        severity="high", rule_id="bob-secret",
+        ai_classification="actual_violation", ai_confidence=0.9,
+    )
+
+    # user 1(alice) 관점 — 본인 repo 알림 1건만, bob 알림 미노출
+    result = dashboard_service.dashboard_security(db, user_id=1)
+    assert result["total_alerts"] == 1
+    assert len(result["recent_pending"]) == 1
+    assert result["recent_pending"][0]["rule_id"] == "alice-rule"
+    rule_ids = {r["rule_id"] for r in result["recent_pending"]}
+    assert "bob-secret" not in rule_ids  # 🔴 타 테넌트 시크릿 룰 미노출
+
+    # admin(user_id 미전달) — 전체 노출 (기존 동작 보존)
+    admin_view = dashboard_service.dashboard_security(db)
+    assert admin_view["total_alerts"] == 2
+
+
 def test_dashboard_security_kill_switch_flag(db, monkeypatch):
     """kill-switch 환경변수 활성 시 flag True."""
     monkeypatch.setenv("SECURITY_AUTO_PROCESS_DISABLED", "1")


### PR DESCRIPTION
## 요약 (보안 — 정합성 감사 U0, cross-tenant 노출)

`/dashboard?mode=security`가 **모든 로그인 사용자에게 타 테넌트 보안 알림 전체 노출**. 라우트(`ui/routes/dashboard.py:224`)는 `require_login` + `user_id=current_user.id` 전달하나, `dashboard_service.dashboard_security`가 `user_id`를 **무시**(unused-argument)하고 `list_pending(db)`·`count_by_classification(db)`를 전체 조회 → counts + `recent_pending`(rule_id·severity·alert_number 등)에 타 사용자 repo 알림 포함.

🔴 RLS는 owner-bypass(Phase 4 전, `postgres` BYPASSRLS 접속)라 **앱 계층 1차 필터가 유일 방어**인데 부재 — db.md가 명시한 `_apply_*_user_filter` 1차 안전망 패턴을 security 모드만 누락.

## 수정

- `security_alert_log_repo._apply_owner_filter(query, user_id)` 신규 — `repo_id → Repository.user_id == user_id OR IS NULL` (`dashboard_service._apply_analysis_user_filter`와 동일 의미론).
- `list_pending`·`count_by_classification`에 `user_id` 파라미터 추가.
- `dashboard_security`가 `user_id=user_id` 전달 + `# pylint: disable=unused-argument` 제거.

🔴 **설계 근거**: `alert.user_id` 컬럼은 pending 시 **NULL**(`record_user_decision`에서만 설정)이라 직접 필터 시 pending 전부 숨음 → **repo 소유권**(`repo_id`→`Repository.user_id`)으로 격리. (사용자 결정 = per-user 필터)

## 검증

- **TDD 회귀 +1**: alice(user 1)·bob(user 2) 2테넌트 — `dashboard_security(db, user_id=1)` → bob-secret 룰 **미노출** + admin(user_id 미전달) → 전체 보존.
- services+repositories+dashboard route **435 pass** · pylint **10.00** · flake8 0 · 단위 +1.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**OK** — 격리 정확성(list/count 양쪽 필터)·admin/legacy 보존(None no-op)·alert.user_id NULL 함정 회피(repo 소유권)·count 중복 없음(PK-FK 1:1 join)·패턴 정합 5항목 전부 확인.

## 🔍 사용자 검증 필요

- 🔴 **운영 영향**: 일반 사용자의 security 대시보드가 이제 **본인 repo 알림만** 표시(이전엔 전체). admin은 변화 없음(user_id 미전달 경로 별도면). legacy NULL-owner repo 알림은 모두에게 노출 유지(`_apply_*` 패턴 일관 — backfill/RLS Phase 4가 별도 처리).
- 운영 smoke: 2개 계정으로 각자 security 모드 진입 시 상호 알림 미노출 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
