### PR TITLE
fix(test): CodeQL #518 py/mixed-returns 해소 — pytest.fail→raise + unused import 제거

### DIFF
--- a/tests/unit/migrations/test_alembic_env_migration_url.py
+++ b/tests/unit/migrations/test_alembic_env_migration_url.py
@@ -20,8 +20,6 @@ DATABASE_URL). This guard statically blocks a regression back to `settings.datab
 import ast
 import pathlib
 
-import pytest
-
 _ENV_PY = pathlib.Path(__file__).resolve().parents[3] / "alembic" / "env.py"
 
 
@@ -45,7 +43,9 @@ def _set_main_option_url_arg() -> ast.AST:
         if node.args and _is_sqlalchemy_url_arg(node.args[0]):
             assert len(node.args) >= 2, "set_main_option(sqlalchemy.url, ...) 두 번째 인자 필요"
             return node.args[1]
-    pytest.fail("alembic/env.py 에서 set_main_option(sqlalchemy.url, ...) 호출을 찾지 못함")
+    # 호출을 못 찾으면 명시적 raise — 함수 끝 fall-through(암묵 None) 제거로 py/mixed-returns 해소.
+    # Explicit raise when not found — removes the implicit-None fall-through (resolves py/mixed-returns).
+    raise AssertionError("alembic/env.py 에서 set_main_option(sqlalchemy.url, ...) 호출을 찾지 못함")
 
 
 def test_env_uses_effective_migration_url():


### PR DESCRIPTION
## 요약

2026-06-16 세션 회고(정책 8, 5+1 다중 에이전트)가 적발한 **open CodeQL alert #518** (`py/mixed-returns`, note) 해소.

`tests/unit/migrations/test_alembic_env_migration_url.py` 의 헬퍼 `_set_main_option_url_arg()` 가 루프 내 `return node.args[1]` + 함수 끝 `pytest.fail()` 를 혼용 → CodeQL 흐름분석이 `pytest.fail` 의 `NoReturn` 을 미인식해 "값 반환 경로 + 암묵 None fall-through 혼재" 로 오탐. #908 작업 self-inflicted (전례 #516 상수 고아화 · #517 이중 import 와 동일 "PR-diff green ≠ main 전체 스캔" 계열, main 머지 후 전체 스캔서만 노출).

## 변경

| 항목 | 내용 |
|------|------|
| `pytest.fail(...)` → `raise AssertionError(...)` | 명시 `raise` = CodeQL 종단 인식 → fall-through(암묵 None) 제거 → `py/mixed-returns` 해소 |
| `import pytest` 제거 | pytest 단일 사용처(`pytest.fail`)가 사라져 unused-import → **`py/unused-import` (#517 재발) 선제 차단**. 파일 내 두 test 함수는 `assert` 만 사용(pytest 미의존) |

> 🔴 retro 권장안은 `pytest.fail→raise` 만 제안했으나, `import pytest` cascade(#517 계열 재발)를 추가로 잡아 함께 제거.

## 검증

- `pytest tests/unit/migrations/test_alembic_env_migration_url.py` → **2 passed**
- `flake8` clean · `pylint` **10.00/10** · unused-import **0**
- 동작 동등 (set_main_option 미발견 시 AssertionError 로 테스트 실패 — pytest.fail 과 동일 효과)
- 테스트 카운트 불변 (단위 4952 · 전체 5106)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

push 전 Codex mutual 검증 완료 — **VERDICT: OK** (4개 항목 전부):
1. `raise AssertionError` ↔ `pytest.fail` 동작 동등 (assertion failure 로 수집·보고) — OK
2. `import pytest` 제거 안전 (파일 내 잔존 사용처 0) — OK
3. `py/mixed-returns` 실제 해소 (fall-through 경로 제거) — OK
4. 새 회귀/CodeQL alert(unused-import 등) 유발 가능성 없음 — OK

## 🔍 사용자 검증 필요

- 머지 후 main 전체 CodeQL 스캔에서 **alert #518 auto-resolve** 확인 (Security 탭 Code Scanning open → 0, 정책 14). self-inflicted CodeQL 은 PR-diff CI 가 아니라 main 머지 후 전체 스캔서 해소됨(#516/#517 전례).
