### PR TITLE
fix(db): 0039/0040 마이그레이션 멱등화 — 운영 alembic 0038 고착 해소 (RLS Phase 4 step 0 선행 차단)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,5 +183,6 @@ jobs:
             tests/integration/test_retry_concurrency_postgres.py \
             tests/unit/migrations/test_0020_round_trip.py::test_migration_alembic_round_trip \
             tests/unit/migrations/test_0020_round_trip.py::test_migration_0041_force_round_trip_postgres \
+            tests/unit/migrations/test_0020_round_trip.py::test_migrations_idempotent_over_prod_drift_postgres \
             tests/unit/migrations/test_orm_alembic_parity.py::test_orm_metadata_matches_migrations \
             -v -rs --timeout=60

--- a/alembic/versions/0039_repositories_user_id_fk.py
+++ b/alembic/versions/0039_repositories_user_id_fk.py
@@ -58,6 +58,12 @@ def upgrade() -> None:
         "WHERE user_id IS NOT NULL "
         "AND user_id NOT IN (SELECT id FROM users)"
     )
+    # 🔴 멱등성 — 운영 DB 에 이미 FK 가 (다른 ondelete 로) 존재할 수 있다.
+    # 2026-06-15 운영 실측: `repositories_user_id_fkey` 가 NO ACTION 으로 사전 존재 →
+    # 무조건 create 가 "already exists" 로 실패해 0039 전체 롤백·alembic 0038 고착.
+    # DROP IF EXISTS 로 먼저 제거(이름·ondelete 무관) 후 SET NULL 로 재생성 → 멱등 + NO ACTION 교정.
+    # CI clean DB 에서는 DROP 이 no-op. Idempotent: drop any pre-existing FK, then (re)create as SET NULL.
+    op.execute("ALTER TABLE repositories DROP CONSTRAINT IF EXISTS repositories_user_id_fkey")
     op.create_foreign_key(
         _FK_NAME,
         "repositories",

--- a/alembic/versions/0040_rename_users_github_id_index.py
+++ b/alembic/versions/0040_rename_users_github_id_index.py
@@ -38,7 +38,28 @@ def upgrade() -> None:
     if not is_postgresql(bind):
         return
 
-    op.execute("ALTER INDEX ix_users_google_id RENAME TO ix_users_github_id")
+    # 🔴 멱등성 + end-state 보장 (Codex mutual) — 시작 상태와 무관하게 종료 시 항상
+    # `ix_users_github_id`(UNIQUE) 존재 + `ix_users_google_id` 부재가 되도록 3단계 구성.
+    # github_id 는 ORM `unique=True` (0005 도 unique 인덱스) — CREATE UNIQUE 정합.
+    #   (1) 정상(google 존재·github 부재): 이름만 stale 한 인덱스를 rename — 인덱스 정의 보존.
+    #   (2) neither(둘 다 부재): ORM 정합 UNIQUE 인덱스 신규 생성으로 end-state 보장.
+    #   (3) 병존/재실행: 잔존 stale source(google) 제거. CI clean DB 는 (1) 경로(=rename).
+    # Guarantees the end state regardless of the starting state: rename when only the old index
+    # exists (preserves its definition), create the ORM-matching UNIQUE index if neither exists,
+    # then drop any stale source. github_id is UNIQUE in the ORM (and 0005), so CREATE UNIQUE matches.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'ix_users_google_id')
+               AND NOT EXISTS (SELECT 1 FROM pg_indexes WHERE schemaname = 'public' AND indexname = 'ix_users_github_id') THEN
+                ALTER INDEX ix_users_google_id RENAME TO ix_users_github_id;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS ix_users_github_id ON users (github_id)")
+    op.execute("DROP INDEX IF EXISTS ix_users_google_id")
 
 
 def downgrade() -> None:

--- a/tests/unit/migrations/test_0020_round_trip.py
+++ b/tests/unit/migrations/test_0020_round_trip.py
@@ -247,3 +247,87 @@ def test_migration_0041_force_round_trip_postgres():
         # 후속 테스트(orm parity 등)가 head 를 기대 — job 내 실행 순서 무관성 보존
         # Later tests (orm parity, etc.) expect head — keep the job order-independent
         alembic_command.upgrade(cfg, "head")
+
+
+def test_migrations_idempotent_over_prod_drift_postgres():
+    """0039/0040 가 운영 drift(사전 존재 NO ACTION FK)에서도 head 까지 적용되는지 실 PG 검증.
+
+    2026-06-15 운영 사고 재현 — alembic 0038 + `repositories_user_id_fkey`(NO ACTION) 가
+    사전 존재한 상태에서 (수정 전) 0039 의 무조건 `create_foreign_key` 가 "already exists" 로
+    실패해 0038 고착(0040/0041 FORCE 전부 미적용)했다. 본 테스트는 drift 를 인위 주입한 뒤
+    `upgrade head` 가 성공 + FK 가 SET NULL 로 교정 + 인덱스 rename + FORCE 적용까지 도달함을
+    봉인한다. 정적 가드(test_0039/0040)가 못 덮는 실행 멱등 경로.
+
+    Reproduces the 2026-06-15 prod incident (pre-existing NO ACTION FK at 0038 stuck alembic
+    because the unguarded create_foreign_key failed) and seals that the idempotent 0039/0040
+    apply head cleanly over the drift.
+
+    🔴 ci.yml pg-concurrency job 의 ::node-id 핀에 등재됨 — 핀 미등재 시 자동 미수집.
+    🔴 Pinned by ::node-id in the ci.yml pg-concurrency job — unpinned tests are not collected.
+    """
+    db_url = os.environ.get("DATABASE_URL_TEST_POSTGRES", "")
+    if not db_url:
+        pytest.skip(
+            "prod-drift idempotency replay requires PostgreSQL — set DATABASE_URL_TEST_POSTGRES"
+        )
+
+    from unittest.mock import patch
+
+    from alembic.config import Config
+    from alembic import command as alembic_command
+    from sqlalchemy.orm import sessionmaker
+
+    from src.config import settings as app_settings
+    from src.services.saas_service import rls_coverage_summary
+
+    cfg = Config("alembic.ini")
+    cfg.set_main_option("sqlalchemy.url", db_url)
+
+    # env.py 가 cfg URL 을 settings.database_url 로 덮어씀 — 싱글톤 patch 의무 (db.md 규칙)
+    with patch.object(app_settings, "database_url", db_url):
+        # clean-base self-isolating (round-trip 패턴 미러)
+        reset_eng = create_engine(db_url)
+        with reset_eng.begin() as conn:
+            conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+            conn.execute(text("CREATE SCHEMA public"))
+        reset_eng.dispose()
+
+        # 0039 직전(0038)까지 적용
+        alembic_command.upgrade(cfg, "0038")
+
+        # 운영 drift 인위 주입: NO ACTION FK 사전 생성 (0039 가 만들 SET NULL 과 불일치, 동일 이름)
+        drift_eng = create_engine(db_url)
+        with drift_eng.begin() as conn:
+            conn.execute(text(
+                "ALTER TABLE repositories ADD CONSTRAINT repositories_user_id_fkey "
+                "FOREIGN KEY (user_id) REFERENCES users (id)"
+            ))
+        drift_eng.dispose()
+
+        # 멱등 0039(DROP IF EXISTS) → 0040(DO block) → 0041 가 drift 위에서 성공해야 한다
+        alembic_command.upgrade(cfg, "head")
+
+        eng = create_engine(db_url)
+        try:
+            with eng.connect() as conn:
+                ondelete = conn.execute(text(
+                    "SELECT confdeltype FROM pg_constraint "
+                    "WHERE conname = 'repositories_user_id_fkey' AND contype = 'f'"
+                )).scalar()
+                github_idx = conn.execute(text(
+                    "SELECT count(*) FROM pg_indexes "
+                    "WHERE schemaname = 'public' AND indexname = 'ix_users_github_id'"
+                )).scalar()
+            # confdeltype 'n' = SET NULL — 사전 NO ACTION FK 가 교정됐는지
+            assert ondelete == "n", (
+                f"0039 후 repositories_user_id_fkey ondelete='{ondelete}' — SET NULL('n') 여야 한다 "
+                "(사전 NO ACTION FK 교정 실패 — 멱등 DROP+recreate 회귀)"
+            )
+            assert github_idx == 1, "0040 후 ix_users_github_id 인덱스가 존재해야 한다 (rename 회귀)"
+            session_factory = sessionmaker(bind=eng)
+            with session_factory() as session:
+                assert rls_coverage_summary(session)["force_applied"] is True, (
+                    "drift 위 upgrade head 후 force_applied=True 여야 한다 (0041 미도달)"
+                )
+        finally:
+            eng.dispose()

--- a/tests/unit/migrations/test_0039_repositories_user_id_fk.py
+++ b/tests/unit/migrations/test_0039_repositories_user_id_fk.py
@@ -33,3 +33,21 @@ def test_repositories_user_id_fk_has_set_null_delete():
         f"repositories.user_id FK ondelete='{fk.ondelete}' — "
         "'SET NULL' 이어야 함 (#18 drift ④ 회귀, nullable 컬럼)"
     )
