### PR TITLE
fix(resilience): 품질감사 P2 코드 nit 묶음 — logs JSON 래핑 + openai fallback 메트릭 대칭 + config validator DRY

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -204,28 +204,14 @@ class Settings(BaseSettings):
         """DATABASE_URL의 postgres:// 스킴을 postgresql://로 변환한다."""
         return cls._normalize_pg_url(v)
 
-    @field_validator("database_url_fallback")
+    @field_validator("database_url_fallback", "database_url_worker", "migration_database_url")
     @classmethod
-    def fix_fallback_url(cls, v: str) -> str:
-        """DATABASE_URL_FALLBACK의 postgres:// 스킴을 postgresql://로 변환한다."""
-        if not v:
-            return v
-        return cls._normalize_pg_url(v)
-
-    @field_validator("database_url_worker")
-    @classmethod
-    def fix_worker_url(cls, v: str) -> str:
-        """DATABASE_URL_WORKER의 postgres:// 스킴을 postgresql://로 변환한다.
-        Normalize the postgres:// scheme of DATABASE_URL_WORKER to postgresql://."""
-        if not v:
-            return v
-        return cls._normalize_pg_url(v)
-
-    @field_validator("migration_database_url")
-    @classmethod
-    def fix_migration_url(cls, v: str) -> str:
-        """MIGRATION_DATABASE_URL의 postgres:// 스킴을 postgresql://로 변환한다.
-        Normalize the postgres:// scheme of MIGRATION_DATABASE_URL to postgresql://."""
+    def fix_optional_pg_url(cls, v: str) -> str:
+        """선택적 postgres URL 3종(fallback/worker/migration)의 postgres:// → postgresql:// 정규화.
+        빈 값은 그대로 통과(미설정 = inert) — required database_url 과 달리 빈-값 가드 절을 보존한다.
+        Normalize postgres:// → postgresql:// for the 3 optional URLs (fallback/worker/migration).
+        Empty values pass through (unset = inert), unlike the required database_url's validator.
+        """
         if not v:
             return v
         return cls._normalize_pg_url(v)

