### PR TITLE
refactor(sonar): S3776 잔여 4건 extract-method — CRITICAL 인지 복잡도 전부 해소

### DIFF
--- a/src/analyzer/io/tools/clippy.py
+++ b/src/analyzer/io/tools/clippy.py
@@ -42,6 +42,37 @@ def _build_temp_cargo_project(rs_content: str) -> str:
     return tmp_dir
 
 
+def _parse_clippy_line(line: str, ctx: AnalyzeContext) -> AnalysisIssue | None:
+    """cargo clippy JSON 행 1개를 AnalysisIssue 로 파싱 (compiler-message 아니면 None).
+
+    Parse one cargo clippy JSON line into an AnalysisIssue (None if not a compiler-message).
+    """
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        obj = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    # compiler-message 이외의 행(build-script-executed 등)은 무시
+    # Skip non-compiler-message lines (e.g. build-script-executed)
+    if obj.get("reason") != "compiler-message":
+        return None
+    msg = obj.get("message", {})
+    level = msg.get("level", "warning").lower()
+    severity = Severity.ERROR if level == "error" else Severity.WARNING
+    spans = msg.get("spans", [{}])
+    line_no = spans[0].get("line_start", 0) if spans else 0
+    return AnalysisIssue(
+        tool="clippy",
+        severity=severity,
+        message=msg.get("message", ""),
+        line=line_no,
+        category=Category.CODE_QUALITY,
+        language=ctx.language,
+    )
+
+
 class _ClippyAnalyzer:
     """cargo clippy Rust 분석기 — JSONL compiler-message 파싱.
     cargo clippy Rust analyzer — parses JSONL compiler-message output.
@@ -78,30 +109,9 @@ class _ClippyAnalyzer:
             )
             issues = []
             for line in (r.stdout or "").splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    obj = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                # compiler-message 이외의 행(build-script-executed 등)은 무시
-                # Skip non-compiler-message lines (e.g. build-script-executed)
-                if obj.get("reason") != "compiler-message":
-                    continue
-                msg = obj.get("message", {})
-                level = msg.get("level", "warning").lower()
-                severity = Severity.ERROR if level == "error" else Severity.WARNING
-                spans = msg.get("spans", [{}])
-                line_no = spans[0].get("line_start", 0) if spans else 0
-                issues.append(AnalysisIssue(
-                    tool="clippy",
-                    severity=severity,
-                    message=msg.get("message", ""),
-                    line=line_no,
-                    category=Category.CODE_QUALITY,
-                    language=ctx.language,
-                ))
+                issue = _parse_clippy_line(line, ctx)
+                if issue is not None:
+                    issues.append(issue)
             return issues
         except subprocess.TimeoutExpired:
             ctx.timed_out = True

--- a/src/services/merge_retry_service.py
+++ b/src/services/merge_retry_service.py
@@ -228,7 +228,28 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
         counts["succeeded"] += 1
         return
 
-    # ── f. 실패 분류 ──────────────────────────────────────────────
+    # ── f. 실패 처리 (terminal/expired/transient 분류 + 로깅·알림·큐 복귀) ──
+    await _handle_merge_failure(
+        db, row=row, cfg=cfg, token=token, pr_data=pr_data,
+        reason=reason, now=now, language=language, counts=counts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# 비공개 헬퍼 함수
+# ---------------------------------------------------------------------------
+
+
+async def _handle_merge_failure(  # pylint: disable=too-many-arguments
+    db: Session, *, row, cfg: RepoConfigData, token: str, pr_data: dict,
+    reason: str, now: datetime, language: str, counts: dict[str, int],
+) -> None:
+    """merge_pr 실패 후 처리 — terminal/expired/transient 분류 + 로깅·알림·큐 복귀.
+
+    Handle a failed merge_pr outcome: classify terminal/expired/transient, log, notify, requeue.
+    `_process_single_retry` 의 실패 경로(f/g)를 분리 — 인지 복잡도 감소.
+    """
     reason_tag = parse_reason_tag(reason)
     # F1: pr_data 에 이미 base.ref 가 있으므로 추가 호출 없이 활용
     # base 키가 present-but-None 일 수 있어 `or {}` 정규화 (PR #124 패턴)
@@ -265,7 +286,7 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
             await _create_failure_issue_safe(token, row, cfg, reason, reason_tag, language=language)
         return
 
-    # ── g. 일시적 실패 — 백오프 후 재시도 대기로 복귀 ────────────
+    # ── 일시적 실패 — 백오프 후 재시도 대기로 복귀 ────────────
     next_retry_at = compute_next_retry_at(
         row.attempts_count,
         now=now,
@@ -278,12 +299,6 @@ async def _process_single_retry(  # pylint: disable=too-many-locals,too-many-ret
         last_failure_reason=reason_tag, last_detail_message=reason,
     )
     counts["released"] += 1
-
-
-# ---------------------------------------------------------------------------
-# Private helpers
-# 비공개 헬퍼 함수
-# ---------------------------------------------------------------------------
 
 
 def _resolve_github_token(db: Session, repo_full_name: str) -> str | None:

--- a/src/services/repo_insight_service.py
+++ b/src/services/repo_insight_service.py
@@ -72,6 +72,28 @@ def compute_score_kpi(
     return avg_score, score_delta, grade
 
 
+def _count_issues_and_high_security(analyses: list) -> tuple[dict[str, int], int]:
+    """분석 목록에서 이슈 빈도 카운터 + 보안 HIGH/ERROR 카운트 집계.
+
+    Aggregate the issue-frequency counter + count of HIGH/ERROR security issues from analyses.
+    """
+    issue_counter: dict[str, int] = {}
+    high_security = 0
+    for a in analyses:
+        for issue in (a.result or {}).get("issues", []):
+            if not isinstance(issue, dict):
+                continue
+            key = issue.get("message") or issue.get("code")
+            if key:
+                issue_counter[key] = issue_counter.get(key, 0) + 1
+            if (
+                issue.get("category") == "security"
+                and issue.get("severity", "").upper() in ("HIGH", "ERROR")
+            ):
+                high_security += 1
+    return issue_counter, high_security
+
+
 def repo_kpi(  # pylint: disable=too-many-locals
     db: Session, repo_id: int, days: int = 30, now: datetime | None = None
 ) -> dict[str, Any]:
@@ -100,22 +122,7 @@ def repo_kpi(  # pylint: disable=too-many-locals
 
     avg_score, score_delta, grade = compute_score_kpi(cur, prev)
 
-    # 이슈 빈도 카운트
-    # Issue frequency count
-    issue_counter: dict[str, int] = {}
-    high_security = 0
-    for a in cur:
-        for issue in (a.result or {}).get("issues", []):
-            if not isinstance(issue, dict):
-                continue
-            key = issue.get("message") or issue.get("code")
-            if key:
-                issue_counter[key] = issue_counter.get(key, 0) + 1
-            if (
-                issue.get("category") == "security"
-                and issue.get("severity", "").upper() in ("HIGH", "ERROR")
-            ):
-                high_security += 1
+    issue_counter, high_security = _count_issues_and_high_security(cur)
 
     top_issue, top_count = None, 0
     if issue_counter:
@@ -319,6 +326,23 @@ def _extract_narrative_json(text: str) -> str:
     return cleaned
 
 
+def _record_narrative_error(
+    db: Session, *, user_id: int | None, repo_id: int, days: int,
+    language: str, error_type: str, now: datetime,
+) -> None:
+    """user_id 가 있으면 내러티브 캐시에 에러 기록 (no_data/api_error 경로 공통).
+
+    Record a narrative error in the cache when user_id is set (shared by no_data/api_error paths).
+    """
+    if user_id is None:
+        return
+    from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+    insight_narrative_cache_repo.record_error_repo(
+        db, user_id=user_id, repo_id=repo_id, days=days,
+        language=language, error_type=error_type, now=now,
+    )
+
+
 async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many-locals
     db: Session,
     repo_id: int,
@@ -359,12 +383,10 @@ async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many
                 return cached
 
     if not kpi.get("analysis_count"):
-        if user_id is not None:
-            from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
-            insight_narrative_cache_repo.record_error_repo(
-                db, user_id=user_id, repo_id=repo_id, days=days,
-                language=language, error_type="no_data", now=_now,
-            )
+        _record_narrative_error(
+            db, user_id=user_id, repo_id=repo_id, days=days,
+            language=language, error_type="no_data", now=_now,
+        )
         return {"text": "", "status": "no_data"}
 
     user_prompt = (
@@ -414,12 +436,10 @@ async def repo_insight_narrative(  # pylint: disable=too-many-arguments,too-many
             error_type=type(exc).__name__,
         )
         logger.exception("repo_insight_narrative API call failed")
-        if user_id is not None:
-            from src.repositories import insight_narrative_cache_repo  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
-            insight_narrative_cache_repo.record_error_repo(
-                db, user_id=user_id, repo_id=repo_id, days=days,
-                language=language, error_type=type(exc).__name__, now=_now,
-            )
+        _record_narrative_error(
+            db, user_id=user_id, repo_id=repo_id, days=days,
+            language=language, error_type=type(exc).__name__, now=_now,
+        )
         return {"text": "", "status": "api_error"}
     finally:
         # 호출당 생성한 AsyncAnthropic httpx 커넥션 풀 해제 — 미종료 시 FD 누수 (WBS P1).


### PR DESCRIPTION
## Summary

SonarCloud **CRITICAL** `python:S3776`(인지 복잡도 > 15) **잔여 4건** 전부 해소 (extract-method). 이번 PR로 **CRITICAL → 0** 도달 예정. (잔여 CRITICAL 추가 정리 2/2)

## 변경 내용

| 함수 | 복잡도 | 추출 헬퍼 |
|------|:---:|------|
| `clippy.py` run | 16 | `_parse_clippy_line(line, ctx)` — JSON 행 파싱 (run 은 try/except/finally + 단순 루프만) |
| `repo_insight_service` repo_kpi | 17 | `_count_issues_and_high_security(analyses)` — 이슈 집계 (counter + high_security 튜플) |
| `repo_insight_service` repo_insight_narrative | 16 | `_record_narrative_error(...)` — no_data/api_error 중복 에러기록(user_id 가드 내장) |
| `merge_retry_service` _process_single_retry | 18 | `_handle_merge_failure(...)` — 실패 처리(terminal/expired/transient 분류·로깅·알림·큐 복귀) |

모두 동작 보존(behavior-preserving), 호출자 복잡도 < 15.

## 🔴 이전 보류 근거(S107) 불성립 — 실측

#950 에서 merge_retry 를 "8~9 param 헬퍼 = S107 유발" 우려로 보류했으나 **실측 결과 `python:S107` = 0건**이고 10-param `repo_insight_narrative` 도 미플래그 → S107 무관. 9-param `_handle_merge_failure` 안전. pylint R0913 만 `# pylint: disable=too-many-arguments`(코드베이스 `repo_insight_narrative` 패턴 일관).

## 테스트
- 전체 **5159 passed · 8 skipped** · `pylint src/` 10.00 · flake8 신규 0(E501 import 1 = 기존 2 대체 net -1, soft-pass).

## 체크리스트
- [x] `make test` 통과 (0 failed)
- [x] `make lint` 통과 (pylint 10.00)

## 🔍 사용자 검증 필요
- [ ] CI(SonarCloud) 통과 + CRITICAL S3776 4건 해소(→ CRITICAL 0) 확인

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [x] **Codex 검증 OK** — 4 추출 전부 동작 보존(파싱·집계 mutation 순서·user_id 가드·terminal/expired/transient 시퀀스·counts·알림·이슈 생성 등가)·테스트 51 passed·diff clean. 결론 **OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
