### PR TITLE
fix(n8n): 출하 워크플로 chatId 하드코딩 제거 + 하드닝 안내 명확화 (notifier-002, C-safe)

### DIFF
--- a/docs/integrations/n8n-auto-fix.md
+++ b/docs/integrations/n8n-auto-fix.md
@@ -308,13 +308,13 @@ Rules:
 
 > ⚠️ **번들 `n8n-workflow.json` 구현 + 운영자 필수 조치**:
 > - Telegram 노드는 **기본 `disabled: true`** 다(자격증명 미설정 환경 보호). 알림을 받으려면 노드를 활성화(`disabled: false`)하고 Telegram credential 을 설정할 것.
-> - **출하 JSON 은 `chatId` 가 하드코딩**(`1984552353`)되어 있다 — **반드시 본인 chat_id 로 교체**(또는 아래처럼 `{{ $env.TELEGRAM_CHAT_ID }}` 표현식으로 변경)할 것.
+> - **출하 JSON 의 `chatId` 는 `{{ $env.TELEGRAM_CHAT_ID }}` 표현식**(n8n 환경변수)으로 설정돼 있다 — **n8n 인스턴스에 `TELEGRAM_CHAT_ID` 환경변수를 설정**(또는 본인 chat_id 리터럴로 교체)할 것. (이전 출하본은 실제 chat_id 가 하드코딩돼 있었음 — notifier-002 정정.)
 > - 출하 JSON 의 텍스트는 **단일 generic 문구**(`❌ Issue #N 처리 실패 (exit N)`)다. 아래 exit별 문구는 **권장 커스터마이징**(Switch 출력별 분기).
 
 권장 — 기존 SCAManager Telegram Bot Token 재사용 + exit별 문구:
 
 ```
-Chat ID: {{ $env.TELEGRAM_CHAT_ID }}   # 번들 JSON 은 하드코딩값 — 교체 의무
+Chat ID: {{ $env.TELEGRAM_CHAT_ID }}   # 번들 JSON 기본값 — n8n 환경변수 TELEGRAM_CHAT_ID 설정
 Text (권장 — exit별 분기):
   exit 2: ❌ *Issue #{{ $json.issue_number }}* 자동 처리 실패\n`{{ $json.repo }}`
   exit 3: ❌ *Issue #{{ $json.issue_number }}* push 실패\n`{{ $json.repo }}`

--- a/docs/integrations/n8n-workflow.json
+++ b/docs/integrations/n8n-workflow.json
@@ -16,7 +16,7 @@
     },
     {
       "parameters": {
-        "jsCode": "const fs = require('fs');\nconst crypto = require('crypto');\n\nconst secret = fs.readFileSync('/etc/n8n-secrets/hmac_secret', 'utf8').trim();\nconst all = items[0].json;\nconst header = (all.headers && all.headers['x-scamanager-signature-256']) || '';\nconst body = all.body || {};\nconst rawBody = JSON.stringify(body);\n\nconst expected = 'sha256=' + crypto.createHmac('sha256', secret)\n  .update(rawBody, 'utf8').digest('hex');\n\n// ⚠️ HMAC soft-pass (보안 약화 — 운영 배포 전 하드닝 의무): JS JSON.stringify(공백X) != Python json.dumps(공백O)\n// 직렬화 불일치를 회피하려 불일치 시에도 통과시킨다. 무인증 트리거를 차단하지 못하므로, 운영에서는 Webhook Raw Body\n// + rawBody 기반 hard-reject 로 교체할 것 (docs/integrations/n8n-auto-fix.md Node 2 보안 주석 참조).\nif (header && header !== expected) {\n  console.warn('HMAC mismatch — soft pass (INSECURE: harden to hard-reject for production)');\n}\nreturn items;"
+        "jsCode": "const fs = require('fs');\nconst crypto = require('crypto');\n\nconst secret = fs.readFileSync('/etc/n8n-secrets/hmac_secret', 'utf8').trim();\nconst all = items[0].json;\nconst header = (all.headers && all.headers['x-scamanager-signature-256']) || '';\nconst body = all.body || {};\nconst rawBody = JSON.stringify(body);\n\nconst expected = 'sha256=' + crypto.createHmac('sha256', secret)\n  .update(rawBody, 'utf8').digest('hex');\n\n// ⚠️ HMAC soft-pass (보안 약화 — 운영 배포 전 하드닝 의무): JS JSON.stringify(공백X) != Python json.dumps(공백O)\n// 직렬화 불일치를 회피하려 불일치 시에도 통과시킨다. 무인증 트리거를 차단하지 못하므로, 운영에서는 Webhook Raw Body\n// + rawBody 기반 hard-reject 로 교체할 것 (docs/integrations/n8n-auto-fix.md Node 2 보안 주석 참조).\nif (header && header !== expected) {\n  console.warn('HMAC mismatch — soft pass (INSECURE: harden to hard-reject before production — see docs/integrations/n8n-auto-fix.md Node 2)');\n}\nreturn items;"
       },
       "id": "a36d145a-79c2-4a0d-bb2d-2a7d8abb0ca3",
       "name": "HMAC 검증",
@@ -131,7 +131,7 @@
     },
     {
       "parameters": {
-        "chatId": "={{ 1984552353 }}",
+        "chatId": "={{ $env.TELEGRAM_CHAT_ID }}",
         "text": "={{ '❌ Issue #' + $json.issue_number + ' 처리 실패 (exit ' + $json.exitCode + ')\\nRepo: ' + $json.repo }}",
         "additionalFields": {}
       },


### PR DESCRIPTION
## 요약

출하 번들 `docs/integrations/n8n-workflow.json`의 Telegram 노드 `chatId`가 **실제 chat_id(`1984552353`)로 하드코딩**돼 있었습니다 — 템플릿을 import한 운영자가 교체하지 않으면 개발자 chat으로 실패 알림이 발송되는 footgun + 사소한 정보 노출. n8n 환경변수 표현식 `{{ $env.TELEGRAM_CHAT_ID }}` 플레이스홀더로 교체했습니다 (산문 가이드 권장값과 일치).

## 자율 판단 보고 (정책 3) — ⚠️ 범위 결정

**사용자 C-safe 결정**에 따라 진행했습니다. 품질감사 보류 항목 notifier-002의 핵심은 출하 JSON HMAC 노드의 soft-pass(무인증 트리거)인데, 올바른 수정(raw-body hard-reject)은 n8n의 Webhook "Raw Body" 옵션·IF 재구성 등 **제가 테스트할 수 없는 n8n 버전 의존 의미**에 묶여 있어, 잘못 작성 시 정상 webhook을 전부 거부하거나(또는 재직렬화 fallback으로) 보안을 깨는 위험이 있습니다 (정책 17 안정성 우선).

따라서 **C-safe 범위**:
- ✅ **안전한 부분**: chatId 하드코딩 footgun 정정 (의미 변경 0).
- ✅ **하드닝 안내 명확화**: HMAC `console.warn`에 하드닝 문서 참조 추가 + 산문 동기화.
- ⏸ **HMAC hard-reject 자체**: 산문 가이드(`n8n-auto-fix.md` Node 2)가 이미 raw-body hard-reject 방법을 상세 설명 — **운영자가 실 n8n 인스턴스에서 적용·검증할 영역**(정책 11/13, Claude 정적 검증 불가).

## 변경

| 파일 | 변경 |
|------|------|
| `docs/integrations/n8n-workflow.json` | chatId → `{{ $env.TELEGRAM_CHAT_ID }}` 플레이스홀더 + HMAC `console.warn`에 문서 참조 추가 (검증 로직 불변) |
| `docs/integrations/n8n-auto-fix.md` | Node 9 chatId 안내를 "하드코딩 교체 의무" → "env 설정"으로 동기화 |

**src 코드 변경 0.**

## 검증

- `python -c "import json; json.load(...)"` = **JSON valid**
- `grep -rn 1984552353 docs/ README*` = **0건** (하드코딩 chatId 완전 제거)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**완료 — MUTUAL VERIFICATION: OK (5/5).** Codex가 ① JSON 유효성 ② chatId 플레이스홀더 산문 일치 ③ HMAC accept/reject 로직 불변(C-safe) ④ 산문 동기화 정합 ⑤ 하드코딩 잔여 0 전항 검증.

## 🔍 사용자 검증 필요 (정책 2)

- [ ] **운영 n8n 인스턴스 사용 시**: import 후 `TELEGRAM_CHAT_ID` 환경변수 설정(또는 chatId 리터럴 교체) 확인 — Telegram 노드는 기본 `disabled: true`.
- [ ] **보안(중요)**: 출하 JSON의 HMAC 노드는 여전히 soft-pass(무인증 트리거 미차단). 운영 배포 전 `n8n-auto-fix.md` Node 2의 raw-body hard-reject로 교체하고 실 인스턴스에서 동작 확인 — **운영자 의무**(Claude 정적 검증 불가).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
