### PR TITLE
fix(gate): merge_retry 단일 행 예상외 예외 격리 — 배치 중단 방지 (정합성 감사 C3)

### DIFF
--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -97,6 +97,41 @@ async def process_pending_retries(
                 "retry worker infra error row_id=%d: %s", row.id, type(exc).__name__
             )
             counts["released"] += 1
+        except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+            # 🔴 예상외 단일 행 결함(KeyError/ValueError 등) 격리 — 전체 배치 중단 방지(C3).
+            # 좁은 except 만 있을 때는 한 행의 예상외 예외가 process_pending_retries 전체를 중단해
+            # 무고한 잔여 claimed 행이 처리 안 되고 claim 이 5분 stale 까지 묶였다. rollback 후 클레임을
+            # 해제(다음 사이클 재시도)하고 전체 traceback 을 보존한 뒤 다음 행을 계속 처리한다.
+            # Isolate an unexpected single-row failure (KeyError/ValueError etc.) so it can't abort the
+            # whole batch (C3): a narrow except let one row's surprise exception abort
+            # process_pending_retries, leaving innocent remaining rows unprocessed and claims held until
+            # the 5-min stale window. Rollback, release the claim (retry next cycle), keep the traceback,
+            # and continue with the next row.
+            logger.exception("retry worker unexpected error row_id=%d", row.id)
+            try:
+                db.rollback()
+                # 🔴 이미 terminal(succeeded/terminal/abandoned/expired)로 커밋된 뒤 부수효과(알림 등)
+                # 에서 예외가 났을 수 있다 — 그 완료 행에 release_claim 을 하면 last_failure_reason 을
+                # 'unexpected_error'로 덮어써 감사 추적을 오염시킨다(Codex mutual 적발). 현재 status 가
+                # 'pending'(미확정·claimed)일 때만 클레임 해제 — terminal 행은 작업 완료라 건드리지 않음.
+                # The exception may have fired after a terminal status was committed (e.g. during the
+                # post-merge notification); calling release_claim then would overwrite last_failure_reason
+                # on a finished row (Codex mutual finding). Only release when status is still 'pending'.
+                db.refresh(row)
+                if row.status == "pending":
+                    _now_naive = now.replace(tzinfo=None) + timedelta(seconds=30)
+                    merge_retry_repo.release_claim(
+                        db,
+                        row.id,
+                        next_retry_at=_now_naive,
+                        last_failure_reason="unexpected_error",
+                        last_detail_message=str(exc)[:200],
+                    )
+                    counts["released"] += 1
+            except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+                # 클레임 해제 자체 실패해도 배치는 계속 (다음 행 처리). 5분 stale 재클레임이 안전망.
+                # Even if claim release fails, keep the batch going; the 5-min stale reclaim is the net.
+                logger.exception("retry worker: claim release failed row_id=%d", row.id)
 
     return counts
 

--- a/tests/unit/services/test_merge_retry_service.py
+++ b/tests/unit/services/test_merge_retry_service.py
@@ -237,6 +237,71 @@ class TestProcessPendingRetries:
         # Check claimed_at was reset to None
         assert row.claimed_at is None
 
