### PR TITLE
chore(gate): dead-code/docstring 정리 (정합성 감사 C23/C24/C25/C26)

### DIFF
--- a/src/analyzer/pure/review_prompt.py
+++ b/src/analyzer/pure/review_prompt.py
@@ -19,7 +19,7 @@ Token budget strategy:
 """
 from __future__ import annotations
 
-from src.analyzer.pure.language import detect_language, is_test_file
+from src.analyzer.pure.language import detect_language
 from src.analyzer.pure.review_guides import get_guide, get_tier
 from src.constants import (
     LANG_GUIDE_ALL_FULL_MAX,
@@ -344,12 +344,3 @@ def build_review_prompt(
         diff_text=diff_text,
     )
     return user_prompt, languages
-
-
-def has_test_files(patches: list[tuple[str, str]]) -> bool:
-    """패치 목록에 테스트 파일이 포함되어 있는지 확인."""
-    for fname, _ in patches:
-        lang = detect_language(fname)
-        if is_test_file(fname, lang):
-            return True
-    return False

--- a/src/gate/merge_reasons.py
+++ b/src/gate/merge_reasons.py
@@ -49,8 +49,6 @@ ALREADY_MERGED = "already_merged"
 SHA_DRIFT = "sha_drift"
 # 사용자가 설정 변경 (auto_merge 해제 등) / User changed config (auto_merge disabled etc.)
 CONFIG_CHANGED = "config_changed"
-# 실패 체크가 선택적(optional)만 포함 / Only optional checks are failing
-OPTIONAL_CHECK_ONLY = "optional_check_only"
 
 # 재시도 시스템이 대기할 수 있는 태그 집합 (is_retriable_tag 단일 출처)
 # Tag set the retry system can wait out (single source for is_retriable_tag)
@@ -71,19 +69,19 @@ def http_status_to_reason(code: int) -> str:
     return _HTTP_STATUS_TO_REASON.get(code, f"http_{code}")
 
 
-# mergeable_state → reason tag 매핑
-# "unknown" 은 포함하지 않음 — mergeable_state_to_reason 이 UNKNOWN 태그로 처리
-# "unknown" is not included — mergeable_state_to_reason handles it as UNKNOWN tag
+# mergeable_state → reason tag 매핑 — 차단 상태(_MERGEABLE_BLOCK)만 등재.
+# 🔴 호출처(github_review.py:152)는 `if state in _MERGEABLE_BLOCK`(dirty/blocked/behind/draft/unstable)
+# 가드 내부에서만 호출되므로 그 5종만 조회된다. non-block 상태(has_hooks/clean 등)는 lookup 도달 불가라
+# 등재하지 않는다(도달 불가 데이터=오인 소지, 정합성 감사 C24 제거). 미지 상태는 .get(state, UNKNOWN).
+# Only the blocking states (_MERGEABLE_BLOCK) are mapped — the sole caller (github_review.py:152) runs
+# inside `if state in _MERGEABLE_BLOCK`, so non-block states (has_hooks/clean) can never be looked up;
+# unreachable entries were removed (audit C24). Unknown states fall through to .get(state, UNKNOWN).
 _MERGEABLE_STATE_TO_REASON: dict[str, str] = {
     "dirty": DIRTY_CONFLICT,
     "blocked": BRANCH_PROTECTION_BLOCKED,
     "behind": BEHIND_BASE,
     "draft": DRAFT_PR,
     "unstable": UNSTABLE_CI,
-    "has_hooks": "has_hooks",  # 훅 검사 중 — 대기 상태
-                               # Awaiting hook checks — transient hold state
-    "clean": "clean",          # 병합 가능 — 실패 아님
-                               # Mergeable — not a failure state
 }
 
 

--- a/src/models/merge_retry.py
+++ b/src/models/merge_retry.py
@@ -6,8 +6,8 @@ When a merge fails because CI is still running, enqueue and retry.
 상태 전이 (status transitions):
   pending → succeeded        — 재시도 성공
   pending → failed_terminal  — 재시도 가능하지 않은 오류 (권한 없음, branch protection 등)
-  pending → abandoned        — max_attempts 초과
-  pending → expired          — 커밋 SHA 가 더 이상 PR head 가 아님(force-push) 또는 max_age 초과
+  pending → abandoned        — max_attempts 초과 / 설정 변경(auto_merge 해제) / SHA drift(force-push 로 커밋 SHA 변경)
+  pending → expired          — max_age 초과 (aged out) — 🔴 force-push/SHA-drift 는 abandoned (감사 C26 정정)
 """
 from datetime import datetime, timezone
 

--- a/src/repositories/merge_retry_repo.py
+++ b/src/repositories/merge_retry_repo.py
@@ -406,12 +406,12 @@ def mark_expired(
     reason: str | None = None,
     now: datetime | None = None,
 ) -> bool:
