### PR TITLE
fix(notifier): Slack AI 요약 i18n 비대칭 + truncate_message 경계 봉인 (품질감사 P2)

### DIFF
--- a/src/notifier/_common.py
+++ b/src/notifier/_common.py
@@ -51,10 +51,16 @@ def get_all_issues(analysis_results: list) -> list:
 
 
 def truncate_message(text: str, max_length: int, suffix: str = "...") -> str:
-    """텍스트를 max_length 이하로 절단하고 suffix를 붙인다."""
+    """텍스트를 max_length 이하로 절단하고 suffix를 붙인다 (출력 길이 ≤ max_length 보장).
+
+    Truncate to <= max_length and append suffix (output length never exceeds max_length).
+    """
     if len(text) <= max_length:
         return text
-    return text[:max_length - len(suffix)] + suffix
+    # max_length < len(suffix) 시 음수 슬라이스 방지 + 최종 클램프로 계약 보장 (감사 notifier-004)
+    # Guard against negative slice when max_length < len(suffix); final clamp enforces the contract.
+    cut = max(max_length - len(suffix), 0)
+    return (text[:cut] + suffix)[:max_length]
 
 
 def truncate_issue_msg(msg: str) -> str:

--- a/src/notifier/slack.py
+++ b/src/notifier/slack.py
@@ -12,7 +12,8 @@ from src.scorer.calculator import ScoreResult
 from src.analyzer.io.static import StaticAnalysisResult
 from src.analyzer.io.ai_review import AiReviewResult
 from src.notifier._common import (
-    escape_slack_mrkdwn, format_ref, get_all_issues, truncate_issue_msg, truncate_message,
+    escape_slack_mrkdwn, format_ref, get_all_issues, resolve_ai_summary,
+    truncate_issue_msg, truncate_message,
 )
 
 logger = logging.getLogger(__name__)
@@ -52,8 +53,12 @@ def _build_payload(  # pylint: disable=too-many-positional-arguments,too-many-lo
     )
 
     blocks = []
-    if ai_review and ai_review.summary:
-        blocks.append(ai_review.summary)
+    # AI 요약은 resolve_ai_summary 경유 — 실패(status != success) 시 현지화된 unavailable 메시지로 대체
+    # (5채널 동일 패턴 — Slack i18n 비대칭 봉인, 감사 notifier-001)
+    # Route AI summary through resolve_ai_summary so failures show the localized unavailable message.
+    ai_summary = resolve_ai_summary(ai_review, language)
+    if ai_summary:
+        blocks.append(ai_summary)
 
     all_issues = get_all_issues(analysis_results)
     if all_issues:

--- a/tests/unit/notifier/test_common_truncate.py
+++ b/tests/unit/notifier/test_common_truncate.py
@@ -1,0 +1,31 @@
+"""truncate_message 경계 회귀 가드 (품질감사 notifier-004).
+
+truncate_message boundary regression guard (audit notifier-004).
+
+max_length < len(suffix) 일 때 기존 구현 `text[:max_length - len(suffix)]` 은 음수 슬라이스가 되어
+출력이 오히려 max_length 를 초과하는 계약 위반이 발생했다(예: truncate_message("hello world", 2)
+== "hello worl..."). 현재 운영 호출자(discord 4096·slack 3000·telegram 4096·기본 80)는 suffix(3)보다
+훨씬 커 도달 불가였으나 잠재 footgun → 출력 ≤ max_length 계약을 봉인한다.
+"""
+import pytest
+
+from src.notifier._common import truncate_message
+
+
+@pytest.mark.parametrize("max_length", [0, 1, 2, 3])
+def test_truncate_never_exceeds_max_length_below_suffix(max_length):
+    """max_length 가 suffix 길이 이하라도 출력은 max_length 를 넘지 않는다."""
+    out = truncate_message("hello world", max_length)
+    assert len(out) <= max_length, f"max_length={max_length} 인데 출력 {out!r}(len {len(out)}) 초과"
+
+
+def test_truncate_no_truncation_when_within_limit():
+    """한도 이내 텍스트는 그대로 반환 (회귀)."""
+    assert truncate_message("short", 100) == "short"
+
+
+def test_truncate_appends_suffix_when_over_limit():
+    """한도 초과 + 충분한 여유 시 잘라내고 suffix 부착 (정상 케이스 회귀)."""
+    out = truncate_message("hello world", 8)
+    assert out == "hello..."
+    assert len(out) == 8

