### PR TITLE
fix(ui): dashboard grade dead assertion + 트렌드 nav REPO_NAME 인코딩 (정합성 감사 C30/U3)

### DIFF
--- a/src/templates/analysis_detail.html
+++ b/src/templates/analysis_detail.html
@@ -929,7 +929,11 @@
           var idx = elements[0].index;
           var targetId = TREND[idx].id;
           if (targetId !== CURRENT_ID) {
-            window.location.href = '/repos/' + REPO_NAME + '/analyses/' + targetId;
+            // 🔴 U3: REPO_NAME(owner/repo)의 '/' 인코딩 — 형제 feedback URL(encodeURIComponent)과
+            // 대칭. 미인코딩 시 라우트(/repos/{repo}/analyses/{id}) 경로 분절로 nav 깨짐.
+            // U3: encode REPO_NAME (its '/') to mirror the sibling feedback URL; otherwise the route
+            // path is mis-segmented and navigation breaks.
+            window.location.href = '/repos/' + encodeURIComponent(REPO_NAME) + '/analyses/' + targetId;
           }
         }
       },

--- a/tests/unit/services/test_dashboard_service.py
+++ b/tests/unit/services/test_dashboard_service.py
@@ -112,7 +112,9 @@ class TestDashboardKpi:
 
         result = dashboard_kpi(db, days=7, now=now)
         assert result["avg_score"]["value"] == pytest.approx(85.0, abs=0.1)
-        assert result["avg_score"]["grade"] in ("A", "B", "C", "D", "F", "B+")
+        # 🔴 C30: avg=85 → calculate_grade(85) 는 결정론적 'B' (GRADE_THRESHOLDS B=75). 이전 dead
+        # assertion 은 모든 등급 + 가공의 'B+' 까지 허용해 grade 계산 회귀(예: 85→'A')를 못 잡았다.
+        assert result["avg_score"]["grade"] == "B"
 
     def test_avg_score_delta_compares_previous_window(self, db, repos):
         """delta = 현재 days 평균 - 직전 동일 days 평균 (양수 = 개선)."""

--- a/tests/unit/templates/test_detail_i18n_render.py
+++ b/tests/unit/templates/test_detail_i18n_render.py
@@ -367,3 +367,13 @@ def test_analysis_detail_cycle143_issue_form_renders():
     """analysis_detail.html ko — 사이클 143 issue_form 라벨 렌더."""
     out = _render("analysis_detail.html", locale="ko", **_analysis_ctx())
     assert "제목" in out  # issue_form.title
+
+
+def test_analysis_detail_trend_nav_encodes_repo_name():
+    """🔴 U3: 트렌드 차트 클릭 nav 가 REPO_NAME 을 encodeURIComponent 로 인코딩(형제 feedback URL 대칭).
+
+    REPO_NAME='owner/repo' 의 '/' 미인코딩 시 라우트 경로 분절로 nav 깨짐 → 인코딩 패턴 봉인.
+    """
+    out = _render("analysis_detail.html", locale="ko", **_analysis_ctx())
+    assert "encodeURIComponent(REPO_NAME)" in out          # 인코딩 적용
+    assert "'/repos/' + REPO_NAME + '/analyses/'" not in out  # 미인코딩 패턴 부재


### PR DESCRIPTION
## 요약 (정합성 감사 P2 2건)
- **C30** test_dashboard_service grade 검증 dead assertion — value=85.0 고정인데 grade 를 (A,B,C,D,F,B+) 전체+가공 'B+' 허용 → 회귀(85→'A') 미감지. calculate_grade(85)='B' 결정론적 → `== "B"` 정정.
- **U3** analysis_detail.html 트렌드 차트 클릭 nav REPO_NAME 미인코딩 → encodeURIComponent(형제 feedback URL :535 대칭) — 라우트 경로 분절 nav 깨짐 해소. JS URL-인코딩 fix(시각 변경 0).

🔴 **백로그 보류**: C1(save_gate_decision dead wrapper+55 patch, CONFIRMED dead #712 reconcile, 대규모 리팩토링) · U2(effects.js hx-boost, E2E 필요) · U1(0027 RLS legacy NULL, migration 민감·미검증) · C12(OTP rate-limit feature) · C22(diff truncation 다층).

## 검증
TDD +2 · dashboard+detail 40 pass · pylint 10.00 · Codex OK(2/2).

## 🔍 사용자 검증 필요
U3 = JS URL 인코딩(시각 변경 0, 정책 11 8조합 불필요). 트렌드 차트 클릭 시 정상 이동 확인 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)