### PR TITLE
feat(db): MIGRATION_DATABASE_URL — RLS Phase 4 마이그레이션 credential 게이트 (owner role 분리)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,13 @@ DB_FAILOVER_PROBE_INTERVAL=30
 # Empty reuses DATABASE_URL (current behavior). Must be BYPASSRLS worker role credentials when set
 DATABASE_URL_WORKER=
 
+# === 마이그레이션 전용 DB URL (owner role) — RLS Phase 4 "두 번째 벽" ===
+# Migration-only DB URL (owner role) — RLS Phase 4 "second wall" (rls-role-separation.md §6)
+# 빈 값이면 DATABASE_URL 사용 (현행 동작 보존 — 미설정 시 발효 0).
+# Phase 4 에서 DATABASE_URL 이 비-BYPASSRLS app role 로 바뀔 때 owner 자격 마이그레이션을 위해 설정.
+# Empty uses DATABASE_URL (current behavior). Set in Phase 4 so migrations keep owner credentials.
+MIGRATION_DATABASE_URL=
+
 # === DB 연결 고급 설정 (온프레미스 PostgreSQL) ===
 # SSL 모드: "require", "verify-full", "disable" 등 (빈 값=미적용)
 DB_SSLMODE=

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -9,6 +9,10 @@ from alembic import context
 # access to the values within the .ini file in use.
 config = context.config
 
+# alembic config 의 DB URL 키 (중복 리터럴 제거 — SonarCloud S1192)
+# Alembic config key for the DB URL (single literal — SonarCloud S1192)
+_SQLALCHEMY_URL = "sqlalchemy.url"
+
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.
 if config.config_file_name is not None:
@@ -26,8 +30,12 @@ from src.config import settings
 
 target_metadata = Base.metadata
 
-# Override sqlalchemy.url from application settings
-config.set_main_option("sqlalchemy.url", settings.database_url)
+# Override sqlalchemy.url from application settings.
+# effective_migration_url = MIGRATION_DATABASE_URL or DATABASE_URL — RLS Phase 4 마이그레이션
+# credential 게이트(owner role 분리). 미설정 시 DATABASE_URL 그대로 사용(현행 동작 보존).
+# effective_migration_url = MIGRATION_DATABASE_URL or DATABASE_URL — RLS Phase 4 migration
+# credential gate (owner role separation). Unset reuses DATABASE_URL (current behavior).
+config.set_main_option(_SQLALCHEMY_URL, settings.effective_migration_url)
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:
@@ -47,7 +55,7 @@ def run_migrations_offline() -> None:
     script output.
 
     """
-    url = config.get_main_option("sqlalchemy.url")
+    url = config.get_main_option(_SQLALCHEMY_URL)
     context.configure(
         url=url,
         target_metadata=target_metadata,
@@ -66,7 +74,7 @@ def run_migrations_online() -> None:
     and associate a connection with the context.
 
     """
-    url = config.get_main_option("sqlalchemy.url", "")
+    url = config.get_main_option(_SQLALCHEMY_URL, "")
     # db_force_ipv4/db_sslmode 설정을 동일하게 적용, connect_timeout=10으로 hang 방지
     # Apply db_force_ipv4/db_sslmode settings identically; connect_timeout=10 prevents hangs
     if url.startswith("postgresql"):

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -125,6 +125,7 @@ Sentry 외 자동 로깅은 별도 환경변수 없이 동작:
 | `DATABASE_URL_FALLBACK` | Failover용 보조 DB URL (빈 값이면 failover 비활성) | `postgresql://user:pass@supabase.co/db?sslmode=require` |
 | `DB_FAILOVER_PROBE_INTERVAL` | Primary DB 복구 확인 주기 (초) | `30` |
 | `DATABASE_URL_WORKER` | background(webhook/worker/gate/notifier/cron/CLI hook) 전용 DB URL — RLS role 분리 옵션 A ([rls-role-separation.md](../runbooks/rls-role-separation.md) Phase 2). 빈 값이면 `DATABASE_URL` 팩토리 재사용 (현행 동작). 반드시 `BYPASSRLS` worker role(`scamanager_worker`) 자격 지정 — 비-BYPASSRLS role 지정 시 FORCE 활성 후 background 차단. ⚠️ 트레이드오프: worker 경로 failover 미지원 (primary 장애 시 background 중단) + 동일 프로세스 연결 풀 2배 (Supabase 연결 상한 고려) | `postgresql://scamanager_worker:pass@host/db` |
