### PR TITLE
fix(a11y): settings.html 폼 라벨 7건 컨트롤 연결 — SonarCloud Web:S6853

### DIFF
--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -833,13 +833,13 @@
           <div class="s-section-label">{{ 'settings_page.notify.section_telegram' | i18n_args(locale | default('ko')) }}</div>
           <div class="channel-grid">
             <div class="field-row">
-              <label class="field-label">
+              <label class="field-label" for="notify_chat_id">
                 <span class="conn-dot {% if config.notify_chat_id %}is-on{% else %}is-off{% endif %}"></span>
                 {{ 'settings_page.notify.telegram_chat_id_label' | i18n_args(locale | default('ko')) }}
               </label>
               <span class="field-hint">{{ 'settings_page.notify.telegram_chat_id_hint' | i18n_args(locale | default('ko')) }}</span>
               <div class="masked-field">
-                <input class="field-input" type="password" name="notify_chat_id"
+                <input class="field-input" type="password" name="notify_chat_id" id="notify_chat_id"
                        aria-label="{{ 'settings_page.notify.telegram_chat_id_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.notify_chat_id or '' }}"
                        placeholder="-100xxxxxxxxx" autocomplete="off">
@@ -850,7 +850,7 @@
 
             {# Telegram OTP / Phase 2 PR-8 — i18n #}
             <div class="field-row">
-              <label class="field-label">{{ 'settings_page.notify.telegram_link_label' | i18n_args(locale | default('ko')) }}</label>
+              <div class="field-label">{{ 'settings_page.notify.telegram_link_label' | i18n_args(locale | default('ko')) }}</div>
               <div id="telegram-connect-section-notify">
                 {% if current_user.is_telegram_connected %}
                 <p class="text-success" style="font-size:13px;margin:0;">{{ 'settings_page.notify.telegram_link_connected' | i18n_args(locale | default('ko')) }}</p>
@@ -919,12 +919,12 @@
               <div class="s-section-label" style="grid-column:1/-1;margin:.6rem 0 .25rem;">{{ 'settings_page.notify.section_messengers' | i18n_args(locale | default('ko')) }}</div>
             </div>
             <div class="field-row adv-only">
-              <label class="field-label">
+              <label class="field-label" for="discord_webhook_url">
                 <span class="conn-dot {% if config.discord_webhook_url %}is-on{% else %}is-off{% endif %}"></span>
                 {{ 'settings_page.notify.discord_label' | i18n_args(locale | default('ko')) }}
               </label>
               <div class="masked-field">
-                <input class="field-input" type="password" name="discord_webhook_url"
+                <input class="field-input" type="password" name="discord_webhook_url" id="discord_webhook_url"
                        aria-label="{{ 'settings_page.notify.discord_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.discord_webhook_url or '' }}"
                        placeholder="https://discord.com/api/webhooks/..." autocomplete="off">
@@ -933,12 +933,12 @@
               </div>
             </div>
             <div class="field-row adv-only">
-              <label class="field-label">
+              <label class="field-label" for="slack_webhook_url">
                 <span class="conn-dot {% if config.slack_webhook_url %}is-on{% else %}is-off{% endif %}"></span>
                 {{ 'settings_page.notify.slack_label' | i18n_args(locale | default('ko')) }}
               </label>
               <div class="masked-field">
-                <input class="field-input" type="password" name="slack_webhook_url"
+                <input class="field-input" type="password" name="slack_webhook_url" id="slack_webhook_url"
                        aria-label="{{ 'settings_page.notify.slack_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.slack_webhook_url or '' }}"
                        placeholder="https://hooks.slack.com/services/..." autocomplete="off">
@@ -947,13 +947,13 @@
               </div>
             </div>
             <div class="field-row adv-only">
-              <label class="field-label">
+              <label class="field-label" for="email_recipients">
                 <span class="conn-dot {% if config.email_recipients %}is-on{% else %}is-off{% endif %}"></span>
                 {{ 'settings_page.notify.email_label' | i18n_args(locale | default('ko')) }} <span class="field-tag">{{ 'settings_page.notify.email_tag' | i18n_args(locale | default('ko')) }}</span>
               </label>
               <span class="field-hint">{{ 'settings_page.notify.email_hint' | i18n_args(locale | default('ko')) }}</span>
               <div class="masked-field">
-                <input class="field-input" type="password" name="email_recipients"
+                <input class="field-input" type="password" name="email_recipients" id="email_recipients"
                        aria-label="{{ 'settings_page.notify.email_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.email_recipients or '' }}"
                        placeholder="admin@example.com, dev@example.com" autocomplete="off">
@@ -962,12 +962,12 @@
               </div>
             </div>
             <div class="field-row adv-only">
-              <label class="field-label">
+              <label class="field-label" for="custom_webhook_url">
                 <span class="conn-dot {% if config.custom_webhook_url %}is-on{% else %}is-off{% endif %}"></span>
                 {{ 'settings_page.notify.custom_label' | i18n_args(locale | default('ko')) }}
               </label>
               <div class="masked-field">
-                <input class="field-input" type="password" name="custom_webhook_url"
+                <input class="field-input" type="password" name="custom_webhook_url" id="custom_webhook_url"
                        aria-label="{{ 'settings_page.notify.custom_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.custom_webhook_url or '' }}"
                        placeholder="https://example.com/webhook/..." autocomplete="off">
@@ -979,12 +979,12 @@
               <div class="s-section-label" style="grid-column:1/-1;margin:.6rem 0 .25rem;">{{ 'settings_page.notify.section_automation' | i18n_args(locale | default('ko')) }}</div>
             </div>
             <div class="field-row adv-only">
-              <label class="field-label">
+              <label class="field-label" for="n8n_webhook_url">
                 <span class="conn-dot {% if config.n8n_webhook_url %}is-on{% else %}is-off{% endif %}"></span>
                 {{ 'settings_page.notify.n8n_label' | i18n_args(locale | default('ko')) }}
               </label>
               <div class="masked-field">
-                <input class="field-input" type="password" name="n8n_webhook_url"
+                <input class="field-input" type="password" name="n8n_webhook_url" id="n8n_webhook_url"
                        aria-label="{{ 'settings_page.notify.n8n_label' | i18n_args(locale | default('ko')) }}"
                        value="{{ config.n8n_webhook_url or '' }}"
                        placeholder="https://n8n.example.com/webhook/..." autocomplete="off">

--- a/tests/unit/ui/test_label_associated_control.py
+++ b/tests/unit/ui/test_label_associated_control.py
@@ -1,0 +1,92 @@
+"""접근성 회귀 가드 — field-label <label> 가 폼 컨트롤과 연결됨 (SonarCloud Web:S6853).
+
+Accessibility regression guard — every `field-label` <label> is associated with a
+form control (SonarCloud Web:S6853 LabelHasAssociatedControlCheck).
+
+배경 (Background):
+    Web:S6853 = "A form label must be associated with a control and have accessible
+    text." 룰은 <label> 종료 시점에 `for` 속성도 없고 내부에 컨트롤
+    (input/select/textarea/meter/output/progress)도 없으면 MAJOR 코드 스멜로 검출.
+    settings.html 알림 채널 카드의 <label class="field-label"> 7건이 형제 input 과
+    미연결(dangling) 상태였음 → 6건은 for/id 연결, 컨트롤 없는 1건(telegram_link)은
+    <div> 전환으로 해소.
+    Web:S6853 flags a <label> that has neither a `for` attribute nor a nested control.
+    Six channel labels are now associated via for/id; the control-less telegram_link
+    caption is now a <div>.
+
+검사 방식 (Method):
+    SonarCloud 룰과 동일하게 **raw 템플릿** 을 정적 파싱 — for/id 연결과 dangling 부재를 단언.
+    Statically parse the raw template, asserting for/id association and no dangling label.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+_SETTINGS = Path("src/templates/settings.html")
+
+# for/id 로 연결돼야 하는 6 알림 채널 input name
+# The 6 notification-channel input names that must be associated via for/id.
+_ASSOCIATED = [
+    "notify_chat_id",
+    "discord_webhook_url",
+    "slack_webhook_url",
+    "email_recipients",
+    "custom_webhook_url",
+    "n8n_webhook_url",
+]
+
+
+def _html() -> str:
+    return _SETTINGS.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("name", _ASSOCIATED)
+def test_field_label_associated_with_control(name: str):
+    """각 채널 input 이 id 를, 매칭 라벨이 for 를 보유 (Web:S6853 해소)."""
+    html = _html()
+    input_pat = re.compile(r'<input\b[^>]*name="' + re.escape(name) + r'"[^>]*>')
+    match = input_pat.search(html)
+    assert match, f"input name={name} not found in settings.html"
+    assert f'id="{name}"' in match.group(0), (
+        f"input name={name} 에 id 부재 — for/id 연결 끊김 (Web:S6853 회귀). "
+        f"tag={match.group(0)!r}"
+    )
+    assert f'<label class="field-label" for="{name}"' in html, (
+        f"label for={name} 부재 — Web:S6853 회귀 (dangling label)"
+    )
+
+
+def test_no_dangling_field_label():
+    """모든 <label class="field-label"> 는 for= 를 보유 (Web:S6853 — dangling 금지)."""
+    html = _html()
+    dangling = [
+        tag
+        for tag in re.findall(r'<label class="field-label"[^>]*>', html)
+        if "for=" not in tag
+    ]
+    assert not dangling, (
+        f"for 속성 없는 field-label 라벨 = Web:S6853 dangling 회귀: {dangling!r}"
+    )
+
+
+def test_telegram_link_caption_is_not_label_element():
+    """컨트롤 없는 telegram_link 캡션은 <label> 대신 <div> (Web:S6853 — 연결 컨트롤 부재)."""
+    html = _html()
+    key = "settings_page.notify.telegram_link_label"
+    div_pat = re.compile(r'<div class="field-label">\s*\{\{\s*\'' + re.escape(key))
+    label_pat = re.compile(r'<label class="field-label">\s*\{\{\s*\'' + re.escape(key))
+    assert div_pat.search(html), (
+        "telegram_link 캡션이 <div class=\"field-label\"> 로 전환되지 않음 (Web:S6853)"
+    )
+    assert not label_pat.search(html), (
+        "telegram_link 이 여전히 <label class=\"field-label\"> — Web:S6853 회귀 "
+        "(연결할 폼 컨트롤이 없는 라벨)"
+    )
+
+
+def test_associated_channel_count_is_locked():
+    """for/id 연결 대상 채널 수 = 6 (누락/중복 방지 동결)."""
+    assert len(_ASSOCIATED) == 6


### PR DESCRIPTION
## 🖼️ Claude 시각 검증 불가 (정책 11)

이 PR 은 `src/templates/settings.html`(UI 템플릿)을 변경한다. Claude 는 정적 코드만 검증 가능 — 4-테마(dark/light/pastel/catppuccin) × 모바일/데스크탑 **8 조합** 시각 정합성은 사용자 검증 의무.

> ⚠️ 단, 본 변경은 **비시각 a11y 속성**(`for`/`id` 추가 + `<label>`→`<div>` 전환)이며 `.field-label` 은 클래스 셀렉터(L208)라 시각 렌더는 동일할 것으로 예상. 그래도 정책 11 에 따라 체크리스트를 명시한다.

- [ ] dark — 데스크탑 / 모바일 (알림 채널 카드 라벨·conn-dot 정렬)
- [ ] light — 데스크탑 / 모바일
- [ ] pastel — 데스크탑 / 모바일
- [ ] catppuccin — 데스크탑 / 모바일
- [ ] 라벨 클릭 시 해당 input 포커스 이동(for/id 연결 UX) 동작 확인

## Summary

SonarCloud `Web:S6853`("A form label must be associated with a control and have accessible text") MAJOR 코드 스멜 7건을 해소한다. 직전 세션(#948~#955)이 "범위 외(미수정)"로 명시한 deferred 항목.

## 변경 내용

알림 채널 카드의 `<label class="field-label">` 7건이 형제 폼 컨트롤과 미연결(dangling) 상태였다. 권위 룰 소스 [`LabelHasAssociatedControlCheck.java`](https://raw.githubusercontent.com/SonarSource/sonar-html/master/sonar-html-plugin/src/main/java/org/sonar/plugins/html/checks/accessibility/LabelHasAssociatedControlCheck.java) 실측 — 위반 조건은 `!foundControl`(라벨에 `for` 속성 없고 내부에 컨트롤 태그 없음).

- **6 채널 라벨**(telegram_chat_id/discord/slack/email/custom/n8n): 라벨에 `for="<name>"` + 형제 input 에 `id="<name>"` 부여로 연결. 의미적 정확 + 라벨 클릭 → input 포커스 UX. 기존 `aria-label` 유지(별개 룰 `InputWithoutLabelCheck` #946 보존 — 중복이나 무해).
- **telegram_link 캡션**(L853): 연결할 폼 컨트롤이 없음(OTP 버튼 기반 섹션) → `<label class="field-label">` → `<div class="field-label">` 전환. `.field-label` 클래스 셀렉터라 시각 동일.

ID 충돌 없음 실측(`grep id=`), JS `getElementById` 의존 없음 실측.

## 테스트

- 신규 회귀 가드 `tests/unit/ui/test_label_associated_control.py` 9 케이스 (for/id 연결 6 parametrize + dangling 부재 + telegram_link div 전환 + count-lock). **RED→GREEN** 검증.
- 기존 `test_input_aria_labels.py`(20+1) 회귀 없음(aria-label 유지).
- 전체: 단위 **5013→5022** · 전체 수집 **5176**(5168 passed + 8 PG-skip) · UI 235 pass · settings.html Jinja2 파싱 OK.
- IDE SonarLint 진단: 편집 후 S6853 7건 전부 클리어 실측(머지 후 main 재스캔으로 최종 확증 예정).

## 🔍 사용자 검증 필요

- [ ] 머지 후 main SonarCloud 재스캔 → `Web:S6853` 7건 해소 + code smells 116→109 확인(게이트는 이미 OK, MAJOR 라 무영향).
- [ ] settings.html 알림 채널 카드 라벨 클릭 시 포커스 이동 동작(운영 화면).

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex 검증 의뢰 완료 — **VERDICT s6853: OK** (push 전 수신).
- Codex 가 `git diff main..fix/sonar-s6853-label-assoc` 직접 검사 → 6 input unique id + 매칭 label for / telegram_link div 전환 안전(JS·CSS 비의존) / aria-label+for 병존 a11y 무해 확증.

## 📌 비고

- edit-guard hook false-positive 로 인해 본 템플릿 수정이 일시 차단됐고, 선행 수정을 **별도 PR #956**(`chore/edit-hook-interpreter-robust`)로 분리했다. 두 PR 독립(main 기반) — 머지 순서 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