+    # C3: 단일 행 예상외 예외 격리 — 전체 배치 미중단
+    async def test_unexpected_error_isolates_row_and_continues_batch(self, db_session):
+        """🔴 C3: 한 행의 예상외 예외(ValueError 등)가 전체 배치를 중단하지 않고 격리된다.
+
+        좁은 except (httpx/SQLAlchemy) 만 있으면 한 행의 KeyError/ValueError 가
+        process_pending_retries 전체를 중단해 무고한 잔여 행이 처리 안 되고 claim 이 5분 stale 까지
+        묶였다. broad-except 격리로 실패 행은 클레임 해제 + 나머지 행 계속 처리.
+        """
+        row1 = _seed_queue_row(db_session, commit_sha="aaa111")
+        row2 = _seed_queue_row(db_session, commit_sha="bbb222")
+        calls: list[int] = []
+
+        async def _flaky(_db, row, _now, _counts):
+            calls.append(row.id)
+            if row.id == row1.id:
+                raise ValueError("unexpected single-row defect")
+            # row2 는 정상 (no-op)
+
+        with patch(
+            "src.services.merge_retry_service._process_single_retry",
+            side_effect=_flaky,
+        ):
+            result = await process_pending_retries(
+                db_session, only_ids=[row1.id, row2.id]
+            )
+
+        # 두 행 모두 처리 시도됨 (배치 미중단) + 예외 미전파 (함수 정상 반환)
+        assert row1.id in calls and row2.id in calls
+        # 실패 행은 격리되어 released 카운트 증가
+        assert result["released"] >= 1
+        # 실패 행 클레임 해제 확인 (다음 사이클 재시도 가능)
+        db_session.refresh(row1)
+        assert row1.claimed_at is None
+
+    # C3 (Codex mutual): terminal 커밋 후 예외 → 완료 행 미오염 (release_claim skip)
+    async def test_unexpected_error_after_terminal_commit_does_not_corrupt_row(self, db_session):
+        """🔴 C3 Codex NG fix: 예외가 status 확정(succeeded) 커밋 후 부수효과에서 나면 완료 행을
+        release_claim 으로 건드리지 않는다 (last_failure_reason 오염·재시도 부활 차단).
+
+        broad-except 가 무조건 release_claim 하면 완료(succeeded)된 행의 last_failure_reason 을
+        'unexpected_error'로 덮어써 감사 추적이 오염된다. status='pending' 가드로 방어.
+        """
+        row = _seed_queue_row(db_session, commit_sha="ccc333")
+
+        async def _commit_then_raise(_db, r, _now, _counts):
+            # status 확정 커밋(머지 성공 등) 후 알림 단계에서 예외 — 부분 진행 시나리오
+            db_session.query(MergeRetryQueue).filter_by(id=r.id).update(
+                {"status": "succeeded", "last_failure_reason": None}
+            )
+            db_session.commit()
+            raise ValueError("notification failed after success commit")
+
+        with patch(
+            "src.services.merge_retry_service._process_single_retry",
+            side_effect=_commit_then_raise,
+        ):
+            result = await process_pending_retries(db_session, only_ids=[row.id])
+
+        db_session.refresh(row)
+        # 완료 행 보존: status=succeeded 유지 + last_failure_reason 미오염
+        assert row.status == "succeeded"
+        assert row.last_failure_reason != "unexpected_error"
+        # terminal 행은 released 카운트 미증가 (release_claim 미호출)
+        assert result["released"] == 0
+
     # T9-3: 설정 변경 시 abandoned 마킹
     # T9-3: Config changed → abandoned
     async def test_process_config_changed_abandons(self, db_session):


### PR DESCRIPTION
## 요약 (정합성 감사 P1 — C3, retry 배치 복원력)

`merge_retry_service.process_pending_retries`의 per-row 핸들러가 `(httpx.HTTPError, SQLAlchemyError)`만 포착 → `_process_single_retry`가 **다른 예외**(KeyError/ValueError/RuntimeError 등 단일 행 결함)를 던지면 **전체 배치가 중단**돼 무고한 잔여 claimed 행이 처리 안 되고 claim이 5분 stale까지 묶였다. engine 자동 경로 대비 비대칭.

## 수정

좁은 except 뒤 **broad-except 격리** — 단일 행 예상외 예외를 잡아 `rollback` + 클레임 해제(다음 사이클 재시도) + `logger.exception`(traceback) 후 **다음 행 계속 처리**. 해제 자체 실패도 inner except로 흡수(5분 stale 재클레임 안전망). #787 race 복구 패턴 정합.

## 🔴 Codex mutual NG 해소 (동일 PR 내 즉시 수정, 정책 18 §3b)

**1차 NG**: 예외가 terminal status(succeeded/abandoned) **커밋 후** 부수효과(알림)에서 나면 무조건 release_claim이 완료 행의 `last_failure_reason`을 `unexpected_error`로 오염.
**해소**: `db.refresh(row)`로 현재 DB status 재조회 → **`if row.status == "pending"`(미확정·claimed)일 때만** release_claim. terminal 행은 작업 완료라 건드리지 않음. (claim_batch는 status='pending'만 클레임, release_claim은 claimed_at만 리셋 — 실측 확인.)

## 검증

- **TDD 회귀 +2**: (1) 2행 중 1행 ValueError → 격리(released) + 나머지 행 계속 + 예외 미전파 (2) terminal 커밋 후 예외 → 완료 행 status=succeeded 유지 + last_failure_reason 미오염 + released 미증가.
- merge_retry **37 pass** · pylint **10.00** · flake8 0.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**1차 NG(항목 3) → 수정 → 재검증 OK** (Codex가 18 pass 직접 실행). 5항목 전부 확인 — NG 해소·pre-commit 격리 보존·refresh 안전성·테스트 2시나리오 봉인·기존 경로 회귀 0.

## 🔍 사용자 검증 필요

- 백그라운드 retry 워커 복원력 개선 — 단일 결함 행이 더 이상 전체 재시도 배치를 중단하지 않음. 정상 동작 영향 없음(운영 smoke 불필요, 코드 복원력).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