-    """status='expired' 마킹 — 더 이상 머지 시도하지 않는 비-실패 종료.
-    SHA 가 PR head 가 아닐 때(force-push 등) 또는 max_age 초과로 만료된 경우.
-    Mark status as 'expired' — a non-failure stop: SHA no longer PR head (e.g. force-push)
-    or the row aged out past max_age (merge_retry_service terminal 분기에서 사용).
-    행 없으면 False 반환.
-    Returns False if row not found.
+    """status='expired' 마킹 — 더 이상 머지 시도하지 않는 비-실패 종료(max_age 초과 = aged out).
+    🔴 force-push/SHA-drift 는 expired 가 아니라 abandoned(reason='sha_drift') 로 라우팅된다
+    (merge_retry_service:206). expired 의 유일 producer 는 max_age 분기(:255) — 감사 C26 정정.
+    Mark status as 'expired' — a non-failure stop when the row aged out past max_age. Force-push /
+    SHA-drift route to abandoned (not expired); expired's only producer is the max_age branch (C26).
+    행 없으면 False 반환. / Returns False if row not found.
     """
     _now = now or _now_naive()
     return _mark_status(db, row_id, status="expired", reason=reason, now=_now)

--- a/tests/unit/analyzer/pure/test_review_guides.py
+++ b/tests/unit/analyzer/pure/test_review_guides.py
@@ -5,7 +5,6 @@ from src.analyzer.pure.review_guides import get_guide, get_tier, supported_langu
 from src.analyzer.pure.review_prompt import (
     build_review_prompt,
     detect_languages_from_patches,
-    has_test_files,
 )
 
 
@@ -135,20 +134,3 @@ class TestBuildReviewPrompt:
         patches = [("main.rs", "fn main() {}")]
         prompt, _ = build_review_prompt("feat: add main", patches)
         assert "rust" in prompt.lower() or "감지" in prompt
-
-
-class TestHasTestFiles:
-    def test_python_test_file(self):
-        assert has_test_files([("test_foo.py", "def test_x(): pass")])
-
-    def test_non_test_file(self):
-        assert not has_test_files([("app.py", "x = 1")])
-
-    def test_go_test_file(self):
-        assert has_test_files([("foo_test.go", "func TestFoo(t *testing.T) {}")])
-
-    def test_js_test_file(self):
-        assert has_test_files([("foo.test.ts", "test('x', () => {})")])
-
-    def test_empty_patches(self):
-        assert not has_test_files([])

--- a/tests/unit/gate/test_merge_reasons.py
+++ b/tests/unit/gate/test_merge_reasons.py
@@ -15,7 +15,6 @@ from src.gate.merge_reasons import (
     ALREADY_MERGED,
     CONFIG_CHANGED,
     DEFERRED,
-    OPTIONAL_CHECK_ONLY,
     SHA_DRIFT,
     UNKNOWN_STATE_TIMEOUT,
     UNSTABLE_CI,
@@ -72,16 +71,14 @@ def test_is_retriable_tag_terminal_tags_return_false(tag):
 # ---------------------------------------------------------------------------
 
 
-def test_mergeable_state_to_reason_has_hooks():
-    # "has_hooks" 상태는 "has_hooks" 태그를 반환해야 함
-    # "has_hooks" state should return the "has_hooks" tag
-    assert mergeable_state_to_reason("has_hooks") == "has_hooks"
-
-
-def test_mergeable_state_to_reason_clean():
-    # "clean" 상태는 "clean" 태그를 반환해야 함 (병합 성공, 실패 아님)
-    # "clean" state should return "clean" tag (merge succeeded, not a failure)
-    assert mergeable_state_to_reason("clean") == "clean"
+def test_mergeable_state_to_reason_non_block_states_return_unknown():
+    # 🔴 비-차단 상태(has_hooks/clean)는 호출처(_MERGEABLE_BLOCK 가드)에서 도달 불가라
+    # 매핑에서 제거됨(감사 C24) → .get(state, UNKNOWN) 로 UNKNOWN 반환.
+    # Non-block states are unreachable at the call site (_MERGEABLE_BLOCK guard) and were removed
+    # from the map (audit C24); they now fall through to UNKNOWN.
+    from src.gate.merge_reasons import UNKNOWN  # pylint: disable=import-outside-toplevel
+    assert mergeable_state_to_reason("has_hooks") == UNKNOWN
+    assert mergeable_state_to_reason("clean") == UNKNOWN
 
 
 # ---------------------------------------------------------------------------
@@ -97,4 +94,3 @@ def test_new_constants_are_importable_and_correct():
     assert ALREADY_MERGED == "already_merged"
     assert SHA_DRIFT == "sha_drift"
     assert CONFIG_CHANGED == "config_changed"
-    assert OPTIONAL_CHECK_ONLY == "optional_check_only"


### PR DESCRIPTION
## 요약 (정합성 감사 P2 dead-code 4건)

정책 16 미사용 코드 제거:
- **C23** `review_prompt.has_test_files()` 제거 (src 호출처 0, test_score는 LLM 채점 위임) + is_test_file import 정리
- **C24** `merge_reasons._MERGEABLE_STATE_TO_REASON` has_hooks/clean 엔트리 제거 (호출처 _MERGEABLE_BLOCK 가드 내부라 도달 불가) — 테스트 non-block→UNKNOWN 갱신
- **C25** `OPTIONAL_CHECK_ONLY` dead 상수 제거 (producer/consumer 0)
- **C26** merge_retry expired docstring 정정 (force-push→abandoned, expired=max_age만)

## 검증
gate+analyzer 1373 pass · pylint 10.00 · flake8 0 · 단위 4907→4901(dead 테스트 6 제거).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
**OK** — dead 확인(grep 0)·_MERGEABLE_BLOCK 가드·C26 라우팅 정합 4항목.

🤖 Generated with [Claude Code](https://claude.com/claude-code)