### PR TITLE
fix(config): Supabase SSL hostname/query-param 파싱 — substring false-positive 제거 (회고 P2 CODE-2)

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,6 @@
 """Application settings loaded from environment variables via pydantic-settings."""
 import logging
+from urllib.parse import urlparse, parse_qs
 from pydantic_settings import BaseSettings
 from pydantic import Field, field_validator, model_validator
 from src.constants import MERGE_VERIFIER_BAND_DEFAULT
@@ -150,8 +151,19 @@ class Settings(BaseSettings):
         """postgres:// → postgresql:// 변환 + Supabase SSL 자동 추가."""
         if v.startswith("postgres://"):
             v = v.replace("postgres://", "postgresql://", 1)
-        if 'supabase.co' in v and 'sslmode' not in v:
-            v += '?sslmode=require'
+        # Supabase 호스트는 SSL 필수 — direct(db.<ref>.supabase.co) + pooler(aws-N.pooler.supabase.com).
+        # 전체 URL substring 대신 hostname 을 파싱해 .supabase.co/.supabase.com 으로 endswith 판정 —
+        # credential/path/query 에 'supabase.com' 이 섞인 비-Supabase URL 의 SSL 오강제(false-positive)와
+        # 'evil-supabase.com' 류 유사 도메인을 배제. pooler(.com) 누락 회귀도 함께 차단(2026-06-15 맥락).
+        # sslmode 존재 판정은 query param 기준(password 내 'sslmode' 문자열 false-negative 방지),
+        # append 는 기존 query 유무로 separator 선택(? vs &)해 '?...?' query 손상 방지. urlunparse
+        # 전체 재구성은 round-trip 재인코딩 위험이 있어 append-only 유지(정책 16 — URL 원형 보존).
+        # Host-parse for SSL targeting; sslmode checked per query-param; append uses ?/& by existing query.
+        parsed = urlparse(v)
+        host = parsed.hostname or ''
+        is_supabase = host.endswith('.supabase.co') or host.endswith('.supabase.com')
+        if is_supabase and 'sslmode' not in parse_qs(parsed.query):
+            v += ('&' if parsed.query else '?') + 'sslmode=require'
         return v
 
     @field_validator("session_secret")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -113,6 +113,44 @@ def test_supabase_url_ssl_added(monkeypatch):
     assert "sslmode=require" in s.database_url
 
 
+def test_supabase_pooler_url_ssl_added(monkeypatch):
+    # 🔴 회귀 가드: pooler 호스트(aws-N...pooler.supabase.com, .com TLD)에도 sslmode=require 자동 추가.
+    # Railway IPv4-only egress 는 pooler(.supabase.com) 강제 → 매칭이 '.supabase.co' 만으로 좁혀지면
+    # pooler SSL 누락 → 마이그레이션/연결 운영 장애. _normalize_pg_url 의 hostname endswith 매칭을 잠근다.
+    # Regression guard: pooler host (.supabase.com TLD) must also auto-add sslmode=require.
+    s = _reload_settings(
+        monkeypatch,
+        extra={"DATABASE_URL": "postgresql://u:p@aws-1-ap-northeast-1.pooler.supabase.com:5432/postgres"},
+    )
+    assert "sslmode=require" in s.database_url
+
+
+def test_supabase_substring_in_credential_no_ssl(monkeypatch):
+    # 🔴 회귀 가드: hostname 파싱 — 'supabase.com' 이 host 가 아니라 credential 에 있으면 SSL 미강제.
+    # full-URL substring 매칭이었다면 SSL 이 오강제됐을 케이스(실제 host=onprem-db.internal).
+    # Host-parsing guard: 'supabase.com' in the credential (not the host) must NOT force SSL.
+    s = _reload_settings(
+        monkeypatch,
+        extra={"DATABASE_URL": "postgresql://supabase.com:pw@onprem-db.internal:5432/app"},
+    )
+    assert "sslmode" not in s.database_url
+
+
+def test_supabase_url_preserves_existing_query(monkeypatch):
+    # 🔴 회귀 가드: 기존 query 가 있으면 '&' 로 병합(? 중복 금지), 이미 sslmode 있으면 중복 추가 안 함.
+    # Existing query merges with '&' (no double '?'); an existing sslmode param is not duplicated.
+    s = _reload_settings(
+        monkeypatch,
+        extra={"DATABASE_URL": "postgresql://u:p@db.abc.supabase.co/postgres?connect_timeout=10"},
+    )
+    assert s.database_url.endswith("?connect_timeout=10&sslmode=require")
+    s2 = _reload_settings(
+        monkeypatch,
+        extra={"DATABASE_URL": "postgresql://u:p@db.abc.supabase.co/postgres?sslmode=disable"},
+    )
+    assert s2.database_url.count("sslmode") == 1
+
+
 # ---------------------------------------------------------------------------
 # MIGRATION_DATABASE_URL — RLS Phase 4 마이그레이션 credential 분리 (owner role)
 # MIGRATION_DATABASE_URL — RLS Phase 4 migration credential separation (owner role)


