### PR TITLE
fix(ui): repo_detail 점수추이 차트 미표시 — I18N 스코프 격리 버그 (운영 사고)

### DIFF
--- a/e2e/test_repos_mode.py
+++ b/e2e/test_repos_mode.py
@@ -63,6 +63,30 @@ def test_repos_mode_score_trend_chart_renders(seeded_page: Page, base_url: str):
 
 
 @pytest.mark.e2e
+def test_repo_detail_score_chart_renders(seeded_page: Page, base_url: str):
+    """repo_detail(`/repos/{name}`) 의 점수 추이 차트(scoreChart)가 실제로 렌더돼야 한다.
+
+    🔴 운영 사고 회귀(2026-06-18): `I18N` 이 한 `<script>` block(IIFE) 내 `const` 로 격리돼,
+    별도 block 의 `buildChart` 가 stats 배지에서 `I18N.chartAvg` 참조 시 `ReferenceError:
+    I18N is not defined` → buildChart throw → `new Chart` 미도달 → scoreChart 영구 미표시.
+    호출 경로: vendor chart.umd.min.js onload → _repoChartReady → buildChart. 캐시 즉시 로드
+    (라이브 immutable)가 onload 를 I18N 정의보다 앞당겨 트리거. window.I18N 전역화 +
+    buildChart typeof I18N 가드로 봉인. conftest pageerror trap 이 throw 를, wait_for_function
+    이 Chart 인스턴스 부착을 양방향 검증한다(repos 모드 차트와 다른 템플릿/canvas).
+    """
+    db_path = os.environ.get("DATABASE_URL", "").replace("sqlite:///", "")
+    _seed_trend_analyses(db_path)
+    seeded_page.goto(f"{base_url}/repos/owner/testrepo")
+    expect(seeded_page.locator("#scoreChart")).to_be_visible()
+    # Chart.js 로드 후 scoreChart canvas 에 Chart 인스턴스 부착(미부착=I18N throw 로 차트 공백)
+    # After Chart.js loads, a Chart instance must be attached to the scoreChart canvas.
+    seeded_page.wait_for_function(
+        "() => !!(window.Chart && Chart.getChart && Chart.getChart('scoreChart'))",
+        timeout=6000,
+    )
+
+
+@pytest.mark.e2e
 def test_repos_tab_visible(page: Page, base_url: str):
     """repos 탭 링크가 Dashboard에 표시된다."""
     page.goto(f"{base_url}/dashboard")

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -727,6 +727,13 @@
     if (!canvasEl) return;
     /* Chart.js 비동기 로드 미완료 시 안전 종료 / Guard against async Chart.js load race */
     if (typeof Chart === 'undefined') return;
