### PR TITLE
fix: 품질감사 minor P2 묶음 — grade 순서·repo_kpi 결정성·KeyError·캐시 상한

### DIFF
--- a/src/scorer/calculator.py
+++ b/src/scorer/calculator.py
@@ -100,7 +100,9 @@ def calculate_score(
 
 def calculate_grade(score: int) -> str:
     """점수(0–100)를 등급 문자열(A/B/C/D/F)로 변환한다."""
-    for grade, threshold in GRADE_THRESHOLDS.items():
+    # 임계값 내림차순 정렬 — dict 삽입 순서 의존 제거(순서 바뀌어도 정답, 감사 worker-core-001)
+    # Sort thresholds descending so the result is independent of dict insertion order.
+    for grade, threshold in sorted(GRADE_THRESHOLDS.items(), key=lambda kv: kv[1], reverse=True):
         if score >= threshold:
             return grade
     return "F"

--- a/src/services/repo_insight_service.py
+++ b/src/services/repo_insight_service.py
@@ -116,6 +116,9 @@ def repo_kpi(  # pylint: disable=too-many-locals
             .where(Analysis.created_at >= prev_since)
             .where(Analysis.created_at < prev_until)
             .where(Analysis.result.isnot(None))
+            # cur(_fetch_analyses)와 동일하게 정렬 — limit(_MAX_ANALYSES) 결정성 확보(감사 services-002)
+            # Order like cur so the limited window is deterministic (avoids flaky score_delta).
+            .order_by(Analysis.created_at.desc())
             .limit(_MAX_ANALYSES)
         ).all()
     )

--- a/src/ui/routes/add_repo.py
+++ b/src/ui/routes/add_repo.py
@@ -29,6 +29,20 @@ _user_repos_cache: dict[int, tuple[list[dict], float]] = {}
 # _required_contexts_cache / _webhook_secret_cache 와 동일 5분 TTL
 # Same 5-minute TTL as _required_contexts_cache / _webhook_secret_cache.
 _USER_REPOS_CACHE_TTL = 300
+# 🔴 상한 — 인증 사용자 누적 증가에 따른 무한 캐시 성장 차단 (api.md webhook-secret 캐시 패턴, 감사 api-ui-001)
+# Cap entries to bound growth across distinct authenticated users (mirrors the webhook-secret cache).
+_USER_REPOS_CACHE_MAX = 1024
+
+
+def _store_user_repos(user_id: int, repos: list[dict], now: float) -> None:
+    """TTL 캐시에 저장하되 상한 초과 시 만료분 정리 + 가장 빨리 만료될 엔트리 evict."""
+    # Store with TTL; on overflow purge expired then evict the soonest-to-expire entry.
+    if user_id not in _user_repos_cache and len(_user_repos_cache) >= _USER_REPOS_CACHE_MAX:
+        for k in [k for k, (_, exp) in _user_repos_cache.items() if now >= exp]:
+            del _user_repos_cache[k]
+        if len(_user_repos_cache) >= _USER_REPOS_CACHE_MAX:
+            del _user_repos_cache[min(_user_repos_cache, key=lambda k: _user_repos_cache[k][1])]
+    _user_repos_cache[user_id] = (repos, now + _USER_REPOS_CACHE_TTL)
 
 
 @router.get("/repos/add", response_class=HTMLResponse)