+| `MIGRATION_DATABASE_URL` | alembic 마이그레이션 전용 DB URL (**owner role**) — RLS Phase 4 "두 번째 벽" ([rls-role-separation.md](../runbooks/rls-role-separation.md) §6 마이그레이션 credential 게이트). `alembic/env.py` 가 `effective_migration_url`(= 이 값 또는 `DATABASE_URL`)을 `sqlalchemy.url` 로 사용 → pre-deploy `alembic upgrade head` + lifespan 양쪽에 적용. 빈 값이면 `DATABASE_URL` 사용 (**현행 동작 보존 — 미설정 시 발효 0**). 🔴 Phase 4 에서 `DATABASE_URL` 이 비-BYPASSRLS app role(`scamanager_app`)로 전환될 때 설정 — 미설정 시 마이그레이션이 app role 로 돌아 `alembic_version` default-deny 차단. 🔴 런타임 `DATABASE_URL`/`DATABASE_URL_WORKER` 를 마이그레이션 credential 로 재사용 금지 | `postgresql://postgres:pass@host/db` |
 
 **주의:** `.env` 파일은 절대 git commit 하지 말 것 (`.gitignore`에 포함됨)
 

--- a/src/config.py
+++ b/src/config.py
@@ -73,6 +73,15 @@ class Settings(BaseSettings):
     # Background-only DB URL — RLS role separation Option A (Phase 2).
     # Empty string reuses the DATABASE_URL factory (preserves current behavior).
     database_url_worker: str = ""
+    # 마이그레이션 전용 DB URL (owner role) — RLS Phase 4 "두 번째 벽" (rls-role-separation.md §6)
+    # alembic/env.py 가 effective_migration_url(= 이 값 or DATABASE_URL)을 sqlalchemy.url 로 사용.
+    # 빈 문자열이면 DATABASE_URL 사용(현행 동작 보존). Phase 4 에서 DATABASE_URL 이
+    # 비-BYPASSRLS app role 로 바뀔 때, owner 자격 마이그레이션을 위해 이 값을 설정한다.
+    # Migration-only DB URL (owner role) — RLS Phase 4 "second wall" (rls-role-separation.md §6).
+    # alembic/env.py uses effective_migration_url (= this or DATABASE_URL) as sqlalchemy.url.
+    # Empty reuses DATABASE_URL (current behavior). Set this in Phase 4 — when DATABASE_URL
+    # switches to the non-BYPASSRLS app role — so migrations still run with owner credentials.
+    migration_database_url: str = ""
     # Auto-merge unknown 상태 재시도 (Phase F Quick Win) — 운영 중 튜닝용
     merge_unknown_retry_limit: int = 3        # 기본 3회
     merge_unknown_retry_delay: float = 3.0    # 기본 3초 간격 (총 최대 9초)
@@ -199,6 +208,28 @@ class Settings(BaseSettings):
         if not v:
             return v
         return cls._normalize_pg_url(v)
+
+    @field_validator("migration_database_url")
+    @classmethod
+    def fix_migration_url(cls, v: str) -> str:
+        """MIGRATION_DATABASE_URL의 postgres:// 스킴을 postgresql://로 변환한다.
+        Normalize the postgres:// scheme of MIGRATION_DATABASE_URL to postgresql://."""
+        if not v:
+            return v
+        return cls._normalize_pg_url(v)
+
+    @property
+    def effective_migration_url(self) -> str:
+        """alembic 마이그레이션 실행에 쓸 URL — MIGRATION_DATABASE_URL 우선, 미설정 시 DATABASE_URL.
+
+        RLS Phase 4 에서 DATABASE_URL 이 비-BYPASSRLS app role 로 전환돼도 owner 자격으로
+        마이그레이션을 돌리기 위한 단일 결정점. 미설정 시 DATABASE_URL 재사용(현행 동작 보존).
+
+        URL for running alembic migrations — prefers MIGRATION_DATABASE_URL, else DATABASE_URL.
+        Single decision point so migrations keep owner credentials even after RLS Phase 4
+        switches DATABASE_URL to the non-BYPASSRLS app role. Unset reuses DATABASE_URL.
+        """
+        return self.migration_database_url or self.database_url
 
     @model_validator(mode="after")
     def _validate_retry_backoff_bounds(self) -> "Settings":

