### PR TITLE
fix(pipeline): AI-fail fail-open 봉인 2건 — 반자동 approve 가드(C6) + ai_review 키누락 parity(C2)

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -242,13 +242,23 @@ def _parse_response(text: str) -> AiReviewResult:
         test_feedback=str(data.get("test_feedback", "")),
         file_feedbacks=list(data.get("file_feedbacks", [])),
     )
-    if not (commit_ok and direction_ok and test_ok):
-        # 점수 필드 비숫자/Infinity — feedback·복구가능 점수는 보존하되 parse_error 로 표시해
+    # 🔴 점수 키 누락 = parse_error (hook _coerce_ai_scores keys_present 와 대칭 — PARITY GUARD).
+    # data.get(key, DEFAULT) 는 키 부재 시 인플레 기본값(17/17→~89/B)을 ok=True 로 반환하므로,
+    # 키 자체가 없으면(채점 안 된 응답) success 로 위장돼 #804 fail-closed 가 작동하지 않는다.
+    # commit/direction 만 검사 — test_score 는 _coerce_test_score 가 has_tests 폴백(부재=0, 인플레 X)
+    # 으로 정당 처리하므로 제외(인플레 위험 없음).
+    # Missing score key = parse_error (mirrors hook _coerce_ai_scores keys_present — PARITY GUARD).
+    # data.get(key, DEFAULT) returns the inflated default (17/17→~89/B) with ok=True when a key is
+    # absent, so a non-scored response would masquerade as success and #804 fail-closed would not fire.
+    # Only commit/direction are checked — test_score's has_tests fallback (absent → 0, not inflated)
+    # legitimately handles absence.
+    score_keys_present = "commit_message_score" in data and "direction_score" in data
+    if not (score_keys_present and commit_ok and direction_ok and test_ok):
+        # 점수 필드 비숫자/Infinity/키누락 — feedback·복구가능 점수는 보존하되 parse_error 로 표시해
         # #804(#8) ai_review_failed 게이트의 fail-closed(auto-merge/approve 차단)를 유지한다.
         # (이전: 전량 _default_result 로 feedback 까지 폐기. 게이트 동작은 동일, 데이터만 보존.)
-        # Non-numeric/Infinity score field: keep feedback/recoverable scores but mark parse_error so
-        # the #804 gate stays fail-closed (was: total discard via _default_result; gate behaviour
-        # unchanged, only the data is preserved).
+        # Non-numeric/Infinity/missing-key score field: keep feedback/recoverable scores but mark
+        # parse_error so the #804 gate stays fail-closed (was: total discard via _default_result).
         result.status = "parse_error"
     return result
 

--- a/src/gate/actions/approve.py
+++ b/src/gate/actions/approve.py
@@ -100,7 +100,28 @@ class ApproveAction(GateAction):
             logger.error("GitHub Review 실패: %s", type(exc).__name__)
 
     async def _run_semi_auto(self, ctx: GateContext) -> None:
