### PR TITLE
docs: rules path 메타데이터 정합 — .codex 미러 drift + CLAUDE.md 표 동기화 (품질감사 doccon-1/2/3)

### DIFF
--- a/.codex/rules/deploy.md
+++ b/.codex/rules/deploy.md
@@ -6,8 +6,9 @@ paths:
   - "requirements.txt"
   - "requirements-dev.txt"
   - ".env.example"
-  - "Procfile"
+  - ".python-version"
   - "alembic.ini"
+  - "sonar-project.properties"
 ---
 
 # 배포 규칙 (Codex)

--- a/.codex/rules/security.md
+++ b/.codex/rules/security.md
@@ -6,6 +6,7 @@ paths:
   - "src/shared/log_safety.py"
   - "src/api/auth.py"
   - "src/webhook/validator.py"
+  - "src/main.py"
 ---
 
 # 보안 규칙 (Codex)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -401,10 +401,10 @@ GitHub Code Scanning 점검 detail 절차 + 운영 통합 = `docs/runbooks/opera
 | DB / 마이그레이션 | [`.claude/rules/db.md`](.claude/rules/db.md) | `alembic/**`, `src/models/**`, `src/database.py`, `src/repositories/**` |
 | 파이프라인 / 비즈니스 로직 | [`.claude/rules/pipeline.md`](.claude/rules/pipeline.md) | `src/worker/pipeline.py`, `src/analyzer/**`, `src/scorer/**`, `src/webhook/**`, `src/gate/**` |
 | API / 알림 채널 | [`.claude/rules/api.md`](.claude/rules/api.md) | `src/api/**`, `src/notifier/**`, `src/webhook/**`, `src/gate/**`, `src/main.py` |
-| 보안 | [`.claude/rules/security.md`](.claude/rules/security.md) | `src/auth/**`, `src/crypto.py`, `src/shared/log_safety.py`, `src/api/auth.py`, `src/webhook/validator.py` |
+| 보안 | [`.claude/rules/security.md`](.claude/rules/security.md) | `src/auth/**`, `src/crypto.py`, `src/shared/log_safety.py`, `src/api/auth.py`, `src/webhook/validator.py`, `src/main.py` |
 | UI / 템플릿 | [`.claude/rules/ui.md`](.claude/rules/ui.md) | `src/templates/**`, `src/static/**`, `src/ui/**` |
 | 다국어 / i18n | [`.claude/rules/i18n.md`](.claude/rules/i18n.md) | `src/i18n/**`, `src/middleware/locale.py`, `src/notifier/_language.py`, `src/analyzer/pure/review_guides/**` |
-| 배포 | [`.claude/rules/deploy.md`](.claude/rules/deploy.md) | `railway.toml`, `nixpacks.toml`, `requirements.txt`, `requirements-dev.txt`, `.env.example` |
+| 배포 | [`.claude/rules/deploy.md`](.claude/rules/deploy.md) | `railway.toml`, `nixpacks.toml`, `requirements.txt`, `requirements-dev.txt`, `.env.example`, `.python-version`, `alembic.ini`, `sonar-project.properties` |
 
 🔴 표시는 과거 사고로 검증된 고위험 규칙이다 (각 `.claude/rules/<area>.md` 파일 본문 참조).
 


### PR DESCRIPTION
## 요약

품질 감사 워크플로우(9차원·24에이전트, `wf_c9b58749`)가 발견한 **path-scoped rules 미러 메타데이터 drift** 해소 (doccon-1/2/3). 코드 무변경 (docs/메타 only).

`.claude/rules/<area>.md`(Claude용)와 `.codex/rules/<area>.md`(Codex용) 미러는 frontmatter `paths:`로 path-scoped 자동 로드된다. 둘의 paths가 어긋나면 정책 18(Claude↔Codex mutual 검증) 환경에서 동일 파일에 대해 두 LLM이 서로 다른 규칙 컨텍스트를 갖게 된다.

| 변경 | 내용 | 결함 |
|------|------|------|
| `.codex/rules/deploy.md` | 유령 `Procfile`(미존재 dead glob) 제거 + 실재 `.python-version`·`sonar-project.properties` 추가 | doccon-2 (P1) |
| `.codex/rules/security.md` | `src/main.py` 추가 (SecurityHeaders/LimitBodySize/CSP/SESSION_SECRET prod-guard 보유 보안 영역) | doccon-1 (P2) |
| `CLAUDE.md:404` 보안 행 | `src/main.py` 추가 (line 364 매트릭스·rules frontmatter와 정합) | doccon-3 (P2) |
| `CLAUDE.md:407` 배포 행 | `.python-version`·`alembic.ini`·`sonar-project.properties` 추가 (권위 `.claude/rules/deploy.md`와 완전 정합) | 자율 판단 (동일 부류 SSOT 정합) |

## 자율 판단 보고 (정책 3)

- `CLAUDE.md:407` 배포 행은 audit가 직접 지목하지 않았으나 doccon-2와 동일 부류(deploy path SSOT)라 함께 정합화했습니다. 권위 출처 `.claude/rules/deploy.md` paths(8종)와 완전 일치시킴.
- content(rule 본문)는 의도적 축약본이라 **건드리지 않고 paths/표만** 동기화 (적대검증 verdict: codex 미러는 의도적 축약).

## 검증

- 전 8개 rule 쌍(.claude↔.codex) paths `Compare-Object` **IDENTICAL** 실측 (testing/db/pipeline/api/security/ui/i18n/deploy).
- `git ls-files Dockerfile Procfile` = `Procfile` 미존재 확인 (dead glob 제거 근거), `.python-version`·`sonar-project.properties` 실재 확인.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

✅ **Codex built-in 리뷰어 OK** — `git diff 466aa41...` 실파일 직접 검증 후 "no discrete correctness, security, or maintainability issue introduced by this patch".

⚠️ 참고: 1차 codex-rescue(o3)가 존재하지 않는 `Dockerfile`/`.github/workflows/**` paths를 환각해 false-NG를 냈으나, ground-truth 직접 재검증(`git ls-files`·실파일 Read)으로 거짓 확정 → built-in 리뷰어가 실파일 기반으로 OK 독립 확증. (메모리 원칙: *audit verdict 맹신 금지·EXACT 직접 재검증*)

## 🔍 사용자 검증 필요

- [ ] 본 변경은 path-scoped rules 메타데이터/표만 수정 — 운영·런타임 영향 0 (코드 무변경). 별도 시각/운영 확인 불요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
