### PR TITLE
docs(n8n): 통합 가이드 산문↔출하 JSON↔코드 divergence 정합 (품질감사 P1·P2)

### DIFF
--- a/docs/integrations/n8n-auto-fix.md
+++ b/docs/integrations/n8n-auto-fix.md
@@ -125,8 +125,13 @@ CLAUDE_OUT=$(mktemp); CLAUDE_ERR=$(mktemp)
 # printf 를 부모 셸에서 직접 실행해 파이프로 stdin 전달 (timeout 은 claude 만 래핑, set -o pipefail 로 실패 전파).
 # 🔴 PROMPT is a parent-shell var; a `sh -c '...'` subshell does NOT inherit non-exported vars → empty prompt.
 # Run printf in the parent shell and pipe into claude (timeout wraps claude only).
-if ! printf '%s' "$PROMPT" | timeout 900 claude -p --permission-mode acceptEdits \
-      > "${CLAUDE_OUT}" 2> "${CLAUDE_ERR}"; then
+# rc 캡처(|| rc=$?)로 set -e 중단 회피 + pipefail 로 claude/timeout 종료코드 전파.
+# Capture rc to avoid set -e abort; pipefail propagates claude/timeout's status.
+rc=0
+printf '%s' "$PROMPT" | timeout 900 claude -p --permission-mode acceptEdits \
+      > "${CLAUDE_OUT}" 2> "${CLAUDE_ERR}" || rc=$?
+if [ "${rc}" -ne 0 ]; then
+  [ "${rc}" -eq 124 ] && exit 124   # timeout 은 124 보존 (exit code 표 참조)
   head -c 4000 "${CLAUDE_ERR}" >&2
   exit 2
 fi
@@ -234,12 +239,15 @@ False 경로는 NoOp으로 연결 (무시).
 ### Node 4 — 작업 변수 세팅 (Set)
 
 ```
-repo         = {{ $json.repo }}
-issue_number = {{ $json.data.issue.number }}
-issue_title  = {{ $json.data.issue.title }}
-issue_body   = {{ $json.data.issue.body }}
-work_key     = {{ $json.repo + '#' + $json.data.issue.number }}
+repo         = {{ $json.body.repo }}
+issue_number = {{ $json.body.data.issue.number }}
+issue_title  = {{ $json.body.data.issue.title }}
+issue_body   = {{ $json.body.data.issue.body || '' }}
+work_key     = {{ $json.body.repo + '#' + $json.body.data.issue.number }}
+repo_token   = {{ $json.body.data.repo_token || '' }}
 ```
+
+> envelope 은 webhook body 아래 중첩되므로 표현식은 `$json.body.*` 경로다(출하 JSON Set 노드와 일치). `repo_token` 은 SCAManager 가 릴레이한 GitHub 토큰(Node 6 `GH_TOKEN` 출처).
 
 ### Node 5 — 세마포어 락 (Code)
 

--- a/docs/integrations/n8n-auto-fix.md
+++ b/docs/integrations/n8n-auto-fix.md
@@ -285,12 +285,14 @@ Environment Variables:
 ```
 Value: {{ $json.exitCode }}
 Rules:
-  0   → 성공 분기
-  1   → NO_CHANGE_NEEDED 분기
-  2   → claude 실패 분기
-  3   → push 실패 분기
-  124 → timeout 분기
+  0   → 성공 분기 (output 0, 미연결)
+  1   → NO_CHANGE_NEEDED 분기 (output 1 → Issue 코멘트)
+  2   → claude 실패 분기 (output 2 → Issue 코멘트 + Telegram)
+  3   → push 실패 분기 (output 3 → Issue 코멘트 + Telegram)
+  124 / 그 외 → fallbackOutput (output 4 → Telegram 알림)
 ```
+
+> timeout(124) 등 0~3 외 종료코드는 Switch 의 `fallbackOutput`(output 4)으로 떨어진다 — 번들 JSON 은 output 4 → Telegram 알림으로 연결한다(Telegram 노드는 기본 disabled, Node 9 참조).
 
 ### Node 8 — GitHub Issue Comment
 

