### PR TITLE
fix(deploy): STRICT_MIGRATION opt-in — 마이그레이션 실패 시 fail-fast (P1-②, 감사)

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -22,7 +22,8 @@
 | `API_AUTH_DISABLED` | `1` 설정 시 `API_KEY` 미설정이어도 REST API 무인증 통과 허용 — **로컬 개발 전용 명시 opt-out** (운영 절대 설정 금지). 미설정(기본 `0`) + `API_KEY` 미설정 = 503 fail-closed. `*_DISABLED` kill-switch | `1` (로컬 dev) / 미설정 (운영) |
 | `APP_BASE_URL` | Railway 등 리버스 프록시에서 HTTPS redirect_uri 강제 지정 + **CORS allow_origins 출처 결정** (사이클 142 Phase C — `src/main.py` CORSMiddleware, 미설정 시 CORS 미등록) | `https://your-app.railway.app` |
 | `TOKEN_ENCRYPTION_KEY` | GitHub Access Token 암호화 키 (미설정 시 평문 저장) | `32자 이상 랜덤` |
-| `STRICT_TOKEN_ENCRYPTION` | `true` 설정 시 `TOKEN_ENCRYPTION_KEY` 미설정이면 lifespan startup 차단 (기본값 `false` = 평문 저장 허용 + WARNING 출력) | `false` (기본) |
+| `STRICT_TOKEN_ENCRYPTION` | `true` 설정 시 `TOKEN_ENCRYPTION_KEY` 미설정 **또는 형식 오류**면 lifespan startup 차단 (기본값 `false` = 평문 저장 허용 + WARNING 출력). P1-① 2026-06-29 감사로 invalid 키도 차단 대상 추가 | `false` (기본) |
+| `STRICT_MIGRATION` | `true` 설정 시 lifespan DB 마이그레이션 실패/timeout 면 앱 기동 차단(fail-fast). 기본 `false` = 기존 동작(로그 후 "starting app anyway"). Railway 는 pre-deploy `alembic upgrade head` 가 1차 게이트라 무해하나 온프레미스/비-Railway prod 는 lifespan 이 유일 게이트 (P1-② 2026-06-29 감사) | `false` (기본) |
 | `CLAUDE_REVIEW_MODEL` | AI 코드리뷰에 사용할 Claude 모델 ID | `claude-sonnet-4-6` (기본) |
 | `CLAUDE_REVIEW_MAX_TOKENS` | AI 코드리뷰 응답 출력 토큰 상한 — 한국어 리뷰 JSON(~2660 토큰) 여유값. 🔴 저한도 모델(claude-3-haiku/opus=4096)을 `CLAUDE_REVIEW_MODEL` 로 쓰면 이 값을 모델 출력 한도 이하로 낮춰야 함(8192 일괄 적용 시 Anthropic 400 → `api_error`). 구값 1500 이 응답을 절단해 `parse_error` 로 출시 이래 ~80% 리뷰 실패한 사고 fix (제약 `ge=1`) | `8192` (기본) |
 | `CLAUDE_INSIGHT_MODEL` | Insight narrative (`/dashboard?mode=insight`) 4 카드 생성용 Claude 모델 ID — 코드리뷰보다 단순 task → Haiku 분기로 토큰 비용 ↓ (Cycle 74 PR-A #247) | `claude-haiku-4-5` (기본) |

--- a/src/config.py
+++ b/src/config.py
@@ -70,6 +70,13 @@ class Settings(BaseSettings):
     # Strict mode (Phase 2): when True, refuses to start in prod (HTTPS) without
     # a token_encryption_key. Defaults to False for backwards-compatible warnings.
     strict_token_encryption: bool = False
+    # STRICT_MIGRATION (P1-② 2026-06-29 감사): True 면 lifespan DB 마이그레이션 실패/timeout 시
+    # 앱 기동 차단(fail-fast). 기본 False = 기존 동작(로그 후 "starting app anyway").
+    # Railway 는 pre-deploy `alembic upgrade head` 가 1차 게이트라 무해하나, 온프레미스/비-Railway
+    # prod 는 lifespan 이 유일 게이트이므로 명시 opt-in 으로 fail-fast.
+    # STRICT_MIGRATION: when True, abort startup if the lifespan DB migration fails/times out.
+    # Default False keeps the legacy "start anyway" behavior (Railway pre-deploy is the primary gate).
+    strict_migration: bool = False
     n8n_webhook_secret: str = ""  # n8n 전송 HMAC 서명 시크릿 (빈 문자열이면 서명 생략)
     # n8n issue 릴레이에 GitHub repo 토큰 포함 여부 — 명시적 opt-in (default off, 자격증명 유출 차단)
     # Whether to include the GitHub repo token in the n8n issue relay — explicit opt-in (default off)

--- a/src/main.py
+++ b/src/main.py
@@ -164,13 +164,26 @@ async def lifespan(_app: FastAPI):
     try:
         await asyncio.wait_for(asyncio.to_thread(_run_migrations), timeout=30)
         logger.info("DB migration completed")
-    except asyncio.TimeoutError:
-        logger.error("DB migration timed out after 30s — starting app anyway")
-    except Exception:  # pylint: disable=broad-exception-caught  # noqa: BLE001
+    except asyncio.TimeoutError as exc:
+        logger.error("DB migration timed out after 30s")
+        # P1-②: STRICT_MIGRATION=true 면 fail-fast — 마이그레이션 없는 stale 스키마로 서비스 차단.
+        # P1-②: with STRICT_MIGRATION=true, fail fast instead of serving on a stale schema.
+        if settings.strict_migration:
+            raise RuntimeError(
+                "DB migration timed out and STRICT_MIGRATION=true — refusing to start"
+            ) from exc
+        logger.error("starting app anyway (set STRICT_MIGRATION=true to fail fast)")
+    except Exception as exc:  # pylint: disable=broad-exception-caught  # noqa: BLE001
         # Phase H PR-6A: logger.exception 으로 stack trace 보존
         # Railway 로그에서 마이그레이션 실패 원인 추적 가능
         # logger.exception preserves stack trace; Railway logs surface failure cause
         logger.exception("DB migration failed")
+        # P1-②: STRICT_MIGRATION=true 면 fail-fast (온프레미스/비-Railway prod 의 fail-open 차단).
+        # P1-②: with STRICT_MIGRATION=true, fail fast (closes the fail-open on non-Railway prod).
+        if settings.strict_migration:
+            raise RuntimeError(
+                "DB migration failed and STRICT_MIGRATION=true — refusing to start"
+            ) from exc
     await init_http_client()
 
     # Phase 2 — GitHub API warm-up ping. PR #105 silent skip 사고 분석에서 cold

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -130,6 +130,50 @@ def test_lifespan_exception_does_not_crash():
     assert response.status_code == 200
 
 
+# --- P1-② (2026-06-29 감사): STRICT_MIGRATION fail-fast ---
+
+def test_lifespan_strict_migration_raises_on_timeout():
+    """P1-②: STRICT_MIGRATION=true + 마이그레이션 timeout → 기동 차단(stale 스키마 fail-open 방지)."""
+    with patch("src.main._run_migrations", side_effect=TimeoutError), \
+         patch("src.main.settings") as mock_settings:
+        mock_settings.session_secret = "test-session-secret-32-chars-long!"
+        mock_settings.anthropic_api_key = "sk-ant-test-key"
+        mock_settings.app_base_url = ""
+        mock_settings.token_encryption_key = ""
+        mock_settings.strict_migration = True
+        with pytest.raises(RuntimeError, match="STRICT_MIGRATION"):
+            with TestClient(app):
+                pass
+
+
+def test_lifespan_strict_migration_raises_on_exception():
+    """P1-②: STRICT_MIGRATION=true + 마이그레이션 일반 예외 → 기동 차단."""
+    with patch("src.main._run_migrations", side_effect=RuntimeError("db error")), \
+         patch("src.main.settings") as mock_settings:
+        mock_settings.session_secret = "test-session-secret-32-chars-long!"
+        mock_settings.anthropic_api_key = "sk-ant-test-key"
+        mock_settings.app_base_url = ""
+        mock_settings.token_encryption_key = ""
+        mock_settings.strict_migration = True
+        with pytest.raises(RuntimeError, match="STRICT_MIGRATION"):
+            with TestClient(app):
+                pass
+
+
+def test_lifespan_default_migration_continues_on_failure():
+    """P1-②: STRICT_MIGRATION 미설정(기본 False) → 마이그레이션 실패해도 기존대로 기동(하위호환)."""
+    with patch("src.main._run_migrations", side_effect=RuntimeError("db error")), \
+         patch("src.main.settings") as mock_settings:
+        mock_settings.session_secret = "test-session-secret-32-chars-long!"
+        mock_settings.anthropic_api_key = "sk-ant-test-key"
+        mock_settings.app_base_url = ""
+        mock_settings.token_encryption_key = ""
+        mock_settings.strict_migration = False
+        with TestClient(app) as c:
+            response = c.get("/health")
+    assert response.status_code == 200
+
+
 # --- ANTHROPIC_API_KEY 부재 경고 ---
 
 def test_lifespan_warns_when_anthropic_key_missing(caplog):


### PR DESCRIPTION
## 요약 (2026-06-29 Codex cross-vendor 감사 P1-②)

lifespan DB 마이그레이션이 timeout/예외로 실패해도 `"starting app anyway"`로 계속 기동해, RLS/제약/컬럼 누락 **stale 스키마로 서비스가 요청을 받을 수 있었다(fail-open)**.

🔴 **Railway는 pre-deploy `alembic upgrade head`(railway.toml)가 1차 게이트라 무해**하나, 프로젝트가 지원하는 **온프레미스/비-Railway prod는 lifespan이 유일 게이트** → fail-open.

`STRICT_TOKEN_ENCRYPTION` 패턴을 미러링 — **`STRICT_MIGRATION=true` 명시 opt-in** 시 마이그레이션 timeout/예외에서 RuntimeError(fail-fast). 기본 `false` = 기존 동작 보존(하위호환).

> 🔑 이 P1은 **Codex가 발견**하고 Claude 8-에이전트 deep sweep이 놓친 항목.

## 변경

| 파일 | 변경 |
|------|------|
| `src/config.py` | `strict_migration: bool = False` 필드 추가 |
| `src/main.py` | lifespan 마이그레이션 timeout/예외 분기에 strict 시 fail-fast |
| `docs/reference/env-vars.md` | `STRICT_MIGRATION` 등재 (+ STRICT_TOKEN_ENCRYPTION invalid 키 설명 보강) |
| `tests/unit/test_main.py` | TDD 3건 (timeout→raise / exception→raise / 기본 False→하위호환 기동) |

## 검증

- `pytest tests/unit` = **5112 passed + 4 skipped** (신규 3, 회귀 0)
- `pylint src/` = **10.00/10** · env-vars 싱크 훅 Passed

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**완료 — OK (6/6).** Codex가 ① timeout+예외 양 분기 fail-fast ② 기본 False 하위호환 보존 ③ 기존 테스트 무영향 ④ raise lifespan 밖 전파 ⑤ config+env-vars 정합 ⑥ Railway 게이트 관계 타당 전항 OK.

## 🔍 사용자 검증 필요 (정책 2)

- [ ] **Railway 운영자**: 동작 변화 없음(`STRICT_MIGRATION` 미설정 = 기존대로). pre-deploy 게이트가 1차 방어 유지.
- [ ] **온프레미스/비-Railway 운영자**: 마이그레이션 무결성을 강제하려면 `STRICT_MIGRATION=true` 설정 시 마이그레이션 실패 = 기동 차단(fail-fast)되는지 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
