### PR TITLE
fix(alembic): env.py 전 ORM 모델(11) 전수 import — autogenerate drop_table 데이터손실 함정 차단

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -20,11 +20,23 @@ if config.config_file_name is not None:
 
 # add your model's MetaData object here
 # for 'autogenerate' support
+# 🔴 전 ORM 모델(11종) 명시 import 의무 — 일부만 import 하면 autogenerate 가 미등록 테이블을
+# "삭제됨"으로 보고 drop_table 을 생성하는 데이터 손실 함정 (감사 migration-integrity-001, 2026-06-25).
+# empty __init__.py 규칙(testing.md) 보존 — aggregate import 대신 여기서 전수 명시.
+# 회귀 가드: tests/unit/migrations/test_alembic_env_model_completeness.py (신규 모델 추가 시 자동 fail).
+# 🔴 Import EVERY ORM model (11) — a partial import makes autogenerate emit destructive drop_table for
+# the unimported tables. The empty-__init__ convention is preserved; all models are listed here explicitly.
 from src.models.repository import Repository  # noqa: F401
 from src.models.analysis import Analysis      # noqa: F401
+from src.models.analysis_feedback import AnalysisFeedback  # noqa: F401
 from src.models.repo_config import RepoConfig  # noqa: F401
 from src.models.gate_decision import GateDecision  # noqa: F401
+from src.models.merge_attempt import MergeAttempt  # noqa: F401
 from src.models.merge_retry import MergeRetryQueue  # noqa: F401
+from src.models.issue_registration import IssueRegistration  # noqa: F401
+from src.models.insight_narrative_cache import InsightNarrativeCache  # noqa: F401
+from src.models.security_alert_log import SecurityAlertProcessLog  # noqa: F401
+from src.models.user import User  # noqa: F401
 from src.database import Base, _build_connect_args
 from src.config import settings
 

--- a/tests/unit/migrations/test_alembic_env_model_completeness.py
+++ b/tests/unit/migrations/test_alembic_env_model_completeness.py
@@ -1,0 +1,57 @@
+"""alembic/env.py 가 전 ORM 모델 모듈을 import 하는지 검증하는 정적 완전성 가드.
+
+Static completeness guard: assert alembic/env.py imports every ORM model module.
+
+감사 migration-integrity-001 (2026-06-25): env.py 가 `target_metadata = Base.metadata` 를 쓰는데
+11 ORM 모델 중 일부만 import 하면, autogenerate 가 미등록 테이블을 ORM 에 "없는" 것으로 보고
+`op.drop_table()` 을 생성한다 → `make revision --autogenerate` 시 데이터 손실 함정.
+
+The autogenerate path compares Base.metadata against the live DB; if env.py imports only a subset of
+models, the unimported tables look "removed" and autogenerate emits destructive drop_table ops.
+
+🔴 empty `__init__.py` 규칙 보존 (testing.md 사이클 115) — `src/models/__init__.py` 는 빈 파일 유지.
+aggregate import 대신 env.py 가 모든 모델 모듈을 명시적으로 import 해 완전성을 확보한다.
+The empty-__init__ convention is preserved; env.py imports each model module explicitly.
+"""
+import ast
+import pathlib
+
+# tests/unit/migrations/<this>.py → parents[3] = 레포 루트 / repo root
+_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_ENV_PY = _ROOT / "alembic" / "env.py"
+_MODELS_DIR = _ROOT / "src" / "models"
+
+
+def _model_modules() -> set[str]:
+    """src/models/ 의 ORM 모델 모듈명 집합 (__init__ 제외)."""
+    # Set of ORM model module stems under src/models/ (excluding __init__).
+    return {p.stem for p in _MODELS_DIR.glob("*.py") if p.stem != "__init__"}
+
+
+def _env_imported_model_modules() -> set[str]:
+    """alembic/env.py 가 import 하는 src.models.* 모듈명 집합 (AST 실측)."""
+    # Module stems that env.py imports from src.models.* (measured via AST).
+    tree = ast.parse(_ENV_PY.read_text(encoding="utf-8"))
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and node.module.startswith("src.models."):
+            imported.add(node.module.split(".")[-1])
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith("src.models."):
+                    imported.add(alias.name.split(".")[-1])
+    return imported
+
+
+def test_env_imports_every_orm_model_module():
+    """env.py 가 모든 ORM 모델 모듈을 import 해야 autogenerate drop_table 함정이 차단된다."""
+    models = _model_modules()
+    # 모델 모듈이 실제로 존재함을 먼저 보장 (glob 빈 집합 시 vacuous pass 방지)
+    # Guard against a vacuous pass if the glob returns nothing.
+    assert len(models) >= 11, f"src/models/ 모델 모듈 수가 예상보다 적음: {sorted(models)}"
+    missing = models - _env_imported_model_modules()
+    assert not missing, (
+        f"alembic/env.py 가 ORM 모델 모듈 {sorted(missing)} 를 import 하지 않음 — "
+        "autogenerate(target_metadata=Base.metadata) 시 해당 테이블에 drop_table 생성 위험. "
+        "env.py 상단에 `from src.models.<module> import <Model>  # noqa: F401` 추가 의무."
+    )


