### PR TITLE
fix(pipeline): pylint/bandit 파서 방어 접근 + AI리뷰 언어감지 content 전달 (정합성 감사 C10/C18)

### DIFF
--- a/src/analyzer/io/tools/python.py
+++ b/src/analyzer/io/tools/python.py
@@ -43,12 +43,16 @@ class _PylintAnalyzer:
                 capture_output=True, text=True, timeout=STATIC_ANALYSIS_TIMEOUT, check=False,
             )
             items = json.loads(r.stdout) if r.stdout.strip().startswith("[") else []
+            # C10: item.get() 방어 접근 — 도구가 키 누락 JSON 을 내도 KeyError 로 analyzer 전체가
+            # 중단(이슈 전량 무음 폐기 + incomplete 미설정 = fail-open)되지 않게 한다(golangci_lint 패턴).
+            # C10: defensive .get() — a missing key must not raise KeyError and silently drop the whole
+            # analyzer's issues without an incomplete marker (golangci_lint pattern).
             return [
                 AnalysisIssue(
                     tool="pylint",
-                    severity=Severity.ERROR if item["type"] in ("error", "fatal") else Severity.WARNING,
-                    message=item["message"],
-                    line=item["line"],
+                    severity=Severity.ERROR if item.get("type") in ("error", "fatal") else Severity.WARNING,
+                    message=str(item.get("message") or ""),  # None/비-str 도 안전
+                    line=item.get("line") or 0,              # None → 0
                     category=self.category,
                     language=ctx.language,
                 )
@@ -131,12 +135,15 @@ class _BanditAnalyzer:
                 capture_output=True, text=True, timeout=STATIC_ANALYSIS_TIMEOUT, check=False,
             )
             data = json.loads(r.stdout) if r.stdout.strip().startswith("{") else {}
