### PR TITLE
fix(workflows): retrospective.mjs C10-d — coverage<1.0 시 UNVERIFIED bounded 재검증

### DIFF
--- a/.claude/workflows/retrospective.mjs
+++ b/.claude/workflows/retrospective.mjs
@@ -280,6 +280,26 @@ try {
   log(`completeness 라운드 실패 — best-effort 건너뜀 (verified ${verified.length}건 보존): ${e?.message ?? e}`)
 }
 
+// ── coverage<1.0 보강: UNVERIFIED 만 1회 bounded 재검증 (C10-d 반자동→자동) ──
+// 고동시성 StructuredOutput flake 로 verdict 미수신된 소수만 추가 1라운드 — 토큰 비용 최소(UNVERIFIED 한정).
+// One bounded re-verify pass over only the UNVERIFIED findings to raise verdict_coverage toward 1.0
+// (C10-d). Low cost — re-runs just the few StructuredOutput-flake misses, not the whole set.
+const unresolved = verified.filter((v) => v.verdict === 'UNVERIFIED')
+if (unresolved.length) {
+  log(`UNVERIFIED ${unresolved.length}건 → coverage 보강 1회 bounded 재검증`)
+  const reResolved = new Map(
+    (await verifyAll(unresolved, context))
+      .filter((v) => v.verdict !== 'UNVERIFIED')
+      .map((v) => [key(v), v]),
+  )
+  if (reResolved.size) {
+    verified.forEach((v, i) => {
+      if (v.verdict === 'UNVERIFIED' && reResolved.has(key(v))) verified[i] = reResolved.get(key(v))
+    })
+    log(`재검증으로 ${reResolved.size}건 verdict 해소 (coverage ↑)`)
+  }
+}
+
 // ── Report (구조화 데이터 반환 — 리포트 파일 작성은 호출자/스킬 책임) ──
 // Report (returns structured data — writing the report file is the caller/skill's job)
 phase('Report')

--- a/docs/runbooks/retrospective.md
+++ b/docs/runbooks/retrospective.md
@@ -47,7 +47,7 @@ Workflow({ scriptPath: '<repo-abs>/.claude/workflows/retrospective.mjs',
 ## 알려진 한계 (2026-06-23 첫 dogfooding → C10 일부 해소)
 - ✅ **completeness 라운드 회복력**(C10): try/catch 격리 — API 일시 오류 시 gap 라운드만 건너뛰고 본체 회고·Report 는 보존(이전엔 전체 소실 위험). 단 gap 라운드 자체는 미수행(best-effort).
 - ✅ **evidence·citation_verified 환류**(C10): 최종 confirmed 출력에 포함(보고서 추적성 복원, 이전엔 소실). adjusted_severity 도 명시 노출.
-- ⚠️ verdict_coverage < 1.0 자동 재시도 부재(반자동) — 수동 재실행 권고(백로그 C10-d, 토큰 비용 트레이드오프 = 사용자 결정).
+- ✅ **verdict_coverage < 1.0 자동 보강**(C10-d): UNVERIFIED finding 만 1회 bounded 재검증(고동시성 StructuredOutput flake 해소) — 토큰 비용 최소(소수 한정). 1회 후에도 UNVERIFIED 면 보고서 unverified 표 노출(현행).
 - ⚠️ SEVERITY_ADJUST 시 adjusted_severity 미수신이면 count 가 원 severity 로 graceful fallback — 스키마 강제(if/then) 미적용(백로그 C10-c, 검증기 스키마 위험 회피).
 - 자유 발언·회고 질문·cross-verify 생략 정량 표는 워크플로우 출력 밖 = 스킬/Claude 절차 의존.
 - 회귀 가드: `tests/unit/scripts/test_retrospective_resilience.py` (try/catch + evidence 출력, 주석 false-pass 봉인). 추적: [`docs/_archive/reports/2026-06-23-retrospective.md`](../_archive/reports/2026-06-23-retrospective.md) §C10.

--- a/tests/unit/scripts/test_retrospective_resilience.py
+++ b/tests/unit/scripts/test_retrospective_resilience.py
@@ -79,3 +79,26 @@ def test_resilience_guard_rejects_comment_only_try():
         "phase('Report')\n"
     )
     assert not _completeness_is_resilient(_strip_comments(fake))
+
+
+# --- coverage<1.0 보강: UNVERIFIED 1회 bounded 재검증 (C10-d) ---
+
+def _has_coverage_boost(code: str) -> bool:
+    """coverage<1.0 시 UNVERIFIED 만 1회 bounded 재검증하는가 (C10-d)."""
+    return "verified.filter" in code and "verifyAll(unresolved" in code
+
+
+def test_coverage_boost_reverifies_unverified():
+    """UNVERIFIED 만 1회 bounded 재검증으로 verdict_coverage 보강 (C10-d, 실코드 기준)."""
+    assert _has_coverage_boost(_code()), \
+        "coverage 보강 재검증(UNVERIFIED 1회 bounded) 누락 (C10-d 회귀)"
+
+
+def test_coverage_boost_guard_rejects_comment_only():
+    """재검증 토큰이 주석에만 있으면 false-pass 하지 않음 (#936 봉인)."""
+    fake = (
+        "// const unresolved = verified.filter((v) => v.verdict === 'UNVERIFIED')\n"
+        "// verifyAll(unresolved, context)\n"
+        "phase('Report')\n"
+    )
+    assert not _has_coverage_boost(_strip_comments(fake))


### PR DESCRIPTION
## 요약
회고 백로그 **C10-d**(verdict_coverage<1.0 자동 재시도 부재) 해소 — "다음 진행" 위임.

## 변경
- `retrospective.mjs`: completeness 라운드 후, **UNVERIFIED**(고동시성 StructuredOutput flake 로 verdict 미수신) finding 만 **1회 bounded 재검증**(`verifyAll`) → verdict_coverage(회고 핵심 ROI 지표) 1.0 방향 보강. 🔴 **토큰 비용 최소** — 전체가 아닌 UNVERIFIED 소수만 재시도(정책 16#5). 1회 후에도 UNVERIFIED 면 현행(보고서 unverified 표).
- 회귀 가드 +2(재검증 존재 정적 단언 + 주석 false-pass 봉인). runbook 한계 C10-d ⚠️→✅.
- 결함 3(SEVERITY_ADJUST)은 #978 에서 이미 graceful(출력 null·count fallback) → 무변경.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
✅ **VERDICT: OK**. Codex 적대 검증: **bounded**(1회 extra pass·UNVERIFIED만·crossVerify 3-attempt cap → 최악 UNVERIFIED×3, **무한루프/runaway 없음**)·in-place 교체 정확(const array 인덱스 할당·still-UNVERIFIED 유지)·key()/verifyAll scope OK·async-wrap 구문 OK·테스트 genuine(HEAD^서 FAIL·11 passed)·loop-sync 무회귀.

## 🔍 사용자 검증 필요
- [ ] 운영 영향 없음(워크플로우 도구 — production 코드 0). 다음 `/retrospective` 시 verdict_coverage 보강 동작.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)