### PR TITLE
chore(governance): codex mutual 운용 도구 default codify + .codex_* gitignore 가드 (PROC-1/3)

### DIFF
--- a/.claude/policies/active.md
+++ b/.claude/policies/active.md
@@ -397,6 +397,20 @@ git push -u origin <branch>
 - 🔴 **토큰 만료/런타임 오류 fallback 예외 (사이클 161 회고 신설)** — Codex 액세스 토큰 만료(`refresh token already used`)·샌드박스 제약·CLI 런타임 오류로 mutual 자동 검증 불능 시 = **사용자 명시 승인 하 Claude 직접검증 fallback** 정당 (정책 18 예외 "사용자 직접 결정 영역" + 사이클 119/125/161 전례). fallback PR 본문에 ① 만료/오류 사유 ② 사용자 승인 ③ 직접검증 근거(적대적 분석·TDD·lint) 3종 명시 의무.
   - 🔴 **복구 강제 가드 (mutual 2-layer 가치 회귀 차단)** — 동일 fallback 이 **≥ 2 사이클 또는 ≥ 5 PR 연속** 시 = 다음 세션 진입 전 `codex logout; codex login` 복구를 **사용자 1줄 확인으로 강제 트리거** (메모리 [[feedback-codex-post-validation-mandatory]] + [[integrity-audit-session]] 재개법 "codex login 권장" → "복구 강제"로 강화). mutual = 외부 LLM 다양성 핵심 가치이므로 장기 1-layer 운영 금지.
 
+### codex mutual 운용 도구 default (사이클 167 신설 — 2026-06-16 회고 PROC-1/3)
+
+본 Windows 호스트 환경은 `codex-cli` 가용 → Claude 가 `codex exec` 로 직접 mutual 검증 가능 (위 "운영 흐름" 의 사용자-대리 시나리오 A 와 별개 경로). 이때 도구 마찰 재발 방지 default:
+
+🔴 **쉘 주의**: codex stdin 파이프 호출은 **Bash 툴(POSIX sh) 로 수행** — PowerShell 은 `<` 입력 리다이렉션·`/dev/null` 미지원이라 codex 파이프엔 부적합 (PowerShell 은 git/lint 용). 아래 관용구·`/dev/null` 규칙은 **Bash 툴 기준**.
+
+- 🔴 **입력(프롬프트/diff) 전달 = `codex exec -` stdin 파이프 또는 repo 밖 임시파일만**. argv 직접 전달은 거대 입력서 `Argument list too long` (STATE 거대 라인 전례). 권장 관용구 (Bash 툴): `{ echo "<prompt>"; git diff main...HEAD; } | codex exec -s read-only --skip-git-repo-check -`.
+- 🔴 **repo 내부 임시파일 + `git add -A` 금지** — `.codex_*` scratch 가 staging 되면 trailing-whitespace pre-commit hook fail → **commit 무음 실패** → Codex 가 구(pre-fix) diff 리뷰 = false NG (2026-06-15 사고). 명시 path `git add <file>` 의무. `.codex_*` 은 `.gitignore` 가드(probe 가드 아래) — `.codex/`(추적 설정 디렉토리)는 패턴 비매칭이라 안전.
+- 🔴 **(Bash 툴) `< /dev/null` 은 prompt 를 arg 로 줄 때만** (stdin 대기 방지). stdin 파이프로 prompt 전달 시 `< /dev/null` 은 파이프를 덮어써 `No prompt provided via stdin` → 동시 사용 금지.
+- 정적 리뷰만 요청 (pytest **실행** 요청 금지 — Codex 가 `pytest` 를 model 명으로 오파싱). 로컬 test/lint 증거를 본문에 첨부 → genuine OK.
+- **검증 직후 `git status` 로 임시파일 staging 0 확인 후 commit** (PowerShell 다중 commit 메시지는 here-string 깨짐 주의 → repo 밖 파일 + `git commit -F` 권장).
+
+cross-ref: 메모리 [[feedback-codex-post-validation-mandatory]].
+
 ### 17 정책 cross-reference 표 (CLAUDE.md 정책 18 본문서 이관 — docs reorg Phase 3d)
 
 mutual 검증이 다른 정책과 맺는 충돌/페어 7건:

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@ env/
 *.dbpw
 db_probe.py
 
