### PR TITLE
fix(security): CORSMiddleware를 미들웨어 체인 마지막(outermost)으로 — SonarCloud S8414 BLOCKER

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -203,17 +203,6 @@ app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(LimitBodySizeMiddleware)
-# A4: CORS — APP_BASE_URL 기반 명시적 출처 허용 (allow_origins=["*"] 금지)
-# A4: CORS — explicit origin from APP_BASE_URL, never allow_origins=["*"]
-if settings.app_base_url:
-    _origin = settings.app_base_url.rstrip("/")
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origins=[_origin],
-        allow_credentials=True,
-        allow_methods=["GET", "POST", "PUT", "DELETE"],
-        allow_headers=["*"],
-    )
 # Phase 3 postlude — RLS 운영 활성화 미들웨어. Starlette LIFO 미들웨어 스택:
 # add_middleware 마지막 호출이 outer (request 먼저 처리). 원하는 흐름 = SessionMiddleware → RLSSessionMiddleware → route
 # 따라서 RLS 먼저 등록 (inner), SessionMiddleware 나중 등록 (outer — RLS 보다 먼저 호출).
@@ -239,6 +228,23 @@ app.add_middleware(
     same_site="lax",
     max_age=60 * 60 * 24 * 7,  # 7 days
 )
+
+# A4: CORS — APP_BASE_URL 기반 명시적 출처 허용 (allow_origins=["*"] 금지).
+# 🔴 CORSMiddleware 는 반드시 마지막 add_middleware (outermost) — SonarCloud S8414.
+# outermost 여야 preflight OPTIONS + CORS 헤더가 Session/RLS 등 inner 미들웨어의
+# 인증·세션 거부 응답에도 적용된다 (CORS 가 inner 면 거부 응답에 CORS 헤더 누락).
+# A4: CORS — explicit origin from APP_BASE_URL, never allow_origins=["*"].
+# CORSMiddleware MUST be the last add_middleware (outermost) — SonarCloud S8414 — so that
+# preflight + CORS headers apply even when inner middleware (Session/RLS) reject the request.
+if settings.app_base_url:
+    _origin = settings.app_base_url.rstrip("/")
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=[_origin],
+        allow_credentials=True,
+        allow_methods=["GET", "POST", "PUT", "DELETE"],
+        allow_headers=["*"],
+    )
 
 
 # 정적 파일 캐시 — 버전 해시 없는 URL(`/static/js/effects.js` 등)이라 immutable 장기 캐시 금지.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,4 +1,6 @@
 """Tests for src/main.py — FastAPI app entry point, lifespan, and route registration."""
+import re
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -37,6 +39,20 @@ def test_health_security_headers(client):
     response = client.get("/health")
     assert response.headers.get("x-content-type-options") == "nosniff"
     assert response.headers.get("x-frame-options") == "DENY"
+
+
+def test_cors_middleware_registered_last_outermost():
+    # CORSMiddleware 는 마지막 add_middleware (outermost) 여야 함 — SonarCloud S8414 (BLOCKER).
+    # Starlette LIFO: 마지막 등록 = outermost (request 먼저 처리). CORS 가 outermost 여야
+    # preflight OPTIONS + CORS 헤더가 인증/세션 거부 응답에도 적용된다.
+    # CORSMiddleware must be the last-registered (outermost) middleware (SonarCloud S8414).
+    # Outermost CORS ensures preflight + CORS headers apply even to auth/session rejections.
+    src = Path("src/main.py").read_text(encoding="utf-8")
+    order = re.findall(r"app\.add_middleware\(\s*(\w+)", src)
+    assert "CORSMiddleware" in order, "CORSMiddleware 등록 누락"
+    assert order[-1] == "CORSMiddleware", (
+        f"CORSMiddleware 가 마지막(outermost)이 아님 — S8414 위반. 등록 순서={order}"
+    )
 
 
 def test_health_tools_removed(client):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,4 +1,5 @@
 """Tests for src/main.py — FastAPI app entry point, lifespan, and route registration."""
+import importlib
 import re
 from pathlib import Path
 from unittest.mock import patch
@@ -53,6 +54,29 @@ def test_cors_middleware_registered_last_outermost():
     assert order[-1] == "CORSMiddleware", (
         f"CORSMiddleware 가 마지막(outermost)이 아님 — S8414 위반. 등록 순서={order}"
     )