--- a/tests/unit/migrations/test_alembic_env_migration_url.py
+++ b/tests/unit/migrations/test_alembic_env_migration_url.py
@@ -1,0 +1,69 @@
+"""alembic/env.py 가 MIGRATION_DATABASE_URL 게이트를 사용하는지 잠그는 회귀 가드.
+Regression guard locking alembic/env.py to the MIGRATION_DATABASE_URL gate.
+
+RLS Phase 4 에서 DATABASE_URL 이 비-BYPASSRLS app role(`scamanager_app`)로 바뀌면,
+env.py:30 이 `settings.database_url` 로 마이그레이션을 돌릴 경우 pre-deploy/lifespan
+`alembic upgrade head` 가 app role 로 실행 → `alembic_version`(relrowsecurity=true·policy 0건
+= default-deny) 차단 → 배포 실패. 따라서 env.py 는 `settings.effective_migration_url`
+(= MIGRATION_DATABASE_URL or DATABASE_URL)을 sqlalchemy.url 로 사용해야 한다.
+이 가드는 누군가 무심코 `settings.database_url` 로 되돌려 Phase 4 게이트를 무력화하는
+회귀를 정적으로 차단한다.
+
+In RLS Phase 4, DATABASE_URL switches to the non-BYPASSRLS app role; if env.py used
+`settings.database_url` for migrations, the pre-deploy/lifespan `alembic upgrade head`
+would run as the app role and hit `alembic_version` default-deny → deploy failure.
+env.py must therefore use `settings.effective_migration_url` (MIGRATION_DATABASE_URL or
+DATABASE_URL). This guard statically blocks a regression back to `settings.database_url`.
+
+절차: docs/runbooks/rls-role-separation.md §6 마이그레이션 credential 게이트.
+"""
+import ast
+import pathlib
+
+import pytest
+
+_ENV_PY = pathlib.Path(__file__).resolve().parents[3] / "alembic" / "env.py"
+
+
+def _is_sqlalchemy_url_arg(arg: ast.AST) -> bool:
+    """첫 인자가 리터럴 "sqlalchemy.url" 또는 상수 `_SQLALCHEMY_URL` 인지 판정."""
+    if isinstance(arg, ast.Constant) and arg.value == "sqlalchemy.url":
+        return True
+    return isinstance(arg, ast.Name) and arg.id == "_SQLALCHEMY_URL"
+
+
+def _set_main_option_url_arg() -> ast.AST:
+    """env.py 의 `config.set_main_option(<url-key>, <arg>)` 호출의 <arg> AST 를 반환."""
+    tree = ast.parse(_ENV_PY.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "set_main_option"):
+            continue
+        # 첫 인자가 sqlalchemy.url 키(리터럴 또는 상수)인 호출만
+        if node.args and _is_sqlalchemy_url_arg(node.args[0]):
+            assert len(node.args) >= 2, "set_main_option(sqlalchemy.url, ...) 두 번째 인자 필요"
+            return node.args[1]
+    pytest.fail("alembic/env.py 에서 set_main_option(sqlalchemy.url, ...) 호출을 찾지 못함")
+
+
+def test_env_uses_effective_migration_url():
+    """env.py 가 sqlalchemy.url 을 settings.effective_migration_url 로 설정해야 한다."""
+    arg = _set_main_option_url_arg()
+    src = ast.unparse(arg)
+    assert "effective_migration_url" in src, (
+        "alembic/env.py 는 sqlalchemy.url 을 settings.effective_migration_url 로 설정해야 한다 "
+        f"(현재: {src}). RLS Phase 4 마이그레이션 credential 게이트 회귀."
+    )
+
+
+def test_env_does_not_use_database_url_directly():
+    """env.py 가 sqlalchemy.url 인자로 settings.database_url 을 직접 쓰면 안 된다 (Phase 4 게이트 무력화)."""
+    arg = _set_main_option_url_arg()
+    src = ast.unparse(arg)
+    assert "database_url" not in src, (
+        "alembic/env.py 가 sqlalchemy.url 을 settings.database_url 로 직접 설정 — "
+        "RLS Phase 4 에서 app role 마이그레이션 → alembic_version default-deny 차단. "
+        "settings.effective_migration_url 사용 필수."
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -114,6 +114,65 @@ def test_supabase_url_ssl_added(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# MIGRATION_DATABASE_URL — RLS Phase 4 마이그레이션 credential 분리 (owner role)
+# MIGRATION_DATABASE_URL — RLS Phase 4 migration credential separation (owner role)
+#   alembic/env.py 가 effective_migration_url 을 sqlalchemy.url 로 사용:
+#   설정 시 owner credential 로 마이그레이션, 미설정 시 DATABASE_URL 재사용(현행 보존).
+# ---------------------------------------------------------------------------
+
+
+def test_migration_database_url_default_empty(monkeypatch):
+    # MIGRATION_DATABASE_URL 미설정 시 빈 문자열이어야 한다 (inert-when-unset).
+    # Unset MIGRATION_DATABASE_URL must default to an empty string (inert-when-unset).
+    s = _reload_settings(monkeypatch)
+    assert s.migration_database_url == ""
+
+
+def test_migration_database_url_normalizes_postgres_scheme(monkeypatch):
+    # postgres:// → postgresql:// 정규화 (database_url 과 동일 validator).
+    # postgres:// → postgresql:// normalization (same validator as database_url).
+    s = _reload_settings(
+        monkeypatch,
+        extra={"MIGRATION_DATABASE_URL": "postgres://owner:pw@localhost/db"},
+    )
+    assert s.migration_database_url.startswith("postgresql://")
+
+
+def test_migration_database_url_supabase_ssl_added(monkeypatch):
+    # supabase.co 호스트면 sslmode=require 자동 추가 (database_url 과 동일).
+    # supabase.co host auto-adds sslmode=require (same as database_url).
+    s = _reload_settings(
+        monkeypatch,
+        extra={"MIGRATION_DATABASE_URL": "postgresql://owner:pw@db.abc.supabase.co/postgres"},
+    )
+    assert "sslmode=require" in s.migration_database_url
+
+
+def test_effective_migration_url_falls_back_to_database_url(monkeypatch):
+    # MIGRATION_DATABASE_URL 미설정 → effective_migration_url 은 database_url 과 동일 (현행 동작).
+    # Unset → effective_migration_url equals database_url (current behavior preserved).
+    s = _reload_settings(
+        monkeypatch,
+        extra={"DATABASE_URL": "postgresql://app:pw@localhost/db"},
+    )
+    assert s.effective_migration_url == s.database_url
+
+
+def test_effective_migration_url_prefers_migration_url(monkeypatch):
+    # MIGRATION_DATABASE_URL 설정 → effective_migration_url 은 그것을 우선 사용 (owner credential).
+    # Set → effective_migration_url prefers it (owner credential), not database_url.
+    s = _reload_settings(
+        monkeypatch,
+        extra={
+            "DATABASE_URL": "postgresql://app:pw@localhost/db",
+            "MIGRATION_DATABASE_URL": "postgresql://owner:pw@localhost/db",
+        },
+    )
+    assert s.effective_migration_url == "postgresql://owner:pw@localhost/db"
+    assert s.effective_migration_url != s.database_url
+
+
+# ---------------------------------------------------------------------------
 # Phase 1 PR-1a — i18n 환경변수 5건 + field_validator 4건 검증 (Cycle 84+)
 # Phase 1 PR-1a — i18n env vars 5 + field_validators 4 (Cycle 84+)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

RLS Phase 4 "두 번째 벽" 해소 — alembic 마이그레이션 credential 을 런타임 app credential 과 분리. follow-up ② (#907 §6 게이트의 코드 구현). **미설정 시 동작 완전 동일 = 발효 0** (`DATABASE_URL_WORKER` 와 동일한 inert-when-unset 패턴).

## 문제

`alembic/env.py` 가 `sqlalchemy.url` 을 무조건 `settings.database_url` 로 override 한다 — 이 단일 결정점은 lifespan `command.upgrade()` 와 `railway.toml preDeployCommand`(#906) 양쪽이 공유한다. RLS Phase 4 에서 `DATABASE_URL` 이 비-BYPASSRLS app role(`scamanager_app`)로 전환되면, 두 마이그레이션 경로가 app role 로 실행 → `alembic_version`(relrowsecurity=true·policy 0건 = default-deny) 차단 → 배포 실패.

## 변경 내용

- **`config.py`**: `migration_database_url` 필드 + `postgres://` 정규화 validator(`fix_migration_url`, `fix_worker_url` 미러) + **`effective_migration_url` property** (`= migration_database_url or database_url`).
- **`alembic/env.py`**: `sqlalchemy.url = settings.effective_migration_url` (offline/online 양 경로 + pre-deploy CLI + lifespan 자동 적용). `"sqlalchemy.url"` 리터럴 3건 → `_SQLALCHEMY_URL` 상수화(SonarCloud S1192 선제 해소).
- **`env-vars.md` + `.env.example`**: `MIGRATION_DATABASE_URL` 등재(owner role·Phase 4·미설정 발효 0·런타임 URL 재사용 금지).
- **테스트 7건**: config 5(default empty / postgres 정규화 / supabase ssl / fallback / precedence) + `test_alembic_env_migration_url.py` ast 회귀 가드 2(`effective_migration_url` 사용 강제 + `database_url` 직접 사용 금지) — Phase 4 게이트 무력화 회귀를 정적으로 차단.

## 설계 — inert-when-unset (위험 0)

`migration_database_url` default `""` → `effective_migration_url` = `"" or database_url` = `database_url`. 기존 마이그레이션 테스트(`patch.object(settings, "database_url", ...)`, db.md 패턴)도 그대로 통과. Phase 4 운영 전환 시 `MIGRATION_DATABASE_URL`(owner) env 설정만으로 자동 발효 — `railway.toml`/`main.py` 변경 불요.

## 검증

- 전체 **5098 passed · 8 skipped** (회귀 0). pylint `src/` **10.00** / flake8 · bandit clean. (TDD Red→Green: 신규 7건 사전 실패 확인.)
- **Codex mutual(정책 18) OK** — 7개 체크(fallback·offline/online·validator·회귀·상수화·ast 가드·bypass 부재) 전부 확인. 비차단 노트: owner credential 이 in-process(lifespan) — `DATABASE_URL`/`DATABASE_URL_WORKER` 와 동일 노출 클래스(신규 위험 0).

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인 (pylint floor 9.90 / SonarCloud / codecov).
- [ ] **운영(Phase 4 시점)**: `MIGRATION_DATABASE_URL` 은 Railway **secret** 으로 설정(owner 자격) — 로그 노출 금지(기존 `DATABASE_URL*` 와 동일 취급). Phase 4 전환은 [`rls-role-separation.md`](docs/runbooks/rls-role-separation.md) §Phase 4 순서대로.

## ⚠️ 자율 판단 보고 (정책 3)

- `railway.toml` **미변경** — env.py 단일 결정점이 pre-deploy CLI 까지 자동 커버하므로 #906 과 충돌 없음(독립 머지 가능).
- **S1192 상수화**는 env.py line 38 을 수정하며 SonarCloud 가 "새 코드"로 귀속할 위험 선제 차단(pre-existing 3중 리터럴).
- 🔴 **post-merge sync 필요**: #907 이 추가한 `rls-role-separation.md §6` / `db.md` / `.codex/rules/db.md` 의 "별도 코드 PR (미구현)" 게이트 문구를 **"✅ 구현됨 (이 PR)"** 으로 갱신하는 작은 docs sync 가 #907+이 PR 머지 후 필요(이 PR 은 main 기준 브랜치라 #907 의 해당 줄을 건드리지 않음 — 충돌 회피).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex 검증 완료 — **Verdict: OK** (7/7 체크 통과). 비차단 보안 노트(secret scope/로그) 위 §사용자 검증에 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