+    /* I18N 은 repo 고유 전역(window._repoChartI18N) — 다른 페이지 var I18N 전역 충돌 회피(Codex P2).
+       지역 var 로 참조 + 미정의 시 graceful return(onload race: vendor chart.umd.min.js 캐시 즉시
+       로드로 onload→_repoChartReady→buildChart 가 I18N block 정의 전 호출 → 이후 applyFilters→
+       buildChart 가 재렌더). ReferenceError/TypeError throw 방지.
+       Repo-scoped global; reference locally and skip if not yet defined (vendor onload race). */
+    var I18N = window._repoChartI18N;
+    if (!I18N) return;
 
     /* 빈 상태 처리 / Empty state */
     if (!_chartData || _chartData.length === 0) {
@@ -857,7 +864,14 @@ const PAGE_SIZE = 20;
 // Phase 2 PR-7 — 다국어 동적 텍스트 (data-i18n-* 속성 — 서버 Jinja injection 페어, XSS 차단)
 // Phase 2 PR-7 — i18n dynamic text (data-i18n-* attributes — server-side Jinja, XSS-safe)
 const _i18nCard = document.querySelector('.history-card');
-const I18N = {
+// 🔴 repo 고유 전역(window._repoChartI18N) 노출 — buildChart(별도 <script> block)가 참조하므로
+// IIFE-격리 const 면 `ReferenceError: I18N is not defined` 로 차트 throw(운영 scoreChart 미표시
+// 사고, 2026-06-18 F12). 🔴 범용 window.I18N 은 다른 페이지(add_repo 의 var I18N 등)와 전역
+// 네임스페이스 충돌 → hx-boost 왕복(repo_detail→/repos/add→Back) 시 덮어써져 차트 재빌드가
+// 깨짐(Codex P2) → repo 고유명 사용. const I18N 은 이 block 내부 참조용으로 유지.
+// Repo-scoped global so buildChart (separate block) can reference it WITHOUT clobbering other
+// pages' global `I18N` (add_repo's var I18N) across hx-boost back-nav. const I18N stays for block-local use.
+const I18N = window._repoChartI18N = {
   historyRecent: _i18nCard.dataset.i18nHistoryRecent,
   historyFiltered: _i18nCard.dataset.i18nHistoryFiltered,
   filterEmpty: _i18nCard.dataset.i18nFilterEmpty,

--- a/tests/unit/ui/test_chart_race_guards.py
+++ b/tests/unit/ui/test_chart_race_guards.py
@@ -111,3 +111,37 @@ def test_dashboard_loads_chartjs_in_repos_mode():
     assert "if(document._reposChartReady)document._reposChartReady()" in src, (
         "dashboard.html: vendor onload 가 _reposChartReady 미호출 → repos 모드 async 로드 후 차트 미재빌드"
     )
+
+
+def test_repo_detail_i18n_accessible_to_buildchart():
+    """🔴 repo_detail.html: I18N 이 buildChart 에서 접근 가능(전역)해야 + onload race graceful 가드.
+
+    운영 사고(2026-06-18, F12 `Uncaught ReferenceError: I18N is not defined at buildChart`):
+    `I18N` 이 block2 IIFE 내 `const` 로 격리(repo_detail.html:860)돼 있어, block1 의 `buildChart`
+    (:722)가 stats 배지에서 `I18N.chartAvg`(:751)를 참조하면 전역 스코프만 탐색 → IIFE const 가
+    안 보여 ReferenceError → buildChart throw → `new Chart` 미도달 → scoreChart 영구 미표시.
+    호출 경로: vendor chart.umd.min.js onload(:686) → _repoChartReady(:848) → buildChart.
+    캐시 즉시 로드(라이브 immutable)가 onload 를 I18N 정의보다 앞당겨 트리거.
+
+    수정 봉인: (1) I18N 을 window 전역으로 노출(IIFE const 격리 회귀 차단 — buildChart 가 전역
+    탐색으로 접근) + (2) buildChart 가 I18N 미정의 시 graceful return(onload race: I18N 정의 전
+    호출 시 throw 대신 skip, 이후 applyFilters→buildChart 가 정상 렌더).
+    """
+    src = _read("src/templates/repo_detail.html")
+    # (1) repo 고유 전역 노출 — buildChart(별도 block)가 접근. IIFE-격리 const 단독이면 ReferenceError.
+    assert "window._repoChartI18N" in src, (
+        "repo_detail.html: I18N 을 repo 고유 전역(window._repoChartI18N)으로 미노출 → IIFE const "
+        "격리 시 buildChart 의 I18N 참조가 ReferenceError (운영 scoreChart 미표시 사고)"
+    )
+    # 🔴 범용 window.I18N 전역 회귀 차단 — 다른 페이지(add_repo 의 var I18N 등)와 충돌해 hx-boost
+    # 왕복 시 덮어써져 차트 재빌드가 깨진다(Codex P2). repo 고유 네임스페이스만 허용.
+    # `window.I18N = {` 할당 패턴만 검사(주석의 'window.I18N' 언급은 허용)
+    assert "window.I18N = {" not in src, (
+        "repo_detail.html: 범용 window.I18N 전역 할당 회귀 → 다른 페이지 var I18N(add_repo.html:201)과 "
+        "충돌(hx-boost 왕복 시 덮어쓰기, Codex P2). window._repoChartI18N 고유 네임스페이스 사용"
+    )
+    # (2) buildChart 가 고유 전역을 지역 참조 + onload race graceful (미정의 시 return)
+    assert "var I18N = window._repoChartI18N" in src, (
+        "repo_detail.html: buildChart 가 고유 전역(window._repoChartI18N) 지역 참조 누락 → 스코프/충돌 "
+        "회귀. onload race(I18N block 정의 전 호출) 시 graceful return 동반 필요"
+    )


### PR DESCRIPTION
## 요약

운영 repo_detail(`/repos/{name}`) 페이지의 **점수 추이 차트(scoreChart)가 영구 미표시**되던 사고를 수정합니다. 사용자 F12 + 5+1 다중 에이전트 + 적대적 검증 + 라이브 DB로 근본을 **`I18N` 스코프 격리 버그**로 규명했습니다.

## 근본 원인 (F12 결정적)

운영 F12: `Uncaught ReferenceError: I18N is not defined at buildChart`

- `I18N` 이 한 `<script>` block(IIFE) 내 `const` 로 격리(repo_detail.html:860)
- 별도 block 의 `buildChart`(:722)가 stats 배지에서 `I18N.chartAvg`(:751) 참조 → 전역 스코프만 탐색 → IIFE const 가 안 보여 **ReferenceError → throw → `new Chart`(:769) 미도달 → 차트 미표시** (empty-state 도 `length===0` 기준이라 미발동 → 일러스트 없는 완전 빈 공간)
- 호출 경로: vendor `chart.umd.min.js` onload(:686) → `_repoChartReady`(:848) → buildChart
- **라이브-only 트리거**: 캐시된 chart.umd.min.js(immutable) 즉시 로드 → onload 가 I18N 정의보다 앞서 발화 (로컬은 로드 지연으로 가려짐)

🔴 **#929/#930 은 dashboard.html(다른 페이지)만 수정** → repo_detail 과 무관했습니다 (이전 "#929 후에도 안 보임"의 진짜 이유). 차트 데이터는 정상입니다(최근 100건 중 score 24건, 라이브 DB 실측).

## 수정

- **repo_detail.html**: `I18N` 을 **repo 고유 전역(`window._repoChartI18N`)** 으로 노출 → buildChart(별도 block)가 접근 가능. `const I18N`(block 내부 참조용)은 유지. buildChart 는 지역 `var` 로 참조 + 미정의 시 graceful return(onload race).
- **회귀 가드**:
  - 정적(`test_chart_race_guards.py`): 고유 전역 노출 + 범용 `window.I18N` 할당 회귀 차단 + buildChart 지역 참조 단언 (기존 `typeof Chart` 가드는 I18N 스코프 미검사라 이 버그를 못 잡음)
  - E2E(`test_repos_mode.py`): repo_detail scoreChart 렌더 + pageerror trap (런타임 봉인, repos 모드 차트와 다른 템플릿/canvas)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**Codex mutual 적대적 검증 2라운드**:
- **1차 P2 적발**: 초기 수정(범용 `window.I18N` 전역화)이 **`add_repo.html:201` 의 `var I18N` 과 전역 네임스페이스 충돌** → hx-boost 왕복(repo_detail→/repos/add→Back) 시 add_repo 의 I18N 이 덮어써져 차트 재빌드가 undefined labels + tooltip TypeError. (ground-truth 직접 확인: add_repo var I18N 실재 — Codex 환각 아님)
- **수정**: repo 고유 네임스페이스(`window._repoChartI18N`)로 변경
- **2차 재검증 OK**: *"The scoped global resolves the cross-script I18N access failure while retaining graceful load-race handling. Targeted unit and E2E tests passed."*

## 🔍 사용자 검증 필요 (정책 2 / 11)

1. **운영 배포 후 F12 재확인** — repo_detail 페이지에서 점수 추이 **차트가 실제로 표시**되는지 + Console 의 `I18N is not defined` 에러가 사라졌는지 (이게 최종 검증). 차트 데이터(24건)는 충분하므로 표시돼야 합니다.
2. (정책 11) repo_detail.html 변경은 **시각/레이아웃 동일**, 차트 표시만 복구 (4-테마 영향 없는 순수 JS 스코프 fix).

검증: 단위 5125 / E2E +1 / pylint 10.00 / flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
