### PR TITLE
refactor(sonar): S3776 인지 복잡도 3건 extract-method — CRITICAL

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -94,9 +94,12 @@ def _run_migrations() -> None:
     command.upgrade(alembic_cfg, "head")
 
 
-@asynccontextmanager
-async def lifespan(_app: FastAPI):
-    """Run DB migrations on startup, then yield control to the application."""
+def _validate_startup_config() -> None:
+    """프로덕션 시작 전 필수 설정 검증 — 위험 설정 시 RuntimeError 또는 경고 로그.
+
+    Validate critical config before startup; raise RuntimeError or log a warning on risky settings.
+    프로덕션(HTTPS) 판정은 APP_BASE_URL 기준. lifespan 에서 startup 직전 1회 호출.
+    """
     is_prod_like = settings.app_base_url.startswith("https")
     _DEFAULT_SESSION_SECRET = "dev-secret-change-in-production"  # nosec B105
     if settings.session_secret == _DEFAULT_SESSION_SECRET:  # nosec B105
@@ -152,6 +155,12 @@ async def lifespan(_app: FastAPI):
             "the value configured in your Telegram bot's webhook settings.",
             settings.app_base_url,
         )
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    """Run DB migrations on startup, then yield control to the application."""
+    _validate_startup_config()
     try:
         await asyncio.wait_for(asyncio.to_thread(_run_migrations), timeout=30)
         logger.info("DB migration completed")

