### PR TITLE
fix(test): CodeQL #517 — 모듈 재import 제거 (py/import-and-import-from)

### DIFF
--- a/tests/unit/notifier/test_telegram_commands.py
+++ b/tests/unit/notifier/test_telegram_commands.py
@@ -530,11 +530,13 @@ def test_dispatcher_returns_not_connected_constant_directly():
     symbol usage via ast.
     """
     import ast
+    import inspect
     from pathlib import Path
 
-    import src.notifier.telegram_commands as mod
-
-    source = Path(mod.__file__).read_text(encoding="utf-8")
+    # 이미 import 된 디스패처 심볼로 모듈 소스 경로 획득 (모듈 재import 회피 — py/import-and-import-from).
+    # Resolve the module source via the already-imported dispatcher symbol (avoids re-importing
+    # the module, which would trip py/import-and-import-from).
+    source = Path(inspect.getsourcefile(handle_message_command)).read_text(encoding="utf-8")
     returns_constant = any(
         isinstance(node, ast.Return)
         and isinstance(node.value, ast.Name)


### PR DESCRIPTION
## 요약

CodeQL `py/import-and-import-from` (alert **#517**, note) 해소 — 모듈 재import 제거.

직전 머지된 **#888** 정적 가드 테스트(`test_dispatcher_returns_not_connected_constant_directly`)가 `import src.notifier.telegram_commands as mod` 를 추가했는데, 파일 상단에 이미 `from src.notifier.telegram_commands import (...)` 가 있어 **동일 모듈 이중 import 스타일**로 플래그됨 (main 전체 스캔서 노출).

## 변경 내용

| 위치 | 변경 |
|------|------|
| `test_telegram_commands.py` (가드 테스트 내부) | `import src.notifier.telegram_commands as mod` + `Path(mod.__file__)` → 이미 import된 `handle_message_command` 심볼로 `inspect.getsourcefile(handle_message_command)` |

→ 모듈 재import 제거(상단 `from ... import`만 잔존) → py/import-and-import-from 트리거 제거. ast 가드 로직(`return _NOT_CONNECTED_MSG` 단언) 동일.

## 검증

- `pytest tests/unit/notifier/test_telegram_commands.py` = **26 passed** (가드 동작 동일)
- 단위 **4939 불변** (test 1개 내부 구현만 변경) · src 무변경
- 신규 unused-import 없음 (ast/inspect/Path 전부 사용)

## 정책 14 분류

- (a) **실제 위반 → fix PR** (#888 테스트가 유발한 style 위반)

## 🔍 사용자 검증 필요

- [ ] docs/test-only — 운영 영향 없음. 머지 후 main CodeQL 재스캔서 #517 auto-fix 확인 예정

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex mutual 검증 완료 — **OK(push 가능)** 수신 후 push (HEAD ede7bb9 확인)
  - 4개 항목 OK: ① CodeQL 해소(as-import 0건) · ② 정확성(경로·ast 가드·import 사용 정상) · ③ 테스트 동작(26 passed·4939 불변) · ④ 회귀(src 무변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
