### PR TITLE
fix(notifier): CodeQL #516 — _NOT_CONNECTED_MSG 디스패처 단일출처화 (py/unused-global-variable 해소)

### DIFF
--- a/src/notifier/telegram_commands.py
+++ b/src/notifier/telegram_commands.py
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 
 # Phase 3 PR-9 (사이클 84) — 미연결 사용자 공통 안내 메시지 (settings.default_locale 적용).
 # Phase 3 PR-9 (Cycle 84) — common prompt for disconnected users (settings.default_locale).
-# 백워드 호환 — 기존 단위 테스트 (`test_telegram_commands.py`) `_NOT_CONNECTED_MSG` 직접 비교 영역.
-# Backwards-compat — preserved for legacy tests doing direct equality comparisons.
+# 디스패처(handle_telegram_command)의 미연결 응답 단일 출처 + 단위 테스트 직접 비교 영역.
+# Single source for the dispatcher's unlinked-user reply, also compared directly in unit tests.
 _NOT_CONNECTED_MSG = get_text("notifier.commands.not_connected", settings.default_locale)
 
 
@@ -237,7 +237,7 @@ def handle_message_command(db: Session, telegram_user_id: str, text: str) -> str
     if user is None:
         # 미연결 사용자 응답 = settings.default_locale (User row 없음)
         # Unlinked user reply = settings.default_locale (no User row)
-        return get_text("notifier.commands.not_connected", settings.default_locale)
+        return _NOT_CONNECTED_MSG
 
     lang = _resolve_user_language(user)
 


### PR DESCRIPTION
## 요약

CodeQL `py/unused-global-variable` (alert **#516**, severity note) 해소 — `_NOT_CONNECTED_MSG` 디스패처 단일출처화.

방금 머지된 **#884 (C12)** 가 not_connected 경로를 리팩토링하며 `src/notifier/telegram_commands.py` 디스패처(line 240)를 inline `get_text("notifier.commands.not_connected", settings.default_locale)` 로 바꿔, 모듈 상수 `_NOT_CONNECTED_MSG`(line 46)가 src 에서 고아화 → CodeQL 신규 alert (머지 전 open 0 → 후 1).

## 변경 내용

| 위치 | 변경 |
|------|------|
| `telegram_commands.py:240` | inline `get_text(...)` → `return _NOT_CONNECTED_MSG` (상수 직접 반환) |
| `telegram_commands.py:44-45` | 주석 정정 — "legacy 테스트 비교용" → "디스패처 단일 출처 + 테스트 비교" |

→ CodeQL 해소 + 중복 `get_text` 제거(DRY, 정책 16). `settings.default_locale` 은 정적 설정이라 import-time(상수) ≡ call-time(inline) → **동작 동일**.

## 검증

- `pytest tests/unit/notifier/{test_telegram_commands,test_telegram_i18n,test_otp_attempt_limiter}.py` = **55 passed** (3건이 이미 `result == _NOT_CONNECTED_MSG` 비교 — 동일 객체 반환으로 더 견고)
- `pylint src/notifier/telegram_commands.py` = **10.00/10**
- 테스트 무증감 (단위 4938 유지) · 신규 unused-import 없음 (get_text/settings 다수 사용처 존재)

## 정책 14 분류

- (a) **실제 위반 → fix PR** (false-positive/intended 아님 — line 240 이 상수와 동일 값을 중복 계산하던 redundancy)

## 🔍 사용자 검증 필요

- [ ] (운영) 미연결 Telegram 사용자가 `/stats` 등 명령 시 안내 메시지가 정상 표시되는지 (동작 회귀 없음 확인)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex mutual 검증 완료 — **OK(push 가능)** 수신 후 push
  - 4개 항목 OK: ① 정확성(동일 표현식·default_locale 정적·동작 동일) · ② CodeQL 해소(line 240 read·신규 unused-import 없음) · ③ 테스트 통과(55 passed·pylint 10.00) · ④ 대안 적절성(1줄 복원 < 상수 제거+테스트 3건 수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
