### PR TITLE
fix(test): CodeQL #520 py/import-and-import-from 해소 — test_auth string-path 패치

### DIFF
--- a/tests/unit/api/test_auth.py
+++ b/tests/unit/api/test_auth.py
@@ -142,11 +142,12 @@ def test_api_auth_disabled_allows_access(monkeypatch):
 
 def test_api_auth_disabled_logs_warning(monkeypatch):
     # API_AUTH_DISABLED=1 통과 시 logger.warning(무인증 경고) 호출돼야 함
-    import src.api.auth as _auth_mod
+    # 🔴 모듈은 파일 상단에서 from-import 로 이미 들어옴 — 모듈 객체 별칭 import 를 추가하지 않고
+    # string-path 패치로 통일해 CodeQL py/import-and-import-from(#520) 이중 import 를 회피.
     monkeypatch.setattr("src.api.auth.settings.api_key", "")
     monkeypatch.setattr("src.api.auth.settings.api_auth_disabled", True)
     mock_logger = MagicMock()
-    monkeypatch.setattr(_auth_mod, "logger", mock_logger, raising=False)
+    monkeypatch.setattr("src.api.auth.logger", mock_logger, raising=False)
     client.get("/protected")
     mock_logger.warning.assert_called()
 


### PR DESCRIPTION
## 요약

#964 머지 후 main 전체 CodeQL 스캔에서 노출된 **자초 alert #520**(`py/import-and-import-from`, `tests/unit/api/test_auth.py`)을 해소합니다(정책 14). PR-diff CodeQL 은 green 이었으나 main full-scan 만 노출(메모리 #516/#517 동형).

## 원인·수정

`test_api_auth_disabled_logs_warning` 이 함수 내 `import src.api.auth as _auth_mod` + 파일 상단 `from src.api.auth import require_api_key` 로 동일 모듈을 이중 import → CodeQL 위반. 함수 내 별칭 import 제거 + `monkeypatch.setattr("src.api.auth.logger", ...)` string-path 패치로 통일(py/import-and-import-from 표준 해소 패턴). 주석의 리터럴 토큰까지 제거해 grep 노이즈 0.

## 검증

- `grep "import src.api.auth" tests/unit/api/test_auth.py` = **0건**(코드+주석).
- test_auth 10 passed(동작·수 불변). flake8 clean.
- string-path 패치는 함수 내 import 와 동일 모듈 logger 를 가리켜 의미 동등.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18) — OK

Codex(codex-rescue): 별칭 import 제거 + string-path 패치 의미 동등 확인. (초기 NG = 주석 grep false-match → 주석 토큰 제거로 해소, 실제 import 구문 0건 = CodeQL AST 해소 조건 충족)

## 🔍 사용자 검증 필요 (정책 2)

- test-only 변경 — 머지 후 main CodeQL 스캔에서 #520 close 확인(운영 영향 없음).
