### PR TITLE
fix(pipeline): AI 리뷰 diff 절단 마커 → auto-merge/approve 차단 (정합성 감사 C22)

### DIFF
--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -17,7 +17,11 @@ from dataclasses import dataclass, field
 
 import anthropic
 
-from src.analyzer.pure.review_prompt import build_review_prompt, get_system_prompt
+from src.analyzer.pure.review_prompt import (
+    MAX_DIFF_CHARS,
+    build_review_prompt,
+    get_system_prompt,
+)
 from src.config import settings
 from src.constants import (
     AI_DEFAULT_COMMIT_RAW, AI_DEFAULT_DIRECTION_RAW, AI_DEFAULT_TEST_RAW,
@@ -52,6 +56,11 @@ class AiReviewResult:  # pylint: disable=too-many-instance-attributes
     # 실제 사용된 모델명 — None = 전역 기본값 사용
     # Actual model used — None means global default was used
     used_model: str | None = None
+    # C22: diff 가 MAX_DIFF_CHARS 로 잘렸는지 — 잘린 부분 미검토로 점수가 인플레될 수 있어
+    # auto-merge/auto-approve 차단 마커(ai_review_truncated)로 전파된다(static_analysis_incomplete 대칭).
+    # C22: whether the diff was truncated at MAX_DIFF_CHARS — the unseen part may inflate the score,
+    # so it propagates as an auto-merge/approve block marker (mirrors static_analysis_incomplete).
+    truncated: bool = False
 
 
 async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching + 예외 분기로 인한 누적 (사이클 84 i18n)
@@ -83,6 +92,12 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
     )
     if not diff_text.strip():
         return _default_result("empty_diff")
+
+    # C22: 프롬프트에 들어가는 diff 가 MAX_DIFF_CHARS 로 잘렸는지 판정 (build_review_prompt 와 동일 길이 기준).
+    # 잘렸다면 리뷰는 성공해도 일부만 보고 채점한 것이라 점수가 인플레될 수 있어 마커로 전파한다.
+    # C22: detect whether the diff fed into the prompt was truncated at MAX_DIFF_CHARS (same length basis
+    # as build_review_prompt). If so, the review scored only a partial diff → propagate as a marker.
+    was_truncated = len(diff_text) > MAX_DIFF_CHARS
 
     # Anthropic SDK 기본 timeout=600s 는 BackgroundTask 슬롯을 10분 점유 위험.
     # HTTP_CLIENT_TIMEOUT 보다 여유 두고 60s 로 설정 — 평균 응답 5-15s 대비 충분.
@@ -131,6 +146,12 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
         result.input_tokens = input_tokens
         result.output_tokens = output_tokens
         result.used_model = model
+        # C22: 절단 마커 — 파싱까지 성공(status=="success")한 경우에만 설정. parse_error 는
+        # ai_review_failed 가 차단을 담당하므로 truncated 는 False 유지(success 경로 한정 불변식).
+        # C22: set the truncation marker only on a genuine success (status=="success"). parse_error is
+        # handled by ai_review_failed, so leave truncated False (success-path-only invariant).
+        if result.status == "success":
+            result.truncated = was_truncated
         return result
     except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
         # anthropic/httpx 는 다양한 예외를 발생시킬 수 있음 — 모두 graceful fallback

--- a/src/gate/actions/approve.py
+++ b/src/gate/actions/approve.py
@@ -59,6 +59,16 @@ class ApproveAction(GateAction):
                 ctx.repo_name, ctx.pr_number,
             )
             return
+        # C22: AI 리뷰 diff 절단(truncated) 시 보류 — 잘린 부분 미검토로 점수가 인플레될 수
+        # 있고, auto-approve 가 branch-protection 자동머지를 간접 트리거할 수 있어 결정하지 않는다.
+        # C22: hold auto-approve when the AI-review diff was truncated — the unseen part may inflate
+        # the score and auto-approve could indirectly trigger branch-protection auto-merge.
+        if ctx.result.get("ai_review_truncated"):
+            logger.warning(
+                "AI review diff truncated — auto-approve skipped (repo=%s, pr=%s)",
+                ctx.repo_name, ctx.pr_number,
+            )
+            return
         # AI 리뷰 실제 실패(api_error/parse_error) 시도 보류 — 중립-고점 기본값이 점수를
         # 인플레이션하고, auto-approve 가 branch-protection "approval 시 자동머지" 를 간접
         # 트리거할 수 있으므로 결정을 내리지 않는다 (#8, auto-merge 가드의 approve 경로 확장).