+
+
+def test_cors_block_registers_outermost_when_app_base_url_set(monkeypatch):
+    # APP_BASE_URL 설정 시 CORS 블록(app.add_middleware(CORSMiddleware, ...))이 실행되어
+    # CORSMiddleware 가 outermost(user_middleware[0])로 등록되고 origin/credentials 가 적용되는지 검증.
+    # main 을 reload 해 조건부 CORS 블록을 실제 실행(테스트 기본 env 는 app_base_url 빈 값).
+    # Reload main with APP_BASE_URL set so the conditional CORS block actually executes.
+    import src.config as config_mod
+    import src.main as main_mod
+    monkeypatch.setenv("APP_BASE_URL", "https://cors-test.example.com")
+    try:
+        importlib.reload(config_mod)
+        reloaded = importlib.reload(main_mod)
+        outermost = reloaded.app.user_middleware[0]
+        assert outermost.cls.__name__ == "CORSMiddleware"  # 마지막 등록 = outermost
+        assert outermost.kwargs["allow_origins"] == ["https://cors-test.example.com"]
+        assert outermost.kwargs["allow_credentials"] is True
+    finally:
+        # main/config 를 원래 상태(app_base_url 빈 값, CORS 미등록)로 복원 — 전역 누수 방지
+        # Restore main/config to original state to avoid global state leak.
+        monkeypatch.delenv("APP_BASE_URL", raising=False)
+        importlib.reload(config_mod)
+        importlib.reload(main_mod)
 
 
 def test_health_tools_removed(client):


### PR DESCRIPTION
## Summary

SonarCloud **BLOCKER** `python:S8414` 해소 — `CORSMiddleware` 를 미들웨어 체인 **마지막(outermost)** 으로 이동. (A-1 SonarCloud 정리 1/2)

## 변경 내용

- `if settings.app_base_url:` CORS 블록을 `SessionMiddleware` 등록 뒤로 이동 → CORS 가 마지막 `add_middleware` = **outermost**.
- Starlette LIFO: 마지막 등록이 outermost. CORS 가 inner 면 Session/RLS **인증·세션 거부 응답에 CORS 헤더가 누락**되고 preflight 처리도 inner 로 밀린다.
- 결과 흐름: `CORS → Session → RLS → Locale → LimitBodySize → SecurityHeaders → route`. **Session→RLS→Locale 의도적 상대 순서 보존**(RLS 활성화 주석). CORS 조건·옵션 불변.

## 테스트

- **TDD**: `test_cors_middleware_registered_last_outermost` — `main.py` add_middleware 등록 순서 마지막 = CORSMiddleware 정적 가드(S8414 미러). RED→GREEN.
- **런타임 실측**: `APP_BASE_URL` 설정 시 `app.user_middleware[0]=CORSMiddleware`(outermost) 확인.
- 전체 **5158 passed · 8 skipped** · `pylint src/` 10.00 · flake8 clean.

## 체크리스트
- [x] `make test` 통과 (0 failed)
- [x] `make lint` 통과 (pylint 10.00)

## 🔍 사용자 검증 필요
- [ ] CI(SonarCloud) 통과 + **BLOCKER S8414 해소 확인**
- [ ] (운영) CORS 동작 정상 — `APP_BASE_URL` 출처의 cross-origin 요청 헤더 적용

## ⚠️ 자율 판단 보고 (정책 3)
- **Codex 검증 비차단 caveat**: CORS 가 outermost 라 preflight OPTIONS 응답(CORS 가 직접 응답)에는 `SecurityHeadersMiddleware` 의 `x-content-type-options` 가 미부착. 일반 GET/POST 응답엔 보안 헤더 + CORS 헤더 양쪽 정상. preflight 는 빈 CORS 응답이라 보안 헤더 불필요 — **S8414 권장(CORS outermost)의 의도된 trade-off**, 동작 위험 없음.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [x] **Codex 검증 OK (push 전)** — 4기준 통과: CORS outermost(Starlette LIFO 소스 확인)·Session→RLS 순서 보존·런타임/preflight 독립 재실측(user_middleware[0]=CORS, preflight 200 + ACAO 정상)·정적 가드 S8414 충실. 결론 **OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
