### PR TITLE
fix(test): CodeQL #521 py/unused-local-variable 해소 — test_config_5way 미사용 변수 제거

### DIFF
--- a/tests/unit/scripts/test_config_5way_sync.py
+++ b/tests/unit/scripts/test_config_5way_sync.py
@@ -43,7 +43,6 @@ def test_repo_full_name_is_checked_in_data_comparison():
     #
     # ORM 에 repo_full_name 존재, Data 에 없음 → 누락 보고 기대.
     # repo_full_name exists in ORM but not in Data → expect a missing-field violation.
-    import types
     from pathlib import Path
 
     def _fake_read(self: Path, **_kw: object) -> str:
@@ -62,8 +61,6 @@ def test_repo_full_name_is_checked_in_data_comparison():
         # Update: repo_full_name 없음 (_UPDATE_ONLY_EXEMPT 에 의해 면제)
         # Update: repo_full_name absent (exempted by _UPDATE_ONLY_EXEMPT)
         return "class RepoConfigUpdate:\n    auto_merge: bool = False\n"
-
-    orig = Path.read_text
 
     class _FakeRoot:
         """경로 조합 연산자를 지원하는 가짜 루트 객체.


### PR DESCRIPTION
## 요약

#969 머지 후 main 전체 CodeQL 스캔에서 노출된 **자초 alert #521**(`py/unused-local-variable`, `tests/unit/scripts/test_config_5way_sync.py`)을 해소합니다(정책 14). PR-diff CodeQL 은 green 이었으나 main full-scan 만 노출(#520 동형).

## 원인·수정

#969 의 I-1 fix 테스트 `test_repo_full_name_is_checked_in_data_comparison` 가 미사용 `orig = Path.read_text` + `import types` 를 남김. 테스트는 `_FakePath`/`_FakeRoot` 자체 `read_text` 를 사용(Path.read_text 미패치)하므로 `orig` 불필요 → 2 dead 라인 제거. `from pathlib import Path` 는 타입 힌트(`self: Path`)에서 사용되므로 유지.

## 검증

- `test_config_5way_sync.py` 5 passed(동작·수 불변 5064). flake8 clean.
- `grep "import types\|orig = " ...` = 0건.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18) — OK

Codex(codex-rescue): orig/types 제거·Path 유지·테스트 의미 보존 PASS. (grep 항목만 샌드박스 차단 → 로컬 실측[grep 0·5 passed·flake8 clean] 보완)

## 🔍 사용자 검증 필요 (정책 2)

- test-only dead-code 제거 — 머지 후 main CodeQL 스캔에서 #521 close 확인(운영 영향 없음).
