### PR TITLE
fix(security): Telegram OTP brute-force in-memory rate-limit (정합성 감사 C12)

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -116,6 +116,17 @@ WEBHOOK_SECRET_CACHE_TTL = 300  # per-repo webhook secret 캐시 TTL (초, 5분)
 # repository.full_name (on overflow, purge expired then evict the soonest-expiring entry).
 WEBHOOK_SECRET_CACHE_MAX = 2048
 
+# ── Telegram OTP brute-force 방어 (C12) ──────────────────────────────────────
+# per-telegram_user_id 슬라이딩 윈도우 — 잘못된 /connect 시도만 카운트한다.
+# 6자리 숫자 OTP(공간 10^6) + TTL 5분이라 무제한 추측 시 brute-force 가능 → 한도 차단.
+# Per-telegram_user_id sliding window — counts only failed /connect attempts.
+# A 6-digit OTP (10^6 space) with a 5-min TTL is brute-forceable without a cap.
+OTP_MAX_FAILED_ATTEMPTS = 5          # 윈도우 내 허용 실패 횟수 / allowed failures per window
+OTP_ATTEMPT_WINDOW_SECONDS = 300     # 슬라이딩 윈도우(초) — OTP TTL(5분)과 동일 / window = OTP TTL
+# 🔴 추적 키 상한 — telegram_user_id 가 많아져도 dict 무한 증가를 막는다(메모리 고갈 방지).
+# Tracked-key cap — bounds dict growth across many telegram_user_ids (memory guard).
+OTP_LIMITER_MAX_KEYS = 2048
+
 # ── 파이프라인 이벤트 필터 ─────────────────────────────────────────────────
 # ── Pipeline event filter ─────────────────────────────────────────────────
 HANDLED_EVENTS: frozenset[str] = frozenset({"push", "pull_request", "issues", "check_suite"})

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -813,6 +813,7 @@
       "unknown_command": "Unknown command. Available: /stats <repo>, /settings, /connect <code>",
       "connect_usage": "Usage: /connect <6-digit code>",
       "connect_invalid_otp": "Invalid or expired OTP.",
+      "connect_rate_limited": "Too many attempts. Please try again in a few minutes.",
       "connect_already_linked": "This Telegram account is already linked to another user.",
       "connect_success": "✅ Account linked for {name}!",
       "connect_default_name": "user",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -813,6 +813,7 @@
       "unknown_command": "対応していないコマンドです。利用可能: /stats <repo>, /settings, /connect <コード>",
       "connect_usage": "使い方: /connect <6桁コード>",
       "connect_invalid_otp": "OTP が無効または期限切れです。",
+      "connect_rate_limited": "試行回数が多すぎます。数分後にもう一度お試しください。",
       "connect_already_linked": "この Telegram アカウントは既に他のユーザーに連携されています。",
       "connect_success": "✅ {name} さんのアカウントが連携されました!",
       "connect_default_name": "ユーザー",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -813,6 +813,7 @@
       "unknown_command": "지원하지 않는 명령입니다. 사용 가능: /stats <repo>, /settings, /connect <코드>",
       "connect_usage": "사용법: /connect <6자리 코드>",
       "connect_invalid_otp": "OTP가 잘못되었거나 만료되었습니다.",
+      "connect_rate_limited": "시도 횟수가 너무 많습니다. 몇 분 후 다시 시도해 주세요.",
       "connect_already_linked": "이 Telegram 계정은 이미 다른 사용자에게 연결되어 있습니다.",
       "connect_success": "✅ {name} 님의 계정이 연결되었습니다!",
       "connect_default_name": "사용자",

