### PR TITLE
fix(security): .env.example API_AUTH_DISABLED footgun 제거 + conftest 음성검증 마스킹 추적 (회고 P2 NEW-GAP-1/GAP-5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,7 +21,9 @@ ANTHROPIC_API_KEY=
 API_KEY=
 # 로컬 개발 전용: API_KEY 미설정 상태로 REST API 무인증 통과 허용 (1=허용). 운영 절대 설정 금지.
 # Local dev only: allow keyless REST API access when API_KEY is unset (1=allow). NEVER set in production.
-API_AUTH_DISABLED=1
+# 🔴 기본 주석 처리 — 미설정 시 fail-closed(503). 무인증이 필요한 로컬 개발 시에만 주석 해제.
+# 🔴 Commented out by default — unset = fail-closed(503). Uncomment only for local dev needing keyless access.
+#API_AUTH_DISABLED=1
 
 # OpenAI 키 — 두 용도:
 # OpenAI key — two uses:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,11 +23,19 @@ os.environ["SESSION_SECRET"] = "test-session-secret-32-chars-long!"
 os.environ["CLAUDE_REVIEW_MODEL"] = "claude-sonnet-4-6"
 os.environ["CLAUDE_INSIGHT_MODEL"] = "claude-haiku-4-5"
 # 테스트 환경 = 개발 모드 명시 opt-out — API_KEY 미설정 시 REST API fail-closed(503) 기본값을
-# 우회해 기존 endpoint 테스트(repos/stats 등 키 없이 200 의존)를 보존한다. fail-closed 기본값
-# 자체는 tests/unit/api/test_auth.py 가 api_auth_disabled=False 로 직접 검증.
+# 우회해 기존 endpoint 테스트(repos/stats 등 키 없이 200 의존)를 보존한다.
+# 🔴 음성검증 마스킹 완화 (GAP-5, 2026-06-23 회고 P2): 이 전역 opt-out 은 모든 endpoint 테스트를
+#   무인증으로 돌려 fail-closed 회귀를 가릴 수 있다. 마스킹은 tests/unit/api/test_auth.py 의 전용
+#   가드가 완화한다 — api_auth_disabled=False 로 명시 override 후 503 단언:
+#   test_api_key_empty_default_fail_closed_503 / test_api_key_empty_fail_closed_regardless_of_base_url
+#   / test_api_key_empty_default_ignores_provided_key_503. 이 가드 삭제 시 마스킹 재노출 주의.
 # Test env = explicit dev opt-out — bypass the fail-closed(503) default for unset API_KEY so existing
-# endpoint tests (repos/stats relying on keyless 200) keep passing. The fail-closed default itself is
-# verified directly by test_auth.py with api_auth_disabled=False.
+# endpoint tests (repos/stats relying on keyless 200) keep passing.
+# 🔴 Negative-verification masking mitigation (GAP-5): this global opt-out runs every endpoint test
+#   keyless, which could hide a fail-closed regression. The masking is mitigated by the dedicated guards
+#   in tests/unit/api/test_auth.py — they override api_auth_disabled=False and assert 503
+#   (test_api_key_empty_default_fail_closed_503 / ..._regardless_of_base_url / ..._ignores_provided_key_503).
+#   Removing those guards re-exposes the masking.
 os.environ["API_AUTH_DISABLED"] = "1"
 
 from src.main import app

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,6 @@
 import os
+from pathlib import Path
+
 import pytest
 
 
@@ -431,3 +433,42 @@ def test_is_disabled_i18n_helper_integration(monkeypatch):
     # true (case-insensitive) = True
     monkeypatch.setenv("I18N_DISABLED", "true")
     assert is_disabled("I18N") is True
+
+
+# ---------------------------------------------------------------------------
+# .env.example 안전 기본값 가드 (NEW-GAP-1 — 2026-06-23 회고 P2)
+#   CLAUDE.md 최초 설정 절차 `cp .env.example .env` 가 보안 위험 기본값을 출하하면 안 된다.
+#   API_AUTH_DISABLED=1 을 활성(주석 아닌) 라인으로 출하하면 신규 .env 가 REST API 무인증으로 시작.
+# .env.example safe-default guard (NEW-GAP-1 — 2026-06-23 retrospective P2):
+#   `cp .env.example .env` (CLAUDE.md setup step) must not ship a dangerous default. An active
+#   API_AUTH_DISABLED=1 line means a fresh .env starts with keyless REST API auth.
+# ---------------------------------------------------------------------------
+
+_ENV_EXAMPLE = Path(__file__).resolve().parents[2] / ".env.example"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _active_env_assignments(path: Path) -> dict:
+    # 주석(#)·빈 줄을 제외한 활성 KEY=VALUE 할당만 추출.
+    # Extract only active KEY=VALUE assignments, skipping comments(#) and blank lines.
+    result = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        result[key.strip()] = value.strip()
+    return result
+
+
+def test_env_example_does_not_ship_keyless_api_auth():
+    # 🔴 NEW-GAP-1: .env.example 이 API_AUTH_DISABLED 를 truthy 활성 라인으로 출하하면
+    # `cp .env.example .env` 한 신규 배포가 REST API 무인증으로 시작 (운영 footgun).
+    # 안전 기본 = 주석 처리(config 기본 False → fail-closed 503). 로컬 dev 만 명시 opt-in.
+    # If .env.example ships API_AUTH_DISABLED truthy/active, a fresh `cp .env.example .env`
+    # deploy starts keyless (footgun). Safe default = commented out (config default False).
+    value = _active_env_assignments(_ENV_EXAMPLE).get("API_AUTH_DISABLED", "")
+    assert value.lower() not in _TRUTHY, (
+        "API_AUTH_DISABLED must not be shipped enabled in .env.example — "
+        "comment it out so `cp .env.example .env` defaults to fail-closed(503)."
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -449,15 +449,23 @@ _TRUTHY = {"1", "true", "yes", "on"}
 
 
 def _active_env_assignments(path: Path) -> dict:
-    # 주석(#)·빈 줄을 제외한 활성 KEY=VALUE 할당만 추출.
-    # Extract only active KEY=VALUE assignments, skipping comments(#) and blank lines.
+    # 주석(#)·빈 줄을 제외한 활성 KEY=VALUE 할당만 추출. 값은 인라인 주석(# ...)·감싼 따옴표를
+    # 제거해 정규화하고, `export ` 접두를 벗긴다 (Codex mutual NG #2 false-pass 차단).
+    # Extract active KEY=VALUE assignments, skipping comments(#)/blank lines. Normalize the value
+    # by stripping inline comments and wrapping quotes, and drop an `export ` prefix
+    # (closes the Codex mutual NG #2 false-pass hole).
     result = {}
     for raw in path.read_text(encoding="utf-8").splitlines():
         line = raw.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
         key, _, value = line.partition("=")
-        result[key.strip()] = value.strip()
+        # 인라인 주석 제거 후 좌우 공백·감싼 따옴표 제거.
+        # Strip inline comment, then surrounding whitespace and wrapping quotes.
+        value = value.split("#", 1)[0].strip().strip("\"'")
+        result[key.strip()] = value
     return result
 
 
@@ -472,3 +480,25 @@ def test_env_example_does_not_ship_keyless_api_auth():
         "API_AUTH_DISABLED must not be shipped enabled in .env.example — "
         "comment it out so `cp .env.example .env` defaults to fail-closed(503)."
     )
+
+
+# 🔴 파서 견고성 회귀 가드 (Codex mutual NG #2, 2026-06-23): 인라인 주석/따옴표/export 접두가
+# 정규화되지 않으면 `API_AUTH_DISABLED=1 # x` 나 `API_AUTH_DISABLED="1"` 같은 위험 출하가
+# _TRUTHY 비매칭으로 가드를 false-pass 로 통과. 정규화 후 truthy 탐지 보장.
+# Parser-robustness regression guard (Codex mutual NG #2): without normalizing inline comments,
+# quotes, and the export prefix, a dangerous `API_AUTH_DISABLED=1 # x` or `="1"` line would
+# false-pass the guard by not matching _TRUTHY. Normalization must still detect it as truthy.
+@pytest.mark.parametrize("line,expected", [
+    ("API_AUTH_DISABLED=1", "1"),                      # plain
+    ("API_AUTH_DISABLED=1   # 인라인 주석", "1"),       # inline comment stripped
+    ('API_AUTH_DISABLED="1"', "1"),                    # double-quoted
+    ("API_AUTH_DISABLED='1'", "1"),                    # single-quoted
+    ('API_AUTH_DISABLED="1"  # quoted+comment', "1"),  # quoted then comment
+    ("export API_AUTH_DISABLED=1", "1"),               # export prefix
+    ("#API_AUTH_DISABLED=1", None),                    # commented → absent
+    ("  # API_AUTH_DISABLED=1", None),                 # indented comment → absent
+])
+def test_active_env_assignments_normalizes_value(tmp_path, line, expected):
+    env_file = tmp_path / "env.under_test"
+    env_file.write_text(line + "\n", encoding="utf-8")
+    assert _active_env_assignments(env_file).get("API_AUTH_DISABLED") == expected


### PR DESCRIPTION
## Summary

2026-06-23 정밀 감사 세션 5+1 회고가 식별한 **P2 백로그 2건**(보안 영역)을 해소한다. (1) `.env.example` 이 무인증 REST API 기본값을 출하하던 footgun(NEW-GAP-1) 제거, (2) conftest 전역 opt-out 의 음성검증 마스킹(GAP-5)을 추적 가능하게 명문화.

## 변경 내용

### NEW-GAP-1 — `.env.example` API_AUTH_DISABLED footgun 제거
- `.env.example` 이 `API_AUTH_DISABLED=1` 을 **활성 라인으로 출하** → CLAUDE.md 최초 설정 절차 `cp .env.example .env` 한 신규 배포가 **REST API 무인증으로 시작**하던 footgun.
- 주석 처리(`#API_AUTH_DISABLED=1`)로 전환 → 미설정 시 `config.py` 기본값 `api_auth_disabled=False` = **fail-closed(503)**. 로컬 dev 만 명시 주석 해제로 opt-in (운영 절대 금지 주석 유지).
- 운영 코드(`src/api/auth.py`·`src/config.py`) **무변경** — 템플릿 기본값만 안전화.
- 가드 테스트: `.env.example` 활성 라인에 `API_AUTH_DISABLED` truthy 출하 차단.

### GAP-5 — conftest 음성검증 마스킹 추적성 강화 (주석 only)
- `tests/conftest.py` 전역 `API_AUTH_DISABLED=1` opt-out 은 모든 endpoint 테스트를 무인증으로 돌려 fail-closed 회귀를 가릴 수 있음.
- EXACT 재검증 = **이미 완화됨**: `tests/unit/api/test_auth.py` 의 전용 가드 3종(`api_auth_disabled=False`→503)이 fail-closed 를 독립 검증.
- 마스킹 완화를 추적 가능하게 conftest 주석에 그 3종 테스트명 명시 (정책 16: 중복 메타테스트 회피, 추적성만 강화).

### Codex mutual NG #2 — 가드 파서 견고화 (fix-up)
- Codex push-전 검증이 적발: `_active_env_assignments` 가 값을 정규화 안 해 `API_AUTH_DISABLED=1 # x` 또는 `="1"` 같은 위험 출하가 false-pass.
- 인라인 주석(# 이후)·감싼 따옴표 제거 + `export ` 접두 제거로 봉인. 회귀 가드 +8 parametrize.

## 테스트

- TDD RED→GREEN: `test_env_example_does_not_ship_keyless_api_auth`(+1) + `test_active_env_assignments_normalizes_value`(+8 parametrize) = **+9**.
- `python -m pytest tests/unit/test_config.py tests/unit/api/test_auth.py` → **68 passed**.
- 단위 5064 → **5073** (`pytest --co` 실측). 운영 코드 무변경.

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] **로컬 dev REST API 영향 인지**: 이 PR 후 `cp .env.example .env` 한 신규 로컬 환경은 REST API 가 fail-closed(503). 무인증 REST API 가 필요하면 `.env` 에서 `API_AUTH_DISABLED=1` 주석 해제(웹 UI/OAuth 는 영향 없음).
- 운영 smoke check: **불필요** — 런타임 auth 동작(`src/api/auth.py`) 무변경, `.env.example` 템플릿 + 테스트만 변경.

## ⚠️ 자율 판단 보고 (정책 3)

- **STATE/README 카운트 sync 보류**: 이 PR 이 단위 5064→5073 변경하나 STATE/README 배지 갱신은 **세션 docs sync PR(후속 PR-2)에서 일괄 처리**(#962→#963 패턴, STATE "최신" 블록 이중 churn 회피). check_docs_sync 훅은 STATE↔README 내부 정합만 검사(둘 다 5064 유지=통과)라 본 PR 비차단.
- **GAP-5 처리 방식 = 주석 추적성**: 메타테스트(test_auth.py 가드 존재 단언)는 fragile + 중복이라 회피(정책 16). 이미 완화된 상태의 추적성만 강화.
- **회고 P2 잔여**(별도 처리): DQ-3 verifier 활성화 runbook(후속 PR), P2-2 legacy fail-closed 드롭 문서·GAP-4 Codex artifact-level = 회고 보고서 미아카이브로 범위 모호 → 조사 후 별도 보고/PR-S 귀속.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex 검증 의뢰 완료 — **push 전 mutual 사이클 OK** 수신 후 push.
  - 1차: 보안 정확성·가드 로직·GAP-5 주석 정확성 → **NG #2** (파서 false-pass 홀: 인라인 주석/따옴표 미정규화).
  - 2차(fix-up 8b219d5 후): 정규화 봉인 + 회귀 가드 +8 → **VERDICT OK** (ground-truth line 인용 확인).
  - 단일 정답 버그 회귀 NG → 동일 PR 즉시 수정(정책 18 §3b, 옵션 표 면제).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