+# codex mutual 검증 임시파일 (프롬프트/diff scratch — 절대 커밋 금지, 2026-06-16 회고 PROC-1/3)
+# codex mutual-verification scratch files (prompt/diff — NEVER commit).
+#   ⚠️ 패턴 `.codex_*` 은 추적되는 설정 디렉토리 `.codex/`(agents/hooks/rules)는 매칭하지 않음.
+#   The `.codex_*` pattern does NOT match the tracked `.codex/` config dir.
+.codex_*
+
 # IDE
 .vscode/
 .idea/


### PR DESCRIPTION
## 요약

2026-06-16 세션 회고(정책 8, 5+1 다중 에이전트) **PROC-1/3** — codex mutual 검증(정책 18) 운용 도구 마찰 2건이 세션 narrative 에만 기록되고 영속 default 미승격이던 것을 영구 codify.

## 변경

**PROC-1** — `.claude/policies/active.md` 정책 18 에 "codex mutual 운용 도구 default" 서브섹션 신설:
- 입력(프롬프트/diff) 전달 = `codex exec -` stdin 파이프 또는 repo 밖 임시파일만 (argv 거대 입력 `Argument list too long` 방지)
- repo 내부 임시파일 + `git add -A` **금지** — `.codex_*` staging → trailing-ws hook fail → **commit 무음 실패** → Codex 가 구 diff 리뷰 = false NG (2026-06-15 사고). 명시 path add 의무
- (Bash 툴) `< /dev/null` 은 prompt arg 시만 — stdin 파이프와 동시 사용 시 `No prompt provided via stdin`
- 정적 리뷰만 요청 (pytest 실행 요청 = model 명 오파싱) + 검증 직후 `git status` staging 확인
- 🔴 **쉘 한정**: 위 관용구·`/dev/null` 규칙은 **Bash 툴(POSIX sh) 기준** — PowerShell 은 `<`·`/dev/null` 미지원 (PowerShell 은 git/lint 용)

**PROC-3** — `.gitignore` `.codex_*` 가드 추가 (#907 `.dbpw` probe 가드와 대칭):
- ⚠️ 추적 설정 디렉토리 `.codex/`(agents/hooks/rules)는 패턴 **비매칭**

## 검증

- `git check-ignore -v` 실측: `.codex_review.txt` → IGNORED / `.codex/agents/test-writer.toml` → **NOT ignored** (설정 디렉토리 보존)
- docs/`.gitignore`-only — 테스트/코드 무변경, 카운트 불변 (단위 4952·전체 5106)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

push 전 Codex mutual 검증 — **NG 1회 → 정정 → OK** (정책 18 §3b 단일정답):
- **NG**: `codex exec -` stdin 파이프 + `< /dev/null` 관용구가 POSIX-shell 전용인데 "Windows 호스트 환경"이라 적어 PowerShell 오해 소지 → Codex 적발.
- **정정**: 서브섹션에 "🔴 쉘 주의: Bash 툴(POSIX sh) 기준" 한정자 추가 + bullet 별 "(Bash 툴)" 명시 + PowerShell here-string 깨짐 → `git commit -F` 권장 보너스.
- **재검증 VERDICT: OK** — 쉘 한정 명확·새 모순 없음.

> 본 PR 자체가 codex tooling codify인데 그 안에서 mutual 검증이 정확성 결함을 잡아 정정 — 정책 18 §5 2-layer 가치 실증.

## 🔍 사용자 검증 필요

- 정책 18 본문(active.md) 행동 가이드 변경 — 다음 세션 Claude 의 codex mutual 운용에 적용됨. 의도와 다른 제약이 있으면 알려주세요.