+
+
+def test_0039_upgrade_idempotent_drops_existing_fk():
+    """0039 upgrade 가 DROP CONSTRAINT IF EXISTS 로 멱등한지 정적 단언 (운영 사고 회귀 가드).
+
+    2026-06-15 운영: `repositories_user_id_fkey` 가 NO ACTION 으로 사전 존재 → 무조건
+    `create_foreign_key` 가 "already exists" 로 실패 → 0039 롤백 → alembic 0038 고착
+    (이후 0040/0041 FORCE 전부 미적용). CI clean DB(FK 미존재)는 미검출 → 마이그레이션
+    소스에 멱등 가드 존재를 정적 단언한다.
+    """
+    from pathlib import Path  # noqa: PLC0415
+    src = (
+        Path(__file__).resolve().parents[3]
+        / "alembic" / "versions" / "0039_repositories_user_id_fk.py"
+    ).read_text(encoding="utf-8")
+    assert "DROP CONSTRAINT IF EXISTS repositories_user_id_fkey" in src, (
+        "0039 멱등성 가드(DROP IF EXISTS) 제거됨 — 사전 존재 FK 에 create 실패 시 alembic 고착 회귀"
+    )

--- a/tests/unit/migrations/test_0040_rename_users_github_id_index.py
+++ b/tests/unit/migrations/test_0040_rename_users_github_id_index.py
@@ -31,3 +31,22 @@ def test_users_github_id_index_name_not_legacy_google():
     assert "ix_users_google_id" not in index_names, (
         "legacy ix_users_google_id 가 ORM 에 잔존 — github_id 컬럼명 정합 위반"
     )
