### PR TITLE
test(db): migration-completeness 가드 11종 ORM 전수 명시 import (정합성 감사 C5)

### DIFF
--- a/tests/unit/test_migration_completeness.py
+++ b/tests/unit/test_migration_completeness.py
@@ -23,12 +23,22 @@ import re
 import pytest
 
 # --- import every ORM model so SQLAlchemy registers the tables ---
+# 🔴 11종 ORM 전수 명시 import (C5): 누락 시 conftest→src.main 전이 import 에 우발 의존(self-contained
+# 아님) — 그 4종(insight_narrative_cache·issue_registration·merge_retry·security_alert_log)의 컬럼이
+# 마이그레이션 완전성 검사에서 빠져 ORM↔alembic drift 를 못 잡는다. testing.md "empty __init__ + explicit
+# ORM import 의무" 정합. 신규 ORM 모델 추가 시 이 목록에 등재 의무.
+# Explicitly import all 11 ORM models (C5): otherwise 4 of them rely on the conftest→src.main side-effect
+# import chain (not self-contained), excluding their columns from the completeness check.
 import src.models.analysis  # noqa: F401
 import src.models.analysis_feedback  # noqa: F401
 import src.models.gate_decision  # noqa: F401
+import src.models.insight_narrative_cache  # noqa: F401
+import src.models.issue_registration  # noqa: F401
 import src.models.merge_attempt  # noqa: F401
+import src.models.merge_retry  # noqa: F401
 import src.models.repo_config  # noqa: F401
 import src.models.repository  # noqa: F401
+import src.models.security_alert_log  # noqa: F401
 import src.models.user  # noqa: F401
 from src.database import Base
 


### PR DESCRIPTION
## 요약 (정합성 감사 P1 — C5, 테스트 self-contained)

`test_migration_completeness.py`(ORM↔alembic 컬럼 완전성 정적 가드)가 **7/11 ORM 모델만 명시 import** → 나머지 4종(insight_narrative_cache·issue_registration·merge_retry·security_alert_log)은 `conftest→src.main` 전이 import **부작용에 우발 의존**(self-contained 아님). conftest 변경 시 그 4종 컬럼이 완전성 검사에서 빠져 ORM↔alembic drift를 못 잡을 위험.

## 수정

4종 ORM 명시 import 추가 (testing.md "empty `__init__` + explicit ORM import 의무" 정합). 신규 ORM 추가 시 등재 의무 주석.

## 검증

- **테스트 수 불변(4907)** — 4종은 부작용으로 이미 `Base.metadata` 등록됨 → parametrize 케이스 증가 0, robustness만 확보.
- 4종 컬럼 마이그레이션 완전성 검사 **통과**(실 drift 없음 확인) · 124 pass · flake8 0 · src 변경 0.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**OK** — diff(import 4줄+주석)·4종 모듈 실재·self-contained 보장·테스트 수 불변 4항목 확인.

## 🔍 사용자 검증 필요

- test-only robustness — 운영 영향 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