### PR DESCRIPTION
## 요약

전체 품질 감사(2026-06-25) **migration-integrity-001** 수정 — `alembic/env.py` 의 autogenerate 데이터 손실 함정 차단.

`env.py` 가 `target_metadata = Base.metadata` 를 쓰면서 11 ORM 모델 중 **5종만 import**(Repository/Analysis/RepoConfig/GateDecision/MergeRetryQueue)했습니다. `src/models/__init__.py` 는 빈 파일(의도된 convention, testing.md 사이클 115)이고 모델 간 cross-import 도 0이라, 누락 6종(`analysis_feedback`·`security_alert_log`·`user`·`issue_registration`·`merge_attempt`·`insight_narrative_cache`)이 `Base.metadata` 에 등록되지 않았습니다.

→ `make revision --autogenerate` 실행 시 alembic 이 미등록 6 테이블을 "ORM 에서 삭제됨"으로 보고 **`op.drop_table()` 6건을 자동 생성**하는 데이터 손실 함정.

## 영향 / 현 상태

- **현재 운영 영향 0** — hand-written `alembic upgrade head` 경로는 `target_metadata` 를 소비하지 않으므로 무관. autogenerate 시에만 발현되는 **잠재 footgun**.
- 기존 가드(`test_orm_alembic_parity`·migration round-trip)는 11 모델을 **테스트가 자체 import** 하므로 env.py 의 부분 import 를 검출하지 못했음.

## 변경

1. `alembic/env.py`: 누락 6 모델 import 추가 → **전 11종 명시 import**. `empty __init__.py` 규칙 보존(aggregate import 미채택 — 정책 17 안정성 우선; audit 원안 B[`__init__` 단일출처]보다 convention-preserving 한 A안 채택).
2. 신규 정적 가드 `tests/unit/migrations/test_alembic_env_model_completeness.py`: AST 로 env.py 가 `src/models/` 의 **모든** 모델 모듈을 import 하는지 검증 — 신규 모델 추가 후 env.py 등재 누락 시 CI 자동 fail (정책 4: 단언+회귀가드 페어). vacuous-pass 방어(`len(models) >= 11`) + `import`/`from-import` 양형식 커버.

## 테스트

- 신규 가드: 수정 전 **RED**(누락 6 모델 정확 검출) → 수정 후 **GREEN**.
- `pytest tests/unit/migrations/` → **57 passed, 4 skipped**(PG-only 자동 skip), 회귀 0.
- 단위 테스트 +1 (5089→5090, 머지 후 STATE/README 일괄 sync 예정).

## 🔍 사용자 검증 필요 (정책 2)

- [ ] (선택) 로컬에서 `make revision m="noop test"` 실행 시 생성된 마이그레이션에 **`drop_table` 이 더 이상 없는지** 확인 후 파일 삭제 — 함정 해소 실증. (운영 영향 없는 검증용)
- 이 PR 은 src 런타임 로직 무변경(alembic 메타데이터 + 신규 테스트만) — 배포 동작 영향 없음.

## 🔍 Codex 검증 (push 전, 정책 18)

**Codex mutual 검증 결과: OK** (push 전 의뢰 → 5개 항목 전부 OK 후 push).

| 항목 | 결과 |
|------|------|
| 정확성 (11 모델 전수 import, 누락·오타) | OK — 직접 파일 대조 |
| 가드 견고성 (AST 양형식·vacuous-pass 방어) | OK |
| 회귀 위험 (import cycle·alembic 부작용) | OK — parity test 가 이미 11종 import 중 |
| 대안 평가 (env.py 명시 vs `__init__` 단일출처) | OK — empty-`__init__` convention 보존 타당 |
| pytest 통과 | OK — 57 passed (RED→GREEN 실측) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
