### PR TITLE
fix(security): C12 — Telegram OTP 6→8자리 (계정 로테이션 brute-force 비용 100배)

### DIFF
--- a/src/api/users.py
+++ b/src/api/users.py
@@ -24,7 +24,13 @@ logger = logging.getLogger(__name__)
 LOCALE_COOKIE_VALUE_RE = re.compile(r"^[a-z]{2,3}(?:-[a-z0-9]{2,8})*$")
 
 # OTP 자릿수 — One-time passcode digit count.
-_OTP_LENGTH = 6
+# C12 (회고 P2-c): 6→8 자리. find_by_otp 는 user 무관 전역 풀 조회 + 리미터는 per-sender 라
+# 계정 로테이션 시 전역 brute-force 상한이 없다 → 탐색 공간을 10^6→10^8(100배)로 확대해
+# per-sender 리미터(OTP_MAX_FAILED_ATTEMPTS)와 곱연산으로 추측 비용을 높인다.
+# C12: 6→8 digits. find_by_otp looks up the global (user-agnostic) OTP pool while the limiter is
+# per-sender, so account rotation has no global ceiling → widen the space 10^6→10^8 (100x) to
+# compound with the per-sender limiter.
+_OTP_LENGTH = 8
 # OTP 유효 시간(분) — OTP validity window in minutes.
 _OTP_TTL_MINUTES = 5
 
@@ -35,8 +41,8 @@ router = APIRouter(prefix="/api/users", tags=["users"])
 async def issue_telegram_otp(
     current_user: Annotated[CurrentUser, Depends(require_login)],
 ) -> dict:
-    """Telegram 연동용 6자리 OTP를 발급한다.
-    Issue a 6-digit OTP for Telegram account linking.
+    """Telegram 연동용 8자리 OTP를 발급한다.
+    Issue an 8-digit OTP for Telegram account linking.
 
     기존 OTP가 있으면 덮어쓴다 — 마지막 OTP만 유효.
     Overwrites any existing OTP — only the last issued OTP is valid.

--- a/src/constants.py
+++ b/src/constants.py
@@ -118,9 +118,11 @@ WEBHOOK_SECRET_CACHE_MAX = 2048
 
 # ── Telegram OTP brute-force 방어 (C12) ──────────────────────────────────────
 # per-telegram_user_id 슬라이딩 윈도우 — 잘못된 /connect 시도만 카운트한다.
-# 6자리 숫자 OTP(공간 10^6) + TTL 5분이라 무제한 추측 시 brute-force 가능 → 한도 차단.
+# 8자리 숫자 OTP(공간 10^8, C12 — 6→8) + TTL 5분이라 무제한 추측 시 brute-force 가능 → 한도 차단.
+# 리미터는 per-sender 라 계정 로테이션 시 전역 상한이 없으므로 자릿수 확대(_OTP_LENGTH)와 곱연산으로 방어.
 # Per-telegram_user_id sliding window — counts only failed /connect attempts.