+
+
+def test_0040_upgrade_idempotent_if_exists():
+    """0040 upgrade 가 ALTER INDEX IF EXISTS 로 멱등한지 정적 단언 (부분 적용 상태 방어).
+
+    0039 사전 실패로 0040 이 미적용으로 남거나(2026-06-15) 재실행되는 상태에서도 안전하도록
+    `IF EXISTS` 로 source 부재 시 no-op. CI clean DB 미검출 → 소스 정적 단언.
+    """
+    from pathlib import Path  # noqa: PLC0415
+    src = (
+        Path(__file__).resolve().parents[3]
+        / "alembic" / "versions" / "0040_rename_users_github_id_index.py"
+    ).read_text(encoding="utf-8")
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS ix_users_github_id" in src, (
+        "0040 end-state 보장(neither 상태 시 UNIQUE 인덱스 생성) 제거됨 — github_id 인덱스 미보장 회귀"
+    )
+    assert "DROP INDEX IF EXISTS ix_users_google_id" in src, (
+        "0040 멱등성 가드(stale source DROP) 제거됨 — 병존/재실행 상태 회귀"
+    )


### PR DESCRIPTION
## 요약
운영 RLS Phase 4 step 0 배포가 **alembic 0038 고착**으로 막혀있던 근본 원인 해소. 마이그레이션 `0039`/`0040`을 멱등화하여 운영 DB의 사전 drift(이미 존재하는 `repositories_user_id_fkey`) 위에서도 `upgrade head`가 성공하도록 한다.

## 근본 원인 (운영 MCP 실측, 2026-06-15)
- Supabase 운영 DB가 **alembic 0038 고착 / FORCE 0/11**. postgres 로그: `ERROR: constraint "repositories_user_id_fkey" for relation "repositories" already exists`.
- `repositories_user_id_fkey`가 **NO ACTION으로 사전 존재**(0039 의도는 SET NULL) → 0039의 무조건 `create_foreign_key`가 "already exists"로 실패 → 0039 롤백 → **0038 고착**(0040 rename·0041 FORCE 전부 미적용).
- lifespan(`main.py:160` broad-except)이 마이그레이션 실패를 잡고 앱은 기동(무중단) → **~2026-06-09(0039 추가) 이후 모든 배포에서 조용히 실패**(미발견). CI는 clean DB(FK 미존재)서 시작해 미검출.

## 변경
- **0039**: orphan 정리 후 `DROP CONSTRAINT IF EXISTS` → create SET NULL (멱등 + 사전 NO ACTION FK를 SET NULL로 교정).
- **0040**: 단순 RENAME → **end-state 보장 3-statement** (조건부 rename으로 정의 보존 + neither 상태 시 ORM 정합 `CREATE UNIQUE INDEX IF NOT EXISTS` + stale source `DROP`). 시작 상태 무관 `ix_users_github_id`(UNIQUE) 존재 보장. (github_id = ORM `unique=True` · 0005 unique · prod unique 실측 정합)
- **test_0039/0040**: 멱등 가드 정적 단언.
- **test_0020_round_trip.py**: PG 행동 테스트 `test_migrations_idempotent_over_prod_drift_postgres` — 운영 사고 재현(0038 + NO ACTION FK 주입 → upgrade head 성공 + FK=SET NULL + force_applied=True). ci.yml pg-concurrency `::node-id` 핀 등재.

## 검증
- 로컬: 마이그레이션 테스트 **53 passed / 4 skipped**(PG skip), ci.yml YAML valid.
- **Codex mutual**: round1 NG(0040 collision·PG 행동 테스트 부재)→round2 NG(0040 neither/병존)→**round3 OK**.

## 🔍 사용자 검증 필요 (운영)
🔴 **머지 후 Railway 재배포 필요** — 재배포 시 lifespan이 `alembic upgrade head`로 0039(멱등)→0040→0041 정상 적용:
1. **재배포** 후 `GET /admin/rls-audit` → **`force_applied=True`** (11/11) 확인 (이때 `connection_bypasses_rls=True`+경고 배너는 URL 전환 전 정상).
2. 제가 MCP로 `alembic=0041` + `force_tables=11` 실측 재확인 → RLS Phase 4 **step 2**(URL 전환) 진입.

## 후속
본 PR = RLS Phase 4 step 0(배포→FORCE)의 선행 차단 해소. step 1(PW 교체) 이미 완료(MCP 검증). 머지+재배포 → step 0 게이트 충족 → step 2/3.
