### PR TITLE
fix(robustness): github_client repo_path 인코딩 정합 + DB config 하한 검증 (품질감사 P2)

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -99,10 +99,10 @@ Sentry 외 자동 로깅은 별도 환경변수 없이 동작:
 |------|------|--------|
 | `DB_SSLMODE` | PostgreSQL SSL 모드 (`require`, `verify-full`, `disable` 등, 빈 값=미적용) | 빈 문자열 |
 | `DB_FORCE_IPV4` | Railway IPv4 강제 연결 (온프레미스에서는 `false`) | `false` |
-| `DB_POOL_SIZE` | SQLAlchemy 연결 풀 크기 (PostgreSQL 전용) | `5` |
-| `DB_MAX_OVERFLOW` | 풀 초과 허용 연결 수 | `10` |
-| `DB_POOL_TIMEOUT` | 풀 대기 타임아웃 (초) | `30` |
-| `DB_POOL_RECYCLE` | 연결 재활용 주기 (초) | `1800` |
+| `DB_POOL_SIZE` | SQLAlchemy 연결 풀 크기 (PostgreSQL 전용, **최소 1**) | `5` |
+| `DB_MAX_OVERFLOW` | 풀 초과 허용 연결 수 (`-1`=무제한 sentinel) | `10` |
+| `DB_POOL_TIMEOUT` | 풀 대기 타임아웃 (초, **최소 1**) | `30` |
+| `DB_POOL_RECYCLE` | 연결 재활용 주기 (초, `-1`=비활성 sentinel) | `1800` |
 
 ## CI-aware Auto Merge 재시도 (Phase 12)
 
@@ -128,7 +128,7 @@ Sentry 외 자동 로깅은 별도 환경변수 없이 동작:
 | 변수 | 설명 | 예시 |
 |------|------|------|
 | `DATABASE_URL_FALLBACK` | Failover용 보조 DB URL (빈 값이면 failover 비활성) | `postgresql://user:pass@supabase.co/db?sslmode=require` |
-| `DB_FAILOVER_PROBE_INTERVAL` | Primary DB 복구 확인 주기 (초) | `30` |
+| `DB_FAILOVER_PROBE_INTERVAL` | Primary DB 복구 확인 주기 (초, **최소 1** — 0 시 busy-loop) | `30` |
 | `DATABASE_URL_WORKER` | background(webhook/worker/gate/notifier/cron/CLI hook) 전용 DB URL — RLS role 분리 옵션 A ([rls-role-separation.md](../runbooks/rls-role-separation.md) Phase 2). 빈 값이면 `DATABASE_URL` 팩토리 재사용 (현행 동작). 반드시 `BYPASSRLS` worker role(`scamanager_worker`) 자격 지정 — 비-BYPASSRLS role 지정 시 FORCE 활성 후 background 차단. ⚠️ 트레이드오프: worker 경로 failover 미지원 (primary 장애 시 background 중단) + 동일 프로세스 연결 풀 2배 (Supabase 연결 상한 고려) | `postgresql://scamanager_worker:pass@host/db` |
 | `MIGRATION_DATABASE_URL` | alembic 마이그레이션 전용 DB URL (**owner role**) — RLS Phase 4 "두 번째 벽" ([rls-role-separation.md](../runbooks/rls-role-separation.md) §6 마이그레이션 credential 게이트). `alembic/env.py` 가 `effective_migration_url`(= 이 값 또는 `DATABASE_URL`)을 `sqlalchemy.url` 로 사용 → pre-deploy `alembic upgrade head` + lifespan 양쪽에 적용. 빈 값이면 `DATABASE_URL` 사용 (**현행 동작 보존 — 미설정 시 발효 0**). 🔴 Phase 4 에서 `DATABASE_URL` 이 비-BYPASSRLS app role(`scamanager_app`)로 전환될 때 설정 — 미설정 시 마이그레이션이 app role 로 돌아 `alembic_version` default-deny 차단. 🔴 런타임 `DATABASE_URL`/`DATABASE_URL_WORKER` 를 마이그레이션 credential 로 재사용 금지 | `postgresql://postgres:pass@host/db` |
 