-# A 6-digit OTP (10^6 space) with a 5-min TTL is brute-forceable without a cap.
+# An 8-digit OTP (10^8 space, C12 — 6→8) with a 5-min TTL is brute-forceable without a cap.
+# The limiter is per-sender (no global ceiling under account rotation), so digit widening compounds it.
 OTP_MAX_FAILED_ATTEMPTS = 5          # 윈도우 내 허용 실패 횟수 / allowed failures per window
 OTP_ATTEMPT_WINDOW_SECONDS = 300     # 슬라이딩 윈도우(초) — OTP TTL(5분)과 동일 / window = OTP TTL
 # 🔴 추적 키 상한 — telegram_user_id 가 많아져도 dict 무한 증가를 막는다(메모리 고갈 방지).

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -811,7 +811,7 @@
     "commands": {
       "not_connected": "Connect your account first: /connect <code>",
       "unknown_command": "Unknown command. Available: /stats <repo>, /settings, /connect <code>",
-      "connect_usage": "Usage: /connect <6-digit code>",
+      "connect_usage": "Usage: /connect <8-digit code>",
       "connect_invalid_otp": "Invalid or expired OTP.",
       "connect_rate_limited": "Too many attempts. Please try again in a few minutes.",
       "connect_already_linked": "This Telegram account is already linked to another user.",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -811,7 +811,7 @@
     "commands": {
       "not_connected": "先に /connect <コード> でアカウントを連携してください。",
       "unknown_command": "対応していないコマンドです。利用可能: /stats <repo>, /settings, /connect <コード>",
-      "connect_usage": "使い方: /connect <6桁コード>",
+      "connect_usage": "使い方: /connect <8桁コード>",
       "connect_invalid_otp": "OTP が無効または期限切れです。",
       "connect_rate_limited": "試行回数が多すぎます。数分後にもう一度お試しください。",
       "connect_already_linked": "この Telegram アカウントは既に他のユーザーに連携されています。",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -811,7 +811,7 @@
     "commands": {
       "not_connected": "먼저 /connect <코드>로 계정을 연결하세요.",
       "unknown_command": "지원하지 않는 명령입니다. 사용 가능: /stats <repo>, /settings, /connect <코드>",
-      "connect_usage": "사용법: /connect <6자리 코드>",
+      "connect_usage": "사용법: /connect <8자리 코드>",
       "connect_invalid_otp": "OTP가 잘못되었거나 만료되었습니다.",
       "connect_rate_limited": "시도 횟수가 너무 많습니다. 몇 분 후 다시 시도해 주세요.",
       "connect_already_linked": "이 Telegram 계정은 이미 다른 사용자에게 연결되어 있습니다.",

--- a/tests/unit/api/test_users_api.py
+++ b/tests/unit/api/test_users_api.py
@@ -52,9 +52,9 @@ def _make_db_session_mock(db_mock: MagicMock) -> MagicMock:
 # ── T9-A: POST /api/users/me/telegram-otp ──
 
 
-def test_post_telegram_otp_returns_six_digit_code():
-    """인증된 사용자 호출 시 200과 6자리 숫자 OTP, expires_at을 반환한다.
-    Returns 200 with a 6-digit numeric OTP and expires_at for an authenticated user.
+def test_post_telegram_otp_returns_eight_digit_code():
+    """인증된 사용자 호출 시 200과 8자리 숫자 OTP, expires_at을 반환한다.
+    Returns 200 with an 8-digit numeric OTP and expires_at for an authenticated user.
     """
     mock_db = MagicMock()
     # execute/commit은 부작용만 — 반환값 불필요
@@ -67,10 +67,10 @@ def test_post_telegram_otp_returns_six_digit_code():
 
     assert r.status_code == 200
     body = r.json()
-    # OTP는 6자리 숫자 문자열이어야 한다
-    # OTP must be a 6-digit numeric string.
+    # OTP는 8자리 숫자 문자열이어야 한다 (C12 — 6→8, brute-force 공간 10^8)
+    # OTP must be an 8-digit numeric string (C12 — 6→8, brute-force space 10^8).
     assert "otp" in body
-    assert len(body["otp"]) == 6
+    assert len(body["otp"]) == 8
     assert body["otp"].isdigit()
     # 만료 시각과 TTL 필드가 있어야 한다
     # expires_at and ttl_minutes must be present.
@@ -106,18 +106,18 @@ def test_post_telegram_otp_overwrites_previous_otp():
     otp1 = r1.json()["otp"]
     otp2 = r2.json()["otp"]
 
-    # 두 OTP 모두 6자리 숫자 형식
-    # Both OTPs must be 6-digit numeric strings.
-    assert len(otp1) == 6 and otp1.isdigit()
-    assert len(otp2) == 6 and otp2.isdigit()
+    # 두 OTP 모두 8자리 숫자 형식
+    # Both OTPs must be 8-digit numeric strings.
+    assert len(otp1) == 8 and otp1.isdigit()
+    assert len(otp2) == 8 and otp2.isdigit()
 
     # DB execute가 각 요청마다 호출되어야 한다 (덮어쓰기 보장)
     # DB execute must be called once per request (overwrite guarantee).
     assert mock_db.execute.call_count == 2
     assert mock_db.commit.call_count == 2
 
-    # 연속으로 발급된 OTP가 동일할 확률은 1/1,000,000 — 실용적으로 다름을 기대
-    # Probability of collision is 1/1,000,000 — expect different values in practice.
+    # 연속으로 발급된 OTP가 동일할 확률은 1/100,000,000 (10^8) — 실용적으로 다름을 기대
+    # Probability of collision is 1/100,000,000 (10^8) — expect different values in practice.
     collected_otps.extend([otp1, otp2])
     assert len(collected_otps) == 2
 
@@ -161,7 +161,7 @@ def test_post_telegram_otp_uses_secrets_for_randomness():
     # 숫자 문자만 포함 — secrets.choice("0123456789") 보장
     # Only digit chars — guaranteed by secrets.choice("0123456789").
     assert all(c in "0123456789" for c in otp)
-    assert len(otp) == 6
+    assert len(otp) == 8
 
 
 # ── T-3: asyncio.to_thread 래핑 검증 (사이클 113 P0-D 회귀 가드) ──


### PR DESCRIPTION
## 요약

회고(5+1) **C12** (P2-c, 정책15 High tier — 사용자 결정 **A 채택**) 구현. Telegram 연동 OTP를 **6→8자리**로 확대해 brute-force 탐색 공간을 10⁶→10⁸(100배)로 올린다.

**문제**: `find_by_otp(db, otp)` 는 user 무관 **전역 OTP 풀**을 조회하는데, rate limiter(`_OtpAttemptLimiter`)는 `telegram_user_id` per-sender 키다. 따라서 공격자가 계정을 로테이션하면 윈도우당 `5 × K`(K=계정 수) 추측이 가능하고 **전역/per-OTP 상한이 없다**. 자릿수 확대로 per-sender 리미터와 **곱연산** 방어한다.

## 변경 내용

- `_OTP_LENGTH` 6→8 (`src/api/users.py:27`) — **생성만 변경**. `find_by_otp`/`_handle_connect` 는 길이 검증이 없고 전체 문자열 매칭이라 생성 자릿수 변경만으로 충분.
- **스키마 변경 0** — `telegram_otp` 는 임시 문자열 컬럼, 마이그레이션 불필요. TTL(5분) 불변.
- i18n `connect_usage` **3언어(ko/en/ja) 6→8자리 동기화** + `constants.py` C12 주석 10⁶→10⁸ + 리미터-자릿수 곱연산 설명.
- TDD: `test_users_api.py` OTP 길이 단언 6→8 (함수 rename `..._eight_digit_code`), 충돌 확률 주석 1/10⁸ 갱신.

## 검증

- **44 passed** (test_users_api + test_telegram_commands + test_i18n_smoke), pylint `users.py`+`constants.py` **10.00/10**, JSON 3종 parse OK.
- TDD Red(3 길이 단언 fail) → Green 확인.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

✅ **Codex mutual 검증 완료 (OK, push 전)** — 정적 리뷰 6 checks (companion status `completed` / `OK (safe to push)` 실측):
1. Correctness — 8자 secrets.choice 생성, 길이 검증 부재라 생성-only 변경으로 충분
2. Schema — telegram_otp 문자열 컬럼, 마이그레이션 불필요
3. Completeness — docstring/constants/i18n 3언어 전부 갱신, 템플릿은 동적 표시(literal 없음)
4. i18n — en/ko/ja 일관 갱신, JSON 유효
5. No regression — per-sender 리미터/connect flow 테스트 무영향
6. Security sanity — 8자리 + TTL 5분 + per-sender 리미터 합리적 (잔여: 전역 per-OTP 상한 부재 = 미채택 B안의 트레이드오프, Codex 확인)

## 🔍 사용자 검증 필요 (정책 2)

- [ ] **UX 영향**: 사용자가 `/connect` 시 입력할 OTP가 8자리로 길어짐 (settings 페이지 OTP 표시는 동적이라 자동 반영).
- [ ] **잔여 한계(결정 A 명시)**: 전역/per-OTP 상한은 여전히 없음(B안 미채택). 현재 위험은 낮으나 SaaS 전환(#2) 시 재검토 권장. 기존 미발급/발급된 6자리 OTP는 만료(5분)까지 유효.
- 시각/테마(정책 11) N/A · 인증 smoke(정책 13): OTP 발급은 `require_login` 보호(엔드포인트 인증 경로 변경 없음).

## 자율 판단 보고 (정책 3)

- 사용자 결정 **A(자릿수 6→8)** 를 구현. 결정 시 표로 명시한 트레이드오프(UX 8자리·전역 상한 미해결)대로 진행.
- ⚠️ 작업 중 i18n JSON 3건 edit 이 1차 누락(commit "3 files") → 즉시 적발·수정 후 amend("6 files")로 봉인. push 전 grep 재검증으로 8자리 확정.
