### PR TITLE
fix(services): issue 등록 orphan 가드 — 비-IntegrityError DB 실패 로깅 (services-001)

### DIFF
--- a/src/services/issue_registration_service.py
+++ b/src/services/issue_registration_service.py
@@ -2,15 +2,18 @@
 issue_registration_service — Issue registration and GitHub state sync logic.
 """
 import hashlib
+import logging
 from datetime import datetime, timezone
 
 import httpx
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from src.github_client.issues import create_issue, get_issue_state
 from src.models.issue_registration import IssueRegistration
 from src.repositories import issue_registration_repo
+
+logger = logging.getLogger(__name__)
 
 # GitHub 상태 캐시 TTL (초) — 만료 시 재조회
 # GitHub state cache TTL in seconds — refresh after expiry
@@ -75,6 +78,23 @@ async def register_issue(  # pylint: disable=too-many-arguments
         existing = issue_registration_repo.find_by_key(db, repo_id=repo_id, issue_key=issue_key)
         issue_num = existing.github_issue_number if existing else gh_result["number"]
         raise ValueError(f"DUPLICATE:{issue_num}") from None
+    except SQLAlchemyError:
+        # GitHub Issue 는 이미 생성됐는데 DB 기록이 비-IntegrityError(연결 끊김 등)로 실패 →
+        # 추적되지 않는 orphan Issue 가 남는다. 운영자가 수동 보정할 수 있도록 식별자
+        # (issue number/url/repo)를 ERROR 로그로 남기고 예외를 그대로 전파한다.
+        # GitHub Issue was already created but the DB write failed with a non-IntegrityError
+        # (e.g. dropped connection), leaving an untracked orphan Issue. Emit an ERROR log with
+        # the reconciliation identifiers (issue number/url/repo) and re-raise.
+        db.rollback()
+        logger.error(
+            "issue_registration orphan — GitHub Issue created but DB persist failed: "
+            "repo=%s issue_number=%s url=%s issue_key=%s",
+            repo_full_name,
+            gh_result["number"],
+            gh_result["html_url"],
+            issue_key,
+        )
+        raise
     return {
         "github_issue_number": record.github_issue_number,
         "github_issue_url": gh_result["html_url"],

--- a/tests/unit/services/test_issue_registration_service.py
+++ b/tests/unit/services/test_issue_registration_service.py
@@ -1,11 +1,12 @@
 # tests/unit/services/test_issue_registration_service.py
+import logging
 from datetime import datetime
 from unittest.mock import AsyncMock, patch
 import httpx
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy.exc import IntegrityError, OperationalError
 from src.database import Base
 from src.models.issue_registration import IssueRegistration  # noqa: F401
 from src.services.issue_registration_service import (
@@ -238,6 +239,49 @@ async def test_register_issue_toctou_integrity_error_raises_duplicate(db):
                 github_token="tok", issue_type="ai_suggestion", issue_key="race_key",
                 title="T", body="B", labels=[],
             )
+
+
+# ── orphan 가드 (services-001): 비-IntegrityError DB 실패 시 GitHub Issue orphan 로깅 ──
+# orphan guard (services-001): log orphan GitHub Issue on non-IntegrityError DB failure
+
+@pytest.mark.asyncio
+async def test_register_issue_db_failure_logs_orphan_and_reraises(db, caplog):
+    # GitHub Issue 생성 성공 후 DB INSERT 가 비-IntegrityError(OperationalError 등)로 실패하면
+    # 이미 생성된 GitHub Issue 가 orphan 으로 남는다 — 운영자 보정용 구조화 ERROR 로그 + 예외 재전파.
+    # GitHub Issue is created, then DB INSERT fails with a non-IntegrityError (e.g. OperationalError):
+    # the created GitHub Issue is orphaned — emit a structured ERROR log for reconciliation and re-raise.
+    from src.repositories import issue_registration_repo
+    with (
+        patch(
+            "src.services.issue_registration_service.create_issue",
+            new=AsyncMock(return_value={
+                "number": 77, "html_url": "https://github.com/o/r/issues/77", "state": "open"
+            }),
+        ),
+        patch.object(
+            issue_registration_repo, "create",
+            side_effect=OperationalError("db connection lost", None, None),
+        ),
+    ):
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(OperationalError):
+                await register_issue(
+                    db, analysis_id=1, repo_id=1, repo_full_name="owner/repo",
+                    github_token="tok", issue_type="ai_suggestion", issue_key="orphan_key",
+                    title="T", body="B", labels=[],
+                )
+
+    orphan_logs = [
+        r.getMessage() for r in caplog.records
+        if r.levelno >= logging.ERROR and "orphan" in r.getMessage().lower()
+    ]
+    assert orphan_logs, "orphan ERROR 로그가 없습니다"
+    msg = orphan_logs[0]
+    # 운영자 보정에 필요한 식별자 — issue number + url + repo
+    # Reconciliation identifiers — issue number + url + repo
+    assert "77" in msg
+    assert "https://github.com/o/r/issues/77" in msg
+    assert "owner/repo" in msg
 
 
 # ── get_analysis_issue_status — httpx.HTTPError silent pass (lines 113-116) ──


### PR DESCRIPTION
## 요약

`register_issue`(`src/services/issue_registration_service.py`)는 GitHub Issue를 먼저 생성한 뒤 DB INSERT한다. 기존엔 `IntegrityError`(중복/TOCTOU)만 분기 처리하고 그 외 DB 실패(예: `OperationalError` 연결 끊김)는 예외가 그대로 전파돼 **이미 생성된 GitHub Issue가 추적 불가한 orphan**으로 남았다 (재시도 시 DB에 기록이 없어 중복 Issue 생성 위험).

옵션 b(타깃 로깅) 채택: `except SQLAlchemyError` 분기를 추가해 운영자 보정용 식별자(repo / issue_number / url / issue_key)를 ERROR 로그로 남기고 예외를 그대로 재전파한다. ERROR 로그가 로그 기반 운영 알림 채널 역할.

- **기존 500 동작 보존** — `raise`로 재전파, API 응답 불변.
- **새 실패 표면 0** — 보상 close(추가 API 호출) 대신 로깅만 (정책 16 최소 변경).
- 출처: 전체 품질 감사 보류 항목 services-001 ([project-full-quality-audit-2026-06-25]).

## 변경

| 파일 | 변경 |
|------|------|
| `src/services/issue_registration_service.py` | `except SQLAlchemyError` orphan 로깅 분기 + `logging` import |
| `tests/unit/services/test_issue_registration_service.py` | 회귀 가드 `test_register_issue_db_failure_logs_orphan_and_reraises` (+1) |

## 검증

- `pytest tests/unit/services/test_issue_registration_service.py` = **16 passed** (기존 15 + 신규 1)
- `pylint src/services/issue_registration_service.py` = **10.00/10**
- `flake8 src/` clean

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**완료 — MUTUAL VERIFICATION: OK.** Codex가 5개 포인트(except 순서·rollback 위치·재전파 500 보존·로그 안전성·이중언어/최소변경) 전항 OK 판정. 단일정답 버그/회귀 없음 확인 후 push.

## 🔍 사용자 검증 필요 (정책 2)

- [ ] 운영에서 비-IntegrityError DB 실패는 드물지만(연결 끊김 등), 발생 시 Railway 로그에 `issue_registration orphan — ...` ERROR가 남는지 확인 (현재는 로그 모니터링이 알림 채널 — Telegram 등 능동 알림이 필요하면 별도 요청).
- [ ] orphan 발생 시 수동 보정(GitHub Issue 닫기 또는 DB 재기록)은 운영자 절차로 남음 — 자동 보상 close를 원하면 옵션 a로 별도 진행 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
