### PR TITLE
docs: 품질감사 P2 인용 정확성 정정 — repo_config 리비전·architecture 함수목록·env-vars 라인 (정책 6)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,7 +93,7 @@ src/
 │   ├── merge_failure_advisor.py # get_advice(reason, language) — i18n (사이클 149)
 │   ├── retry_policy.py          # 순수 함수 — should_retry, compute_next_retry_at, is_expired
 │   ├── _merge_attempt_states.py # MergeAttempt.state lifecycle 정규 상수
-│   └── merge_verifier.py        # 2nd-LLM 머지 검증자 (cross-vendor) — is_in_verification_band/should_verify/build_verifier_prompt/interpret_verdict/verify_merge_safety/verifier_blocks_merge (자동·반자동 단일출처 가드 #859 P1-1)
+│   └── merge_verifier.py        # 2nd-LLM 머지 검증자 (cross-vendor) — is_in_verification_band/should_verify/diff_exceeds_cap/build_verifier_prompt/interpret_verdict/verify_merge_safety/verifier_blocks_merge (자동·반자동 단일출처 가드 #859 P1-1, diff cap fail-closed #863)
 ├── notifier/                    # `__init__.py` 가 자동 로드 → REGISTRY 등록
 │   ├── _common.py               # format_ref, get_all_issues, truncate_message
 │   ├── _http.py                 # build_safe_client() — SSRF 방어

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -112,8 +112,8 @@ Sentry 외 자동 로깅은 별도 환경변수 없이 동작:
 | `MERGE_RETRY_MAX_BACKOFF_SECONDS` | 최대 백오프 (초, **>= 1 AND >= INITIAL_BACKOFF** — `Field(ge=1)` + `model_validator` 경계 강제, max<initial 시 startup ValidationError) | `600` |
 | `MERGE_RETRY_CHECK_SUITE_WEBHOOK_ENABLED` | `check_suite.completed` 웹훅 즉각 트리거 활성화 | `true` |
 | `MERGE_RETRY_WORKER_BATCH_SIZE` | cron sweep 1회 처리 최대 행 수 (**>= 1** 제약 — `Field(ge=1)`) | `50` |
-| `MERGE_UNKNOWN_RETRY_LIMIT` | `mergeable_state=unknown` 상태 폴링 최대 재시도 횟수 (`config.py:63`) | `3` |
-| `MERGE_UNKNOWN_RETRY_DELAY` | `mergeable_state=unknown` 재시도 간격 (초, `config.py:64`) | `3.0` |
+| `MERGE_UNKNOWN_RETRY_LIMIT` | `mergeable_state=unknown` 상태 폴링 최대 재시도 횟수 (`config.py:87`) | `3` |
+| `MERGE_UNKNOWN_RETRY_DELAY` | `mergeable_state=unknown` 재시도 간격 (초, `config.py:88`) | `3.0` |
 
 > 기본값으로 운영 환경에 최적화되어 있어 별도 설정 없이 즉시 동작한다.
 > 운영 runbook: `docs/runbooks/merge-retry.md`

--- a/src/models/repo_config.py
+++ b/src/models/repo_config.py
@@ -49,8 +49,8 @@ class RepoConfig(Base):
     # NULL = fall back to settings.claude_review_model global default
     review_model = Column(String(50), nullable=True)
 
-    # per-repo 비활성화 도구 목록 — JSON 배열, 기본값 빈 배열 (Alembic 0035)
-    # Per-repo disabled analyzer names — JSON array, defaults to empty list (Alembic 0035)
+    # per-repo 비활성화 도구 목록 — JSON 배열, 기본값 빈 배열 (Alembic 0036)
+    # Per-repo disabled analyzer names — JSON array, defaults to empty list (Alembic 0036)
     # server_default='[]' — SQLite create_all + PG 양쪽 DDL DEFAULT 적용
     # server_default='[]' — ensures DDL DEFAULT for both SQLite create_all and PostgreSQL
     disabled_tools = Column(JSON, default=list, server_default='[]', nullable=False)