--- a/src/services/dashboard_service.py
+++ b/src/services/dashboard_service.py
@@ -504,6 +504,37 @@ def _group_analyses_by_repo(
     return by_repo
 
 
+def _build_repo_card(repo, cur: list, prev: list) -> dict[str, Any]:
+    """단일 리포의 인사이트 카드 dict 생성 — current/previous 분석 윈도우 기반.
+
+    Build one repo's insight card dict from its current/previous analysis windows.
+    """
+    from src.services.repo_insight_service import compute_score_kpi  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+    avg_score, score_delta, grade = compute_score_kpi(cur, prev)
+
+    # 이슈 빈도 카운트 → count >= 2 만 recurring 집계 (1회성 이슈 제외)
+    # Count issue frequency → only issues appearing >= 2 times are "recurring"
+    issue_counter: dict[str, int] = {}
+    for a in cur:
+        for issue in (a.result or {}).get("issues", []):
+            if not isinstance(issue, dict):
+                continue
+            key = issue.get("message") or issue.get("code")
+            if key:
+                issue_counter[key] = issue_counter.get(key, 0) + 1
+    recurring_count = sum(1 for cnt in issue_counter.values() if cnt >= 2)
+
+    return {
+        "repo_id": repo.id,
+        "full_name": repo.full_name,
+        "avg_score": avg_score,
+        "grade": grade,
+        "recurring_issue_count": recurring_count,
+        "score_trend": _score_trend(score_delta),
+        "insights_url": f"/repos/{repo.full_name}/insights",
+    }
+
+
 def repo_insight_cards(  # pylint: disable=too-many-locals
     db: Session,
     days: int = 30,
@@ -563,37 +594,8 @@ def repo_insight_cards(  # pylint: disable=too-many-locals
         cur = cur_by_repo.get(repo_id, [])
         if not cur:
             continue  # 해당 기간 내 분석 없는 리포 제외 / Skip repos with no analyses in window
-
         prev = prev_by_repo.get(repo_id, [])
-
-        from src.services.repo_insight_service import compute_score_kpi  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
-        avg_score, score_delta, grade = compute_score_kpi(cur, prev)
-
-        # 이슈 빈도 카운트 (recurring 이슈 수)
-        # Count recurring issues
-        issue_counter: dict[str, int] = {}
-        for a in cur:
-            for issue in (a.result or {}).get("issues", []):
-                if not isinstance(issue, dict):
-                    continue
-                key = issue.get("message") or issue.get("code")
-                if key:
-                    issue_counter[key] = issue_counter.get(key, 0) + 1
-        # count >= 2인 항목만 recurring으로 집계 (1회만 등장한 이슈는 제외)
-        # Count only issues appearing >= 2 times (single-occurrence issues excluded)
-        recurring_count = sum(1 for cnt in issue_counter.values() if cnt >= 2)
-
-        trend = _score_trend(score_delta)
-
-        cards.append({
-            "repo_id": repo_id,
-            "full_name": repo.full_name,
-            "avg_score": avg_score,
-            "grade": grade,
-            "recurring_issue_count": recurring_count,
-            "score_trend": trend,
-            "insights_url": f"/repos/{repo.full_name}/insights",
-        })
+        cards.append(_build_repo_card(repo, cur, prev))
 
     # avg_score 내림차순 정렬 후 최대 10개 반환
     # Sort by avg_score descending, return max 10

--- a/src/services/repo_insight_service.py
+++ b/src/services/repo_insight_service.py
@@ -259,6 +259,22 @@ def repo_ai_suggestions(
     ]
 
 
+def _classify_issue_bucket(issue: object) -> str | None:
+    """이슈를 category×severity 4-way 버킷 키로 분류 (해당 없으면 None).
+
+    Classify an issue into one of the 4-way category×severity bucket keys (None if not applicable).
+    """
+    if not isinstance(issue, dict):
+        return None
+    category = issue.get("category", "")
+    is_error = issue.get("severity", "").upper() in ("HIGH", "ERROR")
+    if category == "security":
+        return "security_error" if is_error else "security_warning"
+    if category == "code_quality":
+        return "code_quality_error" if is_error else "code_quality_warning"
+    return None
+
+
 def repo_category_breakdown(
     db: Session, repo_id: int, days: int = 30, now: datetime | None = None
 ) -> dict[str, int]:
@@ -277,15 +293,9 @@ def repo_category_breakdown(
     }
     for a in analyses:
         for issue in (a.result or {}).get("issues", []):
-            if not isinstance(issue, dict):
-                continue
-            category = issue.get("category", "")
-            severity = issue.get("severity", "").upper()
-            is_error = severity in ("HIGH", "ERROR")
-            if category == "security":
-                counts["security_error" if is_error else "security_warning"] += 1
-            elif category == "code_quality":
-                counts["code_quality_error" if is_error else "code_quality_warning"] += 1
+            key = _classify_issue_bucket(issue)
+            if key:
+                counts[key] += 1
 
     counts["total"] = sum(counts.values())
     return counts


### PR DESCRIPTION
## Summary

SonarCloud **CRITICAL** `python:S3776`(인지 복잡도 > 15) 중 **고복잡도 3건**을 extract-method 로 해소. (A-1 SonarCloud 정리 3/3 · 순수 refactor, 동작 보존)

## 변경 내용

| 함수 | 복잡도 | 추출 헬퍼 |
|------|:---:|------|
| `dashboard_service.py` repo_insight_cards | 22 | `_build_repo_card(repo, cur, prev)` — KPI + recurring 이슈 카운트 + 카드 dict |
| `repo_insight_service.py` repo_category_breakdown | 20 | `_classify_issue_bucket(issue) -> str\|None` — category×severity 분류 |
| `main.py` lifespan | 16 | `_validate_startup_config()` (0-param) — 프로덕션 설정 검증 블록 |

모두 응집 블록을 명명 헬퍼로 분리 — **동작 보존**(behavior-preserving), 호출자 가독성↑. 헬퍼 파라미터 3/1/0 → S107 무위험.

## ⚠️ 보류 (정책 16 판단 — 자율 보고)

- **merge_retry `_process_single_retry`(18)**: 깔끔한 추출이 **8~9 파라미터 헬퍼**를 요구 → `S107`(too-many-parameters) 를 **새로 유발**(스멜 교환). 선형 guard 파이프라인은 이미 가독성 양호 → 가독성 안 높이는 추상화 회피. **보류**.
- **16→15 경계 3건**(clippy:66·repo_insight:75·:312): 단 1 초과 — 메트릭 위한 단일 사용 헬퍼 강제는 정책 16 위반 소지. **보류**.
- 결과: CRITICAL 10 → **고복잡도 3 해소**, 잔여 7(maintainability A·게이트 OK 유지·차단성 무).

## 테스트
- 전체 **5159 passed · 8 skipped** · `pylint src/` 10.00 · flake8 신규 0(E501 relocated, soft-pass).
- main.py 99% 커버 · 3 헬퍼 전부 테스트된 함수 실행 경로(new_coverage 안전).

## 체크리스트
- [x] `make test` 통과 (0 failed)
- [x] `make lint` 통과 (pylint 10.00)

## 🔍 사용자 검증 필요
- [ ] CI(SonarCloud) 통과 + CRITICAL S3776 3건 해소 확인

## ⚠️ 자율 판단 보고 (정책 3)
- **merge_retry(18) + 경계 3건 보류** (위 §보류) — 옵션 A 가 18 포함이었으나, 추출이 S107 신규 유발/메트릭 강제 추상화라 정책 16(가독성 안 높이는 추상화 금지)으로 보류 결정. 원하시면 8-param 헬퍼 + S107 임계 조정으로 진행 가능(별도 PR).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [x] **Codex 검증 OK** — 3 추출 동작 보존(repo_id≡repo.id·분류 분기 등가·검증 raise/warning 경로 등가·실행 순서 유지)·복잡도 감소 유효·헬퍼 param 3/1/0 S107 무위험·관련 테스트 46+75 passed. 결론 **OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
