### PR TITLE
ci(test): C1 — PR 변경 test 파일 dead-symbol(F401/F841) 차단 가드 (cascade 근본)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,44 @@ jobs:
           head: ${{ github.sha }}
           extra_args: --only-verified
 
+  # PR 변경 test 파일 dead-symbol 차단 — 신규 미사용 import(F401)·변수(F841)가 main full-scan
+  # CodeQL 에 사후 포착돼 별도 fix PR(#516/#517/#520/#521/#522)을 반복 유발한 cascade 근본 차단(회고 C1, A2: PR diff 한정).
+  # Block dead imports/vars in PR-changed test files — newly introduced ones get caught post-merge by
+  # the main full-scan CodeQL, causing recurring self-inflicted fix PRs (retro C1, A2 diff-scoped).
+  lint-changed-tests:
+    name: Lint changed test files (F401/F841 — C1)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for diff)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install flake8
+        # 버전 고정(requirements.txt 와 동일) + wheel-only — 재현성 + setup-script 실행 차단.
+        # Pinned (matches requirements.txt) + wheel-only — reproducible + blocks setup-script execution.
+        run: "pip install --only-binary=:all: flake8==7.3.0"
+
+      - name: Lint PR-changed tests/ for dead symbols (F401/F841)
+        # 🔴 --isolated 필수 — setup.cfg per-file-ignore(tests/*:F401,F841)를 우회. 없으면 검사 무력화(false-pass).
+        # PR 변경 test 파일만 검사 — 기존 legacy 위반 무관, 신규 도입만 차단. 변경 없으면 통과.
+        # --isolated bypasses the setup.cfg per-file-ignore (else it false-passes). PR-changed test files only.
+        run: |
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          changed=$(git diff --name-only --diff-filter=ACMR "$base_sha" HEAD -- 'tests/' | grep -E '\.py$' || true)
+          if [ -z "$changed" ]; then
+            echo "변경된 test 파일 없음 — skip / no changed test files"
+            exit 0
+          fi
+          echo "검사 대상 / checking:"; echo "$changed"
+          python -m flake8 --isolated --select=F401,F841 $changed
+
   test-and-analyze:
     name: pytest + Codecov + SonarCloud
     runs-on: ubuntu-latest

--- a/tests/unit/scripts/test_ci_dead_symbol_guard.py
+++ b/tests/unit/scripts/test_ci_dead_symbol_guard.py
@@ -1,0 +1,42 @@
+"""CI dead-symbol 가드 정합 (회고 C1 — 자초 CodeQL cascade 근본 차단).
+CI dead-symbol guard integrity (retro C1 — root fix for the self-inflicted CodeQL cascade).
+
+tests/ 미사용 import(F401)·변수(F841)가 pre-merge 에서 안 잡혀 main full-scan CodeQL 에 사후
+포착 → 별도 fix PR(#516/#517/#520/#521/#522) 을 반복 유발한 cascade 를 차단한다(A2: PR diff 한정).
+🔴 핵심 불변식: flake8 호출은 반드시 `--isolated` 동반 — 없으면 setup.cfg per-file-ignore
+(`tests/*:F401,F841`)가 검사를 무력화해 항상 통과(false-pass)한다(실증 확인).
+Critical invariant: the flake8 call MUST use `--isolated`, else the setup.cfg per-file-ignore
+silently masks the check (empirically verified false-pass).
+"""
+import re
+from pathlib import Path
+
+# 리포 루트 / repo root
+_ROOT = Path(__file__).resolve().parents[3]
+_CI = _ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _ci_text() -> str:
+    return _CI.read_text(encoding="utf-8")
+
+
+def test_ci_lints_changed_tests_for_dead_symbols():
+    """CI 가 flake8 --isolated --select=F401,F841 로 dead symbol 을 검사한다 (순서 무관)."""
+    ci = _ci_text()
+    has = re.search(
+        r"flake8[^\n]*--isolated[^\n]*--select=F401,F841"
+        r"|flake8[^\n]*--select=F401,F841[^\n]*--isolated",
+        ci,
+    )
+    assert has, "CI 에 flake8 --isolated --select=F401,F841 dead-symbol 가드 누락"
+
+
+def test_ci_dead_symbol_guard_scoped_to_changed_files():
+    """가드는 PR 변경 파일 한정(A2) — 전체 tests/ 일괄(`flake8 ... tests/` 고정 경로) 금지.
+    full-scan 이면 기존 76건 legacy 위반으로 즉시 실패하므로 PR-diff 스코프여야 함."""
+    ci = _ci_text()
+    # PR 이벤트 한정 + base.sha diff 사용 = 변경 파일 스코프 신호
+    assert "github.event.pull_request.base.sha" in ci, "PR diff base SHA 미사용 (변경 파일 스코프 아님)"
+    # 고정 경로 전체 스캔(`--select=F401,F841 tests/`)이 아님을 확인 — legacy 76건 회피
+    assert not re.search(r"--select=F401,F841\s+tests/\b", ci), \
+        "전체 tests/ 일괄 스캔은 기존 legacy 위반으로 실패 — PR diff 한정이어야 함"

