### PR TITLE
chore: 품질감사 quick wins — cron drift·false-confidence 정직화·CI 주석·테스트 위생

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 # 최소 권한 원칙 — GITHUB_TOKEN 을 읽기 전용으로 제한 (회고 P2 공급망 하드닝).
-# 모든 job(secret-scan/test-and-analyze/pg-concurrency)이 read 만 필요 — write 필요 step 없음.
+# 모든 job(secret-scan/lint-changed-tests/test-and-analyze/pg-concurrency)이 read 만 필요 — write 필요 step 없음.
 # (SonarCloud PR 데코레이션은 SonarCloud GitHub App 경유 — GITHUB_TOKEN write 불필요.)
 # Least-privilege — restrict GITHUB_TOKEN to read-only (retro P2 supply-chain hardening).
 # All jobs need read only — no write step. (SonarCloud PR decoration goes via the SonarCloud

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,13 +100,13 @@ repos:
         description: config.py Settings env 필드 ↔ env-vars.md 등재 정합 (사이클 82/119 누락 차단).
 
       - id: check-config-5way-sync
-        name: "🧩 5-way config 싱크 (RepoConfig ORM↔Data↔Update)"
+        name: "🧩 config 싱크 — RepoConfig 3-layer (ORM↔Data↔Update)"
         language: system
         entry: python scripts/check_config_5way_sync.py
         files: "^(src/models/repo_config\\.py|src/config_manager/manager\\.py|src/api/repos\\.py)$"
         pass_filenames: false
         stages: [pre-commit]
-        description: RepoConfig 5-way 필드 집합 정합 (필드 추가 시 NULL 덮어쓰기 운영 버그 차단).
+        description: "RepoConfig 3-layer(Python: ORM↔Data↔Update) 필드 정합. 폼/PRESETS 2-layer 는 HTML/JS 파싱 fragile 로 범위 외(수동 검토 — design 2026-06-23)."
 
       - id: check-bilingual-comments
         name: "🌐 이중언어 주석 (보수적·staged 한정)"

--- a/README.ko.md
+++ b/README.ko.md
@@ -279,7 +279,7 @@ PR 분석 완료
 `auto_merge=true` 상태에서 CI가 실행 중(`mergeable_state=unstable` 또는 `unknown`)이어서 머지에 실패하면, 포기하는 대신 재시도 큐에 등록합니다:
 
 - 첫 큐 등록 시 Telegram "⏳ merge queued" 알림 (1회)
-- `check_suite.completed` Webhook 또는 5분 cron으로 최대 30회, 24시간 재시도
+- `check_suite.completed` Webhook 또는 1분 cron으로 최대 30회, 24시간 재시도
 - 최종 결과: Telegram 성공/실패 알림 (1회)
 
 > **기존 리포**는 `check_suite` 이벤트 구독을 위해 Webhook 재등록 필요 (설정 → Card ⑤ → "Webhook 재등록")

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Analysis complete
 When `auto_merge=true` and the merge fails because CI is still running (`mergeable_state=unstable` or `unknown`), SCAManager queues the PR for retry instead of giving up:
 
 - First queue: Telegram "⏳ merge queued" notification (1×)
-- Up to 30 retries over 24 hours via `check_suite.completed` webhook or 5-min cron
+- Up to 30 retries over 24 hours via `check_suite.completed` webhook or 1-min cron
 - Final result: Telegram success/failure notification (1×)
 
 > **Existing repos** need Webhook re-registration (Settings → Card ⑤ → "Reinstall Webhook") to subscribe to `check_suite` events.

--- a/scripts/check_config_5way_sync.py
+++ b/scripts/check_config_5way_sync.py
@@ -3,10 +3,13 @@
 3-way config 싱크 점검 — RepoConfig ORM ↔ RepoConfigData ↔ RepoConfigUpdate 필드 집합 정합.
 3-way config sync checker — field-set parity across the three RepoConfig Python layers.
 
-채널/필드 추가 시 일부 레이어 누락 → NULL 덮어쓰기 운영 버그(api.md 5-way) 차단.
+채널/필드 추가 시 Python 레이어 누락 → NULL 덮어쓰기 운영 버그(api.md 5-way)의 일부를 차단.
 Python 3자(ORM·Data·Update)는 AST 견고 비교. 의도적 비대칭 필드는 _ALLOWLIST 제외. stdlib 전용.
+🔴 범위 외(수동 검토 의무): settings.html 폼·PRESETS(JS) 2-layer 는 HTML/JS 파싱 fragile 로 의도적
+미검사(design 2026-06-23). 즉 파일명의 "5way"와 달리 실제 가드 범위는 Python 3-layer 다.
 