--- a/src/railway_client/logs.py
+++ b/src/railway_client/logs.py
@@ -47,6 +47,12 @@ async def fetch_deployment_logs(
         data = resp.json()
     except httpx.HTTPError as exc:
         raise RailwayLogFetchError(f"HTTP 오류: {exc}") from exc
+    except ValueError as exc:
+        # resp.json() 의 JSONDecodeError(ValueError 하위) 래핑 — docstring Raises 계약 준수.
+        # 미래핑 시 deploy-failure Issue 생성 BackgroundTask 까지 전파돼 알림이 silent skip 됨.
+        # Wrap JSONDecodeError (a ValueError subclass) from resp.json() per the Raises contract;
+        # otherwise it propagates to the deploy-failure Issue task and silently skips the alert.
+        raise RailwayLogFetchError(f"응답 파싱 오류: {exc}") from exc
 
     errors = data.get("errors")
     if errors:

--- a/src/verifier/openai_client.py
+++ b/src/verifier/openai_client.py
@@ -80,22 +80,34 @@ async def _call_via_http(
     Fallback when openai SDK is absent — calls the API directly via the shared httpx pool.
     """
     client = get_http_client()
-    resp = await client.post(
-        _OPENAI_CHAT_URL,
-        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-        json={
-            "model": model,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": user_prompt},
-            ],
-            "response_format": {"type": "json_object"},
-            "max_completion_tokens": max_output_tokens,
-        },
-        timeout=timeout,
-    )
-    resp.raise_for_status()
-    data = resp.json()
+    try:
+        resp = await client.post(
+            _OPENAI_CHAT_URL,
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            json={
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+                "response_format": {"type": "json_object"},
+                "max_completion_tokens": max_output_tokens,
+            },
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+        # SDK 경로(call_openai_verifier except Exception)와 대칭 — fallback 실패도 메트릭 기록 후 re-raise.
+        # 이 try/except 가 없으면 예외가 부모의 `except ImportError` 안에서 발생해 형제
+        # `except Exception` 메트릭 로깅을 우회 → 관측성 비대칭(status=error 소실).
+        # Mirrors the SDK path: log status=error then re-raise. Without this, the exception raised
+        # inside the parent's ImportError handler would bypass the sibling except Exception logger.
+        log_openai_api_call(
+            model=model, duration_ms=(time.perf_counter() - start) * 1000,
+            input_tokens=0, output_tokens=0, status="error", error_type=type(exc).__name__,
+        )
+        raise
     usage = data.get("usage") or {}
     log_openai_api_call(
         model=model, duration_ms=(time.perf_counter() - start) * 1000,

--- a/tests/unit/railway_client/test_client.py
+++ b/tests/unit/railway_client/test_client.py
@@ -169,3 +169,24 @@ async def test_fetch_deployment_logs_graphql_error():
     with patch("src.railway_client.logs.get_http_client", return_value=mock_client):
         with pytest.raises(RailwayLogFetchError):
             await fetch_deployment_logs("tok", "deploy-123")
+
+
+@pytest.mark.asyncio
+async def test_fetch_deployment_logs_invalid_json():
+    """응답 본문이 JSON 파싱 실패(ValueError) 시 RailwayLogFetchError 로 래핑돼야 한다.
+    A response body that fails to parse as JSON must be wrapped as RailwayLogFetchError.
+
+    docstring Raises 계약("응답 파싱 오류")을 강제하는 회귀 가드 — 미래핑 시 ValueError 가
+    deploy-failure Issue 생성 BackgroundTask 까지 uncaught 전파돼 알림이 silent skip 된다.
+    Regression guard for the documented Raises contract — an unwrapped ValueError would
+    propagate to the deploy-failure Issue BackgroundTask and silently skip the alert.
+    """
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json.side_effect = ValueError("Expecting value: line 1 column 1 (char 0)")
+    mock_client = AsyncMock()
+    mock_client.post = AsyncMock(return_value=mock_resp)
+
+    with patch("src.railway_client.logs.get_http_client", return_value=mock_client):
+        with pytest.raises(RailwayLogFetchError):
+            await fetch_deployment_logs("tok", "deploy-123")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -223,6 +223,44 @@ def test_effective_migration_url_prefers_migration_url(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# postgres:// URL 정규화 — fallback/worker/migration 3 필드 공유 validator 회귀 가드
+#   (simplicity-2: 3개 byte-identical validator → pydantic 멀티필드 단일화 전후 동등성 봉인)
+# postgres:// URL normalization — shared validator across fallback/worker/migration
+#   (locks behavior before/after collapsing 3 identical validators into one multi-field validator)
+# ---------------------------------------------------------------------------
+
+
+def test_database_url_fallback_normalizes_postgres_scheme(monkeypatch):
+    # DATABASE_URL_FALLBACK 의 postgres:// → postgresql:// 정규화.
+    # DATABASE_URL_FALLBACK normalizes postgres:// → postgresql://.
+    s = _reload_settings(
+        monkeypatch, extra={"DATABASE_URL_FALLBACK": "postgres://u:p@localhost/db"})
+    assert s.database_url_fallback.startswith("postgresql://")
+
+
+def test_database_url_fallback_empty_passthrough(monkeypatch):
+    # 미설정 시 빈 문자열 그대로 통과 (정규화 시도 없이 — required database_url 과 구분되는 가드 절).
+    # Unset passes through as empty string (the guard clause distinguishing it from required database_url).
+    s = _reload_settings(monkeypatch)
+    assert s.database_url_fallback == ""
+
+
+def test_database_url_worker_normalizes_postgres_scheme(monkeypatch):
+    # DATABASE_URL_WORKER 의 postgres:// → postgresql:// 정규화.
+    # DATABASE_URL_WORKER normalizes postgres:// → postgresql://.
+    s = _reload_settings(
+        monkeypatch, extra={"DATABASE_URL_WORKER": "postgres://w:p@localhost/db"})
+    assert s.database_url_worker.startswith("postgresql://")
+
+
+def test_database_url_worker_empty_passthrough(monkeypatch):
+    # 미설정 시 빈 문자열 그대로 통과.
+    # Unset passes through as empty string.
+    s = _reload_settings(monkeypatch)
+    assert s.database_url_worker == ""
+
+
+# ---------------------------------------------------------------------------
 # Phase 1 PR-1a — i18n 환경변수 5건 + field_validator 4건 검증 (Cycle 84+)
 # Phase 1 PR-1a — i18n env vars 5 + field_validators 4 (Cycle 84+)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_worker_session_routing.py
+++ b/tests/unit/test_worker_session_routing.py
@@ -182,8 +182,8 @@ class TestDatabaseUrlWorkerConfig:
     Validates the database_url_worker default and postgres:// → postgresql:// conversion."""
 
     def test_worker_url_postgres_scheme_converted(self):
-        # postgres:// 스킴이 postgresql:// 로 변환되어야 한다 (fix_fallback_url 패턴 미러)
-        # The postgres:// scheme must be converted to postgresql:// (mirrors fix_fallback_url)
+        # postgres:// 스킴이 postgresql:// 로 변환되어야 한다 (fix_optional_pg_url 멀티필드 validator)
+        # The postgres:// scheme must be converted to postgresql:// (fix_optional_pg_url multi-field validator)
         s = _make_settings(database_url_worker="postgres://u:p@h:5432/db")
         assert s.database_url_worker == "postgresql://u:p@h:5432/db"
 

--- a/tests/unit/verifier/test_openai_client.py
+++ b/tests/unit/verifier/test_openai_client.py
@@ -198,3 +198,27 @@ async def test_http_fallback_reraises_on_api_error_fail_closed(monkeypatch):
     with pytest.raises(RuntimeError):
         await openai_client.call_openai_verifier(
             "SYS", "USER", api_key="k", model="gpt-5-mini", timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_http_fallback_logs_error_metric_on_failure(monkeypatch):
+    # bp-1: fallback 경로 실패 시에도 SDK 경로와 대칭으로 status="error" 메트릭을 남겨야 한다.
+    # 기존 fallback 은 _call_via_http 의 raise_for_status 예외가 except ImportError 안에서 발생해
+    # 형제 except Exception 메트릭 로깅을 우회 → 관측성 소실. 이 가드가 대칭을 강제한다.
+    # bp-1: the fallback path must log a status="error" metric symmetrically with the SDK path.
+    _force_sdk_absent(monkeypatch)
+    calls: list[dict] = []
+    monkeypatch.setattr(openai_client, "log_openai_api_call", lambda **kw: calls.append(kw))
+
+    class _BoomHttpClient:
+        async def post(self, url, **kwargs):
+            return _FakeHttpResp({}, boom=True)
+
+    monkeypatch.setattr(openai_client, "get_http_client", lambda: _BoomHttpClient())
+    with pytest.raises(RuntimeError):
+        await openai_client.call_openai_verifier(
+            "SYS", "USER", api_key="k", model="gpt-5-mini", timeout=5.0)
+
+    error_calls = [c for c in calls if c.get("status") == "error"]
+    assert error_calls, "fallback 실패 시 status='error' 메트릭이 기록돼야 한다"
+    assert error_calls[0]["error_type"] == "RuntimeError"


### PR DESCRIPTION
## 요약

품질 감사(9차원 워크플로우 `wf_c9b58749`) confirmed P2 중 **코드 nit 3건**을 응집 단위로 처리. 코어 정확성·보안 무관 위생 결함 (P0 0 영역). 직전 세션에서 P1 2건(#923/#924)·doccon-1/3 머지 완료, 본 PR은 잔여 P2 코드 묶음.

| 항목 | 파일 | 성격 | 회귀 가드 |
|------|------|------|----------|
| resilience-1 | `src/railway_client/logs.py` | `resp.json()` JSONDecodeError 미래핑 → deploy-failure Issue **silent skip** | `test_fetch_deployment_logs_invalid_json` |
| bp-1 | `src/verifier/openai_client.py` | fallback 실패 시 `status="error"` 메트릭 소실 (SDK 경로와 비대칭) | `test_http_fallback_logs_error_metric_on_failure` |
| simplicity-2 | `src/config.py` | postgres URL 정규화 validator 3개 byte-identical → DRY | config 정규화/빈-값 4건 |

## 변경 상세

### resilience-1 — `logs.py` except 확장
`except httpx.HTTPError` 가 `resp.json()` 의 `ValueError`(JSONDecodeError 부모)를 미포착 → BackgroundTask 까지 uncaught 전파돼 `create_deploy_failure_issue` 미호출(알림 silent skip). docstring `Raises` 계약("응답 파싱 오류")을 강제하도록 `except ValueError` 추가 + `from exc` 원인 체인 보존.

### bp-1 — `openai_client.py` fallback 메트릭 대칭화
`_call_via_http` 의 `raise_for_status()` 예외가 부모의 `except ImportError` 안에서 발생 → 형제 `except Exception` 메트릭 로깅을 우회 → `status="error"` 관측성 소실. 내부 `try/except` 로 로깅 후 `raise`(fail-closed 보존). SDK 경로와 대칭. **이중 로깅 없음**(`_call_via_http`는 ImportError 핸들러 내부에서만 호출되므로 부모 except 재포착 불가 — Codex 확인).

### simplicity-2 — `config.py` validator DRY (정책 16)
`fix_fallback_url`/`fix_worker_url`/`fix_migration_url` 3개 byte-identical(`if not v: return v` + `_normalize_pg_url`) → pydantic v2 멀티필드 `@field_validator("database_url_fallback","database_url_worker","migration_database_url")` 단일화(`fix_optional_pg_url`). required `database_url`(빈-값 가드 절 차이)은 `fix_postgres_url` 별도 유지. wrapper·call-site 변경 0. 사용처 3 = 정책 16 "최소 추상화 사용처≥3" 충족.

## 검증

- **단위 4967 pass** (+6 신규: logs 1 · openai 1 · config 4) · 회귀 0
- pylint **10.00/10** · flake8 clean · bandit clean
- TDD: 버그 2건 RED 확인 후 GREEN, refactor 1건 characterization 가드 전후 GREEN 유지

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

✅ **Codex(o3) mutual 검증 완료 — 3건 모두 OK** (push 전, `git show f7a6a3b` 로 실제 diff 직접 확인).
- resilience-1: `ValueError`가 `JSONDecodeError` 부모 → 모든 파싱 오류 포착 · `httpx.HTTPError`와 계층 분리(충돌 없음) · `from exc` 체인 보존.
- bp-1: SDK ↔ fallback 메트릭 대칭 · 이중 로깅 위험 없음 · re-raise fail-closed 보존.
- simplicity-2: 멀티필드 validator 3 필드 독립 실행 · required `database_url` 동작 불변 · 빈-값 가드 절 보존.

## 🔍 사용자 검증 필요

- [ ] 운영 영향 없음 — resilience-1/bp-1 은 예외 경로 관측성 개선(정상 경로 무변경), simplicity-2 는 동작 보존 리팩터. Railway 배포 후 별도 확인 불요 (정적 테스트로 충분).
- [ ] 자율 판단 보고: simplicity 범위는 사용자 결정(config validator만 통합, cache repo 3쌍 현행 유지)에 따름. bp-2(railway.toml FORWARDED_ALLOW_IPS)는 **보류**(정책 17 — 운영 rate-limit 관측 데이터 후 결정).

Co-authored-by: xzawed <xzawed31@gmail.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