--- a/src/config.py
+++ b/src/config.py
@@ -81,13 +81,18 @@ class Settings(BaseSettings):
     # DB 연결 설정 (온프레미스 PostgreSQL 지원)
     db_sslmode: str = ""        # "require", "verify-full" 등 (빈 문자열=미적용)
     db_force_ipv4: bool = False  # True=Railway IPv4 강제 (온프레미스에서는 False)
-    db_pool_size: int = 5
-    db_max_overflow: int = 10
-    db_pool_timeout: int = 30   # seconds
-    db_pool_recycle: int = 1800  # seconds
+    # 🔴 하한 검증 (감사 data-layer-003) — <1 이 무조건 오동작인 필드만 ge=1.
+    # max_overflow(-1=무제한)·pool_recycle(-1=비활성)은 -1 sentinel 이 유효해 미제약(SQLAlchemy 의미론 보존).
+    # Lower-bound validation: only fields where <1 is always broken get ge=1; max_overflow/pool_recycle
+    # keep the valid SQLAlchemy -1 sentinel (unlimited / disabled) so they are intentionally unconstrained.
+    db_pool_size: int = Field(default=5, ge=1)
+    db_max_overflow: int = 10  # -1=무제한 sentinel 허용 (미제약)
+    db_pool_timeout: int = Field(default=30, ge=1)   # seconds
+    db_pool_recycle: int = 1800  # seconds (-1=recycle 비활성 sentinel 허용, 미제약)
     # DB Failover 설정 (빈 문자열이면 failover 비활성)
     database_url_fallback: str = ""
-    db_failover_probe_interval: int = 30  # Primary 복구 확인 주기(초)
+    # 🔴 ge=1 — 0/음수 시 _probe_primary_loop 가 time.sleep(0) busy-loop (100% CPU) (감사 data-layer-003)
+    db_failover_probe_interval: int = Field(default=30, ge=1)  # Primary 복구 확인 주기(초)
     # background 전용 DB URL — RLS role 분리 옵션 A (rls-role-separation.md Phase 2)
     # 빈 문자열이면 DATABASE_URL 팩토리 재사용 (현행 동작 보존)
     # Background-only DB URL — RLS role separation Option A (Phase 2).

--- a/src/github_client/graphql.py
+++ b/src/github_client/graphql.py
@@ -26,7 +26,7 @@ from typing import Any
 import httpx
 
 from src.constants import GITHUB_API
-from src.github_client.helpers import github_api_headers
+from src.github_client.helpers import github_api_headers, repo_path
 from src.shared.http_client import get_http_client
 from src.shared.log_safety import sanitize_for_log
 