--- a/docs/integrations/n8n-auto-fix.md
+++ b/docs/integrations/n8n-auto-fix.md
@@ -29,7 +29,9 @@ PR open
         · Issue 자동 close (Closes #N)
 ```
 
-**SCAManager 코드 변경 없음.** 기존 `notify_n8n_issue()`가 이미 envelope을 전송한다.
+**토큰 릴레이 모델**: `notify_n8n_issue()`(`src/notifier/n8n.py`)가 GitHub 토큰을 envelope `data.repo_token`으로 릴레이한다 — **HMAC 서명 시크릿(`N8N_WEBHOOK_SECRET`)이 설정된 인증 채널로만 전송**(미설정 시 토큰 생략, `n8n.py:93-95` 방어 심화). 따라서 n8n 워크플로는 별도 GitHub credential 없이 이 payload 토큰을 `GH_TOKEN`으로 주입한다(아래 Node 6 참조).
+
+> ⚠️ `repo_token` 파라미터 + 릴레이 로직은 SCAManager 측 코드(`notify_n8n_issue(repo_token=...)`)에 포함된 기능이다 — 본 가이드의 "코드 변경 없음"이라는 과거 서술은 부정확했다(2026-06-25 정정).
 
 ---
 
@@ -71,8 +73,9 @@ echo "0 4 * * * n8n find /var/lib/n8n/claude-workspace -mindepth 2 -mtime +1 -ex
 ```bash
 #!/bin/bash
 # /opt/claude-runner/claude_fix.sh
-# n8n Execute Command 노드가 env로 주입하는 변수:
-#   REPO, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, GH_TOKEN, ANTHROPIC_API_KEY
+# n8n 실행 노드가 env로 주입하는 변수: REPO, ISSUE_NUMBER, ISSUE_TITLE, ISSUE_BODY, GH_TOKEN
+# (GH_TOKEN = SCAManager payload 릴레이 repo_token — Node 6 참조)
+# ANTHROPIC_API_KEY 는 노드가 주입하지 않음 — n8n 호스트 프로세스 env 또는 claude 로그인 상태에서 제공.
 set -euo pipefail
 
 WORK_ROOT="/var/lib/n8n/claude-workspace"
@@ -117,7 +120,12 @@ EOP
 CLAUDE_OUT=$(mktemp); CLAUDE_ERR=$(mktemp)
 
 # claude cli — 15분 타임아웃
-if ! timeout 900 sh -c 'printf "%s" "$PROMPT" | claude -p --permission-mode acceptEdits' \
+# 🔴 PROMPT 은 부모 셸 변수다. `sh -c '...'` 서브셸은 export 안 된 부모 변수를 상속하지 않으므로
+# `sh -c 'printf "%s" "$PROMPT" | ...'` 로 감싸면 $PROMPT 가 빈 문자열이 되어 claude 가 무지시 실행된다.
+# printf 를 부모 셸에서 직접 실행해 파이프로 stdin 전달 (timeout 은 claude 만 래핑, set -o pipefail 로 실패 전파).
+# 🔴 PROMPT is a parent-shell var; a `sh -c '...'` subshell does NOT inherit non-exported vars → empty prompt.
+# Run printf in the parent shell and pipe into claude (timeout wraps claude only).
+if ! printf '%s' "$PROMPT" | timeout 900 claude -p --permission-mode acceptEdits \
       > "${CLAUDE_OUT}" 2> "${CLAUDE_ERR}"; then
   head -c 4000 "${CLAUDE_ERR}" >&2
   exit 2
@@ -206,14 +214,22 @@ if (!valid) {
 return $input.all();
 ```
 
+> 🔴 **보안 — HMAC 검증 (hard-reject) 의무 + 직렬화 주의**: claude_fix.sh 는 GitHub 토큰으로 clone·push·PR 을 수행하는 고권한 경로이므로 **불일치 시 거부(hard-reject)가 운영 기본값**이어야 한다. 위 코드는 그 권장 구현이며 **반드시 Node 1 의 "Raw Body" 옵션을 켜고 `rawBody`(원본 바이트)로 검증**해야 한다.
+>
+> ⚠️ **이유**: SCAManager 는 Python `json.dumps(payload)`(키 사이 공백 O)로 서명하는데, n8n 의 `JSON.stringify(parsedBody)`(공백 X)는 **바이트가 달라 HMAC 이 항상 불일치**한다. 따라서 파싱된 body 를 재직렬화해 검증하면 정상 webhook 도 전부 거부된다 → 반드시 **수신 원본 바이트(`rawBody`)** 로 검증할 것.
+>
+> 🔴 **번들 `n8n-workflow.json` 주의**: 출하 JSON 의 HMAC 노드는 위 직렬화 불일치를 회피하려 **soft-pass(불일치 시 경고만 남기고 통과)** 로 되어 있다 — 즉 **무인증 트리거를 차단하지 못한다**. 운영 배포 전 위 hard-reject 구현으로 교체하고 Raw Body 검증이 동작하는지 **반드시 실 n8n 인스턴스에서 확인**할 것(Claude 정적 검증 불가 영역 — 운영자 의무).
+
 ### Node 3 — 이벤트 필터 (IF)
 
 ```
-Condition: {{ $json.event_type }} == "issue"
-AND: {{ $json.data.action }} == "opened"
+Condition: {{ $json.body.event_type }} == "issue"
+AND: {{ $json.body.data.action }} ∈ {"opened", "reopened"}
 ```
 
 False 경로는 NoOp으로 연결 (무시).
+
+> ⚠️ **이벤트 필터 로직 주의 (번들 JSON 결함)**: 출하 `n8n-workflow.json` 의 이벤트 필터 IF 노드는 세 조건 `[event_type==issue, action==opened, action==reopened]` 를 `combineOperation: any` 로 결합한다. `any` 는 **셋 중 하나만 참이면 통과**하므로 `event_type==issue` 이기만 하면 `closed`·`edited` 등에서도 트리거되어 불필요한 claude_fix.sh 실행이 발생한다. 의도는 `event_type==issue AND action∈{opened,reopened}` 다. 단일 IF(v1) 로는 `A AND (B OR C)` 를 표현할 수 없으므로 **(a) `event_type==issue` 선행 IF(all) + `action∈{opened,reopened}` 후행 IF(any) 2단 분리**, 또는 **(b) Code 노드에서 `event_type==='issue' && ['opened','reopened'].includes(action) ? items : []` 명시 평가**로 교체할 것(운영자 검증 영역).
 
 ### Node 4 — 작업 변수 세팅 (Set)
 
@@ -239,7 +255,7 @@ staticData[key] = Date.now();
 return $input.all();
 ```
 
-### Node 6 — Execute Command
+### Node 6 — claude_fix.sh 실행
 
 ```
 Command: /opt/claude-runner/claude_fix.sh
@@ -248,9 +264,13 @@ Environment Variables:
   ISSUE_NUMBER  = {{ $json.issue_number }}
   ISSUE_TITLE   = {{ $json.issue_title }}
   ISSUE_BODY    = {{ $json.issue_body }}
-  GH_TOKEN      = {{ $credentials.githubPat.token }}
-  ANTHROPIC_API_KEY = {{ $credentials.anthropic.apiKey }}
+  GH_TOKEN      = {{ $json.repo_token }}   # ← SCAManager payload 릴레이(Node 4 repo_token), credential 아님
 ```
+
+> ⚠️ **번들 JSON 구현 차이 (정합 주의)**:
+> - **GH_TOKEN 출처** = `repo_token`(SCAManager 가 HMAC 인증 채널로 릴레이한 payload 토큰, 위 "토큰 릴레이 모델" 참조) — **n8n GitHub credential 이 아니다**.
+> - **`ANTHROPIC_API_KEY` 는 노드 env 로 주입하지 않는다** — 번들 JSON 의 실행 노드 env 에 없으며, claude CLI 는 **n8n 호스트 프로세스 env 또는 claude 설정**에서 키를 읽는다. 호스트에 `ANTHROPIC_API_KEY` 를 export 하거나 `claude` 로그인 상태를 준비할 것.
+> - **실행 방식**: 번들 `n8n-workflow.json` 은 이 단계를 "Execute Command" 노드가 아니라 **Code 노드의 `execFileSync('/opt/claude-runner/claude_fix.sh')`** 로 구현한다(exitCode/stdout/stderr 캡처). UI 로 직접 구성 시 동등 동작이면 무방.
 
 ### Node 7 — Switch (exit code)
 
@@ -276,6 +296,8 @@ Rules:
 
 ### Node 9 — Telegram 알림 (실패 케이스)
 
+> ⚠️ 번들 `n8n-workflow.json` 의 Telegram 노드는 **기본 `disabled: true`** 다(자격증명 미설정 환경 보호). 실패 알림을 받으려면 n8n UI 에서 노드를 활성화(`disabled: false`)하고 Telegram credential·chat_id 를 설정할 것.
+
 기존 SCAManager Telegram Bot Token 재사용:
 
 ```
@@ -292,11 +314,12 @@ Text:
 
 ### n8n Credential 등록
 
-| Credential 이름 | 값 | 용도 |
-|----------------|---|------|
-| `N8N_WEBHOOK_SECRET` | SCAManager `.env`의 `N8N_WEBHOOK_SECRET` 동일 값 | HMAC 검증 |
-| `GH_TOKEN` | GitHub Fine-grained PAT | clone · push · PR 생성 |
-| `ANTHROPIC_API_KEY` | Anthropic Console에서 발급 | claude cli |
+| 항목 | 값 | 용도 | 위치 |
+|------|---|------|------|
+| HMAC 시크릿 | SCAManager `.env`의 `N8N_WEBHOOK_SECRET` 동일 값 | HMAC 검증 | 번들 JSON 은 `/etc/n8n-secrets/hmac_secret` 파일에서 읽음 (n8n credential 로 대체 가능) |
+| GitHub PAT (`githubApi` credential) | GitHub Fine-grained PAT | **Issue 코멘트 작성**(Node 8) | n8n credential |
+| clone·push·PR 용 토큰 | SCAManager 가 릴레이한 `repo_token` | clone · push · PR 생성 | **n8n credential 아님** — payload 릴레이(위 "토큰 릴레이 모델"). SCAManager 측에 토큰 설정 |
+| `ANTHROPIC_API_KEY` | Anthropic Console 발급 | claude cli | **n8n credential 아님** — n8n 호스트 프로세스 env 또는 claude 로그인 |
 
 ### GitHub PAT 권한 (Fine-grained 권장)
 
@@ -333,12 +356,18 @@ Text:
 
 SCAManager의 `create_issue` 기능이 활성화된 리포에서, claude PR이 낮은 점수를 받으면 또 이슈가 생성되어 루프가 발생할 수 있다.
 
-**구현 완료 (Phase 2)**: `src/worker/pipeline.py`의 `_build_notify_tasks()`가 PR `head.ref`를 검사해 `claude-fix/`로 시작하는 브랜치에서는 `create_issue`를 건너뜀 — 토글 off 없이도 무한 루프 자동 차단.
+**구현 완료 (Phase 2)**: `src/notifier/github_issue.py`의 `_IssueNotifier.is_enabled()`가 PR `head.ref`를 `_BOT_PR_PREFIXES`(`claude-fix/`·`bot/`·`renovate/`·`dependabot/`) 중 하나로 시작하는지 검사해 봇/자동화 PR에서는 `create_issue`를 건너뜀 — 토글 off 없이도 무한 루프 자동 차단.
 
 ```python
-is_bot_pr = pr_head_ref and pr_head_ref.startswith("claude-fix/")
-if repo_config and repo_config.create_issue and result_dict and not is_bot_pr:
-    ...  # 봇 PR은 이 블록 전체 스킵
+# src/notifier/github_issue.py:22
+_BOT_PR_PREFIXES = ("claude-fix/", "bot/", "renovate/", "dependabot/")
+
+# _IssueNotifier.is_enabled() 내부
+is_bot_pr = ctx.pr_head_ref and any(
+    ctx.pr_head_ref.startswith(prefix) for prefix in _BOT_PR_PREFIXES
+)
+if is_bot_pr:
+    return False  # 봇 PR은 create_issue 채널 비활성
 ```
 
 ---
@@ -346,7 +375,7 @@ if repo_config and repo_config.create_issue and result_dict and not is_bot_pr:
 ## End-to-end 검증 체크리스트
 
 ```
-[ ] 1. curl로 잘못된 HMAC 서명 전송 → workflow 중단 로그 확인
+[ ] 1. curl로 잘못된 HMAC 서명 전송 → (hard-reject 적용 시) workflow 중단 / (번들 JSON soft-pass 시) "HMAC mismatch — soft pass" 경고 로그 확인 후 hard-reject 로 하드닝
 [ ] 2. "안녕하세요 문의입니다" 이슈 → exit 1 + Issue 코멘트 (코드 변경 없음)
 [ ] 3. "README 오타 수정" 이슈 → PR 생성 → SCAManager 분석 → auto_merge → Issue close
 [ ] 4. 테스트가 있는 리포에 기능 추가 이슈 → claude가 테스트까지 커밋 → PR CI 통과
@@ -362,7 +391,7 @@ if repo_config and repo_config.create_issue and result_dict and not is_bot_pr:
 
 | 증상 | 원인 | 해결 |
 |------|------|------|
-| workflow 2단계에서 중단 | HMAC 불일치 | SCAManager `.env`의 `N8N_WEBHOOK_SECRET` == n8n Credential 값 확인 |
+| (hard-reject 시) workflow 2단계 중단 / (soft-pass 시) "HMAC mismatch" 경고 | HMAC 불일치 | SCAManager `.env`의 `N8N_WEBHOOK_SECRET` == n8n 시크릿 값 확인 + Node 2 가 **rawBody**로 검증하는지 확인(Python json.dumps↔JS JSON.stringify 직렬화 차이) |
 | exit 3 루프 | PAT 권한 부족 또는 만료 | GitHub Fine-grained PAT `contents:write` + `pull_requests:write` 재발급 |
 | claude exit 2, "No such file" | claude cli 미설치 | n8n 호스트에서 `npm i -g @anthropic-ai/claude-code` 재실행 |
 | PR 생성됐지만 SCAManager 분석 안 됨 | 리포에 n8n_webhook_url 미설정 | SCAManager 설정 페이지 → 알림 채널 → n8n URL 입력 |

--- a/docs/integrations/n8n-auto-fix.md
+++ b/docs/integrations/n8n-auto-fix.md
@@ -296,9 +296,9 @@ Rules:
 
 ### Node 8 — GitHub Issue Comment
 
-실패 케이스별 메시지로 Issue에 코멘트 작성:
+> ⚠️ **번들 JSON 구현**: 출하 `n8n-workflow.json` 의 Issue Comment 노드는 **단일 generic body** (`={{ $json.stdout || '자동 처리 완료.' }}`)로 모든 exit 케이스에 claude stdout(또는 기본 문구)을 그대로 코멘트한다. 아래 케이스별 메시지는 **권장 커스터마이징**이다 — Switch 출력(output 1/2/3)을 각각 다른 메시지의 Issue Comment 노드로 분기하면 케이스별 문구를 적용할 수 있다.
 
-| 케이스 | 메시지 |
+| 케이스 | 권장 메시지 |
 |--------|--------|
 | exit 1 | `🤖 코드 변경이 필요하지 않은 이슈로 판단됐습니다. 수동 검토가 필요한 경우 재오픈 해주세요.` |
 | exit 2 | `🤖 자동 처리 중 오류가 발생했습니다:\n\n\`\`\`\n{{ $json.stderr }}\n\`\`\`` |
@@ -306,13 +306,16 @@ Rules:
 
 ### Node 9 — Telegram 알림 (실패 케이스)
 
-> ⚠️ 번들 `n8n-workflow.json` 의 Telegram 노드는 **기본 `disabled: true`** 다(자격증명 미설정 환경 보호). 실패 알림을 받으려면 n8n UI 에서 노드를 활성화(`disabled: false`)하고 Telegram credential·chat_id 를 설정할 것.
+> ⚠️ **번들 `n8n-workflow.json` 구현 + 운영자 필수 조치**:
+> - Telegram 노드는 **기본 `disabled: true`** 다(자격증명 미설정 환경 보호). 알림을 받으려면 노드를 활성화(`disabled: false`)하고 Telegram credential 을 설정할 것.
+> - **출하 JSON 은 `chatId` 가 하드코딩**(`1984552353`)되어 있다 — **반드시 본인 chat_id 로 교체**(또는 아래처럼 `{{ $env.TELEGRAM_CHAT_ID }}` 표현식으로 변경)할 것.
+> - 출하 JSON 의 텍스트는 **단일 generic 문구**(`❌ Issue #N 처리 실패 (exit N)`)다. 아래 exit별 문구는 **권장 커스터마이징**(Switch 출력별 분기).
 
-기존 SCAManager Telegram Bot Token 재사용:
+권장 — 기존 SCAManager Telegram Bot Token 재사용 + exit별 문구:
 
 ```
-Chat ID: {{ $env.TELEGRAM_CHAT_ID }}
-Text:
+Chat ID: {{ $env.TELEGRAM_CHAT_ID }}   # 번들 JSON 은 하드코딩값 — 교체 의무
+Text (권장 — exit별 분기):
   exit 2: ❌ *Issue #{{ $json.issue_number }}* 자동 처리 실패\n`{{ $json.repo }}`
   exit 3: ❌ *Issue #{{ $json.issue_number }}* push 실패\n`{{ $json.repo }}`
   exit 124: ⏱️ *Issue #{{ $json.issue_number }}* 타임아웃 (15분 초과)

--- a/docs/integrations/n8n-workflow.json
+++ b/docs/integrations/n8n-workflow.json
@@ -16,7 +16,7 @@
     },
     {
       "parameters": {
-        "jsCode": "const fs = require('fs');\nconst crypto = require('crypto');\n\nconst secret = fs.readFileSync('/etc/n8n-secrets/hmac_secret', 'utf8').trim();\nconst all = items[0].json;\nconst header = (all.headers && all.headers['x-scamanager-signature-256']) || '';\nconst body = all.body || {};\nconst rawBody = JSON.stringify(body);\n\nconst expected = 'sha256=' + crypto.createHmac('sha256', secret)\n  .update(rawBody, 'utf8').digest('hex');\n\n// HMAC soft-pass: JSON.stringify 재직렬화로 인한 불일치 허용\nif (header && header !== expected) {\n  console.warn('HMAC mismatch — soft pass');\n}\nreturn items;"
+        "jsCode": "const fs = require('fs');\nconst crypto = require('crypto');\n\nconst secret = fs.readFileSync('/etc/n8n-secrets/hmac_secret', 'utf8').trim();\nconst all = items[0].json;\nconst header = (all.headers && all.headers['x-scamanager-signature-256']) || '';\nconst body = all.body || {};\nconst rawBody = JSON.stringify(body);\n\nconst expected = 'sha256=' + crypto.createHmac('sha256', secret)\n  .update(rawBody, 'utf8').digest('hex');\n\n// ⚠️ HMAC soft-pass (보안 약화 — 운영 배포 전 하드닝 의무): JS JSON.stringify(공백X) != Python json.dumps(공백O)\n// 직렬화 불일치를 회피하려 불일치 시에도 통과시킨다. 무인증 트리거를 차단하지 못하므로, 운영에서는 Webhook Raw Body\n// + rawBody 기반 hard-reject 로 교체할 것 (docs/integrations/n8n-auto-fix.md Node 2 보안 주석 참조).\nif (header && header !== expected) {\n  console.warn('HMAC mismatch — soft pass (INSECURE: harden to hard-reject for production)');\n}\nreturn items;"
       },
       "id": "a36d145a-79c2-4a0d-bb2d-2a7d8abb0ca3",
       "name": "HMAC 검증",

--- a/docs/integrations/n8n-workflow.json
+++ b/docs/integrations/n8n-workflow.json
@@ -154,7 +154,8 @@
       [],
       [{"node": "GitHub Issue Comment", "type": "main", "index": 0}],
       [{"node": "GitHub Issue Comment", "type": "main", "index": 0}, {"node": "Telegram 알림", "type": "main", "index": 0}],
-      [{"node": "GitHub Issue Comment", "type": "main", "index": 0}, {"node": "Telegram 알림", "type": "main", "index": 0}]
+      [{"node": "GitHub Issue Comment", "type": "main", "index": 0}, {"node": "Telegram 알림", "type": "main", "index": 0}],
+      [{"node": "Telegram 알림", "type": "main", "index": 0}]
     ]}
   },
   "active": true,


### PR DESCRIPTION
## 요약

전체 품질 감사(2026-06-25) **doc-design-guide** 발견 — n8n 자동수정 통합 가이드(`n8n-auto-fix.md`) 산문이 출하 아티팩트(`n8n-workflow.json`)·실제 코드(`src/notifier/n8n.py`·`github_issue.py`)와 다수 불일치. doc/JSON-only 정합 (src 무변경).

## P1 수정

| # | 발견 | 수정 |
|---|------|------|
| **001** | `claude_fix.sh` `$PROMPT` 빈 프롬프트 — `sh -c '...'` 비-export 서브셸이 부모 변수 미상속 → claude 무지시 실행 | `printf '%s' "$PROMPT" \| timeout 900 claude` 로 printf 를 부모 셸에서 실행. **+ rc 캡처(`\|\| rc=$?`)로 timeout(124) 종료코드 보존** (exit code 표 정합, Codex NG 반영) |
| **002** | HMAC: 산문=hard-reject vs 출하 JSON=soft-pass(무인증 트리거 차단 불가) | soft-pass 가 **Python `json.dumps`(공백O)↔JS `JSON.stringify`(공백X) 직렬화 불일치** 회피용임을 ⚠️ 명시 + **rawBody hard-reject 하드닝 의무 + 운영자 실 n8n 검증 영역**(정책 11) 표기. 체크리스트·트러블슈팅·JSON 주석 정합 |
| **003** | 토큰 모델: "SCAManager 코드 변경 없음" 단언 + Node 6 `GH_TOKEN=credential` | 실제는 `notify_n8n_issue()` 가 `repo_token` 을 envelope 로 relay(HMAC 시크릿 설정 시만, `n8n.py:93-95`). Node 6 → `{{ $json.repo_token }}` payload relay, ANTHROPIC_API_KEY=호스트 env, credential 표 정합 |

## P2 수정

- **봇 PR 가드**: `pipeline.py` 단일 `claude-fix/` → 실제 `github_issue.py:22` `_BOT_PR_PREFIXES`(4종) + `is_enabled` any().
- **이벤트 필터 `combineOperation:any` 로직 결함**: `event_type==issue` 만으로도 통과(closed/edited 트리거) ⚠️ + 2-stage IF/Code 노드 수정안.
- **Node 4 경로**: `$json.repo` → `$json.body.repo`(출하 JSON Set 노드 일치, Codex NG 반영).
- **Switch fallbackOutput(124 timeout) 연결 누락**: JSON output 4 → Telegram 연결 추가(Codex NG 반영).
- **Node 8 Issue Comment / Node 9 Telegram**: 출하 JSON = generic body·하드코딩 chatId·disabled → 번들 baseline 명시 + 케이스별/exit별은 "권장 커스터마이징"(Codex 전수대조 NG 반영).
- Execute=Code execFileSync · Telegram disabled · ANTHROPIC_API_KEY 호스트 env.

## 🔍 사용자(운영자) 검증 필요 (정책 11)

n8n 워크플로 보안/로직 하드닝은 **Claude 정적 검증 불가** — 운영자 실 n8n 인스턴스 검증 의무:
- [ ] HMAC **hard-reject + Raw Body** 검증이 실제 webhook 에서 정상 통과하는지 (직렬화 불일치 미발생)
- [ ] Telegram `chatId` 하드코딩값 교체 + 노드 활성화
- [ ] 이벤트 필터 2-stage/Code 노드 교체(closed/edited 오트리거 방지)

## 🔍 Codex 검증 (push 전, 정책 18)

**Codex mutual 검증: OK** (4-커밋 시리즈 `347d99e→1da82de→3eebcb2→f483f9f`). Codex 가 적대 전수 Node 대조로 4건 추가 불일치 적발 → 전부 단일정답 버그로 즉시 수정(정책 18 §3b): timeout exit code 보존 · Node 4 `body.*` 경로 · Switch fallbackOutput 연결 · Node 8/9 baseline 정합. 최종 잔여 불일치 0 확인 후 push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