--- a/tests/unit/notifier/test_slack.py
+++ b/tests/unit/notifier/test_slack.py
@@ -68,6 +68,26 @@ def test_build_payload_includes_ai_summary():
     assert "좋은 리팩토링입니다." in attachment_text
 
 
+def test_build_payload_localizes_ai_summary_on_failure():
+    """notifier-001: AI 리뷰 실패(status != success) 시 Slack 도 raw summary 대신 현지화 메시지.
+
+    Slack 만 resolve_ai_summary 를 우회해 parse_error 등에서 원시 요약을 현지화 없이 노출하던
+    i18n 비대칭(타 4채널은 헬퍼 경유) 회귀 가드. status=parse_error 는 summary 가 비어있지 않을 수 있다.
+    """
+    ai = AiReviewResult(
+        commit_score=17, ai_score=15, test_score=10,
+        summary="원시 한국어 요약 누출",  # non-empty raw summary on failure path
+        suggestions=[],
+        status="parse_error",
+    )
+    payload = _build_payload(
+        "owner/repo", "abc1234", _make_score(), _make_analysis(), None, ai_review=ai, language="ko",
+    )
+    attachment_text = payload["attachments"][0].get("text", "")
+    assert "AI 리뷰 불가" in attachment_text  # 현지화된 unavailable 메시지 노출
+    assert "원시 한국어 요약 누출" not in attachment_text  # 원시 요약 누출 차단
+
+
 def test_build_payload_includes_issues():
     issues = [AnalysisIssue(tool="pylint", severity="error", message="undefined variable x", line=5)]
     payload = _build_payload("owner/repo", "abc1234", _make_score(), _make_analysis(issues), None)


### PR DESCRIPTION
## 요약

전체 품질 감사(2026-06-25) **notifier P2** 묶음 (TDD, churn 0).

| 발견 | 수정 |
|------|------|
| **notifier-001** Slack i18n 비대칭 | `slack.py` 만 `ai_review.summary` 직접 사용 → AI 실패(`status=parse_error` 등, summary 비어있지 않을 수 있음) 시 원시 요약을 **현지화 없이 노출**. `resolve_ai_summary(ai_review, language)` 경유로 전환 → 5채널(email/discord/telegram/github_comment/slack) 동일 패턴(실패 시 현지화 `ai_unavailable`) |
| **notifier-004** truncate_message 경계 | `text[:max_length - len(suffix)]` 가 `max_length < len(suffix)` 시 **음수 슬라이스 → 출력이 한도 초과**(`truncate('hello world', 2)=='hello worl...'`). `cut=max(.,0)` + 최종 `[:max_length]` 클램프로 **출력 ≤ max_length 계약 봉인** |

현 운영 호출자(discord 4096·slack 3000·telegram 4096·기본 80)는 truncate 음수 슬라이스 도달 불가였으나 잠재 footgun 차단.

## 테스트 (TDD)

- 신규 `test_common_truncate.py`: max_length 0/1/2/3 경계 출력 ≤ 한도(parametrize 4) + 정상 회귀 2 → 수정 전 **RED**(0/1/2), 후 **GREEN**.
- `test_slack.py` +1: `status=parse_error` + 비어있지 않은 summary 시 현지화 메시지 노출 & 원시 요약 미누출 → RED→GREEN.
- 단위 +7. `pytest tests/unit/notifier/` → **286 passed**, 회귀 0.

## 🔍 Codex 검증 (push 전, 정책 18)

**Codex mutual 검증: OK** — slack import/인자/success 회귀·truncate 전 경계(0 포함) 출력 ≤ max_length·정상 케이스 불변 확인. (참고: Codex companion 은 ChatGPT 계정에서 `pytest` 직접 실행 불가 → pytest 결과 제공 + diff 정적 리뷰로 검증.)

## 자율 판단 보고 (정책 3)

**notifier-002 (n8n HMAC 서명 바이트)는 본 PR 에서 보류** — `_post_to_n8n` 의 `json=payload` → `content=signed_bytes` 전환은 16개 테스트 helper(`_captured_payload` = `kwargs["json"]`)를 깨뜨리는 cross-file churn 이 있고, 현재 httpx 기본 separators 가 `json.dumps` 와 일치해 정상 동작하는 P2 fragility 입니다(PR #990 에서 n8n 측 rawBody hard-reject 하드닝은 운영자 영역으로 이미 문서화). 잔여 P2 정리에 포함해 별도 결정받겠습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