--- a/tests/unit/scripts/test_ci_dead_symbol_guard.py
+++ b/tests/unit/scripts/test_ci_dead_symbol_guard.py
@@ -62,9 +62,11 @@ def test_lint_job_is_pr_diff_scoped():
     code = _lint_run_code()
     assert "github.event.pull_request.base.sha" in code, "lint job 이 PR base SHA diff 미사용 (변경 파일 스코프 아님)"
     assert "git diff" in code and "tests/" in code, "lint job 이 변경 파일 diff 미산출"
-    # 🔴 flake8 는 변경 파일 변수($changed)에 실행 — 리터럴 경로 full-scan 금지 (R2 긍정 단언).
-    assert re.search(r"--select=F401,F841\s+\$changed\b", code), \
-        "flake8 가 $changed(변경 파일)이 아닌 리터럴 경로를 스캔 — PR diff 한정이어야 함"
+    # 🔴 flake8 인자는 변경 파일 변수($changed) 단독이어야 함 — 뒤에 리터럴 경로(`$changed tests/`)
+    #    덧붙이기 = 전체 스캔 차단 (R4: $changed 가 마지막/유일 인자임을 `\s*$`(MULTILINE)로 강제).
+    #    flake8 arg must be the lone $changed — forbids appending a literal path that re-enables full-scan (Codex R4).
+    assert re.search(r"--select=F401,F841\s+\$changed\s*$", code, re.MULTILINE), \
+        "flake8 인자가 $changed(변경 파일) 단독이 아님 — 리터럴 경로 덧붙이기 = 전체 스캔 위험"
     # find 기반 전체 스캔 금지 (diff 우회 변조 차단 — R1 적발 케이스)
     assert "find tests" not in code, "find 기반 전체 스캔 금지 — git diff 변경 파일 한정이어야 함"
 

