### PR TITLE
test: 회고 P2-(a) — C12 OTP brute-force 테스트 i18n 키 고정 (substring 결합 제거)

### DIFF
--- a/tests/unit/notifier/test_telegram_commands.py
+++ b/tests/unit/notifier/test_telegram_commands.py
@@ -22,7 +22,9 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+from src.config import settings
 from src.database import Base
+from src.i18n.loader import get_text
 from src.models.analysis import Analysis
 from src.models.repository import Repository
 from src.models.user import User
@@ -32,6 +34,12 @@ from src.notifier.telegram_commands import (
     handle_message_command,
     parse_cmd_callback,
 )
+
+# C12 OTP brute-force 테스트 — i18n 키 고정 비교 (영어 문구 변경에 깨지지 않도록 키 직접 대조)
+# C12 OTP brute-force tests — pin to i18n keys so wording changes don't break assertions
+_OTP_LANG = settings.default_locale
+_RATE_LIMITED_MSG = get_text("notifier.commands.connect_rate_limited", _OTP_LANG)
+_INVALID_OTP_MSG = get_text("notifier.commands.connect_invalid_otp", _OTP_LANG)
 
 
 # ---------------------------------------------------------------------------
@@ -295,13 +303,13 @@ def test_handle_connect_blocks_after_repeated_wrong_otp(db):
     # Up to the cap: each returns the invalid-OTP message and records a failure
     for _ in range(OTP_MAX_FAILED_ATTEMPTS):
         result = handle_message_command(db, "tg-brute", "/connect 000000")
-        assert "OTP" in result
+        assert result == _INVALID_OTP_MSG
 
     # 한도 초과 — rate-limit 메시지 (DB 조회조차 하지 않음)
     # Past the cap — rate-limit message (no DB lookup performed)
     blocked = handle_message_command(db, "tg-brute", "/connect 000000")
-    assert "OTP" not in blocked  # invalid_otp 가 아닌 별도 메시지
-    assert "많" in blocked or "many" in blocked.lower() or "시도" in blocked
+    assert blocked == _RATE_LIMITED_MSG
+    assert blocked != _INVALID_OTP_MSG  # 차단 메시지는 invalid_otp 와 구별된다
 
 
 def test_handle_connect_block_is_per_telegram_user(db):
@@ -315,12 +323,12 @@ def test_handle_connect_block_is_per_telegram_user(db):
 
     # 차단된 공격자
     blocked = handle_message_command(db, "tg-attacker", "/connect 999999")
-    assert "many" in blocked.lower() or "많" in blocked or "시도" in blocked
+    assert blocked == _RATE_LIMITED_MSG
 
     # 다른 사용자는 정상적으로 invalid_otp 응답을 받는다
     # A different user still gets the normal invalid-OTP response
     other = handle_message_command(db, "tg-innocent", "/connect 111111")
-    assert "OTP" in other
+    assert other == _INVALID_OTP_MSG
 
 
 def test_handle_connect_success_resets_failure_counter(db):
@@ -353,7 +361,7 @@ def test_handle_connect_success_resets_failure_counter(db):
     # Counter cleared → another (cap - 1) failures still not blocked
     for _ in range(OTP_MAX_FAILED_ATTEMPTS - 1):
         result = handle_message_command(db, "tg-reset", "/connect 000000")
-        assert "OTP" in result  # 여전히 invalid_otp (차단 아님)
+        assert result == _INVALID_OTP_MSG  # 여전히 invalid_otp (차단 아님)
 
 
 def test_handle_connect_already_linked_preserves_failure_counter(db):


### PR DESCRIPTION
## 요약

회고(5+1) P2-(a) — **테스트 견고성 결함** 해소. `tests/unit/notifier/test_telegram_commands.py` 의 C12 OTP brute-force rate-limit 클러스터(3개 테스트)가 응답 메시지를 `"OTP"`/`"많"`/`"many"`/`"시도"` 부분문자열·OR 휴리스틱으로 검증해 **영어/로케일 문구 변경에 취약**했다. i18n 키 고정 등호 비교로 교체.

`/integrity-audit full` 회고에서 "차기 세션 자율 진입 후보 1순위 (정책15 Low~Medium, 자율 가능)"로 분류된 항목.

## 변경 내용

- 모듈 최상단에 프로덕션과 동일한 로케일 해석으로 기대 메시지 상수 계산:
  ```python
  _OTP_LANG = settings.default_locale
  _RATE_LIMITED_MSG = get_text("notifier.commands.connect_rate_limited", _OTP_LANG)
  _INVALID_OTP_MSG  = get_text("notifier.commands.connect_invalid_otp", _OTP_LANG)
  ```
- 3개 테스트의 substring/OR 단언 → `==` 키 고정 비교로 교체:
  - `blocks_after_repeated_wrong_otp`: `assert blocked == _RATE_LIMITED_MSG` + `assert blocked != _INVALID_OTP_MSG`
  - `block_is_per_telegram_user`: `assert blocked == _RATE_LIMITED_MSG` / `assert other == _INVALID_OTP_MSG`
  - `success_resets_failure_counter`: `assert result == _INVALID_OTP_MSG`

## 근거 / 안전성

- **로케일 정합**: 프로덕션 `_handle_connect` 의 `default_lang = settings.default_locale` 경로와 **동일 소스** 사용 — 하드코딩 로케일 없음 (spurious pass/fail 차단).
- **회귀 검출력 강화**: `==` 는 기존 substring 보다 엄격. 차단↔invalid_otp 메시지를 서로 다른 키로 명시 구별 (OR 붕괴 없음).
- **동작·커버리지·테스트 수 무변경**: 26 passed (단위 4939 불변), `src/` 프로덕션 코드 무변경.
- **스코프**: C12 brute-force 클러스터 3개 테스트만 (회고 P2-(a) 지목 `:303-304` 영역). 스코프 외 테스트 미변경.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

✅ **Codex mutual 검증 완료 (OK, push 전)** — 5개 기준 전부 PASS:
1. Locale parity PASS — `settings.default_locale` 단일 소스, 하드코딩 로케일 없음
2. Assertion strength PASS — `==` 가 substring 보다 엄격, 차단↔invalid_otp 구별
3. No residual fragile assertions PASS — substring/OR 패턴 전량 제거
4. Scope correctness PASS — 테스트 1파일 `+20/−6`, `src/` 무변경
5. pytest GREEN PASS — 26 passed (exit 0)

## 🔍 사용자 검증 필요 (정책 2)

- [ ] **운영 검증 불필요** — 테스트 전용 변경(프로덕션 코드·동작·DB·UI 무변경). CI green 확인만으로 충분.
- 시각/테마(정책 11) N/A · 인증/외부통합 smoke(정책 13) N/A — 해당 경로 미접촉.

## 자율 판단 보고 (정책 3)

- C12 brute-force 클러스터 **3개 테스트 전부**를 fix 대상에 포함 (회고는 `:303-304` 지목했으나 동일 fragility 클래스가 같은 클러스터 318/323/356 에도 분산 → cohesive 단위로 일괄 교체). 이의 있으시면 알려주세요.
- 클러스터 밖 유사 substring 단언(`already`/`Usage` 등 별개 기능 테스트)은 스코프 외로 보류 — 별건.
