### PR TITLE
fix(ai-review): max_tokens 1500→8192 + stop_reason 절단 감지 — 출시 이래 ~80% parse_error 해소

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -23,6 +23,7 @@
 | `TOKEN_ENCRYPTION_KEY` | GitHub Access Token 암호화 키 (미설정 시 평문 저장) | `32자 이상 랜덤` |
 | `STRICT_TOKEN_ENCRYPTION` | `true` 설정 시 `TOKEN_ENCRYPTION_KEY` 미설정이면 lifespan startup 차단 (기본값 `false` = 평문 저장 허용 + WARNING 출력) | `false` (기본) |
 | `CLAUDE_REVIEW_MODEL` | AI 코드리뷰에 사용할 Claude 모델 ID | `claude-sonnet-4-6` (기본) |
+| `CLAUDE_REVIEW_MAX_TOKENS` | AI 코드리뷰 응답 출력 토큰 상한 — 한국어 리뷰 JSON(~2660 토큰) 여유값. 🔴 저한도 모델(claude-3-haiku/opus=4096)을 `CLAUDE_REVIEW_MODEL` 로 쓰면 이 값을 모델 출력 한도 이하로 낮춰야 함(8192 일괄 적용 시 Anthropic 400 → `api_error`). 구값 1500 이 응답을 절단해 `parse_error` 로 출시 이래 ~80% 리뷰 실패한 사고 fix (제약 `ge=1`) | `8192` (기본) |
 | `CLAUDE_INSIGHT_MODEL` | Insight narrative (`/dashboard?mode=insight`) 4 카드 생성용 Claude 모델 ID — 코드리뷰보다 단순 task → Haiku 분기로 토큰 비용 ↓ (Cycle 74 PR-A #247) | `claude-haiku-4-5` (기본) |
 | `DISABLE_PROMPT_CACHE` | Anthropic prompt caching (5분 ephemeral) opt-out — `1` 시 비활성 (Phase 3 PR 1 #218 신설). 운영 비용 통제용 — default `0` (caching 적용) | `0` (기본) / `1` (비활성) |
 | `TELEGRAM_WEBHOOK_SECRET` | Telegram `setWebhook` 시크릿 토큰 — **미설정 시 401 fail-closed** (사이클 142 Phase B S1 #674 보안 강화 — 이전 "헤더 검증 생략"에서 변경). Railway에서 반드시 설정 필요, 미설정 시 Telegram gate callback 전체 비활성 | 빈 문자열 (기본, **운영 시 반드시 설정**) |

--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -32,6 +32,13 @@ from src.shared.claude_metrics import aclose_anthropic_client, extract_anthropic
 
 logger = logging.getLogger(__name__)
 
+# AI 리뷰 응답 출력 토큰 상한 — 한국어 리뷰 JSON(점수 + 5 feedback + file_feedbacks,
+# 실측 ~2660 토큰)을 담을 여유값. 구값 1500 은 응답을 잘라 stop_reason=max_tokens →
+# 불완전 JSON → parse_error 로 출시 이래 ~80% 리뷰 실패 (운영 DB + 실제 API 재현, 2026-06-18).
+# Output-token cap for AI review: headroom for the Korean review JSON (~2660 tokens measured).
+# The old 1500 truncated responses → parse_error for ~80% of reviews since launch (confirmed 2026-06-18).
+_REVIEW_MAX_TOKENS = 8192
+
 
 @dataclass
 class AiReviewResult:  # pylint: disable=too-many-instance-attributes
@@ -121,7 +128,7 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
         # `settings.disable_prompt_cache=True` opts out (cache_control omitted).
         response = await client.messages.create(
             model=model,
-            max_tokens=1500,
+            max_tokens=_REVIEW_MAX_TOKENS,
             system=build_cached_system_param(system_text),
             messages=[{"role": "user", "content": prompt}],
         )
@@ -146,12 +153,24 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
         result.input_tokens = input_tokens
         result.output_tokens = output_tokens
         result.used_model = model
+        # 🔴 출력 토큰 절단 감지 — stop_reason=="max_tokens" 면 응답 JSON 이 _REVIEW_MAX_TOKENS
+        # 에서 잘림. 대부분 불완전 JSON → parse_error(ai_review_failed 가 차단)지만, 운좋게
+        # 유효 JSON(success)이어도 부분 응답이라 점수 인플레 위험 → 명시 로깅 + truncated 마커.
+        # Output truncation: stop_reason=="max_tokens" means the JSON was cut at _REVIEW_MAX_TOKENS.
+        # Usually parse_error; even a parsable partial is unreliable → log + mark truncated.
+        output_truncated = getattr(response, "stop_reason", None) == "max_tokens"
+        if output_truncated:
+            logger.warning(
+                "AI review response truncated at max_tokens=%d (status=%s) — raise _REVIEW_MAX_TOKENS if frequent",
+                _REVIEW_MAX_TOKENS, result.status,
+            )
         # C22: 절단 마커 — 파싱까지 성공(status=="success")한 경우에만 설정. parse_error 는
         # ai_review_failed 가 차단을 담당하므로 truncated 는 False 유지(success 경로 한정 불변식).
-        # C22: set the truncation marker only on a genuine success (status=="success"). parse_error is
-        # handled by ai_review_failed, so leave truncated False (success-path-only invariant).
+        # 입력 diff 절단(was_truncated, C22) + 출력 토큰 절단(output_truncated) 양쪽 OR 결합.
+        # C22: set the marker only on success (parse_error is handled by ai_review_failed).
+        # Combines input-diff truncation (was_truncated) and output-token truncation.
         if result.status == "success":
-            result.truncated = was_truncated
+            result.truncated = was_truncated or output_truncated
         return result
     except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
         # anthropic/httpx 는 다양한 예외를 발생시킬 수 있음 — 모두 graceful fallback

--- a/src/analyzer/io/ai_review.py
+++ b/src/analyzer/io/ai_review.py
@@ -32,13 +32,6 @@ from src.shared.claude_metrics import aclose_anthropic_client, extract_anthropic
 
 logger = logging.getLogger(__name__)
 
-# AI 리뷰 응답 출력 토큰 상한 — 한국어 리뷰 JSON(점수 + 5 feedback + file_feedbacks,
-# 실측 ~2660 토큰)을 담을 여유값. 구값 1500 은 응답을 잘라 stop_reason=max_tokens →
-# 불완전 JSON → parse_error 로 출시 이래 ~80% 리뷰 실패 (운영 DB + 실제 API 재현, 2026-06-18).
-# Output-token cap for AI review: headroom for the Korean review JSON (~2660 tokens measured).
-# The old 1500 truncated responses → parse_error for ~80% of reviews since launch (confirmed 2026-06-18).
-_REVIEW_MAX_TOKENS = 8192
-
 
 @dataclass
 class AiReviewResult:  # pylint: disable=too-many-instance-attributes
@@ -117,6 +110,11 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
     # max_retries=2 — explicit so SDK upgrades cannot silently change retry behavior.
     client = anthropic.AsyncAnthropic(api_key=api_key, timeout=60.0, max_retries=2)
     model = model or settings.claude_review_model
+    # 출력 토큰 상한 — settings 경유 configurable (저한도 모델 override 대응, Codex P2).
+    # 구값 1500 은 한국어 리뷰 JSON(~2660 토큰)을 잘라 stop_reason=max_tokens → parse_error 로
+    # 출시 이래 ~80% 실패 (운영 DB + 실제 API 재현, 2026-06-18). default 8192.
+    # Output-token cap via settings — configurable for low-output-limit model overrides.
+    max_output_tokens = settings.claude_review_max_tokens
     # Phase 4 PR-12 — language 별 system prompt (출력 언어 지시 포함).
     # Phase 4 PR-12 — per-language system prompt (with output language directive).
     system_text = get_system_prompt(language)
@@ -128,7 +126,7 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
         # `settings.disable_prompt_cache=True` opts out (cache_control omitted).
         response = await client.messages.create(
             model=model,
-            max_tokens=_REVIEW_MAX_TOKENS,
+            max_tokens=max_output_tokens,
             system=build_cached_system_param(system_text),
             messages=[{"role": "user", "content": prompt}],
         )
@@ -161,8 +159,8 @@ async def review_code(  # pylint: disable=too-many-locals  # 다국어 + caching
         output_truncated = getattr(response, "stop_reason", None) == "max_tokens"
         if output_truncated:
             logger.warning(
-                "AI review response truncated at max_tokens=%d (status=%s) — raise _REVIEW_MAX_TOKENS if frequent",
-                _REVIEW_MAX_TOKENS, result.status,
+                "AI review truncated at max_tokens=%d (status=%s) — raise CLAUDE_REVIEW_MAX_TOKENS if frequent",
+                max_output_tokens, result.status,
             )
         # C22: 절단 마커 — 파싱까지 성공(status=="success")한 경우에만 설정. parse_error 는
         # ai_review_failed 가 차단을 담당하므로 truncated 는 False 유지(success 경로 한정 불변식).

--- a/src/config.py
+++ b/src/config.py
@@ -33,6 +33,11 @@ class Settings(BaseSettings):
     # Phase 2 d-🅓 (Cycle 74) — model for Insight narrative only (default Haiku — 67% cheaper).
     # AI review (review_code) keeps Sonnet (memory feedback-ai-review-quality-protect.md exclusion).
     claude_insight_model: str = "claude-haiku-4-5"
+    # AI 리뷰 응답 출력 토큰 상한 (환경변수 CLAUDE_REVIEW_MAX_TOKENS) — 한국어 리뷰 JSON(~2660 토큰) 여유값.
+    # 🔴 저한도 모델(claude-3-haiku/opus = 4096)을 claude_review_model 로 쓰면 8192 가 Anthropic 400
+    #    거부 → api_error 이므로 그 경우 이 값을 모델 출력 한도 이하로 낮춰야 한다 (Codex P2).
+    # Output-token cap for AI review (env CLAUDE_REVIEW_MAX_TOKENS); lower it for low-output-limit models.
+    claude_review_max_tokens: int = Field(default=8192, ge=1)
     # 운영 opt-out — Anthropic prompt caching (5분 ephemeral) 비활성화 (default-on)
     # Operational opt-out — disables Anthropic prompt caching (default-on, 5-min ephemeral)
     disable_prompt_cache: bool = False

--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -610,3 +610,23 @@ async def test_review_code_no_truncation_marker_on_normal_stop():
         result = await review_code("sk-test", "feat: x", [("a.py", "+ x = 1")])
     assert result.status == "success"
     assert result.truncated is False
+
+
+async def test_review_code_max_tokens_configurable_via_settings(monkeypatch):
+    """🔴 max_tokens 는 settings.claude_review_max_tokens 에서 가져옴 (Codex P2 — 저한도 모델 대응).
+
+    claude-3-haiku/opus(출력 한도 4096)를 CLAUDE_REVIEW_MODEL/repo override 로 선택하면 8192 일괄
+    적용 시 Anthropic 이 400 거부 → api_error(1500 일 땐 작동하던 모델 회귀). env 로 낮춰 대응.
+    Configurable so low-output-limit models (e.g. claude-3-haiku/opus=4096) still work.
+    """
+    monkeypatch.setattr("src.analyzer.io.ai_review.settings.claude_review_max_tokens", 4096)
+    response_obj = MagicMock()
+    response_obj.content = [MagicMock(text=_FULL_REVIEW_JSON)]
+    response_obj.usage = MagicMock(input_tokens=10, output_tokens=20)
+    response_obj.stop_reason = "end_turn"
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=response_obj)
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client):
+        await review_code("sk-test", "feat: x", [("a.py", "+ x = 1")])
+    create_kwargs = fake_client.messages.create.call_args.kwargs
+    assert create_kwargs["max_tokens"] == 4096

--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -532,3 +532,81 @@ async def test_review_code_closes_anthropic_client():
     with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client):
         await review_code("sk-test", "feat: x", [("app.py", "+ x = 1")])
     fake_client.aclose.assert_awaited_once()
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 🔴 출력 토큰 절단 봉인 — max_tokens 상향 + stop_reason="max_tokens" 감지
+# 🔴 Output-token truncation seal — raise max_tokens + detect stop_reason="max_tokens"
+#
+# 근본 사고: max_tokens=1500 이 한국어 리뷰 JSON(점수 + 5 feedback + file_feedbacks,
+# 실측 ~2660 토큰)을 잘라 stop_reason=max_tokens → 불완전 JSON → parse_error 로 출시
+# 이래 ~80% AI 리뷰 실패. 운영 DB + 실제 API 재현으로 확정 (2026-06-18).
+# Root incident: max_tokens=1500 truncated Korean review JSON (~2660 tokens measured),
+# yielding stop_reason=max_tokens → broken JSON → parse_error ~80% since launch.
+# ──────────────────────────────────────────────────────────────────────────
+
+_FULL_REVIEW_JSON = json.dumps({
+    "commit_message_score": 15, "direction_score": 18, "test_score": 9,
+    "summary": "ok", "suggestions": [],
+    "commit_message_feedback": "", "code_quality_feedback": "",
+    "security_feedback": "", "direction_feedback": "", "test_feedback": "",
+    "file_feedbacks": [],
+})
+
+
+async def test_review_code_passes_sufficient_max_tokens_to_create():
+    """🔴 회귀 가드 — messages.create 의 max_tokens 가 충분히 커야 함 (1500 절단 사고 재발 방지).
+
+    max_tokens=1500 은 한국어 리뷰 JSON(~2660 토큰)을 잘라 stop_reason=max_tokens →
+    불완전 JSON → parse_error 로 출시 이래 ~80% 실패. 작은 값으로 복귀하면 본 테스트 fail.
+    Regression guard: max_tokens must stay large enough to avoid the 1500-token truncation.
+    """
+    response_obj = MagicMock()
+    response_obj.content = [MagicMock(text=_FULL_REVIEW_JSON)]
+    response_obj.usage = MagicMock(input_tokens=10, output_tokens=20)
+    response_obj.stop_reason = "end_turn"
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=response_obj)
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client):
+        await review_code("sk-test", "feat: x", [("a.py", "+ x = 1")])
+    create_kwargs = fake_client.messages.create.call_args.kwargs
+    assert "max_tokens" in create_kwargs
+    assert create_kwargs["max_tokens"] >= 4096, (
+        "max_tokens 가 작으면 리뷰 응답 절단 → parse_error 재발 (실측 필요량 ~2660)"
+    )
+
+
+async def test_review_code_marks_truncated_on_max_tokens_stop_reason():
+    """🔴 stop_reason='max_tokens'(출력 절단) → result.truncated=True (부분 응답 점수 신뢰 불가).
+
+    출력이 잘리면 대부분 parse_error 지만, 운좋게 유효 JSON(success)이어도 부분 응답이라
+    점수 인플레 위험 → truncated 마커로 auto-merge/approve 차단(C22 입력 절단과 대칭).
+    Output truncation: even a parsable partial response is unreliable → mark truncated.
+    """
+    response_obj = MagicMock()
+    response_obj.content = [MagicMock(text=_FULL_REVIEW_JSON)]
+    response_obj.usage = MagicMock(input_tokens=10, output_tokens=20)
+    response_obj.stop_reason = "max_tokens"
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=response_obj)
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client):
+        result = await review_code("sk-test", "feat: x", [("a.py", "+ x = 1")])
+    assert result.status == "success"
+    assert result.truncated is True
+
+
+async def test_review_code_no_truncation_marker_on_normal_stop():
+    """stop_reason='end_turn' + 작은 diff → result.truncated=False (정상 회귀 가드).
+
+    정상 완료 응답에 truncated 마커가 잘못 붙으면 모든 리뷰가 auto-merge 차단됨 → 보존 가드.
+    """
+    response_obj = MagicMock()
+    response_obj.content = [MagicMock(text=_FULL_REVIEW_JSON)]
+    response_obj.usage = MagicMock(input_tokens=10, output_tokens=20)
+    response_obj.stop_reason = "end_turn"
+    fake_client = MagicMock()
+    fake_client.messages.create = AsyncMock(return_value=response_obj)
+    with patch("src.analyzer.io.ai_review.anthropic.AsyncAnthropic", return_value=fake_client):
+        result = await review_code("sk-test", "feat: x", [("a.py", "+ x = 1")])
+    assert result.status == "success"
+    assert result.truncated is False