--- a/tests/unit/scripts/test_ci_dead_symbol_guard.py
+++ b/tests/unit/scripts/test_ci_dead_symbol_guard.py
@@ -3,40 +3,59 @@ CI dead-symbol guard integrity (retro C1 — root fix for the self-inflicted Cod
 
 tests/ 미사용 import(F401)·변수(F841)가 pre-merge 에서 안 잡혀 main full-scan CodeQL 에 사후
 포착 → 별도 fix PR(#516/#517/#520/#521/#522) 을 반복 유발한 cascade 를 차단한다(A2: PR diff 한정).
-🔴 핵심 불변식: flake8 호출은 반드시 `--isolated` 동반 — 없으면 setup.cfg per-file-ignore
-(`tests/*:F401,F841`)가 검사를 무력화해 항상 통과(false-pass)한다(실증 확인).
-Critical invariant: the flake8 call MUST use `--isolated`, else the setup.cfg per-file-ignore
-silently masks the check (empirically verified false-pass).
+
+🔴 불변식은 반드시 `lint-changed-tests` job 영역에 한정해 검증한다 — ci.yml 전체 문자열 검색은
+다른 job(secret-scan 의 base.sha 등)의 동일 토큰에 의해 false-pass 한다(Codex mutual 적발).
+🔴 flake8 호출은 반드시 `--isolated` 동반 — 없으면 setup.cfg per-file-ignore(`tests/*:F401,F841`)가
+검사를 무력화해 항상 통과(false-pass)한다(실증 확인).
+Assertions MUST be scoped to the lint-changed-tests job (a whole-file search false-passes on other
+jobs' identical tokens — Codex mutual finding). The flake8 call MUST use `--isolated`, else the
+setup.cfg per-file-ignore silently masks the check (empirically verified).
 """
 import re
 from pathlib import Path
+
+import yaml
 
 # 리포 루트 / repo root
 _ROOT = Path(__file__).resolve().parents[3]
 _CI = _ROOT / ".github" / "workflows" / "ci.yml"
 
 
-def _ci_text() -> str:
-    return _CI.read_text(encoding="utf-8")
+def _lint_job_text() -> str:
+    """ci.yml 에서 lint-changed-tests job 만 추출해 텍스트로 직렬화 — 다른 job 토큰 누출 차단.
+    Extract only the lint-changed-tests job and serialize it (blocks token leakage from other jobs)."""
+    data = yaml.safe_load(_CI.read_text(encoding="utf-8"))
+    job = data["jobs"].get("lint-changed-tests")
+    assert job is not None, "lint-changed-tests job 부재 / job missing"
+    return yaml.safe_dump(job, allow_unicode=True)
 
 
-def test_ci_lints_changed_tests_for_dead_symbols():
-    """CI 가 flake8 --isolated --select=F401,F841 로 dead symbol 을 검사한다 (순서 무관)."""
-    ci = _ci_text()
+def test_lint_job_uses_isolated_dead_symbol_check():
+    """lint job 이 flake8 --isolated --select=F401,F841 로 검사한다 (순서 무관)."""
+    job = _lint_job_text()
     has = re.search(
         r"flake8[^\n]*--isolated[^\n]*--select=F401,F841"
         r"|flake8[^\n]*--select=F401,F841[^\n]*--isolated",
-        ci,
+        job,
     )
-    assert has, "CI 에 flake8 --isolated --select=F401,F841 dead-symbol 가드 누락"
+    assert has, "lint-changed-tests job 에 flake8 --isolated --select=F401,F841 누락"
 
 
-def test_ci_dead_symbol_guard_scoped_to_changed_files():
-    """가드는 PR 변경 파일 한정(A2) — 전체 tests/ 일괄(`flake8 ... tests/` 고정 경로) 금지.
-    full-scan 이면 기존 76건 legacy 위반으로 즉시 실패하므로 PR-diff 스코프여야 함."""
-    ci = _ci_text()
-    # PR 이벤트 한정 + base.sha diff 사용 = 변경 파일 스코프 신호
-    assert "github.event.pull_request.base.sha" in ci, "PR diff base SHA 미사용 (변경 파일 스코프 아님)"
-    # 고정 경로 전체 스캔(`--select=F401,F841 tests/`)이 아님을 확인 — legacy 76건 회피
-    assert not re.search(r"--select=F401,F841\s+tests/\b", ci), \
+def test_lint_job_is_pr_diff_scoped():
+    """가드는 PR 변경 파일 한정(A2) — 전체 tests/ 일괄/`find` 스캔 금지(기존 legacy 76건 회피).
+    full-scan 이면 즉시 실패하므로 base.sha diff 로 변경 파일만 검사해야 한다."""
+    job = _lint_job_text()
+    assert "github.event.pull_request.base.sha" in job, "lint job 이 PR base SHA diff 미사용 (변경 파일 스코프 아님)"
+    assert "git diff" in job and "tests/" in job, "lint job 이 변경 파일 diff 미산출"
+    # 고정 경로 전체 스캔(`--select=F401,F841 tests/`) 금지 — legacy 위반으로 즉시 실패
+    assert not re.search(r"--select=F401,F841\s+tests/\b", job), \
         "전체 tests/ 일괄 스캔은 기존 legacy 위반으로 실패 — PR diff 한정이어야 함"
+    # find 기반 전체 스캔 금지 (diff 우회 변조 차단 — Codex mutual 적발 케이스)
+    assert "find tests" not in job, "find 기반 전체 스캔 금지 — git diff 변경 파일 한정이어야 함"
+
+
+def test_lint_job_is_pr_only():
+    """lint job 은 PR 이벤트 한정 — push(main)에서 base.sha 부재로 깨지지 않도록."""
+    job = _lint_job_text()
+    assert "pull_request" in job, "lint job 이 PR-only(if) 아님 — push 에서 깨질 수 있음"

--- a/tests/unit/scripts/test_ci_dead_symbol_guard.py
+++ b/tests/unit/scripts/test_ci_dead_symbol_guard.py
@@ -48,9 +48,11 @@ def test_lint_job_is_pr_diff_scoped():
     job = _lint_job_text()
     assert "github.event.pull_request.base.sha" in job, "lint job 이 PR base SHA diff 미사용 (변경 파일 스코프 아님)"
     assert "git diff" in job and "tests/" in job, "lint job 이 변경 파일 diff 미산출"
-    # 고정 경로 전체 스캔(`--select=F401,F841 tests/`) 금지 — legacy 위반으로 즉시 실패
-    assert not re.search(r"--select=F401,F841\s+tests/\b", job), \
-        "전체 tests/ 일괄 스캔은 기존 legacy 위반으로 실패 — PR diff 한정이어야 함"
+    # 🔴 flake8 는 변경 파일 변수($changed)에 실행해야 함 — 리터럴 전체 경로(`... tests/`) 스캔 금지.
+    #    (긍정 단언: `tests/\b` 부정 정규식은 `/`가 비단어문자라 \b 미매칭 = 무력 — Codex Round 2 적발.)
+    #    flake8 must run on the $changed var (diff result), not a literal full path (Codex R2: \b after '/' never matches).
+    assert re.search(r"--select=F401,F841\s+\$changed\b", job), \
+        "flake8 가 $changed(변경 파일)이 아닌 리터럴 경로를 스캔 — PR diff 한정이어야 함"
     # find 기반 전체 스캔 금지 (diff 우회 변조 차단 — Codex mutual 적발 케이스)
     assert "find tests" not in job, "find 기반 전체 스캔 금지 — git diff 변경 파일 한정이어야 함"
 

--- a/tests/unit/scripts/test_ci_dead_symbol_guard.py
+++ b/tests/unit/scripts/test_ci_dead_symbol_guard.py
@@ -4,13 +4,15 @@ CI dead-symbol guard integrity (retro C1 — root fix for the self-inflicted Cod
 tests/ 미사용 import(F401)·변수(F841)가 pre-merge 에서 안 잡혀 main full-scan CodeQL 에 사후
 포착 → 별도 fix PR(#516/#517/#520/#521/#522) 을 반복 유발한 cascade 를 차단한다(A2: PR diff 한정).
 
-🔴 불변식은 반드시 `lint-changed-tests` job 영역에 한정해 검증한다 — ci.yml 전체 문자열 검색은
-다른 job(secret-scan 의 base.sha 등)의 동일 토큰에 의해 false-pass 한다(Codex mutual 적발).
-🔴 flake8 호출은 반드시 `--isolated` 동반 — 없으면 setup.cfg per-file-ignore(`tests/*:F401,F841`)가
-검사를 무력화해 항상 통과(false-pass)한다(실증 확인).
-Assertions MUST be scoped to the lint-changed-tests job (a whole-file search false-passes on other
-jobs' identical tokens — Codex mutual finding). The flake8 call MUST use `--isolated`, else the
-setup.cfg per-file-ignore silently masks the check (empirically verified).
+🔴 불변식 검증 3중 봉인 (Codex mutual R1~R3 적발 반영):
+  (R1) lint-changed-tests job 영역에만 한정 — ci.yml 전체 검색은 다른 job(secret-scan base.sha)
+       토큰으로 false-pass.
+  (R2) flake8 가 변경 파일 변수 `$changed` 에 실행됨을 긍정 단언 — `tests/\b` 부정 정규식은
+       `/`가 비단어문자라 \b 미매칭 = 무력.
+  (R3) run: 스크립트의 셸 주석 제거 후 매칭 — 정답 명령을 주석 decoy 로 넣고 실제론 full-scan 하는
+       comment false-pass 봉인 (#936 학습 — _strip_comments 동일 패턴).
+Three-layer sealing from Codex mutual R1-R3: scope to the lint job, assert flake8 runs on $changed,
+and strip shell comments before matching (so a decoy command in a comment can't false-pass).
 """
 import re
 from pathlib import Path
@@ -22,42 +24,52 @@ _ROOT = Path(__file__).resolve().parents[3]
 _CI = _ROOT / ".github" / "workflows" / "ci.yml"
 
 
-def _lint_job_text() -> str:
-    """ci.yml 에서 lint-changed-tests job 만 추출해 텍스트로 직렬화 — 다른 job 토큰 누출 차단.
-    Extract only the lint-changed-tests job and serialize it (blocks token leakage from other jobs)."""
+def _lint_job() -> dict:
+    """ci.yml 에서 lint-changed-tests job 만 추출 — 다른 job 토큰 누출 차단 (R1).
+    Extract only the lint-changed-tests job (blocks token leakage from other jobs)."""
     data = yaml.safe_load(_CI.read_text(encoding="utf-8"))
     job = data["jobs"].get("lint-changed-tests")
     assert job is not None, "lint-changed-tests job 부재 / job missing"
-    return yaml.safe_dump(job, allow_unicode=True)
+    return job
+
+
+def _lint_run_code() -> str:
+    """lint job 의 run: 스크립트만 합치고 셸 주석 제거 — 주석 decoy false-pass 봉인 (R3/#936).
+    Concatenate only the lint job's run: scripts with shell comments stripped (R3/#936 sealing)."""
+    job = _lint_job()
+    runs = "\n".join(
+        s["run"] for s in job.get("steps", []) if isinstance(s, dict) and "run" in s
+    )
+    # 셸 주석 제거 — 줄 시작 또는 공백 뒤 `#` 부터 줄 끝까지 (run 블록은 셸, `#` = 주석).
+    # Strip shell comments — `#` at line-start or after whitespace to EOL (run block is shell).
+    return re.sub(r"(?m)(?:^|\s)#.*$", "", runs)
 
 
 def test_lint_job_uses_isolated_dead_symbol_check():
-    """lint job 이 flake8 --isolated --select=F401,F841 로 검사한다 (순서 무관)."""
-    job = _lint_job_text()
+    """lint job 의 실행 명령이 flake8 --isolated --select=F401,F841 을 사용한다 (주석 제외, 순서 무관)."""
+    code = _lint_run_code()
     has = re.search(
         r"flake8[^\n]*--isolated[^\n]*--select=F401,F841"
         r"|flake8[^\n]*--select=F401,F841[^\n]*--isolated",
-        job,
+        code,
     )
-    assert has, "lint-changed-tests job 에 flake8 --isolated --select=F401,F841 누락"
+    assert has, "lint-changed-tests 실행 명령에 flake8 --isolated --select=F401,F841 누락"
 
 
 def test_lint_job_is_pr_diff_scoped():
-    """가드는 PR 변경 파일 한정(A2) — 전체 tests/ 일괄/`find` 스캔 금지(기존 legacy 76건 회피).
-    full-scan 이면 즉시 실패하므로 base.sha diff 로 변경 파일만 검사해야 한다."""
-    job = _lint_job_text()
-    assert "github.event.pull_request.base.sha" in job, "lint job 이 PR base SHA diff 미사용 (변경 파일 스코프 아님)"
-    assert "git diff" in job and "tests/" in job, "lint job 이 변경 파일 diff 미산출"
-    # 🔴 flake8 는 변경 파일 변수($changed)에 실행해야 함 — 리터럴 전체 경로(`... tests/`) 스캔 금지.
-    #    (긍정 단언: `tests/\b` 부정 정규식은 `/`가 비단어문자라 \b 미매칭 = 무력 — Codex Round 2 적발.)
-    #    flake8 must run on the $changed var (diff result), not a literal full path (Codex R2: \b after '/' never matches).
-    assert re.search(r"--select=F401,F841\s+\$changed\b", job), \
+    """가드는 PR 변경 파일 한정(A2) — flake8 가 변경 파일 변수 $changed 에 실행돼야 함.
+    리터럴 전체 경로(`... tests/`)·find 전체 스캔이면 기존 legacy 76건으로 즉시 실패."""
+    code = _lint_run_code()
+    assert "github.event.pull_request.base.sha" in code, "lint job 이 PR base SHA diff 미사용 (변경 파일 스코프 아님)"
+    assert "git diff" in code and "tests/" in code, "lint job 이 변경 파일 diff 미산출"
+    # 🔴 flake8 는 변경 파일 변수($changed)에 실행 — 리터럴 경로 full-scan 금지 (R2 긍정 단언).
+    assert re.search(r"--select=F401,F841\s+\$changed\b", code), \
         "flake8 가 $changed(변경 파일)이 아닌 리터럴 경로를 스캔 — PR diff 한정이어야 함"
-    # find 기반 전체 스캔 금지 (diff 우회 변조 차단 — Codex mutual 적발 케이스)
-    assert "find tests" not in job, "find 기반 전체 스캔 금지 — git diff 변경 파일 한정이어야 함"
+    # find 기반 전체 스캔 금지 (diff 우회 변조 차단 — R1 적발 케이스)
+    assert "find tests" not in code, "find 기반 전체 스캔 금지 — git diff 변경 파일 한정이어야 함"
 
 
 def test_lint_job_is_pr_only():
-    """lint job 은 PR 이벤트 한정 — push(main)에서 base.sha 부재로 깨지지 않도록."""
-    job = _lint_job_text()
-    assert "pull_request" in job, "lint job 이 PR-only(if) 아님 — push 에서 깨질 수 있음"
+    """lint job 은 PR 이벤트 한정 — push(main)에서 base.sha 부재로 깨지지 않도록 (job if 단언)."""
+    job = _lint_job()
+    assert "pull_request" in str(job.get("if", "")), "lint job 이 PR-only(if) 아님 — push 에서 깨질 수 있음"


### PR DESCRIPTION
## 요약

2026-06-23 회고 백로그 **C1 (P1, 사용자 결정: A2 diff-한정)** — 자초 CodeQL cascade 근본 차단. tests/ 미사용 import(F401)·변수(F841)가 pre-merge 에서 안 잡혀 main full-scan CodeQL 에 사후 포착 → 별도 fix PR(#516/#517/#520/#521/#522) **5건 반복**. 5건 모두 'PR 에서 신규 도입된' dead symbol 이 원인.

## 해결 (A2 — PR diff 한정)

CI 신규 job `lint-changed-tests`: PR 에서 변경된 `tests/*.py` 만 `flake8 --isolated --select=F401,F841 $changed` 검사.
- **신규 도입 dead symbol 만 차단** → 기존 legacy 76건 정리 불필요(저위험).
- 🔴 **`--isolated` 필수**: `setup.cfg` per-file-ignore(`tests/*:F401,F841`)가 일반 `flake8 --select` 를 **무력화(false-pass)** 하는 것을 실증 확인 → `--isolated` 로 우회.
- `flake8==7.3.0` 핀(requirements.txt 동일) + `--only-binary` (재현성·setup-script 차단).
- PR-only(`if: pull_request`) + `base.sha` diff + 변경 test 없으면 통과.

## 🔴 전제 정정 (투명성)

초기 보고 "tests/ 0 위반, 즉시 적용" 은 **오측**이었습니다 — per-file-ignore 가 마스킹해 실제 **76건(39파일)** 존재. 일부러 dead import 를 심어 `--isolated` 필요성을 실증. A2 는 이 legacy 를 건드리지 않고 신규만 차단(사용자 결정). *(이 오측 자체가 #978 에 추가한 C11 체크포인트 "가정 말고 실측" 의 실사례.)*

## 회귀 가드 (TDD) — `tests/unit/scripts/test_ci_dead_symbol_guard.py` (+3)

Codex mutual 적대 검증 **5라운드**로 가드를 **4중 봉인** (각 NG = (b) 단일 정답 버그 즉시 수정):
| 라운드 | Codex 적발 | 봉인 |
|:---:|------|------|
| R1 | ci.yml 전체 검색이 secret-scan job 의 `base.sha` 로 false-pass | `lint-changed-tests` job 영역에만 한정(yaml 추출) |
| R2 | `tests/\b` 정규식의 `\b` 가 `/` 뒤 미매칭 = 무력 | flake8 가 `$changed` 변수에 실행됨 **긍정 단언** |
| R3 | 정답 명령을 **셸 주석 decoy** 로 넣고 실제 full-scan | run 스크립트 셸 주석 strip 후 매칭(#936 패턴) |
| R4 | `$changed tests/` **인자 덧붙이기** 로 full-scan 재유입 | `\$changed\s*$`(MULTILINE) — 단독 인자 강제 |

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

✅ **VERDICT: OK** (gpt-5.5, push 전, Round 5). Codex 적대 검증이 가드 테스트 결함 4건을 연달아 적발 → 전부 즉시 수정(정책 18 §3 (b) 단일 정답). R4(4회차)는 정책 18 §3 escalation 으로 **사용자 승인 후** 수정. Round 5 = R1~R4 봉인 전건 재확인 + 정상 GREEN(3 passed) + false negative 0 + 잔여 plausible 회귀 gap 0. CI job 자체는 R1부터 일관되게 정확(Codex 매 라운드 확인).

## 🔍 사용자 검증 필요

- [ ] **신규 PR 에서 동작**: 이 가드는 PR 이벤트에서만 작동 — 다음 PR 부터 변경 test 파일에 dead import 가 있으면 CI red. (본 PR 자체는 신규 test 파일 1개 추가 → 가드가 그 파일 검사 통과 = dogfood.)
- [ ] 운영 영향 없음(CI 설정 + 테스트 — production 코드·DB·API 변경 0).

## 자율 판단 보고 (정책 3)
- 기존 **legacy 76건은 본 PR 미정리**(A2 결정 — loud regression 아닌 신규만 차단). 추후 별도 cleanup 원하시면 PR 가능.
- SonarCloud 는 `sonar.sources=src` 라 ci.yml 미스캔 → 추가한 `pip install` 라인은 핀+only-binary 로 클린, 기존 다른 install 라인의 SonarLint 경고는 범위 밖(미수정).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