@@ -113,6 +123,16 @@ class ApproveAction(GateAction):
         if ctx.result.get("static_analysis_incomplete"):
             logger.warning(
                 "static analysis incomplete — semi-auto approve skipped (repo=%s, pr=%s)",
+                ctx.repo_name, ctx.pr_number,
+            )
+            return
+        # C22: AI 리뷰 diff 절단(truncated) 시 미발송 — 절단된 일부만 보고 매긴 인플레 점수를
+        # 사람 승인 버튼으로 노출하면 오해된 점수로 approve+merge 될 수 있다 (_run_auto 가드 대칭).
+        # C22: don't send when the AI-review diff was truncated — showing a partial-diff inflated
+        # score on a human approval button could lead to approve+merge (mirrors _run_auto).
+        if ctx.result.get("ai_review_truncated"):
+            logger.warning(
+                "AI review diff truncated — semi-auto approve skipped (repo=%s, pr=%s)",
                 ctx.repo_name, ctx.pr_number,
             )
             return

--- a/src/gate/actions/auto_merge.py
+++ b/src/gate/actions/auto_merge.py
@@ -50,6 +50,16 @@ class AutoMergeAction(GateAction):
                 ctx.repo_name, ctx.pr_number,
             )
             return
+        # C22: AI 리뷰 diff 절단(truncated) 시 차단 — 잘린 부분 미검토로 점수가 인플레될 수
+        # 있어 자동 머지하지 않는다 (static_analysis_incomplete 대칭).
+        # C22: block when the AI-review diff was truncated — the unseen part may inflate the score,
+        # so never auto-merge it (mirrors static_analysis_incomplete).
+        if ctx.result.get("ai_review_truncated"):
+            logger.warning(
+                "AI review diff truncated — auto-merge skipped (repo=%s, pr=%s)",
+                ctx.repo_name, ctx.pr_number,
+            )
+            return
         # AI 리뷰 실제 실패(api_error/parse_error) 시도 차단 — 중립-고점 기본값(44점)이
         # 점수를 인플레이션해 미검증 코드가 자동 머지되는 fail-open 방지 (#8, 정적분석 대칭).
         # Also block when the AI review genuinely failed — its neutral-high defaults inflate