@@ -67,7 +81,7 @@ async def github_repos_list(
             # GitHub API 오류(401/403/429/timeout) 시 빈 목록 반환
             # Return empty list on GitHub API error (401/403/429/timeout)
             return []
-        _user_repos_cache[current_user.id] = (all_repos, now + _USER_REPOS_CACHE_TTL)
+        _store_user_repos(current_user.id, all_repos, now)
 
     with SessionLocal() as db:
         existing_names = {

--- a/src/worker/pipeline.py
+++ b/src/worker/pipeline.py
@@ -366,7 +366,9 @@ def _extract_event_metadata(event: str, data: dict) -> tuple[str, str, str, int 
     repo_name: str = (data.get("repository") or {}).get("full_name", "")
     commit_message = _extract_commit_message(event, data)
     if event == "pull_request":
-        pr_number: int | None = data["number"]
+        # data.get — 같은 블록의 다른 키(repository/head)와 방어 일관성(감사 worker-core-003)
+        # data.get for defensive consistency with the other keys in this block.
+        pr_number: int | None = data.get("number")
         # head 키도 present-but-None 가능 — 한 단계 더 `or {}` 정규화 (PR #124 패턴)
         # head key may also be present-but-None — normalize one more level (PR #124 pattern)
         commit_sha: str = ((data.get("pull_request") or {}).get("head") or {}).get("sha", "")

--- a/tests/unit/test_minor_p2_batch.py
+++ b/tests/unit/test_minor_p2_batch.py
@@ -61,3 +61,35 @@ def test_store_user_repos_purges_expired_first():
         assert 10_000_000 in mod._user_repos_cache
     finally:
         mod._user_repos_cache.clear()
+
+
+def test_store_user_repos_existing_user_update_does_not_grow():
+    """기존 user 갱신은 크기를 늘리지 않고 evict 도 트리거하지 않는다 (user_id in cache 분기)."""
+    import src.ui.routes.add_repo as mod
+    mod._user_repos_cache.clear()
+    try:
+        now = 1000.0
+        for i in range(mod._USER_REPOS_CACHE_MAX):
+            mod._user_repos_cache[i] = ([], now + mod._USER_REPOS_CACHE_TTL)
+        before = len(mod._user_repos_cache)
+        mod._store_user_repos(0, [{"updated": 1}], now)  # 기존 key 0 갱신
+        assert len(mod._user_repos_cache) == before  # 크기 불변
+        assert mod._user_repos_cache[0][0] == [{"updated": 1}]  # 값 갱신됨
+    finally:
+        mod._user_repos_cache.clear()
+
+
+def test_store_user_repos_evicts_soonest_to_expire():
+    """상한 초과(만료분 없음) 시 가장 빨리 만료될 엔트리를 evict 한다."""
+    import src.ui.routes.add_repo as mod
+    mod._user_repos_cache.clear()
+    try:
+        now = 1000.0
+        # 전부 미래-만료, key 0 이 가장 빨리 만료 (expiry 최소)
+        for i in range(mod._USER_REPOS_CACHE_MAX):
+            mod._user_repos_cache[i] = ([], now + 10 + i)
+        mod._store_user_repos(10_000_000, [{"x": 1}], now)
+        assert 0 not in mod._user_repos_cache  # 가장 빨리 만료될 엔트리 evict
+        assert 10_000_000 in mod._user_repos_cache
+    finally:
+        mod._user_repos_cache.clear()

--- a/tests/unit/test_minor_p2_batch.py
+++ b/tests/unit/test_minor_p2_batch.py
@@ -1,0 +1,63 @@
+"""품질감사 minor P2 묶음 회귀 가드 (2026-06-25).
+
+Audit minor-P2 batch regression guards: grade order-independence, PR payload KeyError defence,
+user-repos cache bound.
+"""
+
+
+def test_calculate_grade_independent_of_threshold_dict_order(monkeypatch):
+    """worker-core-001: GRADE_THRESHOLDS 삽입 순서를 뒤집어도(오름차순) 정답이어야 한다."""
+    # 오름차순(D 먼저) — sorted() 없으면 score>=45 가 먼저 매칭돼 모두 D 로 오분류
+    # Ascending order (D first) — without sorting, score>=45 matches first → mis-grades everything as D.
+    reordered = {"D": 45, "C": 60, "B": 75, "A": 90}
+    monkeypatch.setattr("src.scorer.calculator.GRADE_THRESHOLDS", reordered)
+    from src.scorer.calculator import calculate_grade
+    assert calculate_grade(95) == "A"
+    assert calculate_grade(80) == "B"
+    assert calculate_grade(65) == "C"
+    assert calculate_grade(50) == "D"
+    assert calculate_grade(30) == "F"
+
+
+def test_extract_event_metadata_pr_missing_number_returns_none():
+    """worker-core-003: PR 페이로드에 'number' 키 부재 시 KeyError 없이 pr_number=None."""
+    from src.worker.pipeline import _extract_event_metadata
+    data = {"repository": {"full_name": "owner/r"}, "pull_request": {"head": {"sha": "abc"}}}
+    repo_name, commit_sha, _msg, pr_number = _extract_event_metadata("pull_request", data)
+    assert pr_number is None  # data.get("number") → None (이전 data["number"] 는 KeyError)
+    assert repo_name == "owner/r"
+    assert commit_sha == "abc"
+
+
+def test_store_user_repos_bounds_cache_size():
+    """api-ui-001: _user_repos_cache 가 상한(_USER_REPOS_CACHE_MAX)을 초과 성장하지 않는다."""
+    import src.ui.routes.add_repo as mod
+    mod._user_repos_cache.clear()
+    try:
+        now = 1000.0
+        # 상한만큼 미래-만료 엔트리로 채움
+        for i in range(mod._USER_REPOS_CACHE_MAX):
+            mod._user_repos_cache[i] = ([], now + mod._USER_REPOS_CACHE_TTL)
+        # 신규 user 저장 → 상한 초과 → evict 후 크기 ≤ 상한 + 신규 user 존재
+        mod._store_user_repos(10_000_000, [{"x": 1}], now)
+        assert len(mod._user_repos_cache) <= mod._USER_REPOS_CACHE_MAX
+        assert 10_000_000 in mod._user_repos_cache
+    finally:
+        mod._user_repos_cache.clear()
+
+
+def test_store_user_repos_purges_expired_first():
+    """상한 초과 시 만료 엔트리를 먼저 정리한다 (만료분 우선 evict)."""
+    import src.ui.routes.add_repo as mod
+    mod._user_repos_cache.clear()
+    try:
+        now = 1000.0
+        # 만료된 엔트리로 상한만큼 채움 (expiry < now)
+        for i in range(mod._USER_REPOS_CACHE_MAX):
+            mod._user_repos_cache[i] = ([], now - 1)
+        mod._store_user_repos(10_000_000, [{"x": 1}], now)
+        # 만료분 정리로 신규 포함 크기가 상한 이하
+        assert len(mod._user_repos_cache) <= mod._USER_REPOS_CACHE_MAX
+        assert 10_000_000 in mod._user_repos_cache
+    finally:
+        mod._user_repos_cache.clear()


### PR DESCRIPTION
## 요약

전체 품질 감사(2026-06-25) **minor P2 묶음** (운영 영향 0, 사용자 결정 "묶음 정리"). TDD.

| 발견 | 수정 |
|------|------|
| **worker-core-001** | `calculate_grade` 가 `GRADE_THRESHOLDS` dict **삽입 순서에 암묵 의존** → `sorted(reverse=True)` 로 순서 독립화 (정의 순서 바뀌어도 정답) |
| **services-002** | `repo_kpi` 의 prev 윈도우 쿼리가 `order_by` 없이 `limit(30)` → **비결정적 score_delta** → cur(`_fetch_analyses`)와 동일 `order_by(created_at.desc())` 추가 |
| **worker-core-003** | `_extract_event_metadata` 의 `data["number"]` → `data.get("number")` (같은 블록 다른 키와 방어 일관성, malformed PR 페이로드 KeyError 방지) |
| **api-ui-001** | `_user_repos_cache` 무한 성장 → `_store_user_repos` 헬퍼(상한 1024 + 만료분 정리 + soonest-expire evict, `webhook-secret` 캐시 패턴 미러) |

## 테스트 (TDD)

- 신규 `test_minor_p2_batch.py` +6: grade 순서 독립(reorder dict 검증) · PR number 누락 None · 캐시 상한 · 만료분 우선 purge · 기존 user 갱신 크기 불변 · soonest-evict.
- 단위 +6. ui+services+worker+scorer **703 passed**, 회귀 0.

> **참고**: `repo_kpi` 결정성은 PG 측 비결정성 — SQLite 무정렬 limit 순서 미보장으로 behavioral 테스트가 신뢰 불가하여, cur 경로(이미 order_by 테스트됨)와 동일 패턴 추가 + 기존 repo_kpi 테스트 회귀로 검증 (Codex 동의).

## 🔍 Codex 검증 (push 전, 정책 18)

**Codex mutual 검증: OK** — 4건 모두 코드 수준 정확성 OK(grade 정렬·prev order_by cur 동형·data.get 일관성·캐시 상한 off-by-one 없음·webhook-secret 패턴 일치). Codex 권장(캐시 soonest-evict·기존 user 불변 명시 가드)을 추가 반영.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