+            # C10: item.get() 방어 접근 (pylint 대칭) — 키 누락 JSON 의 KeyError fail-open 차단.
+            # C10: defensive .get() (mirrors pylint) — block the KeyError fail-open on missing keys.
             return [
                 AnalysisIssue(
                     tool="bandit",
-                    severity=Severity.ERROR if item["issue_severity"].upper() == "HIGH" else Severity.WARNING,
-                    message=item["issue_text"],
-                    line=item["line_number"],
+                    severity=(Severity.ERROR if str(item.get("issue_severity") or "").upper() == "HIGH"
+                              else Severity.WARNING),
+                    message=str(item.get("issue_text") or ""),  # None/비-str 도 안전
+                    line=item.get("line_number") or 0,          # None → 0
                     category=self.category,
                     language=ctx.language,
                 )

--- a/src/analyzer/pure/review_prompt.py
+++ b/src/analyzer/pure/review_prompt.py
@@ -178,9 +178,14 @@ def detect_languages_from_patches(
     patches: list[tuple[str, str]],
 ) -> list[str]:
     """패치 목록에서 등장 언어를 빈도순으로 반환 (중복 제거)."""
+    # C18: content 전달 — 확장자 없고 shebang 으로만 식별되는 스크립트(예: 'bin/deploy' +
+    # '#!/usr/bin/env python3')를 정적분석 경로(static.py:64 detect_language(fname, content))와
+    # 동일하게 인식해 언어별 리뷰 가이드 누락을 방지한다.
+    # C18: pass content so shebang-only (extensionless) scripts are detected like the static path,
+    # preventing the language-specific review guide from being skipped.
     freq: dict[str, int] = {}
-    for fname, _ in patches:
-        lang = detect_language(fname)
+    for fname, content in patches:
+        lang = detect_language(fname, content)
         if lang != "unknown":
             freq[lang] = freq.get(lang, 0) + 1
     return sorted(freq, key=lambda lang: -freq[lang])

--- a/tests/unit/analyzer/pure/test_review_guides.py
+++ b/tests/unit/analyzer/pure/test_review_guides.py
@@ -88,6 +88,13 @@ class TestDetectLanguagesFromPatches:
     def test_empty_patches(self):
         assert detect_languages_from_patches([]) == []
 
+    def test_shebang_only_extensionless_script_detected(self):
+        # 🔴 C18: 확장자 없고 shebang 으로만 식별되는 스크립트 — content 전달로 정적분석 경로와
+        # 동일하게 'python' 감지(이전엔 content 미전달로 'unknown' → 언어별 리뷰 가이드 누락).
+        patches = [("bin/deploy", "#!/usr/bin/env python3\nprint('hi')\n")]
+        langs = detect_languages_from_patches(patches)
+        assert langs == ["python"]
+
 
 class TestBuildReviewPrompt:
     def test_returns_prompt_and_languages(self):

--- a/tests/unit/analyzer/tools/test_python.py
+++ b/tests/unit/analyzer/tools/test_python.py
@@ -468,3 +468,76 @@ class TestBanditRunGracefulDegradation:
         with patch("subprocess.run", return_value=_mock_proc("{broken json")):
             issues = _BanditAnalyzer().run(py_ctx)
         assert issues == []
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# C10 — 키 누락 JSON item 방어 (KeyError fail-open 차단)
+# C10 — defensive parsing of key-missing JSON items (block KeyError fail-open)
+# ──────────────────────────────────────────────────────────────────────────
+
+
+class TestC10DefensiveParsing:
+    """도구가 키 누락 JSON 을 내도 KeyError 로 analyzer 전체가 중단(이슈 전량 무음 폐기)되지 않아야 한다."""
+
+    def test_pylint_missing_message_key_does_not_crash(self, py_ctx):
+        # "message" 키 누락 — 이전엔 KeyError → 전량 폐기(fail-open). 이제 빈 message 로 이슈 보존.
+        payload = '[{"type": "warning", "line": 5}]'
+        with patch("subprocess.run", return_value=_mock_proc(payload)):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert len(issues) == 1               # 이슈 보존 (무음 폐기 X)
+        assert issues[0].message == ""
+        assert issues[0].line == 5
+        assert issues[0].severity == Severity.WARNING
+
+    def test_pylint_missing_type_and_line_defaults(self, py_ctx):
+        payload = '[{"message": "bad"}]'
+        with patch("subprocess.run", return_value=_mock_proc(payload)):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert len(issues) == 1
+        assert issues[0].severity == Severity.WARNING  # type 누락 → WARNING
+        assert issues[0].line == 0
+
+    def test_bandit_missing_issue_text_key_does_not_crash(self, py_ctx):
+        payload = '{"results": [{"issue_severity": "HIGH", "line_number": 3}]}'
+        with patch("subprocess.run", return_value=_mock_proc(payload)):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert len(issues) == 1               # 이슈 보존
+        assert issues[0].message == ""
+        assert issues[0].line == 3
+        assert issues[0].severity == Severity.ERROR  # HIGH 보존
+
+    def test_bandit_missing_severity_and_line_keys_does_not_crash(self, py_ctx):
+        # issue_severity·line_number 둘 다 누락 — 직접 subscript 재도입 시 KeyError 회귀 봉인(Codex NG fix).
+        payload = '{"results": [{"issue_text": "found"}]}'
+        with patch("subprocess.run", return_value=_mock_proc(payload)):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert len(issues) == 1
+        assert issues[0].message == "found"
+        assert issues[0].line == 0                       # line_number 누락 → 0
+        assert issues[0].severity == Severity.WARNING    # issue_severity 누락 → 비-HIGH → WARNING
+
+    def test_bandit_none_severity_does_not_crash(self, py_ctx):
+        # issue_severity=None — str() 래핑이 .upper() AttributeError 를 방지하는지 봉인.
+        payload = '{"results": [{"issue_severity": null, "issue_text": "x", "line_number": 2}]}'
+        with patch("subprocess.run", return_value=_mock_proc(payload)):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert len(issues) == 1
+        assert issues[0].severity == Severity.WARNING
+
+    def test_pylint_none_message_and_line_values_safe(self, py_ctx):
+        # message/line 값이 None — `or` 폴백이 None 을 ""/0 으로 정규화하는지 봉인(Codex NG fix).
+        payload = '[{"type": "warning", "message": null, "line": null}]'
+        with patch("subprocess.run", return_value=_mock_proc(payload)):
+            issues = _PylintAnalyzer().run(py_ctx)
+        assert len(issues) == 1
+        assert issues[0].message == ""
+        assert issues[0].line == 0
+
+    def test_bandit_none_text_and_line_values_safe(self, py_ctx):
+        payload = '{"results": [{"issue_severity": "HIGH", "issue_text": null, "line_number": null}]}'
+        with patch("subprocess.run", return_value=_mock_proc(payload)):
+            issues = _BanditAnalyzer().run(py_ctx)
+        assert len(issues) == 1
+        assert issues[0].message == ""
+        assert issues[0].line == 0
+        assert issues[0].severity == Severity.ERROR


### PR DESCRIPTION
## 요약 (정합성 감사 P2 pipeline 하드닝 2건)
- **C10** python.py pylint/bandit 파서가 item["key"] 직접 subscript → 키 누락 JSON 시 KeyError 가 해당 파일 이슈 전량 무음 폐기 + incomplete 미설정(만점 fail-open). item.get() 방어 접근(golangci_lint 패턴), 6키 missing+None 안전 → 이슈 보존(count 정확=게이트 fail-closed 유지).
- **C18** review_prompt.detect_languages_from_patches 가 detect_language(fname) content 미전달 → shebang-only 스크립트 'unknown' 누락 → 언어 가이드 미적용. content 전달로 정적분석 경로 대칭.

🔴 **C22(diff 16000자 무음 절단 score-integrity 비대칭) = 백로그 보류** (다층 신호 전파 설계 + 정책 16 제외 영역 인접).

## 검증
TDD +6(C10 pylint/bandit missing+None 5 + C18 shebang 1). analyzer 970+ pass · pylint 10.00. Codex mutual OK(NG: bandit None 미봉인→6키 missing+None 전수 봉인 수정→재검증 OK).

## 🔍 사용자 검증 필요
정적분석 정상 동작 + 확장자 없는 스크립트 AI리뷰 시 언어 인식 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)