-        """Semi-auto Approve — Telegram 인라인 키보드 발송."""
+        """Semi-auto Approve — Telegram 인라인 키보드 발송.
+
+        🔴 정적분석 불완전·AI 리뷰 실패 시 가드(_run_auto 와 대칭): 인플레 기본 점수를 사람에게
+        승인 버튼으로 노출하면 오해된 점수로 approve+merge 될 수 있으므로 발송하지 않는다
+        (#8/#779 fail-open 봉인의 semi-auto 경로 — 이전엔 자동 경로에만 가드 존재).
+        Hold the semi-auto approval request when static analysis is incomplete or the AI review
+        genuinely failed (mirrors _run_auto): showing an inflated default score on a human approval
+        button could lead to approve+merge of unvetted code (#8/#779 fail-open seal for the semi-auto
+        path — previously only the auto path had the guard).
+        """
+        if ctx.result.get("static_analysis_incomplete"):
+            logger.warning(
+                "static analysis incomplete — semi-auto approve skipped (repo=%s, pr=%s)",
+                ctx.repo_name, ctx.pr_number,
+            )
+            return
+        if ai_review_failed(ctx.result):
+            logger.warning(
+                "AI review failed (%s) — semi-auto approve skipped (repo=%s, pr=%s)",
+                ctx.result.get("ai_review_status"), ctx.repo_name, ctx.pr_number,
+            )
+            return
         if not ctx.config.notify_chat_id:
             logger.warning(
                 "semi-auto 모드이나 notify_chat_id 미설정: %s",

--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -37,6 +37,48 @@ from src.analyzer.io.ai_review import (
 
 
 # ──────────────────────────────────────────────────────────────────────────
+# 점수 키 누락 → parse_error (C2 — hook keys_present 와 parity, 인플레 fail-open 봉인)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def test_parse_response_missing_commit_score_key_is_parse_error():
+    """🔴 commit_message_score 키 누락 → parse_error (인플레 default 17 로 success 위장 차단).
+
+    data.get(key, DEFAULT) 가 키 부재 시 17(인플레)을 ok=True 로 반환 → 이전엔 success →
+    #804 ai_review_failed 게이트 미작동(auto-merge/approve fail-open). 키 누락은 채점 안 된
+    응답이므로 parse_error 로 표시해 NULL-persist + 게이트 차단을 유지한다.
+    """
+    result = _parse_response('{"direction_score": 18, "test_score": 9, "summary": "ok"}')
+    assert result.status == "parse_error"
+
+
+def test_parse_response_missing_direction_score_key_is_parse_error():
+    """direction_score 키 누락 → parse_error (commit 과 동일 인플레 봉인)."""
+    result = _parse_response('{"commit_message_score": 15, "test_score": 9, "summary": "ok"}')
+    assert result.status == "parse_error"
+
+
+def test_parse_response_all_score_keys_present_is_success():
+    """commit/direction/test 키 모두 존재 + 숫자 → success 보존 (회귀 가드)."""
+    result = _parse_response(
+        '{"commit_message_score": 15, "direction_score": 18, "test_score": 9, "summary": "ok"}'
+    )
+    assert result.status == "success"
+
+
+def test_parse_response_missing_test_score_key_stays_success():
+    """test_score 키 부재 → has_tests 폴백(부재=0, 인플레 X)이라 success 보존 (정당 처리).
+
+    test_score 는 commit/direction 과 달리 _coerce_test_score 의 has_tests 레거시 폴백으로
+    부재 시 0(보수적, 인플레 아님)을 정당하게 처리하므로 keys_present 검사에서 제외한다.
+    """
+    result = _parse_response(
+        '{"commit_message_score": 15, "direction_score": 18, "summary": "ok"}'
+    )
+    assert result.status == "success"
+
+
+# ──────────────────────────────────────────────────────────────────────────
 # anthropic API 예외 경로 — 모든 케이스 graceful "api_error" fallback
 # ──────────────────────────────────────────────────────────────────────────
 

--- a/tests/unit/gate/test_gate_actions.py
+++ b/tests/unit/gate/test_gate_actions.py
@@ -169,6 +169,44 @@ async def test_approve_action_semi_auto_calls_send_gate_request():
 
 
 @pytest.mark.asyncio
+async def test_approve_action_semi_auto_skips_when_ai_review_failed():
+    """🔴 C6: AI 리뷰 실제 실패(api_error/parse_error) 시 semi-auto 승인 요청 미발송.
+
+    인플레 기본 점수를 사람에게 승인 버튼으로 노출하면 오해된 점수로 approve+merge 될 수
+    있으므로 발송하지 않는다 (_run_auto 가드 대칭 — 이전엔 자동 경로에만 가드 존재).
+    """
+    from src.gate.actions.approve import ApproveAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(approve_mode="semi-auto")
+    cfg.notify_chat_id = "-100123"
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        result={"score": 89, "ai_review_status": "api_error"},  # 인플레 default, 실제 AI 실패
+        github_token="ghp_test", config=cfg, score=89,
+    )
+    with patch("src.gate.actions.approve.send_gate_request", new=AsyncMock()) as mock_gate:
+        await ApproveAction().execute(ctx)
+    mock_gate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_approve_action_semi_auto_skips_when_static_analysis_incomplete():
+    """🔴 C6: 정적분석 불완전(타임아웃) 시 semi-auto 승인 요청 미발송 (_run_auto 가드 대칭)."""
+    from src.gate.actions.approve import ApproveAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(approve_mode="semi-auto")
+    cfg.notify_chat_id = "-100123"
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        result={"score": 90, "static_analysis_incomplete": True},
+        github_token="ghp_test", config=cfg, score=90,
+    )
+    with patch("src.gate.actions.approve.send_gate_request", new=AsyncMock()) as mock_gate:
+        await ApproveAction().execute(ctx)
+    mock_gate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_approve_action_auto_skips_when_static_analysis_incomplete():
     """정적분석 불완전(타임아웃) 시 score 충족이어도 post_github_review 를 호출하지 않아야 한다.
     Must not call post_github_review even when score qualifies, if static analysis is incomplete.


### PR DESCRIPTION
## 요약 (정합성 감사 P1 2건 — 동일 AI-fail fail-open 테마)

AI 리뷰 genuine 실패(api_error/parse_error)가 인플레 기본 점수로 **승인/머지 게이트를 우회**하는 fail-open 2건 봉인.

### C6 — `approve.py::_run_semi_auto` 반자동 가드 부재
`_run_auto`는 `static_analysis_incomplete` + `ai_review_failed` 가드 보유하나, **`_run_semi_auto`는 부재** → AI 실패 시 인플레 점수(~89/B)를 가드 없이 Telegram 승인 버튼으로 사람에게 노출 → 오해된 점수로 approve+merge 위험. `_run_auto` 가드 2종을 `_run_semi_auto` 진입부에 미러링(발송 skip). #8/#779 fail-open 봉인의 semi-auto 경로 확장.

### C2 — `ai_review.py::_parse_response` 키 누락 비대칭
`commit_message_score`/`direction_score` 키 누락 시 `data.get(key, DEFAULT)`가 인플레 default(17/17)를 `ok=True`로 반환 → `status=success` 위장 → #804 `ai_review_failed` 게이트 미작동(NULL-persist + auto-merge 차단 **둘 다** 우회). hook.py `_coerce_ai_scores`의 `keys_present` 검사와 **parity**(PARITY GUARD) — `score_keys_present` 검사 추가로 키 누락 시 parse_error.

🔴 `test_score`는 `_coerce_test_score`의 has_tests 폴백(부재=0, 인플레 X)으로 정당 처리되므로 keys_present 검사에서 제외(commit/direction만).

## 검증

- **TDD 회귀 +6**: C2 4(commit/direction 키누락→parse_error · 전체 키→success · test_score 부재→success 보존) + C6 2(ai_review_failed/static_incomplete 시 send_gate_request 미발송).
- gate+ai_review **351 pass** · pylint **10.00** · flake8 0 · 단위 4895→**4901**.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**OK** — C6(가드 발송 전 차단·정상 경로 보존·ai_review_failed 정의 정합) + C2(키 누락 parse_error·test_score 제외 타당·hook parity) 6항목 전부 확인.

## 🔍 사용자 검증 필요

- 🔴 **운영 영향**: AI 리뷰가 실제 실패한 PR은 이제 (a) 반자동 Telegram 승인 요청을 받지 않고 (b) 점수가 NULL-persist됩니다(인플레 점수 미노출). 정상 AI 리뷰 PR은 영향 없음.
- 운영 smoke: ANTHROPIC_API_KEY 오류 유발 시 semi-auto PR에 Telegram 승인 버튼 미발송 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