--- a/src/notifier/telegram_commands.py
+++ b/src/notifier/telegram_commands.py
@@ -14,6 +14,9 @@ Phase 3 PR-9 (Cycle 84 — i18n) — `/connect` uses settings default (user not 
 from __future__ import annotations
 
 import logging
+import threading
+import time
+from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from html import escape  # C27: 봇 명령 응답(parse_mode=HTML)의 사용자 입력 HTML 이스케이프
@@ -23,6 +26,11 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from src.config import settings
+from src.constants import (
+    OTP_ATTEMPT_WINDOW_SECONDS,
+    OTP_LIMITER_MAX_KEYS,
+    OTP_MAX_FAILED_ATTEMPTS,
+)
 from src.i18n.loader import get_text
 from src.models.repository import Repository
 from src.repositories import repository_repo, user_repo
@@ -36,6 +44,98 @@ logger = logging.getLogger(__name__)
 # 백워드 호환 — 기존 단위 테스트 (`test_telegram_commands.py`) `_NOT_CONNECTED_MSG` 직접 비교 영역.
 # Backwards-compat — preserved for legacy tests doing direct equality comparisons.
 _NOT_CONNECTED_MSG = get_text("notifier.commands.not_connected", settings.default_locale)
+
+
+class _OtpAttemptLimiter:  # pylint: disable=too-few-public-methods
+    """telegram_user_id별 OTP 실패 시도 슬라이딩 윈도우 레이트 리미터 (C12).
+    Per-telegram_user_id sliding-window rate limiter for failed OTP attempts (C12).
+
+    잘못된 `/connect` 시도만 기록하고(성공 시 clear), 윈도우 내 실패가
+    OTP_MAX_FAILED_ATTEMPTS 이상이면 추가 조회 전에 차단해 brute-force 를 막는다.
+    `BotInteractionLimiter`(webhook/loop_guard.py)와 동형 — deque 슬라이딩 윈도우 + lock.
+    Records only failed `/connect` attempts (cleared on success); once failures within
+    the window reach OTP_MAX_FAILED_ATTEMPTS it blocks before the next lookup.
+    Mirrors `BotInteractionLimiter` (webhook/loop_guard.py): deque sliding window + lock.
+
+    수용된 한계 (단일 worker 전제): is_blocked → 조회 → record_failure 가 별도 lock
+    구간이라 동시 요청이 차단 검사를 함께 통과해 한 버스트에서 한도를 소폭 초과할 수
+    있다(TOCTOU). 실패는 여전히 기록되어 다음 요청부터 차단되므로 brute-force 차단
+    기능은 유지되며, 단일 worker(railway.toml) 환경에서 실용 위험은 낮다. 다중 worker
+    전환 시 atomic check-and-record 로 재검토.
+    Accepted limit (single-worker): is_blocked → lookup → record_failure span separate
+    lock regions, so concurrent requests may overshoot the cap slightly in one burst
+    (TOCTOU). Failures are still recorded and subsequent requests are blocked, so the
+    brute-force guard holds; practical risk is low on a single worker (railway.toml).
+    Revisit with an atomic check-and-record when moving to multiple workers.
+    """
+
+    def __init__(self) -> None:
+        # telegram_user_id → 실패 타임스탬프 deque
+        # telegram_user_id → deque of failure timestamps
+        self._failures: dict[str, deque[float]] = {}
+        # 멀티스레드(asyncio.to_thread 등) 환경에서 _failures 접근 보호
+        # Protect _failures access under multi-threaded execution (asyncio.to_thread, etc.)
+        self._lock = threading.Lock()
+
+    def is_blocked(self, key: str) -> bool:
+        """현재 윈도우 내 실패 횟수가 한도 이상이면 True (차단).
+        Return True when failures within the current window have reached the cap.
+        """
+        now = time.time()
+        cutoff = now - OTP_ATTEMPT_WINDOW_SECONDS
+        with self._lock:
+            window = self._failures.get(key)
+            if not window:
+                return False
+            # 만료(윈도우 밖) 타임스탬프 제거 후 카운트
+            # Evict expired timestamps, then count
+            while window and window[0] <= cutoff:
+                window.popleft()
+            return len(window) >= OTP_MAX_FAILED_ATTEMPTS
+
+    def record_failure(self, key: str) -> None:
+        """실패 시도 1건을 기록한다 (만료분 제거 + 키 상한 적용).
+        Record one failed attempt (evict expired entries + enforce the key cap).
+        """
+        now = time.time()
+        cutoff = now - OTP_ATTEMPT_WINDOW_SECONDS
+        with self._lock:
+            window = self._failures.get(key)
+            if window is None:
+                # 신규 키 추가 전 상한 도달 시 만료 키부터 정리 (메모리 고갈 방지)
+                # At the cap before adding a new key, evict stale keys first (memory guard)
+                if len(self._failures) >= OTP_LIMITER_MAX_KEYS:
+                    self._evict_stale(cutoff)
+                window = self._failures.setdefault(key, deque())
+            while window and window[0] <= cutoff:
+                window.popleft()
+            window.append(now)
+
+    def clear(self, key: str) -> None:
+        """성공 시 해당 키의 실패 기록을 제거한다 (정상 사용자 오타 보호).
+        Clear failure history for the key on success (don't penalize legit typos).
+        """
+        with self._lock:
+            self._failures.pop(key, None)
+
+    def _evict_stale(self, cutoff: float) -> None:
+        """만료(윈도우 전부 지난) 키를 제거한다 — 호출자가 lock 보유 중.
+        Drop keys whose entire window has expired — caller holds the lock.
+        """
+        stale = [k for k, w in self._failures.items() if not w or w[-1] <= cutoff]
+        for k in stale:
+            del self._failures[k]
+        # 정리 후에도 상한 초과면 가장 오래된 활동 키부터 제거 (안전망)
+        # If still over the cap, drop oldest-active keys as a safety net
+        if len(self._failures) >= OTP_LIMITER_MAX_KEYS:
+            oldest = sorted(self._failures, key=lambda k: self._failures[k][-1])
+            for k in oldest[: len(self._failures) - OTP_LIMITER_MAX_KEYS + 1]:
+                del self._failures[k]
+
+
+# 모듈 레벨 싱글톤 — 테스트는 conftest `_clear_otp_attempt_limiter` autouse fixture 로 클리어
+# Module-level singleton — tests clear it via the conftest `_clear_otp_attempt_limiter` autouse fixture
+_otp_limiter = _OtpAttemptLimiter()
 
 
 @dataclass(frozen=True)
@@ -176,10 +276,18 @@ def _handle_connect(db: Session, telegram_user_id: str, otp: str) -> str:
     if not otp:
         return get_text("notifier.commands.connect_usage", default_lang)
 
+    # C12: brute-force 방어 — 동일 telegram_user_id 의 실패 누적이 한도 초과 시 조회 전 차단
+    # C12: brute-force guard — block before lookup once this telegram_user_id's failures exceed the cap
+    if _otp_limiter.is_blocked(telegram_user_id):
+        return get_text("notifier.commands.connect_rate_limited", default_lang)
+
     # 만료되지 않은 OTP로 사용자 조회
     # Look up user by unexpired OTP
     found = user_repo.find_by_otp(db, otp)
     if found is None:
+        # C12: 실패 기록 — 반복 추측이 윈도우 내 누적되면 차단으로 이어진다
+        # C12: record the failure — repeated guesses accumulate within the window toward a block
+        _otp_limiter.record_failure(telegram_user_id)
         return get_text("notifier.commands.connect_invalid_otp", default_lang)
 
     try:
@@ -187,9 +295,15 @@ def _handle_connect(db: Session, telegram_user_id: str, otp: str) -> str:
         # Map telegram_user_id and nullify OTP
         user_repo.set_telegram_user_id(db, found.id, telegram_user_id)
     except ValueError:
-        # 이미 다른 사용자에게 연결된 Telegram ID
-        # Telegram ID already linked to another user
+        # 이미 다른 사용자에게 연결된 Telegram ID — 연결 실패이므로 카운터 미초기화
+        # Telegram ID already linked to another user — connect failed, so do NOT clear the counter
         return get_text("notifier.commands.connect_already_linked", default_lang)
+
+    # C12: 연결 성공 = brute-force 아님 → 실패 카운터 초기화 (정상 사용자 오타 보호)
+    # set_telegram_user_id 성공 이후에만 clear — 실패(ValueError) 시 카운터 보존
+    # C12: a successful link means this isn't a brute-force → clear the counter (protect legit typos)
+    # Clear only after set_telegram_user_id succeeds — preserve the counter on failure (ValueError)
+    _otp_limiter.clear(telegram_user_id)
 
     # 연결 성공 응답 = 연결된 User 의 preferred_language 적용 (즉시 다국어 활성화)
     # Connect success = linked User.preferred_language (immediate i18n activation)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,16 @@ def _clear_user_repos_cache():
 
 
 @pytest.fixture(autouse=True)
+def _clear_otp_attempt_limiter():
+    # Telegram OTP brute-force 슬라이딩 윈도우 (C12) — 모듈 레벨 싱글톤, 테스트 간 격리
+    # Telegram OTP brute-force sliding window (C12) — module-level singleton, isolate per test
+    from src.notifier.telegram_commands import _otp_limiter  # pylint: disable=import-outside-toplevel
+    _otp_limiter._failures.clear()
+    yield
+    _otp_limiter._failures.clear()
+
+
+@pytest.fixture(autouse=True)
 def _reset_rate_limiter():
     """Rate limiter 인메모리 카운터를 테스트마다 초기화한다 — 테스트 간 rate limit 누적 방지.
     Reset in-memory rate limiter counters between tests to prevent cross-test leakage.

--- a/tests/unit/notifier/test_otp_attempt_limiter.py
+++ b/tests/unit/notifier/test_otp_attempt_limiter.py
@@ -1,0 +1,109 @@
+"""_OtpAttemptLimiter 단위 테스트 — OTP brute-force 슬라이딩 윈도우 (C12).
+Unit tests for _OtpAttemptLimiter — OTP brute-force sliding window (C12).
+
+`time.time` 을 patch 해 윈도우 슬라이딩을 결정론적으로 검증한다.
+Patches `time.time` to verify window sliding deterministically.
+"""
+# pylint: disable=redefined-outer-name
+import os
+
+# src 모듈 임포트 전 환경변수 주입 필수
+# Inject env vars before any src.* import that triggers Settings() loading
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+from unittest.mock import patch
+
+import pytest
+
+from src.constants import (
+    OTP_ATTEMPT_WINDOW_SECONDS,
+    OTP_LIMITER_MAX_KEYS,
+    OTP_MAX_FAILED_ATTEMPTS,
+)
+from src.notifier.telegram_commands import _OtpAttemptLimiter
+
+
+@pytest.fixture()
+def limiter() -> _OtpAttemptLimiter:
+    """매 테스트마다 새 limiter 인스턴스 (격리)."""
+    return _OtpAttemptLimiter()
+
+
+def test_not_blocked_initially(limiter):
+    """기록이 없으면 차단되지 않는다."""
+    assert limiter.is_blocked("tg-1") is False
+
+
+def test_blocks_after_max_failures(limiter):
+    """윈도우 내 실패가 한도에 도달하면 차단한다."""
+    for _ in range(OTP_MAX_FAILED_ATTEMPTS):
+        assert limiter.is_blocked("tg-1") is False
+        limiter.record_failure("tg-1")
+    # 한도 도달 — 이후 차단
+    # Cap reached — now blocked
+    assert limiter.is_blocked("tg-1") is True
+
+
+def test_clear_resets_failures(limiter):
+    """clear 호출 시 실패 기록이 초기화된다 (성공 사용자 보호)."""
+    for _ in range(OTP_MAX_FAILED_ATTEMPTS):
+        limiter.record_failure("tg-1")
+    assert limiter.is_blocked("tg-1") is True
+    limiter.clear("tg-1")
+    assert limiter.is_blocked("tg-1") is False
+
+
+def test_per_key_isolation(limiter):
+    """telegram_user_id 별로 카운터가 독립적이다."""
+    for _ in range(OTP_MAX_FAILED_ATTEMPTS):
+        limiter.record_failure("tg-attacker")
+    assert limiter.is_blocked("tg-attacker") is True
+    # 다른 사용자는 영향 없음
+    # A different user is unaffected
+    assert limiter.is_blocked("tg-victim") is False
+
+
+def test_window_slides_after_expiry(limiter):
+    """윈도우 경과 후 옛 실패는 만료되어 다시 허용된다."""
+    base = 1000.0
+    with patch("src.notifier.telegram_commands.time.time") as mock_time:
+        mock_time.return_value = base
+        for _ in range(OTP_MAX_FAILED_ATTEMPTS):
+            limiter.record_failure("tg-1")
+        assert limiter.is_blocked("tg-1") is True
+
+        # 윈도우 + 1초 경과 → 만료 → 차단 해제
+        # Advance past the window → entries expire → unblocked
+        mock_time.return_value = base + OTP_ATTEMPT_WINDOW_SECONDS + 1
+        assert limiter.is_blocked("tg-1") is False
+
+
+def test_partial_window_still_blocks(limiter):
+    """윈도우 일부만 경과하면 옛 실패가 여전히 유효해 차단 유지."""
+    base = 2000.0
+    with patch("src.notifier.telegram_commands.time.time") as mock_time:
+        mock_time.return_value = base
+        for _ in range(OTP_MAX_FAILED_ATTEMPTS):
+            limiter.record_failure("tg-1")
+        # 윈도우 절반만 경과 → 여전히 차단
+        # Only half the window elapsed → still blocked
+        mock_time.return_value = base + OTP_ATTEMPT_WINDOW_SECONDS / 2
+        assert limiter.is_blocked("tg-1") is True
+
+
+def test_key_dict_bounded(limiter):
+    """추적 키 수가 상한(OTP_LIMITER_MAX_KEYS)을 초과해 무한 증가하지 않는다."""
+    base = 5000.0
+    with patch("src.notifier.telegram_commands.time.time") as mock_time:
+        mock_time.return_value = base
+        # 상한 + 여유분 만큼 만료된 키를 생성
+        # Create more keys than the cap, all in an expired window
+        for i in range(OTP_LIMITER_MAX_KEYS + 50):
+            limiter.record_failure(f"tg-{i}")
+        # 새 키 추가 시 만료/정리되어 상한 이내 유지
+        # On insert, stale eviction keeps the dict within the cap
+        mock_time.return_value = base + OTP_ATTEMPT_WINDOW_SECONDS + 1
+        limiter.record_failure("tg-fresh")
+        assert len(limiter._failures) <= OTP_LIMITER_MAX_KEYS

--- a/tests/unit/notifier/test_telegram_commands.py
+++ b/tests/unit/notifier/test_telegram_commands.py
@@ -281,6 +281,121 @@ def test_handle_connect_requires_otp_argument(db):
 
 
 # ---------------------------------------------------------------------------
+# Test: handle_message_command — /connect OTP brute-force rate-limit (C12)
+# ---------------------------------------------------------------------------
+
+
+def test_handle_connect_blocks_after_repeated_wrong_otp(db):
+    """동일 telegram_user_id 의 반복된 잘못된 OTP 시도는 한도 초과 시 차단된다.
+    Repeated wrong-OTP guesses from the same telegram_user_id are blocked past the cap.
+    """
+    from src.constants import OTP_MAX_FAILED_ATTEMPTS
+
+    # 한도까지는 "잘못된 OTP" 응답 (find_by_otp None → 실패 기록)
+    # Up to the cap: each returns the invalid-OTP message and records a failure
+    for _ in range(OTP_MAX_FAILED_ATTEMPTS):
+        result = handle_message_command(db, "tg-brute", "/connect 000000")
+        assert "OTP" in result
+
+    # 한도 초과 — rate-limit 메시지 (DB 조회조차 하지 않음)
+    # Past the cap — rate-limit message (no DB lookup performed)
+    blocked = handle_message_command(db, "tg-brute", "/connect 000000")
+    assert "OTP" not in blocked  # invalid_otp 가 아닌 별도 메시지
+    assert "많" in blocked or "many" in blocked.lower() or "시도" in blocked
+
+
+def test_handle_connect_block_is_per_telegram_user(db):
+    """한 사용자가 차단돼도 다른 telegram_user_id 는 정상 시도 가능하다.
+    Blocking one user does not affect a different telegram_user_id.
+    """
+    from src.constants import OTP_MAX_FAILED_ATTEMPTS
+
+    for _ in range(OTP_MAX_FAILED_ATTEMPTS + 1):
+        handle_message_command(db, "tg-attacker", "/connect 999999")
+
+    # 차단된 공격자
+    blocked = handle_message_command(db, "tg-attacker", "/connect 999999")
+    assert "many" in blocked.lower() or "많" in blocked or "시도" in blocked
+
+    # 다른 사용자는 정상적으로 invalid_otp 응답을 받는다
+    # A different user still gets the normal invalid-OTP response
+    other = handle_message_command(db, "tg-innocent", "/connect 111111")
+    assert "OTP" in other
+
+
+def test_handle_connect_success_resets_failure_counter(db):
+    """잘못된 시도 후 유효 OTP 로 성공하면 실패 카운터가 초기화된다.
+    A successful connect after some wrong tries resets the failure counter.
+    """
+    from src.constants import OTP_MAX_FAILED_ATTEMPTS
+
+    future = datetime.now(timezone.utc) + timedelta(minutes=10)
+    _make_user(
+        db,
+        github_id="gh-reset",
+        email="reset@example.com",
+        display_name="ResetUser",
+        telegram_otp="555555",
+        telegram_otp_expires_at=future,
+    )
+
+    # 한도 미만의 실패 (한도-1)
+    # Fewer failures than the cap (cap - 1)
+    for _ in range(OTP_MAX_FAILED_ATTEMPTS - 1):
+        handle_message_command(db, "tg-reset", "/connect 000000")
+
+    # 유효 OTP 성공 → 카운터 초기화
+    # Valid OTP succeeds → counter cleared
+    ok = handle_message_command(db, "tg-reset", "/connect 555555")
+    assert "ResetUser" in ok
+
+    # 초기화되었으므로 다시 한도-1 회 실패해도 차단되지 않는다
+    # Counter cleared → another (cap - 1) failures still not blocked
+    for _ in range(OTP_MAX_FAILED_ATTEMPTS - 1):
+        result = handle_message_command(db, "tg-reset", "/connect 000000")
+        assert "OTP" in result  # 여전히 invalid_otp (차단 아님)
+
+
+def test_handle_connect_already_linked_preserves_failure_counter(db):
+    """🔴 C12 NG fix (Codex mutual): 유효 OTP 를 맞췄으나 set 이 already_linked
+    (ValueError)로 실패하면 연결 실패이므로 실패 카운터를 초기화하지 않는다.
+    A valid OTP that fails at set (already linked) must NOT reset the counter —
+    clear() runs only after set_telegram_user_id succeeds.
+    """
+    from src.constants import OTP_MAX_FAILED_ATTEMPTS
+    from src.notifier.telegram_commands import _otp_limiter
+
+    future = datetime.now(timezone.utc) + timedelta(minutes=10)
+    _make_user(
+        db,
+        github_id="gh-linked",
+        email="linked@example.com",
+        display_name="LinkedUser",
+        telegram_otp="777777",
+        telegram_otp_expires_at=future,
+    )
+
+    # 한도-1 회 실패 누적
+    # Accumulate (cap - 1) failures
+    for _ in range(OTP_MAX_FAILED_ATTEMPTS - 1):
+        handle_message_command(db, "tg-linked", "/connect 000000")
+    assert len(_otp_limiter._failures.get("tg-linked", [])) == OTP_MAX_FAILED_ATTEMPTS - 1
+
+    # 유효 OTP 이지만 set 이 ValueError → already_linked 응답 (연결 실패)
+    # Valid OTP but set raises ValueError → already_linked response (connect failed)
+    with patch(
+        "src.notifier.telegram_commands.user_repo.set_telegram_user_id",
+        side_effect=ValueError("already mapped"),
+    ):
+        result = handle_message_command(db, "tg-linked", "/connect 777777")
+    assert "이미" in result or "already" in result.lower()
+
+    # 카운터 미초기화 — 여전히 한도-1 (clear 가 set 성공 후에만 실행되므로)
+    # Counter preserved — still (cap - 1), because clear runs only after set succeeds
+    assert len(_otp_limiter._failures.get("tg-linked", [])) == OTP_MAX_FAILED_ATTEMPTS - 1
+
+
+# ---------------------------------------------------------------------------
 # Test: handle_message_command — /stats
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 요약

정합성 감사 백로그 **C12** — Telegram OTP brute-force rate-limit (사용자 결정 ⓐ: in-memory 슬라이딩 윈도우).

`/connect <otp>` 는 6자리 숫자 OTP(공간 10⁶)·TTL 5분이며, `find_by_otp` 호출 전 시도횟수 체크가 없었다. 게다가 `find_by_otp` 는 **만료되지 않은 *모든* 사용자의 OTP** 와 매칭되어, 동시 유효 OTP 가 N개면 무작위 추측 적중 확률이 ~N배로 증가한다. webhook HMAC 인증은 정규 Telegram 사용자의 반복 추측을 막지 못하고, IP `@limiter` 는 단일 Telegram IP 라 부적합(api.md 컨벤션).

→ `telegram_user_id` 별 **슬라이딩 윈도우로 실패 시도만 카운트**해 한도(5회/300초) 초과 시 조회 전 차단.

## 변경 내용

| 파일 | 변경 |
|------|------|
| `src/notifier/telegram_commands.py` | `_OtpAttemptLimiter`(deque 슬라이딩 윈도우 + `threading.Lock`, `BotInteractionLimiter` 동형) + 모듈 싱글톤 + `_handle_connect` 통합(차단→조회→실패 시 record→**성공 시에만 clear**) |
| `src/constants.py` | `OTP_MAX_FAILED_ATTEMPTS=5`·`OTP_ATTEMPT_WINDOW_SECONDS=300`·`OTP_LIMITER_MAX_KEYS=2048`(메모리 가드, `WEBHOOK_SECRET_CACHE_MAX` 패턴) |
| `src/i18n/translations/{en,ko,ja}.json` | `notifier.commands.connect_rate_limited` 3언어 |
| `tests/conftest.py` | `_clear_otp_attempt_limiter` autouse(모듈 싱글톤 테스트 격리) |
| `tests/unit/notifier/test_otp_attempt_limiter.py` | limiter 클래스 단위 7건(차단/만료/슬라이딩/per-key/clear/키 상한) |
| `tests/unit/notifier/test_telegram_commands.py` | `_handle_connect` 통합 4건(차단/per-user/성공 reset/**already_linked 카운터 보존**) |

## 설계 결정 (자율 판단 보고 — 정책 3)

- **실패만 카운트 + 성공 시 clear**: 정상 사용자의 오타를 페널티화하지 않음. `set_telegram_user_id` 성공 이후에만 clear(연결 실패=카운터 보존).
- **키 상한(2048)**: telegram_user_id 다수 유입 시 dict 무한 증가 차단. `WEBHOOK_SECRET_CACHE_MAX` 패턴 재사용(정책 16 최소 추상화).
- **TOCTOU(수용)**: is_blocked→조회→record 가 별도 lock 구간이라 동시 요청이 한 버스트에서 한도를 소폭 초과 가능. 실패는 여전히 기록되어 다음 요청부터 차단되므로 brute-force 차단 기능은 유지. 단일 worker(railway.toml) 환경 실용 위험 낮음 → docstring 명시 + 다중 worker 전환 시 atomic 재검토.

## 검증

- 로컬: `tests/unit/notifier/` **264 통과** (신규 11 포함) · pylint **10.00/10** · flake8 clean
- korean-scan 회귀 가드(`test_no_hardcoded_korean_in_send_modules.py`) 통과 — rate-limit 메시지는 i18n 키 경유

## 🔍 사용자 검증 필요

- [ ] (운영) Telegram 봇에 잘못된 `/connect 000000` 을 6회 반복 시 6번째부터 "시도 횟수가 너무 많습니다…" 응답 확인
- [ ] (운영) 5분 경과 후 동일 사용자 재시도 가능(윈도우 슬라이딩) 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex 검증 의뢰 완료 — **Codex mutual OK 수신 후 push**
  - R1 **NG**: `clear()` 가 `set_telegram_user_id` 전에 있어 already_linked 시 카운터 오초기화 → **단일 정답 버그 회귀 NG** 라 동일 PR 즉시 수정(clear 를 set 성공 후로 이동 + 회귀 테스트 + TOCTOU docstring).
  - R2 **OK — push 가능**: clear 위치(306)·ValueError 경로 카운터 보존·회귀 테스트·TOCTOU docstring 전부 확인, 잔여 우려 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
