### PR TITLE
fix(security): webhook/notifier 로그 sanitize + telegram HTML escape (정합성 감사 C13/C20/C27)

### DIFF
--- a/src/notifier/telegram_commands.py
+++ b/src/notifier/telegram_commands.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from html import escape  # C27: 봇 명령 응답(parse_mode=HTML)의 사용자 입력 HTML 이스케이프
 from typing import Any
 
 from sqlalchemy import select
@@ -194,7 +195,8 @@ def _handle_connect(db: Session, telegram_user_id: str, otp: str) -> str:
     # Connect success = linked User.preferred_language (immediate i18n activation)
     user_lang = _resolve_user_language(found)
     default_name = get_text("notifier.commands.connect_default_name", user_lang)
-    name = found.display_name or found.github_login or default_name
+    # C27: display_name/github_login 은 사용자 제어값 — HTML 모드 응답 전 이스케이프 (분석-알림 경로 대칭)
+    name = escape(found.display_name or found.github_login or default_name)
     return get_text("notifier.commands.connect_success", user_lang, name=name)
 
 
@@ -217,7 +219,7 @@ def _handle_stats(db: Session, user: Any, repo_name: str, language: str) -> str:
     # Verify repo existence and ownership
     repo = repository_repo.find_by_full_name(db, repo_name)
     if repo is None or repo.user_id != user.id:
-        return get_text("notifier.commands.stats_repo_not_found", language, repo=repo_name)
+        return get_text("notifier.commands.stats_repo_not_found", language, repo=escape(repo_name))
 
     # 주간 집계 — 현재 시각 기준 7일 전부터
     # Weekly summary — from 7 days before current time
@@ -226,7 +228,7 @@ def _handle_stats(db: Session, user: Any, repo_name: str, language: str) -> str:
     summary = weekly_summary(db, repo.id, week_start, now=now)
 
     if summary is None:
-        title = get_text("notifier.commands.stats_no_data_title", language, repo=repo_name)
+        title = get_text("notifier.commands.stats_no_data_title", language, repo=escape(repo_name))
         body = get_text("notifier.commands.stats_no_data_body", language)
         return f"{title}\n{body}"
 
@@ -246,7 +248,7 @@ def _handle_stats(db: Session, user: Any, repo_name: str, language: str) -> str:
     return get_text(
         "notifier.commands.stats_summary",
         language,
-        repo=repo_name,
+        repo=escape(repo_name),
         count=count,
         avg=f"{avg:.1f}",
         trend=trend,
@@ -277,5 +279,5 @@ def _handle_settings(db: Session, user: Any, language: str) -> str:
 
     lines = [get_text("notifier.commands.settings_header", language)]
     for repo in repos:
-        lines.append(f"  • {repo.full_name}")
+        lines.append(f"  • {escape(repo.full_name)}")  # C27: HTML 모드 응답 — repo명 이스케이프
     return "\n".join(lines)

--- a/src/webhook/providers/railway.py
+++ b/src/webhook/providers/railway.py
@@ -108,7 +108,8 @@ async def _handle_railway_deploy_failure(
             # Keep exc detail in operator logs only; leave body None so railway_issue
             # substitutes the i18n key (avoids leaking hardcoded Korean into the Issue)
             logger.warning(  # NOSONAR python:S5145 — sanitized via log_safety
-                "Railway 로그 조회 실패 (%s): %s", sanitize_for_log(event.deployment_id), exc,
+                "Railway 로그 조회 실패 (%s): %s",
+                sanitize_for_log(event.deployment_id), sanitize_for_log(str(exc)),  # C13: exc 도 sanitize
             )
             logs_tail = None
 

--- a/src/webhook/providers/telegram.py
+++ b/src/webhook/providers/telegram.py
@@ -108,7 +108,7 @@ async def handle_gate_callback(  # pylint: disable=too-many-locals
             if user is None or repo.user_id != user.id:
                 logger.warning(  # NOSONAR python:S5145 — sanitized via log_safety
                     "handle_gate_callback: unauthorized tg_user=%s for repo=%s (analysis %d) — skipping",
-                    sanitize_for_log(telegram_user_id), repo.full_name, analysis_id,
+                    sanitize_for_log(telegram_user_id), sanitize_for_log(repo.full_name), analysis_id,  # C20
                 )
                 return
             if analysis.pr_number is None:

--- a/tests/unit/notifier/test_telegram_commands.py
+++ b/tests/unit/notifier/test_telegram_commands.py
@@ -199,6 +199,23 @@ def test_handle_connect_accepts_valid_otp(db):
     assert "연결" in result or "linked" in result.lower()
 
 
+def test_handle_connect_escapes_html_in_display_name(db):
+    """🔴 C27: 봇 응답(parse_mode=HTML)의 사용자 제어 display_name HTML 이스케이프.
+
+    display_name 에 <,>,& 가 있으면 raw 노출 시 (a) 자기 채팅 서식 주입 (b) malformed HTML →
+    Telegram API 400 → 봇 silent 실패(가용성). 분석-알림 경로(escape)와 대칭.
+    """
+    future = datetime.now(timezone.utc) + timedelta(minutes=10)
+    _make_user(
+        db, github_id="gh-xss", email="xss@example.com",
+        display_name="Evil<b>Name</b>", telegram_otp="654321",
+        telegram_otp_expires_at=future,
+    )
+    result = handle_message_command(db, "tg-xss", "/connect 654321")
+    assert "Evil&lt;b&gt;Name&lt;/b&gt;" in result   # 이스케이프됨
+    assert "<b>" not in result                       # raw 태그 미노출
+
+
 def test_handle_connect_rejects_expired_otp(db):
     """만료된 OTP는 오류 메시지를 반환해야 한다 (find_by_otp가 None).
     Expired OTP must return an error message (find_by_otp returns None).


### PR DESCRIPTION
## 요약 (정합성 감사 P2 보안 하드닝 3건)
- **C13** railway.py logger.warning exc → `sanitize_for_log(str(exc))` (CRLF 로그 인젝션 차단, NOSONAR 단언 정합)
- **C20** telegram.py 비인가 경고 repo.full_name → sanitize_for_log
- **C27** telegram_commands.py 봇 응답(parse_mode=HTML) 사용자 제어값 **전수 html.escape** (display_name/github_login·repo_name 3곳·repo.full_name) — 분석-알림 경로 대칭. 자기채팅 서식주입+malformed HTML→400 가용성 차단.

🔴 **C12(OTP brute-force rate-limit) = 백로그 보류** (rate-limit 상태 설계 필요, Telegram flood 부분완화 P2).

## 검증
TDD +1(C27 escape) · notifier+webhook 66 pass · pylint 10.00. Codex OK(C27 전수·이중이스케이프 없음·DB raw 보존).

## 🔍 사용자 검증 필요
telegram 봇 명령(/connect·/settings) 정상 동작 + repo명에 <,> 포함 시 깨짐 없이 표시 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)