@@ -154,7 +154,7 @@ async def get_pr_node_id(
     실패 시 None 반환 (호출자가 분기 처리).
     Returns None on failure (caller handles fallback).
     """
-    url = f"{GITHUB_API}/repos/{repo_full_name}/pulls/{pr_number}"
+    url = f"{GITHUB_API}/repos/{repo_path(repo_full_name)}/pulls/{pr_number}"
     try:
         client = get_http_client()
         r = await client.get(url, headers=github_api_headers(token))

--- a/src/github_client/issues.py
+++ b/src/github_client/issues.py
@@ -1,6 +1,6 @@
 """GitHub Issues API helpers."""
 from src.constants import GITHUB_API
-from src.github_client.helpers import github_api_headers
+from src.github_client.helpers import github_api_headers, repo_path
 from src.shared.http_client import get_http_client
 
 
@@ -11,7 +11,7 @@ async def close_issue(
     state_reason: str = "completed",
 ) -> None:
     """Issue 를 closed 상태로 전환. 실패 시 httpx.HTTPStatusError 전파."""
-    url = f"{GITHUB_API}/repos/{repo_full_name}/issues/{issue_number}"
+    url = f"{GITHUB_API}/repos/{repo_path(repo_full_name)}/issues/{issue_number}"
     client = get_http_client()  # 싱글톤
     resp = await client.patch(
         url,
@@ -32,7 +32,7 @@ async def create_issue(
     """GitHub Issue 를 생성하고 number·html_url·state 를 반환한다.
     Create a GitHub Issue and return its number, html_url, and state.
     """
-    url = f"{GITHUB_API}/repos/{repo_full_name}/issues"
+    url = f"{GITHUB_API}/repos/{repo_path(repo_full_name)}/issues"
     client = get_http_client()
     resp = await client.post(
         url,
@@ -56,7 +56,7 @@ async def get_issue_state(
     """GitHub Issue 현재 상태("open" | "closed")를 반환한다.
     Return the current state ("open" | "closed") of a GitHub Issue.
     """
-    url = f"{GITHUB_API}/repos/{repo_full_name}/issues/{issue_number}"
+    url = f"{GITHUB_API}/repos/{repo_path(repo_full_name)}/issues/{issue_number}"
     client = get_http_client()
     resp = await client.get(url, headers=github_api_headers(token))
     resp.raise_for_status()

--- a/tests/unit/github_client/test_repo_path_encoding.py
+++ b/tests/unit/github_client/test_repo_path_encoding.py
@@ -64,3 +64,14 @@ async def test_get_pr_node_id_url_uses_repo_path_encoding():
         await get_pr_node_id("token", _REPO, 7)
     url = client.get.call_args[0][0]
     assert _ENC in url and "re po" not in url
+
+
+async def test_normal_repo_full_name_url_unchanged():
+    """특수문자 없는 평문 owner/repo 는 슬래시 보존·인코딩 artifact 없이 그대로 (정상 케이스 회귀)."""
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=_resp({"state": "open"}))
+    with patch("src.github_client.issues.get_http_client", return_value=client):
+        await get_issue_state("token", "owner/myrepo", 1)
+    url = client.get.call_args[0][0]
+    assert "/repos/owner/myrepo/issues/1" in url
+    assert "%" not in url  # 인코딩 artifact 없음 (슬래시는 safe='/' 로 보존)

--- a/tests/unit/github_client/test_repo_path_encoding.py
+++ b/tests/unit/github_client/test_repo_path_encoding.py
@@ -1,0 +1,66 @@
+"""github_client issues.py·graphql.py URL 빌드의 repo_path() 인코딩 회귀 가드 (품질감사 webhook-ghclient-001).
+
+Regression guard: issues.py / graphql.py must build GitHub API repo URLs via repo_path()
+(checks.py·repos.py 와 일관 — security.md 'repo_path() 경유' 규칙 + SonarCloud S7044 방어 심층).
+
+repo_full_name 은 신뢰 입력(검증된 webhook/DB)이라 실 익스플로잇 위험은 낮으나, 단일출처 인코딩
+규칙 일관성을 봉인한다 — repo_path() 는 슬래시 보존 + 그 외 특수문자 percent-encode.
+"""
+import os
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("GITHUB_WEBHOOK_SECRET", "test_secret")
+os.environ.setdefault("GITHUB_TOKEN", "ghp_test")
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "123:ABC")
+os.environ.setdefault("TELEGRAM_CHAT_ID", "-100123")
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from src.github_client.issues import close_issue, create_issue, get_issue_state
+from src.github_client.graphql import get_pr_node_id
+
+_REPO = "owner/re po"  # 공백 = 인코딩되어야 함 / space must be encoded
+_ENC = "owner/re%20po"  # 슬래시 보존 + 공백 %20 / slash kept, space encoded
+
+
+def _resp(json_body):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json = MagicMock(return_value=json_body)
+    return r
+
+
+async def test_close_issue_url_uses_repo_path_encoding():
+    client = AsyncMock()
+    client.patch = AsyncMock(return_value=_resp({}))
+    with patch("src.github_client.issues.get_http_client", return_value=client):
+        await close_issue("token", _REPO, 42)
+    url = client.patch.call_args[0][0]
+    assert _ENC in url and "re po" not in url
+
+
+async def test_create_issue_url_uses_repo_path_encoding():
+    client = AsyncMock()
+    client.post = AsyncMock(return_value=_resp({"number": 1, "html_url": "x", "state": "open"}))
+    with patch("src.github_client.issues.get_http_client", return_value=client):
+        await create_issue("token", _REPO, title="t", body="b", labels=[])
+    url = client.post.call_args[0][0]
+    assert _ENC in url and "re po" not in url
+
+
+async def test_get_issue_state_url_uses_repo_path_encoding():
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=_resp({"state": "open"}))
+    with patch("src.github_client.issues.get_http_client", return_value=client):
+        await get_issue_state("token", _REPO, 42)
+    url = client.get.call_args[0][0]
+    assert _ENC in url and "re po" not in url
+
+
+async def test_get_pr_node_id_url_uses_repo_path_encoding():
+    client = AsyncMock()
+    client.get = AsyncMock(return_value=_resp({"node_id": "PR_abc"}))
+    with patch("src.github_client.graphql.get_http_client", return_value=client):
+        await get_pr_node_id("token", _REPO, 7)
+    url = client.get.call_args[0][0]
+    assert _ENC in url and "re po" not in url

--- a/tests/unit/test_db_config_validator.py
+++ b/tests/unit/test_db_config_validator.py
@@ -1,0 +1,62 @@
+"""DB 풀/probe config 하한 검증 회귀 가드 (품질감사 data-layer-003).
+
+DB pool/probe config lower-bound validation regression guard (audit data-layer-003).
+
+db_failover_probe_interval=0 이면 database.py::_probe_primary_loop 의 `while True: time.sleep(interval)`
+가 time.sleep(0) busy-loop(100% CPU)로 degenerate. db_pool_size=0/db_pool_timeout<1 도 무조건 오동작.
+→ <1 이 항상 broken 인 3 필드만 ge=1 (max_overflow/-1·pool_recycle/-1 sentinel 은 미제약, SQLAlchemy 보존).
+"""
+import pytest
+from pydantic import ValidationError
+
+from src.config import Settings
+
+_REQUIRED_KWARGS = dict(
+    database_url="sqlite:///:memory:",
+    github_webhook_secret="x",
+    github_token="x",
+    telegram_bot_token="123:ABC",
+    telegram_chat_id="-100",
+)
+
+
+def test_valid_db_defaults_construct_ok():
+    """기본값(5/10/30/1800/30)은 검증자가 거부하면 안 된다 (회귀 가드)."""
+    s = Settings(**_REQUIRED_KWARGS)
+    assert s.db_pool_size == 5
+    assert s.db_pool_timeout == 30
+    assert s.db_failover_probe_interval == 30
+
+
+def test_zero_failover_probe_interval_raises():
+    """db_failover_probe_interval=0 → busy-loop 위험 → ValidationError."""
+    with pytest.raises(ValidationError):
+        Settings(**_REQUIRED_KWARGS, db_failover_probe_interval=0)
+
+
+def test_negative_failover_probe_interval_raises():
+    with pytest.raises(ValidationError):
+        Settings(**_REQUIRED_KWARGS, db_failover_probe_interval=-5)
+
+
+def test_zero_pool_size_raises():
+    """db_pool_size=0 → 풀 고갈 → ValidationError."""
+    with pytest.raises(ValidationError):
+        Settings(**_REQUIRED_KWARGS, db_pool_size=0)
+
+
+def test_zero_pool_timeout_raises():
+    with pytest.raises(ValidationError):
+        Settings(**_REQUIRED_KWARGS, db_pool_timeout=0)
+
+
+def test_max_overflow_negative_one_allowed():
+    """db_max_overflow=-1(SQLAlchemy 무제한 sentinel)은 미제약 → 허용 (회귀 가드)."""
+    s = Settings(**_REQUIRED_KWARGS, db_max_overflow=-1)
+    assert s.db_max_overflow == -1
+
+
+def test_pool_recycle_negative_one_allowed():
+    """db_pool_recycle=-1(SQLAlchemy recycle 비활성 sentinel)은 미제약 → 허용 (회귀 가드)."""
+    s = Settings(**_REQUIRED_KWARGS, db_pool_recycle=-1)
+    assert s.db_pool_recycle == -1

--- a/tests/unit/test_db_config_validator.py
+++ b/tests/unit/test_db_config_validator.py
@@ -60,3 +60,16 @@ def test_pool_recycle_negative_one_allowed():
     """db_pool_recycle=-1(SQLAlchemy recycle 비활성 sentinel)은 미제약 → 허용 (회귀 가드)."""
     s = Settings(**_REQUIRED_KWARGS, db_pool_recycle=-1)
     assert s.db_pool_recycle == -1
+
+
+def test_ge1_boundary_value_one_allowed():
+    """ge=1 경계값 1 은 허용되어야 한다 (off-by-one 회귀 — 1 까지 거부하면 안 됨)."""
+    s = Settings(
+        **_REQUIRED_KWARGS,
+        db_pool_size=1,
+        db_pool_timeout=1,
+        db_failover_probe_interval=1,
+    )
+    assert s.db_pool_size == 1
+    assert s.db_pool_timeout == 1
+    assert s.db_failover_probe_interval == 1


### PR DESCRIPTION
## 요약

전체 품질 감사(2026-06-25) **robustness P2** 묶음 (TDD).

| 발견 | 수정 |
|------|------|
| **webhook-ghclient-001** repo_path 인코딩 비일관 | `issues.py`(close/create/get_issue_state 3 URL)·`graphql.py`(get_pr_node_id 1 URL)가 GitHub API URL 에 raw `repo_full_name` 삽입 → `checks.py`·`repos.py` 와 비일관(security.md `repo_path()` 규칙 + SonarCloud S7044 방어심층). **`repo_path()` 적용**(슬래시 보존 + 특수문자 percent-encode 일관화) |
| **data-layer-003** DB config 하한 부재 | `db_failover_probe_interval=0` 시 `_probe_primary_loop` 가 `time.sleep(0)` **busy-loop(100% CPU)**. `<1` 이 항상 broken 인 `db_pool_size`·`db_pool_timeout`·`db_failover_probe_interval` 만 **`Field(ge=1)`**. `db_max_overflow`(-1=무제한)·`db_pool_recycle`(-1=비활성)은 **SQLAlchemy -1 sentinel 유효라 의도적 미제약** |

`repo_full_name` 은 신뢰 입력(검증된 webhook/DB)이라 실 익스플로잇 위험은 낮음 — 단일출처 인코딩 규칙 정합 + 방어심층.

## 테스트 (TDD)

- `test_repo_path_encoding.py` (신규): issues 3 + graphql 1 URL 의 `owner/re po`→`owner/re%20po` 인코딩(슬래시 보존) + 평문 정상케이스(% artifact 없음) → 수정 전 RED, 후 GREEN.
- `test_db_config_validator.py` (신규): probe_interval/pool_size/pool_timeout =0·음수 거부 + max_overflow/pool_recycle=-1 허용 + ge=1 경계값 1 허용.
- 단위 +13. github_client+config+failover **216 passed** + 신규 13 passed.
- `env-vars.md` 동기화: DB pool/probe 최솟값 제약 + -1 sentinel 명시 (CLAUDE.md config↔env-vars 의무).

## 🔍 Codex 검증 (push 전, 정책 18)

**Codex mutual 검증: OK** (3 커밋 `b30d7af→673c5e4→332256e`). 코드 정확성(repo_path 슬래시 보존·4 URL 적용·DB ge=1 broken 근거·max_overflow/pool_recycle 미제약 SQLAlchemy 의미론 타당) OK + adversarial NG 2건(테스트 완전성: 정상케이스·경계값 1) 즉시 보강 후 최종 OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