--- a/tests/unit/analyzer/io/test_ai_review_errors.py
+++ b/tests/unit/analyzer/io/test_ai_review_errors.py
@@ -554,13 +554,16 @@ _FULL_REVIEW_JSON = json.dumps({
 })
 
 
-async def test_review_code_passes_sufficient_max_tokens_to_create():
-    """🔴 회귀 가드 — messages.create 의 max_tokens 가 충분히 커야 함 (1500 절단 사고 재발 방지).
+async def test_review_code_passes_sufficient_max_tokens_to_create(monkeypatch):
+    """🔴 회귀 가드 — messages.create 의 기본 max_tokens 가 충분히 커야 함 (1500 절단 사고 재발 방지).
 
     max_tokens=1500 은 한국어 리뷰 JSON(~2660 토큰)을 잘라 stop_reason=max_tokens →
-    불완전 JSON → parse_error 로 출시 이래 ~80% 실패. 작은 값으로 복귀하면 본 테스트 fail.
-    Regression guard: max_tokens must stay large enough to avoid the 1500-token truncation.
+    불완전 JSON → parse_error 로 출시 이래 ~80% 실패. 기본값으로 복귀하면 본 테스트 fail.
+    🔴 ambient CLAUDE_REVIEW_MAX_TOKENS(ge=1 허용)에 독립적이도록 의도된 기본값으로 고정 (Codex P3 —
+    환경변수가 낮게 설정된 배포 환경에서 suite 가 실패하지 않도록).
+    Regression guard: pin the intended default so a valid low env override cannot fail the suite.
     """
+    monkeypatch.setattr("src.analyzer.io.ai_review.settings.claude_review_max_tokens", 8192)
     response_obj = MagicMock()
     response_obj.content = [MagicMock(text=_FULL_REVIEW_JSON)]
     response_obj.usage = MagicMock(input_tokens=10, output_tokens=20)


### PR DESCRIPTION
## 요약

SCAManager의 핵심 기능인 **AI 코드 리뷰가 출시(2026-04) 이래 줄곧 ~80% `parse_error`로 실패**하고 있었습니다. 사용자 보고 "점수추이 차트 미표시"를 systematic-debugging으로 추적한 결과 발견된 근본 문제입니다 (차트는 증상). 운영 DB 진단 + 실제 Anthropic API 재현으로 근본 원인을 `max_tokens=1500` 응답 절단으로 확정하고 수정합니다.

## 근본 원인 (증거 체인)

1. **차트 코드 정상** — 로컬에서 두 차트 모두 렌더. empty-state 일러스트는 데이터(score) 부재 시 의도된 표시.
2. **차트가 비는 이유 = score NULL** — overview `trend`는 `score IS NOT NULL`만 그림. 운영 DB 최근 분석 80~90%가 score=NULL.
3. **score=NULL 원인 = `ai_review_status="parse_error"`** — `_persisted_score_is_unreliable()`가 AI 실패 시 score NULL 저장 (집계 오염 방지, 의도된 설계).
4. **parse_error 만성** — 운영 DB 월별 success율: 2026-04 ~17% / 05 ~25% / 06 ~16%. 출시 이래 ~80% 실패.
5. **근본 = `max_tokens=1500`** (PR #3 이후 불변) — 프롬프트가 점수 3 + summary + suggestions + feedback 5종 + `file_feedbacks`(파일별 배열)를 한국어로 요구. 1500 토큰 부족 → 응답 JSON 중간 절단 → `JSONDecodeError` → parse_error.

**왜 지금 가시화됐나**: #853(2026-06-11)이 AI 실패 시 score=NULL 저장을 시작 → 그 전엔 실패해도 인플레 기본점수(89/B)가 차트에 가짜로 찍히다가, NULL로 빠지며 차트에서 사라짐. #853은 버그가 아니라 숨겨진 문제를 드러낸 것.

**실제 API 재현** (운영 동일 모델 `claude-sonnet-4-6`, 실제 레포 git diff 입력):

| max_tokens | stop_reason | output_tokens | parse status |
|-----------|-------------|---------------|--------------|
| 1500 (구) | `max_tokens` (절단) | 1500 (상한 도달) | `parse_error` ❌ |
| 8192 (수정) | `end_turn` (완결) | 2660 | `success` ✅ |

## 변경

1. **`max_tokens` 1500 → `settings.claude_review_max_tokens` (기본 8192)** — 실측 필요량 ~2660 대비 여유.
2. **`stop_reason == "max_tokens"` 출력 절단 감지** — 경고 로깅 + success 경로에서만 `truncated` 마커 (C22 입력 diff 절단 `was_truncated`와 OR 결합). 향후 재발 즉시 관측.
3. **`CLAUDE_REVIEW_MAX_TOKENS` env configurable** (Codex P2 반영) — 저한도 모델(claude-3-haiku/opus=4096) override 시 8192가 Anthropic 400을 유발하므로 env로 조정 가능. `config.py` `Field(default=8192, ge=1)`.
4. **회귀 가드 +4**: max_tokens 충분성(≥4096) / stop_reason 절단 마커 / 정상 케이스 보존 / settings configurable.

## 검증

- 단위 4978 (+4) / 전체 **5124 passed, 8 skipped** / pylint **10.00** / flake8 clean
- end-to-end: `review_code(8192)` → status=success, scores 정상 생성 (실제 API)
- `env-vars.md` `CLAUDE_REVIEW_MAX_TOKENS` 등재 (config field 동기화 의무)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**Codex mutual 검증 수행** (`codex exec review`, gpt-5.5 — companion 런타임 gpt-5.5 spawn_agent 버그/o3 계정 미지원으로 review 서브커맨드 경유):

- **P3 (테스트 격리)** — ambient env에 의존하던 회귀가드 → settings monkeypatch 고정. **수정 완료** (a761383).
- **P2 (per-repo 저한도 모델)** — env는 global이라 per-repo `RepoConfig.review_model` override 시 clamp 권장. → **claude-api 실측 결과 현재 영향 0건**: 운영 8 repo의 `claude-haiku-4-5` = 64K, 기본 `sonnet-4-6` = 64K 모두 8192 상회. 우려 케이스(claude-3-haiku/opus=4096)는 deprecated/retired 미사용. env configurable로 충분 — **사용자 직접 결정 영역**(정책 18 §예외) + 정책 16 over-engineering 회피.

## 🔍 사용자 검증 필요 (정책 2)

1. **Railway 배포 후 AI 리뷰 success율 모니터링** — 다음 push/PR 분석에서 `ai_review_status=success` 비율이 ~20%에서 대폭 상승하는지 (운영 DB `analyses.result->>'ai_review_status'`).
2. **점수추이 차트 복구 확인** — 새 분석이 score를 정상 저장하면서 며칠 후 차트에 데이터 포인트가 채워지는지 (overview / repos 모드).
3. **저한도 모델 사용 시** (해당 시) — `CLAUDE_REVIEW_MODEL`을 구형 저한도 모델로 바꾸면 `CLAUDE_REVIEW_MAX_TOKENS`를 모델 출력 한도 이하로 설정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