--- a/src/webhook/providers/telegram.py
+++ b/src/webhook/providers/telegram.py
@@ -164,17 +164,19 @@ async def handle_gate_callback(  # pylint: disable=too-many-locals
             # _run_auto_merge 가 자체 SessionLocal 을 열고 auto_merge/threshold 가드를 내부 수행한다.
             # 가드는 자동 경로 AutoMergeAction 미러링: (1) 승인 결정만 머지(reject 시 금지),
             # (2) auto_merge 활성, (3) 정적분석 불완전(타임아웃) 시 차단(#779/#783),
-            # (4) AI 리뷰 실제 실패(api_error/parse_error) 시 차단(#8 — 인플레 점수 자동 머지 방지).
+            # (4) AI 리뷰 실제 실패(api_error/parse_error) 시 차단(#8 — 인플레 점수 자동 머지 방지),
+            # (5) AI 리뷰 diff 절단 시 차단(C22 — 잘린 일부만 본 인플레 점수 자동 머지 방지).
             # Delegate semi-auto merge to the automatic path for full parity (retry queue, SHA guard,
             # CI re-check, terminal/deferred notifications). _run_auto_merge opens its own session and
             # applies the auto_merge/threshold guard internally. Guards mirror AutoMergeAction:
             # (1) merge only on approve, (2) auto_merge enabled, (3) skip on incomplete static analysis,
-            # (4) skip on genuine AI review failure (#8).
+            # (4) skip on genuine AI review failure (#8), (5) skip on truncated AI-review diff (C22).
             if (
                 decision == "approve"
                 and config.auto_merge
                 and not result_dict.get("static_analysis_incomplete")
                 and not ai_review_failed(result_dict)
+                and not result_dict.get("ai_review_truncated")
             ):
                 from src.gate import engine  # pylint: disable=import-outside-toplevel
                 await engine._run_auto_merge(  # pylint: disable=protected-access

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -74,6 +74,11 @@ def build_analysis_result_dict(
         "grade": score_result.grade,
         "breakdown": score_result.breakdown,
         "ai_review_status": ai_review.status,
+        # C22: diff 절단 마커 — auto-merge/auto-approve 차단 (static_analysis_incomplete 대칭).
+        # getattr 기본 False: truncated 미보유 구 레코드/더블 안전.
+        # C22: diff-truncation marker — blocks auto-merge/approve (mirrors static_analysis_incomplete).
+        # getattr default False keeps legacy records/doubles without the field safe.
+        "ai_review_truncated": bool(getattr(ai_review, "truncated", False)),
         "ai_summary": ai_review.summary,
         "ai_suggestions": ai_review.suggestions,
         "commit_message_feedback": ai_review.commit_message_feedback,

--- a/tests/unit/analyzer/io/test_ai_review.py
+++ b/tests/unit/analyzer/io/test_ai_review.py
@@ -124,6 +124,73 @@ async def test_review_code_calls_anthropic_and_parses():
     assert result.test_score == 10
 
 
+def test_ai_review_result_truncated_defaults_false():
+    """🔴 C22: AiReviewResult.truncated 기본값은 False (잘리지 않음)."""
+    assert AiReviewResult(commit_score=1, ai_score=1, test_score=1, summary="").truncated is False
+
+
+async def test_review_code_marks_truncated_when_diff_exceeds_limit():
+    """🔴 C22: 합쳐진 diff 가 MAX_DIFF_CHARS 초과 시 result.truncated=True (성공 경로).
+    Truncation marker is set when the assembled diff exceeds MAX_DIFF_CHARS.
+    """
+    from src.analyzer.pure.review_prompt import MAX_DIFF_CHARS  # pylint: disable=import-outside-toplevel
+
+    mock_response = MagicMock()
+    mock_text = json.dumps({"commit_message_score": 18, "direction_score": 17,
+                            "test_score": 10, "summary": "ok", "suggestions": []})
+    mock_response.content = [MagicMock(text=mock_text)]
+
+    big_patch = [("big.py", "x" * (MAX_DIFF_CHARS + 5000))]  # 절단 유발
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        mock_cls.return_value = mock_client
+
+        result = await review_code("sk-test", "feat: big change", big_patch)
+
+    assert result.truncated is True
+    assert result.status == "success"  # 절단이어도 리뷰 자체는 성공
+
+
+async def test_review_code_truncated_false_when_parse_error_on_large_diff():
+    """🔴 C22 NG-1 fix (Codex mutual): 큰 diff 라도 응답 파싱 실패(parse_error)면
+    truncated=False 유지 — success 경로 한정 불변식 (차단은 ai_review_failed 담당).
+    A large diff with a parse_error must NOT set truncated (success-path-only invariant).
+    """
+    from src.analyzer.pure.review_prompt import MAX_DIFF_CHARS  # pylint: disable=import-outside-toplevel
+
+    mock_response = MagicMock()
+    mock_response.content = [MagicMock(text="not valid json at all")]  # → parse_error
+
+    big_patch = [("big.py", "x" * (MAX_DIFF_CHARS + 5000))]
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        mock_cls.return_value = mock_client
+
+        result = await review_code("sk-test", "feat: big", big_patch)
+
+    assert result.status == "parse_error"
+    assert result.truncated is False  # success 경로 아님 → 마커 미설정
+
+
+async def test_review_code_not_truncated_for_small_diff():
+    """🔴 C22: 작은 diff 는 result.truncated=False."""
+    mock_response = MagicMock()
+    mock_text = json.dumps({"commit_message_score": 18, "direction_score": 17,
+                            "test_score": 10, "summary": "ok", "suggestions": []})
+    mock_response.content = [MagicMock(text=mock_text)]
+
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.messages.create = AsyncMock(return_value=mock_response)
+        mock_cls.return_value = mock_client
+
+        result = await review_code("sk-test", "feat: small", [("app.py", "+ x = 1")])
+
+    assert result.truncated is False
+
+
 async def test_review_code_returns_default_on_api_exception():
     with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic") as mock_cls:
         mock_client = AsyncMock()

--- a/tests/unit/gate/test_gate_actions.py
+++ b/tests/unit/gate/test_gate_actions.py
@@ -207,6 +207,25 @@ async def test_approve_action_semi_auto_skips_when_static_analysis_incomplete():
 
 
 @pytest.mark.asyncio
+async def test_approve_action_semi_auto_skips_when_ai_review_truncated():
+    """🔴 C22: AI 리뷰 diff 절단(truncated) 시 semi-auto 승인 요청 미발송 (static 가드 대칭).
+    절단된 일부만 보고 매긴 점수가 인플레될 수 있으므로 사람 승인 버튼으로 노출하지 않는다.
+    """
+    from src.gate.actions.approve import ApproveAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(approve_mode="semi-auto")
+    cfg.notify_chat_id = "-100123"
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        result={"score": 90, "ai_review_truncated": True},  # 90 >= threshold 이나 diff 절단
+        github_token="ghp_test", config=cfg, score=90,
+    )
+    with patch("src.gate.actions.approve.send_gate_request", new=AsyncMock()) as mock_gate:
+        await ApproveAction().execute(ctx)
+    mock_gate.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_approve_action_auto_skips_when_static_analysis_incomplete():
     """정적분석 불완전(타임아웃) 시 score 충족이어도 post_github_review 를 호출하지 않아야 한다.
     Must not call post_github_review even when score qualifies, if static analysis is incomplete.
@@ -219,6 +238,28 @@ async def test_approve_action_auto_skips_when_static_analysis_incomplete():
     ctx = GateContext(
         repo_name="owner/repo", pr_number=42, analysis_id=1,
         result={"score": 90, "static_analysis_incomplete": True},  # 90 >= threshold(70) 이나 불완전
+        github_token="ghp_test", config=cfg, score=90,
+    )
+    with patch("src.gate.actions.approve.post_github_review", new=AsyncMock()) as mock_review, \
+         patch("src.gate.actions.approve.gate_decision_repo"), \
+         patch("src.gate.actions.approve.SessionLocal") as mock_sess:
+        mock_sess.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_sess.return_value.__exit__ = MagicMock(return_value=False)
+        await ApproveAction().execute(ctx)
+    mock_review.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_approve_action_auto_skips_when_ai_review_truncated():
+    """🔴 C22: AI 리뷰 diff 절단(truncated) 시 score 충족이어도 auto-approve 보류 (static 가드 대칭).
+    절단된 부분 미검토로 점수가 인플레될 수 있어 결정을 내리지 않는다.
+    """
+    from src.gate.actions.approve import ApproveAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(approve_mode="auto")
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        result={"score": 90, "ai_review_truncated": True},  # 90 >= threshold(70) 이나 diff 절단
         github_token="ghp_test", config=cfg, score=90,
     )
     with patch("src.gate.actions.approve.post_github_review", new=AsyncMock()) as mock_review, \
@@ -315,6 +356,24 @@ async def test_auto_merge_action_skips_when_static_analysis_incomplete():
     ctx = GateContext(
         repo_name="owner/repo", pr_number=42, analysis_id=1,
         result={"score": 90, "static_analysis_incomplete": True},  # 90 >= threshold 이나 불완전
+        github_token="ghp_test", config=cfg, score=90,
+    )
+    with patch("src.gate.engine._run_auto_merge", new=AsyncMock()) as mock_impl:
+        await AutoMergeAction().execute(ctx)
+    mock_impl.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_merge_action_skips_when_ai_review_truncated():
+    """🔴 C22: AI 리뷰 diff 절단(truncated) 시 score 충족이어도 _run_auto_merge 미호출 (static 가드 대칭).
+    절단된 부분 미검토로 점수가 인플레될 수 있어 자동 머지하지 않는다.
+    """
+    from src.gate.actions.auto_merge import AutoMergeAction  # pylint: disable=import-outside-toplevel
+    from src.gate.actions import GateContext  # pylint: disable=import-outside-toplevel
+    cfg = _make_config(auto_merge=True)
+    ctx = GateContext(
+        repo_name="owner/repo", pr_number=42, analysis_id=1,
+        result={"score": 90, "ai_review_truncated": True},  # 90 >= threshold 이나 diff 절단
         github_token="ghp_test", config=cfg, score=90,
     )
     with patch("src.gate.engine._run_auto_merge", new=AsyncMock()) as mock_impl:

--- a/tests/unit/webhook/test_telegram_provider.py
+++ b/tests/unit/webhook/test_telegram_provider.py
@@ -177,6 +177,28 @@ async def test_handle_gate_callback_approve_with_auto_merge():
                         assert kw["analysis_id"] == 42
 
 
+async def test_handle_gate_callback_skips_auto_merge_when_ai_review_truncated():
+    """🔴 C22: 반자동 승인이어도 ai_review_truncated=True 면 engine._run_auto_merge 미위임.
+    절단된 일부만 본 인플레 점수의 자동 머지 방지 — AutoMergeAction 가드 미러링(parity).
+    """
+    from src.webhook.router import handle_gate_callback
+    # 90 >= threshold(75) 이나 diff 절단 마커 존재
+    mock_analysis = MagicMock(id=42, repo_id=1, pr_number=5, score=90,
+                              result={"score": 90, "ai_review_truncated": True})
+    mock_repo = MagicMock(id=1, full_name="owner/repo", user_id=1)
+    mock_db = MagicMock()
+    mock_db.query.return_value.filter_by.return_value.first.side_effect = [mock_analysis, mock_repo]
+    config = RepoConfigData(repo_full_name="owner/repo", auto_merge=True, merge_threshold=75)
+    with patch("src.webhook.providers.telegram.SessionLocal", return_value=_ctx(mock_db)):
+        with patch("src.webhook.providers.telegram.post_github_review", new_callable=AsyncMock):
+            with patch("src.webhook.providers.telegram.gate_decision_repo.claim_decision"):
+                with patch("src.webhook.providers.telegram.get_repo_config", return_value=config):
+                    with patch("src.gate.engine._run_auto_merge", new_callable=AsyncMock) as mock_am:
+                        await handle_gate_callback(analysis_id=42, decision="approve",
+                                                   decided_by="john", telegram_user_id="1")
+                        mock_am.assert_not_called()  # 절단 → 자동 머지 위임 차단
+
+
 # --- P1-1 반자동 parity 핵심 테스트 (검증자 단일출처화 → result 전파) ---
 # Semi-auto verifier parity: handle_gate_callback 의 반자동 auto-merge 가 engine._run_auto_merge
 # 에 위임할 때 result=result_dict 를 함께 전달해야 한다 — engine 진입부의 단일출처 검증 가드

--- a/tests/unit/worker/test_pipeline_result_dict.py
+++ b/tests/unit/worker/test_pipeline_result_dict.py
@@ -130,3 +130,31 @@ def test_issues_json_empty_when_no_issues() -> None:
         source="cli",
     )
     assert result["issues"] == [], "이슈 0건 시 빈 리스트여야 함 (None 또는 누락 X)"
+
+
+# ─── C22: ai_review_truncated 마커 전파 ──────────────────────────────────────
+
+
+def test_result_dict_propagates_ai_review_truncated() -> None:
+    """🔴 C22: ai_review.truncated=True → result["ai_review_truncated"]=True (auto-merge 차단 마커)."""
+    ai = _make_ai_review()
+    ai.truncated = True
+    result = build_analysis_result_dict(
+        ai_review=ai,
+        score_result=_make_score_result(),
+        analysis_results=[_StubAnalysisResult(issues=[])],
+        source="pr",
+    )
+    assert result["ai_review_truncated"] is True
+
+
+def test_result_dict_truncated_defaults_false_when_attr_absent() -> None:
+    """🔴 C22: ai_review 에 truncated 속성이 없어도(구 더블/레코드) getattr 기본 False."""
+    # _make_ai_review() 더블은 truncated 속성 미보유 → getattr 기본값 검증
+    result = build_analysis_result_dict(
+        ai_review=_make_ai_review(),
+        score_result=_make_score_result(),
+        analysis_results=[_StubAnalysisResult(issues=[])],
+        source="pr",
+    )
+    assert result["ai_review_truncated"] is False


### PR DESCRIPTION
## 요약

정합성 감사 백로그 **C22** — AI 리뷰 diff 무음 절단 → score-integrity 비대칭 해소 (사용자 결정 ⓐ: truncated 마커 → auto-merge 차단).

`review_prompt.py` 가 `MAX_DIFF_CHARS=16000` 으로 diff 를 무음 절단(`[:MAX_DIFF_CHARS]`)하는데, `AiReviewResult` 에 절단 신호 필드가 없었다. 큰 PR 이 절단된 일부만 보고 채점돼 점수가 인플레돼도 incomplete 가 미전파 → 정적분석 `static_analysis_incomplete`(auto-merge 차단) 와 **비대칭**. `truncated` 마커를 추가해 동일하게 차단한다.

🔴 정책 16 §명시 제외(`build_review_prompt` 토큰예산/prompt 구조)에 **인접**하나, 본 변경은 **prompt 구조·토큰예산을 건드리지 않고** `review_code` 에서 절단 여부만 관측·마커로 전파 → 제외 영역 미접촉.

## 변경 내용

| 파일 | 변경 |
|------|------|
| `src/analyzer/io/ai_review.py` | `AiReviewResult.truncated`(bool, default False). `review_code` 가 `status=="success"` 일 때만 `len(diff_text) > MAX_DIFF_CHARS` 로 설정 |
| `src/worker/pipeline.py` | `build_analysis_result_dict` 에 `ai_review_truncated` 전파(`getattr` 기본 False) |
| `src/gate/actions/auto_merge.py`·`approve.py` | 3 가드(execute·_run_auto·_run_semi_auto) — `static_analysis_incomplete` 직후 동일 위치·동일 early-return |
| `src/webhook/providers/telegram.py` | 반자동 `handle_gate_callback` 인라인 가드에 `and not result_dict.get("ai_review_truncated")` |
| 테스트 (4파일) | review_code 4 + result_dict 2 + gate 3 + telegram 반자동 1 = 10 |

## 설계 결정 (자율 판단 보고 — 정책 3)

- **success 경로 한정**: `parse_error` 시 truncated 미설정(차단은 `ai_review_failed` 담당) — Codex NG-1.
- **4 caller 가드 (engine single-source 대신)**: 기존 `static_analysis_incomplete`·`ai_review_failed` 가 caller 인라인에 배치돼 있어, 동일 레이어로 `ai_review_truncated` 도 4 caller(action 3 + telegram 반자동 1)에 추가 — engine 으로 옮기면 기존 2 마커와 비대칭 → 유지보수 일관성 우선 — Codex NG-2.
- **score NULL-persist 미변경**: `static_analysis_incomplete` 와 동일 — auto-merge/approve 만 차단하고 집계엔 유효 신호로 보존(절단이어도 본 부분의 점수는 실측).

## 검증

- 로컬: 신규 10 + `tests/unit/{analyzer,webhook,gate,worker}/` **1504 통과** · pylint **10.00/10** · flake8 clean

## 🔍 사용자 검증 필요

- [ ] (운영) 16000자 초과 대형 diff PR 에서 auto-merge/semi-auto approve 가 차단되는지(Railway 로그 "AI review diff truncated — ... skipped") 확인
- [ ] (운영) 일반 크기 PR 의 auto-merge/approve 는 영향 없음(회귀 없음) 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex 검증 의뢰 완료 — **Codex mutual OK 수신 후 push**
  - R1 **NG 2건**: (NG-1) parse_error 시 truncated 오설정 → success 경로 한정으로 수정. (NG-2) telegram 반자동이 AutoMergeAction 우회 → 인라인 가드 추가. 둘 다 **단일 정답 버그 회귀** 라 동일 PR 즉시 수정 + 회귀 테스트 2건.
  - R2 **코드 정적 OK**, 샌드박스 pytest 차단 → 로컬 테스트 증거 요청.
  - R3 **OK — push 승인**: 로컬 신규 2 PASS + 회귀 1504 통과 + pylint 10/10 + flake8 clean + `git diff --check` 증거 제출 → 최종 승인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