### PR DESCRIPTION
## 요약

2026-06-16 세션 회고 **P2 CODE-2** — `config.py` `_normalize_pg_url` 의 Supabase SSL 자동추가가 `'supabase.co'` 단독 substring 에 의존. `'supabase.co'` 가 pooler `'.supabase.com'` 의 substring 이라 현재 pooler 호스트에도 SSL 이 정확히 붙지만(동작 옳음), 의도된 표현이 아닌 부수효과 — 엄격매칭으로 '정정' 시 pooler SSL 누락 회귀(마이그레이션/연결 운영 장애, 2026-06-15 맥락). RLS Phase 4 transition 안전 하드닝.

## 변경 (Codex mutual 2라운드로 robustness 강화)

| 항목 | before | after |
|------|--------|-------|
| host 판정 | `'supabase.co' in v` (전체 URL substring) | `urlparse(v).hostname` 의 `.supabase.co`/`.supabase.com` **endswith** |
| sslmode 판정 | `'sslmode' not in v` (전체 substring) | `'sslmode' not in parse_qs(parsed.query)` (query-param 기준) |
| append | `v += '?sslmode=require'` | `('&' if parsed.query else '?')` separator |

- credential/path 의 `'supabase.com'` false-positive + `'evil-supabase.com'` 유사도메인 배제.
- password 내 `'sslmode'` false-negative 방지 · 기존 query `'?...?'` 손상 방지.
- `urlunparse` 전체 재구성은 round-trip 재인코딩 위험으로 지양 — append-only(URL 원형 보존, 정책 16).
- **진짜 Supabase host(direct + pooler)는 SSL 보존 — 동작 불변.**

## 검증

- `pytest tests/unit/test_config.py` → **40 passed** (+3: pooler SSL / credential 'supabase.com' SSL 미강제 / 기존 query '&' 병합·sslmode 중복 방지)
- `pylint` **10.00** · `flake8` clean · 단위 4952→**4955** · 전체 5106→**5109**

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

push 전 Codex mutual — **NG 2회 → 정정 → OK** (정책 18 §3b 단일정답 robustness):
- **NG1**: 전체 URL substring 이라 host false-positive 잔존 → host 파싱(urlparse)으로 정정.
- **NG2**: sslmode substring 체크 + 단순 `?` append 위험 → query-param 기준 + separator 로 정정.
- **R3 VERDICT: OK** (4개 항목 전부 — false-negative/query 손상 해소·append-only 합리·동작 불변).

## 🔍 사용자 검증 필요

- 동작 불변(현 운영 pooler URL `aws-1-...pooler.supabase.com` 은 변경 전후 모두 `sslmode=require` 자동 추가) — Phase 4 마이그레이션 credential URL SSL 경로 강화.
