### PR TITLE
fix(db): insight 캐시 cross-lang eviction + i18n ValueError + merge_retry live threshold (정합성 감사 C14/C28/C11)

### DIFF
--- a/src/i18n/loader.py
+++ b/src/i18n/loader.py
@@ -189,7 +189,12 @@ def get_text(key: str, locale: str | None = None, **kwargs) -> str:
 
     try:
         return value.format(**kwargs)
-    except (KeyError, IndexError) as exc:
+    except (KeyError, IndexError, ValueError) as exc:
+        # C28: ValueError 포함 — 번역문에 불균형/리터럴 중괄호(예: 'a { b {name}')가 있으면
+        # str.format() 이 ValueError("unexpected '{' in field name")를 던진다. 미포착 시 페이지
+        # 렌더 500 → graceful 'unformatted 반환' 의도 보존.
+        # C28: include ValueError — an unbalanced/literal brace makes str.format() raise ValueError;
+        # uncaught it would 500 the render instead of the graceful unformatted fallback.
         logger.warning(
             "Format substitution failed for key '%s': %s — returning unformatted",
             key,

--- a/src/repositories/insight_narrative_cache_repo.py
+++ b/src/repositories/insight_narrative_cache_repo.py
@@ -100,25 +100,29 @@ def upsert(
 
 
 def invalidate(db: Session, *, user_id: int, days: int) -> bool:
-    """전체 대시보드 캐시 강제 무효화 (DELETE, repo_id=NULL).
+    """전체 대시보드 캐시 강제 무효화 (DELETE, repo_id=NULL — 모든 언어 행).
 
-    Force invalidate global dashboard cache (DELETE, repo_id=NULL).
-    Returns True if deleted, False if not found.
+    Force invalidate global dashboard cache (DELETE, repo_id=NULL — all language rows).
+    Returns True if any row deleted, False if none.
+
+    🔴 C14: 전역 캐시는 부분 유니크 (user_id, days, language) 키라 동일 (user_id, days)에 언어별
+    다중 행이 공존한다. 이전 `.first()` 단일 삭제는 ORDER BY 없이 비결정적으로 무관한 언어 행을
+    지워 cross-language eviction(타 언어 캐시 부수 손실 → 불필요한 Claude API 재생성)을 유발했다.
+    bulk delete 로 (user_id, days, global)의 모든 언어 행을 결정론적으로 무효화한다.
+    C14: the global cache is keyed (user_id, days, language) so multiple language rows coexist; the old
+    `.first()` single-delete non-deterministically evicted an unrelated language. Bulk-delete all.
     """
-    row = (
+    deleted = (
         db.query(InsightNarrativeCache)
         .filter(
             InsightNarrativeCache.user_id == user_id,
             InsightNarrativeCache.days == days,
             InsightNarrativeCache.repo_id.is_(None),
         )
-        .first()
+        .delete(synchronize_session=False)
     )
-    if row is None:
-        return False
-    db.delete(row)
     db.commit()
-    return True
+    return deleted > 0
 
 
 # ─── 0031: repo-scoped cache helpers ─────────────────────────────────────────

--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -217,7 +217,7 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
         log_merge_attempt(
             db, analysis_id=row.analysis_id, repo_name=row.repo_full_name,
             pr_number=row.pr_number, score=row.score,
-            threshold=row.threshold_at_enqueue, success=True, reason=None,
+            threshold=cfg.merge_threshold, success=True, reason=None,
         )
         merge_retry_repo.mark_succeeded(db, row.id)
         await _notify_merge_succeeded(row, cfg, language=language)
@@ -245,7 +245,7 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
         log_merge_attempt(
             db, analysis_id=row.analysis_id, repo_name=row.repo_full_name,
             pr_number=row.pr_number, score=row.score,
-            threshold=row.threshold_at_enqueue, success=False, reason=reason,
+            threshold=cfg.merge_threshold, success=False, reason=reason,
         )
         if is_terminal_failure:
             merge_retry_repo.mark_terminal(db, row.id, reason=reason_tag)
@@ -469,7 +469,9 @@ async def _notify_merge_terminal(
 async def _create_failure_issue_safe(
     token: str,
     row: MergeRetryQueue,
-    cfg: RepoConfigData,  # pylint: disable=unused-argument
+    # C11: threshold 로그를 live cfg.merge_threshold 로 정합 (이제 사용됨)
+    # C11: align the logged threshold with the live cfg.merge_threshold (now used)
+    cfg: RepoConfigData,
     reason: str | None,
     reason_tag: str,
     *,
@@ -485,7 +487,7 @@ async def _create_failure_issue_safe(
             repo_name=row.repo_full_name,
             pr_number=row.pr_number,
             score=row.score,
-            threshold=row.threshold_at_enqueue,
+            threshold=cfg.merge_threshold,
             reason=reason or reason_tag,
             advice=advice,
             language=language,

--- a/tests/unit/i18n/test_loader.py
+++ b/tests/unit/i18n/test_loader.py
@@ -94,6 +94,19 @@ def test_get_text_format_substitution_failure_returns_unformatted():
     assert result == "Dashboard"
 
 
+def test_get_text_unbalanced_brace_returns_unformatted(monkeypatch):
+    """🔴 C28: 번역문에 불균형/리터럴 중괄호 + kwargs → str.format() ValueError 를 graceful 처리.
+
+    'a { b {name}'.format(name='x') 는 ValueError 를 던진다(KeyError/IndexError 아님). 미포착 시
+    페이지 렌더 500 → ValueError 도 포착해 unformatted 원본 반환(의도된 fallback 보존).
+    """
+    from src.i18n import loader  # pylint: disable=import-outside-toplevel
+    monkeypatch.setattr(loader, "_lookup_key", lambda translations, key: "a { b {name}")
+    # ValueError 가 전파되지 않고 unformatted 원본을 반환해야 한다 (이전엔 미포착 → 500)
+    result = loader.get_text("any.key", "en", name="x")
+    assert result == "a { b {name}"
+
+
 def test_get_text_lru_cache_hit():
     """LRU cache 동작 검증 — 동일 locale 재호출 시 캐시 hit."""
     load_translations.cache_clear()

--- a/tests/unit/repositories/test_insight_narrative_cache_repo.py
+++ b/tests/unit/repositories/test_insight_narrative_cache_repo.py
@@ -87,6 +87,21 @@ def test_invalidate_returns_false_when_absent(db):
     assert deleted is False
 
 
+def test_invalidate_deletes_all_languages(db):
+    """🔴 C14: 전역 캐시는 (user_id, days, language) 키라 언어별 다중 행 공존 → invalidate 가
+    모든 언어 행을 결정론적으로 삭제(이전 .first() 단일 삭제는 비결정적 wrong-language eviction)."""
+    insight_narrative_cache_repo.upsert(db, user_id=1, days=7, language="en", response={"l": "en"})
+    insight_narrative_cache_repo.upsert(db, user_id=1, days=7, language="ko", response={"l": "ko"})
+    insight_narrative_cache_repo.upsert(db, user_id=1, days=7, language="ja", response={"l": "ja"})
+
+    deleted = insight_narrative_cache_repo.invalidate(db, user_id=1, days=7)
+    assert deleted is True
+    # 세 언어 모두 삭제 (cross-language eviction 잔존 0)
+    assert insight_narrative_cache_repo.get_fresh(db, user_id=1, days=7, language="en") is None
+    assert insight_narrative_cache_repo.get_fresh(db, user_id=1, days=7, language="ko") is None
+    assert insight_narrative_cache_repo.get_fresh(db, user_id=1, days=7, language="ja") is None
+
+
 def test_per_user_isolation(db):
     """(user_id, days) 키 격리 — user_id 다르면 독립 캐시."""
     insight_narrative_cache_repo.upsert(db, user_id=1, days=7, response={"u": 1})

--- a/tests/unit/services/test_merge_retry_service.py
+++ b/tests/unit/services/test_merge_retry_service.py
@@ -508,6 +508,29 @@ class TestProcessPendingRetries:
         db_session.refresh(row)
         assert row.status == "succeeded"
 
+    async def test_log_merge_attempt_uses_live_threshold_not_snapshot(self, db_session):
+        """🔴 C11: 관측 로그의 threshold 가 게이팅에 쓴 live cfg.merge_threshold 와 일치해야 한다.
+
+        게이트(:177)는 live cfg.merge_threshold 로 판정하나 이전엔 로그/Issue 가 enqueue 스냅샷
+        (row.threshold_at_enqueue)을 기록 → '실제 머지를 가른 임계값'과 '관측 기록' 발산(감사 부정확).
+        seed snapshot=75, 운영 config=85 일 때 로그 threshold=85(live) 여야 한다.
+        """
+        row = _seed_queue_row(db_session)             # threshold_at_enqueue=75 (스냅샷)
+        live_cfg = _make_fake_cfg(merge_threshold=85)  # 운영 현재값 (스냅샷과 발산)
+
+        patches = _standard_patches(cfg=live_cfg, merge_return=(True, None, "abc123"))
+        with (
+            patches["token"], patches["repo_config"], patches["pr_data"],
+            patches["merge_pr"], patches["ci"], patches["notify_succeeded"],
+            patches["notify_terminal"], patches["notify_config"],
+            patches["log_attempt"] as mock_log,
+        ):
+            await process_pending_retries(db_session, only_ids=[row.id])
+
+        mock_log.assert_called_once()
+        # 로그 threshold = live(85), 스냅샷(75) 아님
+        assert mock_log.call_args.kwargs["threshold"] == 85
+
     # T9-7: CI 진행 중 → 일시적 실패, 클레임 해제
     # T9-7: CI running → transient, release claim
     async def test_process_transient_ci_running_releases(self, db_session):
@@ -730,6 +753,32 @@ class TestProcessPendingRetries:
 
         assert result["terminal"] == 1
         mock_issue.assert_called_once()
+
+    async def test_failure_log_and_issue_use_live_threshold(self, db_session):
+        """🔴 C11 failure 경로: terminal 실패 로그(success=False)와 failure Issue 의 threshold 가
+        enqueue 스냅샷이 아니라 live cfg.merge_threshold 와 일치해야 한다 (3곳 중 248·488 봉인)."""
+        row = _seed_queue_row(db_session)                                   # 스냅샷=75
+        live_cfg = _make_fake_cfg(auto_merge_issue_on_failure=True, merge_threshold=85)
+        patches = _standard_patches(
+            merge_return=(False, "branch_protection_blocked: admin override required", ""),
+            ci_return="failed",
+            cfg=live_cfg,
+        )
+        with (
+            patches["token"], patches["repo_config"], patches["pr_data"],
+            patches["merge_pr"], patches["ci"], patches["notify_succeeded"],
+            patches["notify_terminal"], patches["notify_config"],
+            patches["log_attempt"] as mock_log,
+            patch("src.services.merge_retry_service.create_merge_failure_issue",
+                  new_callable=AsyncMock) as mock_issue,
+        ):
+            await process_pending_retries(db_session, only_ids=[row.id])
+
+        # 실패 로그(248) + failure Issue(488) 모두 live(85), 스냅샷(75) 아님
+        assert mock_log.call_args.kwargs["success"] is False
+        assert mock_log.call_args.kwargs["threshold"] == 85
+        mock_issue.assert_called_once()
+        assert mock_issue.call_args.kwargs["threshold"] == 85
 
     # T9-13: max_attempts 초과 행 → abandoned 처리
     # T9-13: Row exceeding max_attempts → abandoned


### PR DESCRIPTION
## 요약 (정합성 감사 P2 3건)
- **C14** insight_narrative_cache_repo.invalidate .first() 단일삭제 → bulk delete (user_id,days,global 전 언어 결정론적 무효화) — cross-language eviction(타 언어 캐시 부수손실→불필요 Claude API 재생성) 차단.
- **C28** i18n loader get_text format except 에 ValueError 추가 — 번역문 불균형/리터럴 중괄호 시 렌더 500 → graceful unformatted fallback.
- **C11** merge_retry 관측 로그/Issue threshold 가 enqueue 스냅샷 → live cfg.merge_threshold(게이트 정합) — '머지 가른 임계값'과 '관측 기록' 발산 해소.

## 검증
TDD +4(C14 3언어 bulk·C28 ValueError·C11 success+failure log+Issue threshold=live). 67+ pass · pylint 10.00. Codex mutual OK(NG: C11 failure 미봉인+주석 영어누락→3곳 전수 봉인+이중언어 수정→재검증 OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)