### PR TITLE
fix(test): 자초 CodeQL 5건 해소 — #981 #noqa 보호 import 실제 非load-bearing 제거

### DIFF
--- a/tests/unit/analyzer/tools/test_semgrep.py
+++ b/tests/unit/analyzer/tools/test_semgrep.py
@@ -531,14 +531,6 @@ class TestSemgrepAnalyzeFileIntegration:
         # semgrep 미설치 환경에서는 _SemgrepAnalyzer가 is_enabled()=False → run() 호출 안 됨
         from src.analyzer.io.static import analyze_file
 
-        run_called = []
-
-        def fake_run(ctx):
-            run_called.append(ctx)
-            return []
-
-
-        # REGISTRY에서 semgrep analyzer를 찾아 run을 교체
         with patch("shutil.which", return_value=None):
             result = analyze_file("module.py", "x = 1\n")
 

--- a/tests/unit/config_manager/test_manager.py
+++ b/tests/unit/config_manager/test_manager.py
@@ -11,7 +11,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from src.database import Base
 from src.models.repo_config import RepoConfig
-from src.models.gate_decision import GateDecision  # noqa: F401
 from src.config_manager.manager import get_repo_config, upsert_repo_config, RepoConfigData
 
 

--- a/tests/unit/migrations/test_0020_round_trip.py
+++ b/tests/unit/migrations/test_0020_round_trip.py
@@ -17,7 +17,6 @@ import pytest
 from sqlalchemy import create_engine, inspect, text
 
 from src.database import Base
-import src.models.merge_retry  # noqa: F401  # ensure model is registered on Base.metadata
 
 
 def test_orm_creates_merge_retry_queue_table():

--- a/tests/unit/repositories/test_repo_config_repo.py
+++ b/tests/unit/repositories/test_repo_config_repo.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import sessionmaker
 
 from src.database import Base
 from src.models.repo_config import RepoConfig
-from src.models.repository import Repository  # noqa: F401
 from src.repositories import repo_config_repo
 
 

--- a/tests/unit/services/test_analytics_service.py
+++ b/tests/unit/services/test_analytics_service.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import Session
 
 from src.database import Base
 from src.models.analysis import Analysis
-from src.models.repo_config import RepoConfig  # noqa: F401
 from src.models.repository import Repository
 from src.models.user import User
 


### PR DESCRIPTION
## 요약
#981(dead-symbol 정리) 머지 후 main 전체 스캔서 **자초 CodeQL 5건** 노출(정책 14): `py/unused-import` 4 + `py/unused-local-variable` 1.

## 근본 원인 (학습 2건)
🔴 **(1) `# noqa: F401` ≠ CodeQL 억제**: #981 이 4 ORM import 를 "load-bearing(create_all 등록)" 추정해 `# noqa: F401` 보호 → flake8 만 억제, **CodeQL py/unused-import 은 여전히 적발**.
🔴 **(2) load-bearing 추정 오류**: 실제 4건 모두 **非load-bearing**(각 제거+테스트 실증 — `test_orm_creates_merge_retry_queue_table` 도 import 없이 PASS, 모델은 conftest/repo 모듈서 등록, "ensure registered" 주석 obsolete).

## 변경 (5파일 −12줄)
- 4 ORM import 제거(flake8 F401 + CodeQL py/unused-import 동시 해소): `Repository`·`GateDecision`·`RepoConfig`·`merge_retry`.
- `test_semgrep` `run_called`/`fake_run` dead 스파이 제거(patch 미wiring·assert 없음, flake8 F841 은 append 를 "사용" 으로 봐 놓침) + stale 주석.

## 검증
- `flake8 --isolated --select=F401,F841 tests/` = **0** · 단위 **5081 passed/4 skipped(=5085 불변)** · 영향 105 passed.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
✅ **VERDICT: OK**. Codex가 직접 4 import 非load-bearing 독립 실증(`test_orm_creates_merge_retry_queue_table` PASSED 명시 확인)·dead 스파이 미wiring 확인·flake8=0·카운트 5085 불변·잘못 제거된 load-bearing 없음.

## 🔍 사용자 검증 필요
- [ ] 머지 후 main CodeQL 전체 스캔서 5건 alert 해소 확인(정책 14 — PR diff 아닌 main 스캔서 close).

## 자율 판단 보고 (정책 3)
- "선진행" 위임 + 정책 14(자초 CodeQL 점검 의무)로 자율 진행. #981 의 과보수적 `# noqa` 가 자초한 alert 정정.
- 🔴 교훈 메모리 기록: load-bearing 추정 금지(제거+테스트 실증) · `# noqa: F401` 은 flake8 전용(CodeQL 무관).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)