### PR TITLE
fix(gate): native auto-merge head_sha 미확보 시 fail-closed (SHA 원자성 보존)

### DIFF
--- a/src/gate/native_automerge.py
+++ b/src/gate/native_automerge.py
@@ -37,6 +37,7 @@ from src.gate.github_review import (
     get_pr_mergeable_state,
     merge_pr,
 )
+from src.gate.merge_reasons import NETWORK_ERROR
 from src.github_client.graphql import (  # noqa: F401  # pylint: disable=unused-import
     # ENABLE_DISABLED_IN_REPO + ENABLE_PERMISSION_DENIED 는 외부 (tests/unit/gate/test_native_automerge.py
     # + tests/unit/gate/test_engine_defensive_guards.py) 에서 본 모듈 경로로 import 하는 re-export 영역.
@@ -136,6 +137,24 @@ async def enable_or_fallback_with_path(
             )
         except httpx.HTTPError as exc:
             logger.warning("get_pr_mergeable_state 실패 (pr=%d): %s", pr_number, exc)
+        # 🔴 fail-closed (감사 보안 #2 — 2026-06-23): head_sha 미확보(전달 X + 조회 실패/빈값) 시
+        # SHA 원자성 가드 없이 enable/merge_pr 을 하면 expected_head_oid=None / expected_sha=None 으로
+        # 전달돼 force-push 차단 계약이 사라진다. 머지를 시도하지 않고 terminal 실패(NETWORK_ERROR)로
+        # 반환한다 — engine 의 is_retriable_tag(NETWORK_ERROR)=False 라 _handle_terminal_merge_failure
+        # 로 가시화(머지 안 함). 이벤트성 auto-merge 1회 드롭은 다음 webhook 이 재트리거(희소).
+        # (genuine retry 미선택 사유: effective_sha="" 면 should_retry(unknown)=False + enqueue
+        #  commit_sha="" 라 retriable 경로가 실제로 작동 안 함 — 사용자 결정 A=terminal.)
+        # fail-closed: never enable/merge without a head-SHA guard (would lose force-push protection).
+        # Return terminal NETWORK_ERROR (not retriable) → surfaced via _handle_terminal_merge_failure,
+        # no merge happens. A rare double-fetch failure drops this one auto-merge; next webhook re-triggers.
+        if not head_sha:
+            logger.warning(
+                "head_sha 미확보 — SHA 가드 없는 머지 차단 (terminal, repo=%s, pr=%d)",
+                repo_full_name, pr_number,
+            )
+            return MergeOutcome(
+                ok=False, reason=NETWORK_ERROR, head_sha="", path=PATH_NO_ATTEMPT,
+            )
 
     # 2. PR node_id 조회
     pr_node_id = await get_pr_node_id(github_token, repo_full_name, pr_number)

--- a/tests/unit/gate/test_engine_defensive_guards.py
+++ b/tests/unit/gate/test_engine_defensive_guards.py
@@ -46,7 +46,8 @@ from src.gate.engine import (
     _run_auto_merge,
     _run_auto_merge_retry,
 )
-from src.gate.native_automerge import MergeOutcome, PATH_REST_FALLBACK
+from src.gate.merge_reasons import NETWORK_ERROR
+from src.gate.native_automerge import MergeOutcome, PATH_NO_ATTEMPT, PATH_REST_FALLBACK
 from src.repositories.merge_retry_repo import EnqueueResult
 
 
@@ -114,6 +115,37 @@ async def test_retry_path_handles_get_mergeable_state_httperror(caplog):
     mock_terminal.assert_called_once()
     # WARNING 로그가 남음
     assert any("get_pr_mergeable_state" in r.message for r in caplog.records)
+
+
+async def test_retry_path_fail_closed_network_error_goes_terminal_no_enqueue():
+    """🔴 감사 보안 #2 (fail-closed 종단): native 가 head_sha 미확보로 NETWORK_ERROR(터미널) 반환 시
+    engine 은 _handle_terminal_merge_failure 로 처리하고 retry 큐에 넣지 않는다 — guardless merge 차단.
+    NETWORK_ERROR 는 _RETRIABLE_TAGS 미포함이라 is_retriable_tag=False → 즉시 터미널(머지/enqueue 없음).
+    """
+    mock_db = MagicMock()
+    config = _config()
+
+    with patch("src.gate.engine.settings") as mock_settings, \
+         patch("src.gate.engine.get_pr_mergeable_state", new_callable=AsyncMock) as mock_state, \
+         patch("src.gate.engine.native_enable_with_path", new_callable=AsyncMock) as mock_enable, \
+         patch("src.gate.engine._handle_terminal_merge_failure", new_callable=AsyncMock) as mock_terminal, \
+         patch("src.gate.engine._enqueue_merge_retry", new_callable=AsyncMock) as mock_enqueue, \
+         patch("src.gate.engine.log_merge_attempt"):
+        mock_settings.merge_retry_enabled = True
+        # engine 자체 fetch 실패 → head_sha="" → native 에 expected_sha=None 전달
+        mock_state.side_effect = httpx.ConnectError("DNS down")
+        # native 가 head_sha 미확보로 fail-closed (NETWORK_ERROR, PATH_NO_ATTEMPT) 반환
+        mock_enable.return_value = MergeOutcome(
+            ok=False, reason=NETWORK_ERROR, head_sha="", path=PATH_NO_ATTEMPT,
+        )
+        await _run_auto_merge_retry(
+            config, "ghp_token", "owner/repo", 42, 80,
+            analysis_id=1, db=mock_db,
+        )
+
+    # 터미널 처리 (머지 안 함) + retry 큐 미진입
+    mock_terminal.assert_called_once()
+    mock_enqueue.assert_not_called()
 
 
 # ──────────────────────────────────────────────────────────────────────────

--- a/tests/unit/gate/test_native_automerge.py
+++ b/tests/unit/gate/test_native_automerge.py
@@ -22,6 +22,7 @@ from unittest.mock import AsyncMock, patch
 import httpx
 
 from src.gate.native_automerge import enable_or_fallback
+from src.gate.merge_reasons import NETWORK_ERROR
 from src.github_client.graphql import (
     ENABLE_API_ERROR,
     ENABLE_DISABLED_IN_REPO,
@@ -234,23 +235,25 @@ async def test_expected_sha_none_calls_get_pr_state():
     assert sha == HEAD_SHA
 
 
-async def test_get_pr_state_failure_does_not_block_enable():
-    """get_pr_mergeable_state 가 httpx.HTTPError 던져도 enable 시도는 진행 (head_sha="").
-    Even if get_pr_mergeable_state raises httpx.HTTPError, enable is still attempted (head_sha="").
+async def test_get_pr_state_failure_blocks_enable_fail_closed():
+    """🔴 fail-closed: head_sha 미확보(expected_sha 미전달 + 조회 실패) 시 SHA 원자성 가드 없는
+    enable/merge 를 시도하지 않고 terminal(NETWORK_ERROR)로 반환 — engine 이 머지 없이 실패로
+    가시화(force-push 차단 계약 보존, guardless merge 차단). NETWORK_ERROR 는 _RETRIABLE_TAGS 미포함.
+    Fail-closed: when head_sha is unavailable (no expected_sha + fetch failed), do NOT attempt a
+    guardless enable/merge — return terminal NETWORK_ERROR so no merge happens (preserves the
+    SHA-atomicity / force-push protection contract).
     """
     p_enable, p_merge, p_node, p_state, enable_mock, _, _, _ = _patch_native(
         enable_result=EnableAutoMergeResult(ENABLE_OK),
         state_result=httpx.ConnectError("DNS down"),
     )
     with p_enable, p_merge, p_node, p_state:
-        ok, _reason, sha = await enable_or_fallback(TOKEN, REPO, PR, expected_sha=None)
+        ok, reason, sha = await enable_or_fallback(TOKEN, REPO, PR, expected_sha=None)
 
-    enable_mock.assert_awaited_once()
-    # head_sha 가 빈 문자열인 채로 enable 호출 → expected_head_oid 는 None 으로 전달
-    # head_sha is empty → expected_head_oid is passed as None
-    call_kwargs = enable_mock.await_args.kwargs
-    assert call_kwargs.get("expected_head_oid") is None
-    assert ok is True
+    # SHA 가드 없이 머지 시도 금지 — enable 자체가 호출되지 않아야 함
+    enable_mock.assert_not_awaited()
+    assert ok is False
+    assert reason == NETWORK_ERROR
     assert sha == ""
 
 
@@ -400,20 +403,23 @@ async def test_enable_with_path_fallback_failure_propagates_reason():
     assert outcome.path == PATH_REST_FALLBACK
 
 
-async def test_enable_with_path_handles_get_pr_state_failure():
-    """Phase 3 PR-B1: get_pr_mergeable_state 실패 → head_sha="" 로 진행."""
+async def test_enable_with_path_get_pr_state_failure_fail_closed():
+    """🔴 fail-closed (path 버전): expected_sha 미전달 + 조회 실패 → enable 미시도, terminal
+    (NETWORK_ERROR) + PATH_NO_ATTEMPT 반환. SHA 가드 없는 머지 차단."""
     from src.gate.native_automerge import (
-        PATH_NATIVE_ENABLE, enable_or_fallback_with_path,
+        PATH_NO_ATTEMPT, enable_or_fallback_with_path,
     )
 
-    p_enable, p_merge, p_node, p_state, _, _, _, _ = _patch_native(
+    p_enable, p_merge, p_node, p_state, enable_mock, _, _, _ = _patch_native(
         enable_result=EnableAutoMergeResult(ENABLE_OK),
         state_result=httpx.HTTPError("network down"),
     )
     with p_enable, p_merge, p_node, p_state:
-        # expected_sha 미전달 → 자체 조회 → HTTPError → head_sha="" 로 진행
+        # expected_sha 미전달 → 자체 조회 → HTTPError → head_sha 미확보 → fail-closed
         outcome = await enable_or_fallback_with_path(TOKEN, REPO, PR)
 
-    assert outcome.ok is True
-    assert outcome.path == PATH_NATIVE_ENABLE
+    enable_mock.assert_not_awaited()
+    assert outcome.ok is False
+    assert outcome.reason == NETWORK_ERROR
     assert outcome.head_sha == ""
+    assert outcome.path == PATH_NO_ATTEMPT


### PR DESCRIPTION
## 요약

정밀 감사 보안 #2 (사용자 선택 항목): native auto-merge의 **SHA 원자성(force-push 차단) 가드가 transient fetch 실패 시 silently 무력화**되는 fail-open을 fail-closed로 봉인.

## 근본 원인

[native_automerge.py](src/gate/native_automerge.py) `enable_or_fallback_with_path`가 `expected_sha` 미전달 + 내부 `get_pr_mergeable_state`가 `httpx.HTTPError`(transient)로 실패 시 `head_sha=""`로 진행 → `enable_pull_request_auto_merge(expected_head_oid=None)` / REST `merge_pr(expected_sha=None)` 양 경로가 SHA 가드를 잃어 **force-push된 코드가 가드 없이 머지될 위험**(api.md force-push 차단 계약이 흔한 transient 조건에서 무력화).

## 수정 (fail-closed, 사용자 결정 A = terminal)

head_sha 미확보(전달 X + 조회 실패/빈값) 시 enable/merge를 시도하지 않고 **terminal 실패(`NETWORK_ERROR`)** 반환 → engine의 `is_retriable_tag(NETWORK_ERROR)=False`라 `_handle_terminal_merge_failure`로 가시화(머지 안 함, enqueue 안 함). `expected_sha`가 전달된 정상 경로는 무변경.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18) — NG→수정→OK

- **1차 NG (정확)**: 초안은 retriable(`UNKNOWN_STATE_TIMEOUT`) 반환이었으나 Codex가 적발 — (a) `should_retry(UNKNOWN_STATE_TIMEOUT, ci)`는 `ci=="running"`일 때만 True인데 `effective_sha=""` → `ci="unknown"` → terminal로 빠짐, (b) enqueue `commit_sha=effective_sha or ""`라 가드가 빈 값 → "retry with stored commit_sha"가 실제로 작동 안 함. 직접 코드 재추적으로 검증 확인.
- **설계 결정 (정책 18 #3a)**: 사용자에게 옵션 제시 → **A(terminal)** 선택 → 정직하게 terminal(`NETWORK_ERROR`)로 변경.
- **2차 OK (5/5)**: NETWORK_ERROR=terminal 확정·회귀 0·guardless merge 차단·테스트 비동어반복·success 라벨링 미유발.

## 테스트

- native 2 (flip): `test_get_pr_state_failure_blocks_enable_fail_closed` + `_enable_with_path_*_fail_closed` — enable 미호출 + `NETWORK_ERROR` + `PATH_NO_ATTEMPT`.
- engine 종단 (신규): `test_retry_path_fail_closed_network_error_goes_terminal_no_enqueue` — `_handle_terminal_merge_failure` 호출 + `_enqueue_merge_retry` 미호출.
- 313 gate/retry pass · pylint 10.00 · flake8 0.

## 🔍 사용자 검증 필요 (정책 2)

- [ ] (선택) head_sha 이중 fetch 실패는 희소 — 운영에서 NETWORK_ERROR terminal 발생 시 다음 webhook 재트리거 정상 동작 확인.

## 🤖 자율 판단 보고 (정책 3)

- terminal 방식은 transient 이중 fetch 실패 1회의 auto-merge를 드롭(다음 push 재트리거). genuine retry(옵션 B)는 enqueue/should_retry 손봐야 해 보류 — 사용자 결정 A.
- **STATE.md/cycle-history 동기화는 미포함** — 세션 종료 신호로 다음 세션에 처리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
