### PR TITLE
fix(test): CodeQL #522 py/unused-import 해소 — test_config.py 미사용 import os 제거

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
## Summary

CodeQL alert **#522** (`py/unused-import`, note severity) 해소 — `tests/unit/test_config.py:1` 의 미사용 `import os` 단독 제거 (1줄 삭제).

## 변경 내용

- **자초 cascade**: PR #970 (CodeQL #521 `py/unused-local-variable` 해소) 이 `test_config_5way` 의 `os` 사용 코드를 제거하면서 `import os` 가 dead import 로 남음 → main full-scan 에서 alert #522 노출.
- `grep -nE "\bos\b"` 실측 = `os` 는 line 1 에만 존재. `Path`(L447/L451)·`pytest`(9회) 는 사용 중이라 미변경 (over-removal 회피).
- flake8 `per-file-ignores` 가 `tests/*` 의 F401 을 무시 → lint 미감지, **CodeQL 별도 룰셋만 포착** (정책 14: PR-diff green ≠ main scan).

## 테스트

- `pytest tests/unit/test_config.py` → **58 passed**
- F821 `undefined name 'Settings'` (L26) 는 **기존 이슈**(origin/main 에도 존재·`make lint` 는 `src/` 만 스캔) — 본 PR 무관·범위 외 (정책 7/15).

## 🔍 사용자 검증 필요

- [ ] CI 통과 확인
- [ ] 머지 후 main 전체 CodeQL 스캔에서 alert #522 `fixed` 전환 확인 (정책 14)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex 검증 의뢰 완료 — **VERDICT: OK** (push 전 회신 수신)
- Codex ground-truth 4항목 검증: ① diff = `import os` 한 줄 삭제만 ② `git grep` 종료코드 1 = `os` 동적 사용 없음(false-positive 제거 아님) ③ `Path`/`pytest` 미변경(over-removal 없음) ④ monkeypatch env 주입이라 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