-Channel/field additions that miss a layer can silently NULL-overwrite DB values (api.md 5-way rule).
+Blocks the Python-layer subset of the api.md 5-way NULL-overwrite bug. The settings.html form and
+PRESETS (JS) layers are intentionally OUT OF SCOPE (fragile HTML/JS parsing) — manual review required.
 Three Python layers (ORM, Data, Update) are compared via AST (reliable). stdlib only.
 """
 import ast

--- a/tests/unit/analyzer/pure/test_registry.py
+++ b/tests/unit/analyzer/pure/test_registry.py
@@ -314,7 +314,7 @@ class TestPythonAnalyzers:
         )
 
     @pytest.fixture
-    def test_py_ctx(self):
+    def py_test_file_ctx(self):
         """테스트 파일 Python 컨텍스트 — bandit은 비활성화되어야 한다."""
         from src.analyzer.pure.registry import AnalyzeContext
         return AnalyzeContext(
@@ -350,10 +350,10 @@ class TestPythonAnalyzers:
         from src.analyzer.io.tools.python import _BanditAnalyzer
         assert _BanditAnalyzer().is_enabled(py_ctx) is True
 
-    def test_bandit_analyzer_is_disabled_for_test_file(self, test_py_ctx):
+    def test_bandit_analyzer_is_disabled_for_test_file(self, py_test_file_ctx):
         # _BanditAnalyzer.is_enabled()는 is_test=True 컨텍스트에서 False를 반환한다
         from src.analyzer.io.tools.python import _BanditAnalyzer
-        assert _BanditAnalyzer().is_enabled(test_py_ctx) is False
+        assert _BanditAnalyzer().is_enabled(py_test_file_ctx) is False
 
     def test_flake8_analyzer_category_is_code_quality(self):
         # _Flake8Analyzer.category는 "code_quality"이다

--- a/tests/unit/api/test_repo_insights_route.py
+++ b/tests/unit/api/test_repo_insights_route.py
@@ -33,7 +33,7 @@ def db_session():
 
 
 @pytest.fixture()
-def test_user(db_session):
+def owner_user(db_session):
     u = User(github_id=1, github_login="owner", email="owner@x.com", display_name="O")
     db_session.add(u)
     db_session.commit()
@@ -51,8 +51,8 @@ def other_user(db_session):
 
 
 @pytest.fixture()
-def repo(db_session, test_user):
-    r = Repository(full_name="owner/myrepo", user_id=test_user.id)
+def repo(db_session, owner_user):
+    r = Repository(full_name="owner/myrepo", user_id=owner_user.id)
     db_session.add(r)
     db_session.commit()
     db_session.refresh(r)
@@ -84,8 +84,8 @@ def _make_client(db_session, user):
 
 
 @pytest.fixture()
-def client(db_session, test_user):
-    yield from _make_client(db_session, test_user)
+def client(db_session, owner_user):
+    yield from _make_client(db_session, owner_user)
 
 
 @pytest.fixture()


### PR DESCRIPTION
## 요약

전체 품질 감사(2026-06-25) **P2 quick wins** 묶음 — 저위험 doc/naming/CI 정합 + 테스트 위생.

## 변경

| 항목 | 발견 | 수정 |
|------|------|------|
| **cron drift** | doc-root-002 / migration-integrity-002 | `README.md`·`README.ko.md` retry cron "5분/5-min" → **"1분/1-min"** (정본 `railway.toml` `* * * * *`·내부 docs 1분 정합) |
| **false-confidence 명명** | ci-supply-chain-001 | `check_config_5way_sync` 훅명·description·docstring 을 **"3-layer(ORM↔Data↔Update)"** 로 정직화 + 폼/PRESETS 2-layer 의도적 범위 외 명문화 (실제 검사 범위와 일치) |
| **CI 주석 stale** | ci-supply-chain-003 | `ci.yml` 권한 주석 job 목록에 `lint-changed-tests` 추가(4 job 실제 반영) |
| **테스트 위생** | tests-quality-001 | `test_` 접두 fixture 2건 rename: `test_user`→`owner_user` · `test_py_ctx`→`py_test_file_ctx` (`@pytest.fixture` 누락 시 assertion-free 테스트 silent 수집 잠재위험 제거) |

## 자율 판단 보고 (정책 3)

**`check_config_5way_sync.py` 파일명·훅 id 는 유지**했습니다 (정책 17 안정성 우선). audit 권장은 파일 rename(`check_config_3way_sync.py`)이었으나, 파일명/id 변경은 `.pre-commit-config` entry·architecture.md 트리·SKIP 참조 등 cross-file churn 위험이 있고, 갭은 이미 design 문서·cycle-history 에 명문화되어 실위험이 낮습니다. **표시명(name)·description·docstring 만 정직화**해 false-confidence 의 가장 가시적 지점을 해소했습니다. 이의 있으시면 파일 rename 으로 추가 진행하겠습니다.

## 테스트

테스트 수 불변(rename + docs only). `pytest tests/unit/api/test_repo_insights_route.py tests/unit/analyzer/pure/test_registry.py` → **58 passed**.

## 🔍 사용자 검증 필요 (정책 2)

- [ ] (선택) 운영 retry cron 주기가 실제 1분(`railway.toml`)인지 — 문서 정정값과 운영 SLA 일치 확인.

## 🔍 Codex 검증 (push 전, 정책 18)

**Codex mutual 검증: OK** — cron 정본(railway.toml) 대조·check_config 동작 일치·ci.yml 4 job·fixture 참조 전수 갱신 확인 + Codex 직접 pytest 58 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