### PR DESCRIPTION
## 요약

품질 감사(9차원 워크플로우 `wf_c9b58749`) confirmed P2 중 **순수 인용 정확성 정정 3건**. 코드 동작 무변경 → 회귀 가드 불요(정책 6 line:span 정정).

| 항목 | 파일 | 정정 내용 |
|------|------|----------|
| consistency-1 | `src/models/repo_config.py:52-53` | `disabled_tools` 주석 `Alembic 0035` → `0036` |
| docacc-1 | `docs/architecture.md:96` | `merge_verifier` 함수 목록에 `diff_exceeds_cap` 누락 → 추가 |
| doccon-5 | `docs/reference/env-vars.md:115-116` | `MERGE_UNKNOWN_RETRY` `config.py:63/64` → `87/88` |

## 변경 상세

### consistency-1 — repo_config 리비전 정정
`disabled_tools` 컬럼을 추가한 실제 마이그레이션 = `0036_repo_config_disabled_tools.py` (0035 = `issue_registrations` 무관). `.pyc` 캐시에 `0035_repo_config_disabled_tools` 흔적 = 0035→0036 리넘버 전례. 주석 2곳(한/영) 정정.

### docacc-1 — architecture.md 함수 목록 보완
`merge_verifier.py` 7개 public 함수 중 6개만 열거 — `#863` diff cap fail-closed 진입점 `diff_exceeds_cap` 누락. 정의 순서대로 `should_verify`↔`build_verifier_prompt` 사이 삽입 + `#863` 출처 병기.

### doccon-5 — env-vars 라인 인용 정정
`config.py:63/64` = `db_sslmode`/`db_force_ipv4` (무관 필드 오인용). 실제 `merge_unknown_retry_limit` = line 87, `merge_unknown_retry_delay` = line 88 (`git show` 실측).

## 🔴 자율 판단 보고 — doccon-4 FALSE POSITIVE 드롭 (정책 3)

감사 confirmed P2 중 **doccon-4**(`cycle-history`/`STATE` `[[memory]]` slug)는 **직접 재검증 결과 false positive** 로 드롭했습니다.
- 감사 전제: `[[project-audit-backlog-2026-06-12]]`(하이픈) ≠ 파일명 `project_audit_backlog_2026-06-12.md`(언더스코어) → underscore 정정 권고.
- **실측 반증**: wikilink `[[name]]` 은 파일명이 아닌 **frontmatter `name:` 슬러그** 참조(메모리 시스템 규약). 실제 `name:` = `project-audit-backlog-2026-06-12` / `rls-owner-bypass-finding` (**둘 다 하이픈**) → 현재 docs slug 이미 정확. underscore 변경 시 오히려 링크 파손.
- 메모리 학습 "audit verdict 맹신 금지·EXACT 직접 재검증 default" 적용 사례.

## 검증

- repo_config 모델 테스트 7 pass · pylint **10.00/10** (주석 변경 sanity)
- 문서 변경 검증 테스트 없음 (architecture.md/env-vars 자동 대조 가드 부재) → 정적 정확성 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

✅ **Codex(o3) mutual 검증 완료 — 3건 전부 OK** (push 전, `git show`/`git ls-files` 로 실제 파일 직접 확인).
- consistency-1: `0036_repo_config_disabled_tools.py` 존재·`0035_*disabled_tools` 부재 확인.
- docacc-1: `diff_exceeds_cap` 실제 public def·삽입 위치 정의 순서 일치 확인.
- doccon-5: `config.py` line 87/88 = retry 필드·63/64 = db_sslmode/force_ipv4 직접 실측 확인.
- doccon-4 FP 판정 타당성 동의(메모리 frontmatter 근거 충분 시 OK).

## 🔍 사용자 검증 필요

- [ ] 문서 정정만 — 운영/시각 영향 없음. Railway 배포 후 별도 확인 불요.

Co-authored-by: xzawed <xzawed31@gmail.com>
🤖 Generated with [Claude Code](https://claude.com/claude-code)
