### PR TITLE
fix(a11y): 폼 입력 20건 aria-label 부여 — SonarCloud Quality Gate ERROR 해소 (Web:InputWithoutLabelCheck)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -249,6 +249,10 @@
     "history_count_filtered": "{filtered} / total {total} entries",
     "search_placeholder": "Search commit message or SHA…",
     "score_range_label": "Score",
+    "date_from_aria": "From date",
+    "date_to_aria": "To date",
+    "score_min_aria": "Minimum score",
+    "score_max_aria": "Maximum score",
     "table": {
       "date": "Date",
       "commit": "Commit",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -249,6 +249,10 @@
     "history_count_filtered": "{filtered}件 / 全体 {total}件",
     "search_placeholder": "コミットメッセージまたはSHA検索…",
     "score_range_label": "スコア",
+    "date_from_aria": "開始日",
+    "date_to_aria": "終了日",
+    "score_min_aria": "最小スコア",
+    "score_max_aria": "最大スコア",
     "table": {
       "date": "日付",
       "commit": "コミット",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -249,6 +249,10 @@
     "history_count_filtered": "{filtered}건 / 전체 {total}건",
     "search_placeholder": "커밋 메시지 또는 SHA 검색…",
     "score_range_label": "점수",
+    "date_from_aria": "시작 날짜",
+    "date_to_aria": "종료 날짜",
+    "score_min_aria": "최소 점수",
+    "score_max_aria": "최대 점수",
     "table": {
       "date": "날짜",
       "commit": "커밋",

--- a/src/templates/repo_detail.html
+++ b/src/templates/repo_detail.html
@@ -543,6 +543,7 @@
   <!-- 필터 바 / Filter bar -->
   <div class="filter-bar">
     <input type="search" class="filter-search" id="searchInput"
+      aria-label="{{ 'repo_detail.search_placeholder' | i18n_args(locale | default('ko')) }}"
       placeholder="{{ 'repo_detail.search_placeholder' | i18n_args(locale | default('ko')) }}" autocomplete="off">
     <div class="filter-group" id="dateFilter">
       <button class="filter-btn active" data-date="all">{{ 'repo_detail.filter_all' | i18n_args(locale | default('ko')) }}</button>
@@ -553,9 +554,11 @@
       <button class="filter-btn" data-date="custom">{{ 'repo_detail.date_filter.custom' | i18n_args(locale | default('ko')) }}</button>
     </div>
     <div class="custom-date-wrap" id="customDateWrap">
-      <input type="date" class="date-input" id="dateFrom">
+      <input type="date" class="date-input" id="dateFrom"
+        aria-label="{{ 'repo_detail.date_from_aria' | i18n_args(locale | default('ko')) }}">
       <span style="color:var(--text-2);font-size:11px">–</span>
-      <input type="date" class="date-input" id="dateTo">
+      <input type="date" class="date-input" id="dateTo"
+        aria-label="{{ 'repo_detail.date_to_aria' | i18n_args(locale | default('ko')) }}">
     </div>
     <div class="filter-divider"></div>
     <div class="filter-group" id="gradeFilter">
@@ -579,8 +582,10 @@
       <div class="dual-slider-track" id="dualSliderTrack">
         <div class="dual-slider-bg"></div>
         <div class="dual-slider-fill" id="sliderFill"></div>
-        <input type="range" id="scoreMin" min="0" max="100" value="0" step="1">
-        <input type="range" id="scoreMax" min="0" max="100" value="100" step="1">
+        <input type="range" id="scoreMin" min="0" max="100" value="0" step="1"
+          aria-label="{{ 'repo_detail.score_min_aria' | i18n_args(locale | default('ko')) }}">
+        <input type="range" id="scoreMax" min="0" max="100" value="100" step="1"
+          aria-label="{{ 'repo_detail.score_max_aria' | i18n_args(locale | default('ko')) }}">
       </div>
       <span class="score-val-label" id="scoreMinLabel">0</span>
       <span style="color:var(--text-2);font-size:11px">–</span>

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -660,9 +660,11 @@
               </div>
               <div class="threshold-ctrl">
                 <input type="range" class="approve-range" name="merge_threshold"
+                       aria-label="{{ 'settings_page.pr_rules.merge_threshold_label' | i18n_args(locale | default('ko')) }}"
                        min="0" max="100" value="{{ config.merge_threshold }}"
                        oninput="document.getElementById('mergeVal').value=this.value">
                 <input type="number" id="mergeVal" class="num-input"
+                       aria-label="{{ 'settings_page.pr_rules.merge_threshold_label' | i18n_args(locale | default('ko')) }}"
                        min="0" max="100" value="{{ config.merge_threshold }}"
                        oninput="this.previousElementSibling.value=this.value">
               </div>
@@ -703,9 +705,11 @@
                 </div>
                 <div class="threshold-ctrl">
                   <input type="range" class="approve-range" name="approve_threshold"
+                         aria-label="{{ 'settings_page.pr_rules.approve_threshold_label' | i18n_args(locale | default('ko')) }}"
                          min="0" max="100" value="{{ config.approve_threshold }}"
                          oninput="document.getElementById('approveVal').value=this.value">
                   <input type="number" id="approveVal" class="num-input"
+                         aria-label="{{ 'settings_page.pr_rules.approve_threshold_label' | i18n_args(locale | default('ko')) }}"
                          min="0" max="100" value="{{ config.approve_threshold }}"
                          oninput="this.previousElementSibling.value=this.value">
                 </div>
@@ -717,9 +721,11 @@
                 </div>
                 <div class="threshold-ctrl">
                   <input type="range" class="reject-range" name="reject_threshold"
+                         aria-label="{{ 'settings_page.pr_rules.reject_threshold_label' | i18n_args(locale | default('ko')) }}"
                          min="0" max="100" value="{{ config.reject_threshold }}"
                          oninput="document.getElementById('rejectVal').value=this.value">
                   <input type="number" id="rejectVal" class="num-input danger"
+                         aria-label="{{ 'settings_page.pr_rules.reject_threshold_label' | i18n_args(locale | default('ko')) }}"
                          min="0" max="100" value="{{ config.reject_threshold }}"
                          oninput="this.previousElementSibling.value=this.value">
                 </div>
@@ -834,6 +840,7 @@
               <span class="field-hint">{{ 'settings_page.notify.telegram_chat_id_hint' | i18n_args(locale | default('ko')) }}</span>
               <div class="masked-field">
                 <input class="field-input" type="password" name="notify_chat_id"
+                       aria-label="{{ 'settings_page.notify.telegram_chat_id_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.notify_chat_id or '' }}"
                        placeholder="-100xxxxxxxxx" autocomplete="off">
                 <button type="button" class="mask-toggle" onclick="toggleFieldMask(this)"
@@ -918,6 +925,7 @@
               </label>
               <div class="masked-field">
                 <input class="field-input" type="password" name="discord_webhook_url"
+                       aria-label="{{ 'settings_page.notify.discord_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.discord_webhook_url or '' }}"
                        placeholder="https://discord.com/api/webhooks/..." autocomplete="off">
                 <button type="button" class="mask-toggle" onclick="toggleFieldMask(this)"
@@ -931,6 +939,7 @@
               </label>
               <div class="masked-field">
                 <input class="field-input" type="password" name="slack_webhook_url"
+                       aria-label="{{ 'settings_page.notify.slack_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.slack_webhook_url or '' }}"
                        placeholder="https://hooks.slack.com/services/..." autocomplete="off">
                 <button type="button" class="mask-toggle" onclick="toggleFieldMask(this)"
@@ -945,6 +954,7 @@
               <span class="field-hint">{{ 'settings_page.notify.email_hint' | i18n_args(locale | default('ko')) }}</span>
               <div class="masked-field">
                 <input class="field-input" type="password" name="email_recipients"
+                       aria-label="{{ 'settings_page.notify.email_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.email_recipients or '' }}"
                        placeholder="admin@example.com, dev@example.com" autocomplete="off">
                 <button type="button" class="mask-toggle" onclick="toggleFieldMask(this)"
@@ -958,6 +968,7 @@
               </label>
               <div class="masked-field">
                 <input class="field-input" type="password" name="custom_webhook_url"
+                       aria-label="{{ 'settings_page.notify.custom_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.custom_webhook_url or '' }}"
                        placeholder="https://example.com/webhook/..." autocomplete="off">
                 <button type="button" class="mask-toggle" onclick="toggleFieldMask(this)"
@@ -974,6 +985,7 @@
               </label>
               <div class="masked-field">
                 <input class="field-input" type="password" name="n8n_webhook_url"
+                       aria-label="{{ 'settings_page.notify.n8n_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.n8n_webhook_url or '' }}"
                        placeholder="https://n8n.example.com/webhook/..." autocomplete="off">
                 <button type="button" class="mask-toggle" onclick="toggleFieldMask(this)"
@@ -1038,6 +1050,7 @@
         <div class="masked-field">
           <input class="field-input" type="password" name="railway_api_token"
                  form="settingsForm"
+                 aria-label="{{ 'settings_page.inbound.section_railway_token' | i18n_args(locale | default('ko')) }}"
                  placeholder="{{ 'settings_page.inbound.railway_token_placeholder' | i18n_args(locale | default('ko')) }}"
                  value="{{ '****' if railway_api_token_set else '' }}"
                  autocomplete="off">
@@ -1055,6 +1068,7 @@
       <div class="field-row">
         <div style="display:flex;gap:.5rem;align-items:center">
           <input type="text" readonly class="field-input" id="railway-webhook-url"
+                 aria-label="{{ 'settings_page.inbound.section_railway_webhook' | i18n_args(locale | default('ko')) }}"
                  value="{{ railway_webhook_url }}" style="font-family:monospace;font-size:12px;flex:1">
           <button type="button" class="hook-btn"
                   onclick="navigator.clipboard.writeText(document.getElementById('railway-webhook-url').value)">📋</button>
@@ -1077,7 +1091,8 @@
     </div>
     <div class="s-card-body">
       <div class="field-row">
-        <select name="review_model" form="settingsForm" class="field-input" style="max-width:420px;">
+        <select name="review_model" form="settingsForm" class="field-input" style="max-width:420px;"
+                aria-label="{{ 'settings.model_card_title' | i18n_args(locale | default('ko')) }}">
           <option value="">{{ 'settings.use_global_default' | i18n_args(locale | default('ko')) }}</option>
           {% for m in claude_models %}
           <option value="{{ m.id }}" {% if config.review_model == m.id %}selected{% endif %}>{{ m.label }}</option>

--- a/tests/unit/templates/test_detail_i18n_render.py
+++ b/tests/unit/templates/test_detail_i18n_render.py
@@ -369,6 +369,30 @@ def test_analysis_detail_cycle143_issue_form_renders():
     assert "제목" in out  # issue_form.title
 
 
+def test_repo_detail_filter_input_aria_labels_render_korean():
+    """repo_detail.html ko — 필터 input aria-label 신규 키 렌더 (date_from/to · score_min/max + search 재사용).
+
+    SonarCloud Web:InputWithoutLabelCheck 해소용 aria-label 의 i18n 키가
+    raw 키가 아닌 번역 텍스트로 렌더되는지 검증 (오타 키 회귀 차단 — render-parity).
+    """
+    out = _render("repo_detail.html", locale="ko", **_repo_ctx())
+    assert 'aria-label="시작 날짜"' in out          # date_from_aria
+    assert 'aria-label="종료 날짜"' in out          # date_to_aria
+    assert 'aria-label="최소 점수"' in out          # score_min_aria
+    assert 'aria-label="최대 점수"' in out          # score_max_aria
+    assert 'aria-label="커밋 메시지 또는 SHA 검색…"' in out  # search_placeholder 재사용
+
+
+def test_repo_detail_filter_input_aria_labels_render_english():
+    """repo_detail.html en — 필터 input aria-label 신규 키 렌더."""
+    out = _render("repo_detail.html", locale="en", **_repo_ctx())
+    assert 'aria-label="From date"' in out          # date_from_aria
+    assert 'aria-label="To date"' in out            # date_to_aria
+    assert 'aria-label="Minimum score"' in out      # score_min_aria
+    assert 'aria-label="Maximum score"' in out      # score_max_aria
+    assert 'aria-label="Search commit message or SHA…"' in out  # search_placeholder 재사용
+
+
 def test_analysis_detail_trend_nav_encodes_repo_name():
     """🔴 U3: 트렌드 차트 클릭 nav 가 REPO_NAME 을 encodeURIComponent 로 인코딩(형제 feedback URL 대칭).
 

--- a/tests/unit/ui/test_input_aria_labels.py
+++ b/tests/unit/ui/test_input_aria_labels.py
@@ -1,0 +1,84 @@
+"""접근성 회귀 가드 — 폼 입력 요소 aria-label 부여 (SonarCloud Web:InputWithoutLabelCheck).
+
+Accessibility regression guard — form controls carry an aria-label
+(SonarCloud Web:InputWithoutLabelCheck).
+
+배경 (Background):
+    SonarCloud Quality Gate 가 settings.html(15) + repo_detail.html(5) 의 라벨 없는
+    input/select 20건을 MAJOR 신뢰성 버그(Web:InputWithoutLabelCheck)로 검출 →
+    new_reliability_rating C → 게이트 ERROR. 각 컨트롤에 i18n 바인딩 aria-label 부여로 해소.
+    SonarCloud flagged 20 unlabeled input/select controls as MAJOR reliability bugs,
+    failing the Quality Gate. Each control gets an i18n-bound aria-label.
+
+검사 방식 (Method):
+    SonarCloud 룰과 동일하게 **raw 템플릿** 의 컨트롤 태그를 추출해 aria-label 존재를 단언.
+    aria-label 값은 반드시 i18n `{{ ... }}` 바인딩 (하드코딩 금지 — i18n.md 규칙).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_TEMPLATES = Path("src/templates")
+
+
+def _control_tag(html: str, attr: str) -> str:
+    """`attr` 를 포함하는 첫 input/select/textarea 태그 전체를 반환.
+
+    Returns the first input/select/textarea tag containing `attr`.
+    `<input ... attr ... >` — 속성값에 '>' 가 없음을 전제(이 템플릿들에서 성립).
+    """
+    pat = re.compile(
+        r"<(?:input|select|textarea)\b[^>]*" + re.escape(attr) + r"[^>]*>"
+    )
+    match = pat.search(html)
+    assert match, f"control with {attr} not found in template"
+    return match.group(0)
+
+
+# (템플릿 파일, 컨트롤 식별 속성) — SonarCloud 가 지목한 20 컨트롤
+# (template file, identifying attribute) — the 20 controls SonarCloud flagged
+_FLAGGED_CONTROLS = [
+    # settings.html — PR 임계값 슬라이더/숫자 (pr_rules)
+    ("settings.html", 'name="merge_threshold"'),
+    ("settings.html", 'id="mergeVal"'),
+    ("settings.html", 'name="approve_threshold"'),
+    ("settings.html", 'id="approveVal"'),
+    ("settings.html", 'name="reject_threshold"'),
+    ("settings.html", 'id="rejectVal"'),
+    # settings.html — 알림 채널 masked 입력 (notify)
+    ("settings.html", 'name="notify_chat_id"'),
+    ("settings.html", 'name="discord_webhook_url"'),
+    ("settings.html", 'name="slack_webhook_url"'),
+    ("settings.html", 'name="email_recipients"'),
+    ("settings.html", 'name="custom_webhook_url"'),
+    ("settings.html", 'name="n8n_webhook_url"'),
+    # settings.html — 인바운드 토큰/URL + 모델 select
+    ("settings.html", 'name="railway_api_token"'),
+    ("settings.html", 'id="railway-webhook-url"'),
+    ("settings.html", 'name="review_model"'),
+    # repo_detail.html — 필터 바 (검색/날짜/점수 슬라이더)
+    ("repo_detail.html", 'id="searchInput"'),
+    ("repo_detail.html", 'id="dateFrom"'),
+    ("repo_detail.html", 'id="dateTo"'),
+    ("repo_detail.html", 'id="scoreMin"'),
+    ("repo_detail.html", 'id="scoreMax"'),
+]
+
+
+@pytest.mark.parametrize("template, attr", _FLAGGED_CONTROLS)
+def test_flagged_control_has_i18n_aria_label(template: str, attr: str):
+    """플래그된 각 컨트롤이 i18n 바인딩 aria-label 을 보유 (Web:InputWithoutLabelCheck 해소)."""
+    html = (_TEMPLATES / template).read_text(encoding="utf-8")
+    tag = _control_tag(html, attr)
+    assert 'aria-label="{{' in tag, (
+        f"{template} 의 {attr} 컨트롤에 i18n aria-label 부재 — "
+        f"Web:InputWithoutLabelCheck 회귀. tag={tag!r}"
+    )
+
+
+def test_flagged_control_count_is_locked():
+    """가드 대상 컨트롤 수 = 20 (SonarCloud 검출 건수와 동결 — 누락/중복 방지)."""
+    assert len(_FLAGGED_CONTROLS) == 20


### PR DESCRIPTION
## Summary

SonarCloud **Quality Gate ERROR(신뢰성 C)** 의 유일 원인인 라벨 없는 폼 입력 20건에 i18n 바인딩 `aria-label` 을 부여해 게이트를 복구한다. (`Web:InputWithoutLabelCheck`, MAJOR 신뢰성 버그 ×20 → `new_reliability_rating` C → ERROR)

## 변경 내용

- **settings.html (15건)** — PR 임계값 슬라이더/숫자 6, 알림 채널 masked 입력 6, Railway 토큰/URL 2, 모델 select 1
- **repo_detail.html (5건)** — 검색창, 날짜 from/to, 점수 슬라이더 min/max
- 각 컨트롤에 **i18n 바인딩 aria-label** 부여 (하드코딩 금지 — `i18n.md` 규칙). 16건은 기존 가시 라벨 키 재사용, 신규 4키(`date_from/date_to/score_min/score_max` × ko/en/ja) 추가.
- **근거**: 권위 있는 룰 소스 [`InputWithoutLabelCheck.registerControl`](https://raw.githubusercontent.com/SonarSource/sonar-html/master/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/sonar/InputWithoutLabelCheck.java) 가 `hasProperty("aria-label")` 시 즉시 return → aria-label 로 위반 해소. 편집 중 IDE 라이브 진단에서도 aria-label 추가분이 `InputWithoutLabelCheck` 에서 사라짐을 실측 확인.

## 테스트

- **TDD**: `tests/unit/ui/test_input_aria_labels.py` — 20 컨트롤 raw 템플릿 aria-label 정적 가드(SonarCloud 와 동일 raw HTML 검사) + count-lock(20). RED(20 fail) → GREEN.
- **render-parity**: `test_detail_i18n_render.py` — 신규 4키 ko/en 번역 렌더 가드(오타 키 회귀 차단).
- 전 33 aria-label i18n 바인딩 3 로케일(ko/en/ja) 해소 OK — 오타 키 0.
- **전체 `pytest tests/`: 5157 passed · 8 skipped** · pylint 10.00 · flake8 clean · JSON 3 로케일 유효.

> **범위 외**: 동일 영역 `Web:S6853` 7건(`<label>` 코드 스멜)은 maintainability=A 유지·게이트 무영향 → 별도 정리 대상.

## 체크리스트

### 기본
- [x] `make test` 통과 (0 failed — 5157 passed/8 skipped)
- [x] `make lint` 통과 (pylint 10.00 · flake8 clean)

## 🔍 사용자 검증 필요

- [ ] CI(SonarCloud) 통과 + **Quality Gate ERROR→OK 전환 확인** (new_reliability_rating C→A)
- [ ] (정책 11) UI 시각 영향 — **`aria-label` 은 스크린리더 전용 속성으로 화면 렌더 변화 0** (4테마×2뷰포트 시각 회귀 위험 사실상 없음). 다만 `settings.html`·`repo_detail.html` 변경이므로 형식상 8조합 체크리스트 첨부:

| 테마 | 데스크탑 | 모바일 |
|------|---------|--------|
| dark | [ ] | [ ] |
| light | [ ] | [ ] |
| pastel | [ ] | [ ] |
| catppuccin | [ ] | [ ] |

> Claude 시각 검증 불가 영역(정책 11) — 단, 본 변경은 비시각(aria-label) 이므로 레이아웃/색상 영향 없음.

## ⚠️ 자율 판단 보고 (정책 3)

- **aria-label 채택 결정**: `<label for>` 재구조화 대신 i18n 바인딩 aria-label 선택 — (a) 권위 룰 소스가 aria-label 수용 확인, (b) 시각 변화 0(레이아웃 무손상), (c) 사이클 147 #707(S6853) aria-label 선례와 일관. 두 슬라이더 등 중복 라벨 방지를 위해 min/max·from/to 구분 키 부여.
- **문서 sync 잔여**: 테스트 수 변경(→5157)에 따른 `docs/STATE.md`·`README` 배지·`cycle-history` + `src/templates/**` 변경에 따른 `.claude/rules/ui.md` InputWithoutLabelCheck→aria-label 규칙 추가는 **후속 sync 로 분리**(정책 7 응집 단위) — 본 PR 머지 후 진행 예정.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] **Codex 검증 OK 수신 (push 전)** — `codex exec` 독립 검증 결론 **OK**:
  1. aria-label 룰 만족 — SonarSource 소스 `getPropertyValue("aria-label") != null → return` 재확인 (동일 출처 독립 도달)
  2. Jinja2 `{{ }}` 바인딩 — Python HTMLParser 로 속성 인식 확인
  3. 누락/회귀 위험 낮음 — 두 템플릿 스캔 시 미라벨 0건, i18n 키 ko/en/ja 존재, 테스트 47 passed 재실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)
