### PR TITLE
chore(robustness): 감사 P2 저위험 quick-win 3건 — 주석 drift + 500 방어 2건

### DIFF
--- a/src/api/repos.py
+++ b/src/api/repos.py
@@ -53,8 +53,8 @@ class RepoConfigUpdate(BaseModel):
     # 리포별 Claude 코드리뷰 모델 override (Alembic 0032)
     # NULL = settings.claude_review_model 전역 기본값 사용
     review_model: str | None = None
-    # per-repo 비활성화 도구 목록 — JSON 배열, 기본값 빈 배열 (Alembic 0035)
-    # Per-repo disabled analyzer names — JSON array, defaults to empty list (Alembic 0035)
+    # per-repo 비활성화 도구 목록 — JSON 배열, 기본값 빈 배열 (Alembic 0036)
+    # Per-repo disabled analyzer names — JSON array, defaults to empty list (Alembic 0036)
     disabled_tools: list = Field(default_factory=list)
     # leaderboard_opt_in 폐기 (그룹 60 사용자 결정 정정 — alembic 0025)
 

--- a/src/config_manager/manager.py
+++ b/src/config_manager/manager.py
@@ -36,8 +36,8 @@ class RepoConfigData:  # pylint: disable=too-many-instance-attributes
     # 리포별 Claude 코드리뷰 모델 override (Alembic 0032)
     # NULL = settings.claude_review_model 전역 기본값 사용
     review_model: str | None = None
-    # per-repo 비활성화 도구 목록 — JSON 배열, 기본값 빈 배열 (Alembic 0035)
-    # Per-repo disabled analyzer names — JSON array, defaults to empty list (Alembic 0035)
+    # per-repo 비활성화 도구 목록 — JSON 배열, 기본값 빈 배열 (Alembic 0036)
+    # Per-repo disabled analyzer names — JSON array, defaults to empty list (Alembic 0036)
     disabled_tools: list = field(default_factory=list)
     # leaderboard_opt_in 폐기 (그룹 60 사용자 결정 정정 — alembic 0025)
 

--- a/src/services/issue_registration_service.py
+++ b/src/services/issue_registration_service.py
@@ -125,9 +125,15 @@ async def _sync_state_if_stale(
     try:
         state = await get_issue_state(github_token, repo_full_name, rec.github_issue_number)
         issue_registration_repo.update_state(db, record=rec, state=state)
-    except httpx.HTTPError:
-        # 동기화 실패 시 기존 상태 유지 — 사용자에게 오류 미노출
-        # Keep existing state on sync failure — silent fallback
+    except (httpx.HTTPError, KeyError, ValueError):
+        # 동기화 실패 시 기존 상태 유지 — 사용자에게 오류 미노출.
+        # httpx.HTTPError(5xx/네트워크) 외에 GitHub 응답이 malformed 면 get_issue_state 의
+        # resp.json()["state"] 가 KeyError/JSONDecodeError(ValueError) 를 던질 수 있어 함께 포착
+        # (동기화 실패가 API 라우트 500 으로 전파되지 않도록 — silent fallback 의도 일관, 감사 P2).
+        # Keep existing state on sync failure — silent fallback. Besides httpx.HTTPError
+        # (5xx/network), a malformed GitHub response makes get_issue_state's
+        # resp.json()["state"] raise KeyError/JSONDecodeError(ValueError); catch those too
+        # so a sync failure never surfaces as a 500 from the API route.
         pass
 
 

--- a/src/webhook/providers/railway.py
+++ b/src/webhook/providers/railway.py
@@ -40,6 +40,12 @@ async def railway_webhook(  # pylint: disable=too-many-locals
         body = await request.json()
     except Exception:  # pylint: disable=broad-except
         body = {}
+    # 유효 JSON 이지만 비-dict(배열/스칼라) 면 {} 로 정규화 — parse_railway_payload 의
+    # body.get(...) AttributeError→500 차단 (telegram provider 와 대칭, 감사 P2).
+    # Normalize a valid-but-non-dict JSON body (array/scalar) to {} so parse_railway_payload's
+    # body.get(...) doesn't raise AttributeError→500 (symmetry with the telegram provider).
+    if not isinstance(body, dict):
+        body = {}
 
     with SessionLocal() as db:
         config = repo_config_repo.find_by_railway_webhook_token(db, token)

--- a/tests/unit/services/test_issue_registration_service.py
+++ b/tests/unit/services/test_issue_registration_service.py
@@ -352,3 +352,24 @@ async def test_get_repo_issue_summary_keeps_state_on_sync_error(db):
             db, repo_id=1, repo_full_name="o/r", github_token="tok"
         )
     assert result[0]["github_issue_state"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_sync_keeps_state_on_malformed_github_response(db):
+    # get_issue_state 가 malformed 응답으로 KeyError/JSONDecodeError(ValueError) 를 던져도
+    # httpx.HTTPError 와 동일하게 silent fallback — API 라우트 500 전파 차단 (감사 P2)
+    # A malformed GitHub response (KeyError/ValueError) is swallowed like httpx.HTTPError.
+    from src.repositories import issue_registration_repo
+    issue_registration_repo.create(
+        db, analysis_id=1, repo_id=1, issue_type="static_issue",
+        issue_key="malformed_key", github_issue_number=99,
+    )
+    with patch(
+        "src.services.issue_registration_service.get_issue_state",
+        new=AsyncMock(side_effect=KeyError("state")),  # resp.json()["state"] 키 부재 모사
+    ):
+        result = await get_repo_issue_summary(
+            db, repo_id=1, repo_full_name="o/r", github_token="tok"
+        )
+    # 예외가 전파되지 않고 기존 "open" 상태 유지
+    assert result[0]["github_issue_state"] == "open"

--- a/tests/unit/webhook/test_railway_provider.py
+++ b/tests/unit/webhook/test_railway_provider.py
@@ -107,3 +107,17 @@ def test_non_deploy_type_returns_200_ignored():
         resp = client.post(f"/webhooks/railway/{_TOKEN}", content=payload)
     assert resp.status_code == 200
     assert resp.json()["status"] == "ignored"
+
+
+def test_non_dict_json_body_returns_200_ignored():
+    """유효 토큰 + 비-dict JSON 바디(배열) → 500 아닌 graceful 200 ignored.
+
+    감사 P2: 비-dict 바디는 parse_railway_payload 의 body.get(...) AttributeError→500 을
+    유발했으나, isinstance(dict) 정규화로 telegram provider 와 대칭(graceful ignore).
+    """
+    payload = json.dumps([1, 2, 3]).encode()  # 유효 JSON 이나 dict 아님
+    mock_db = _db_with_config(_mock_config())
+    with patch("src.webhook.providers.railway.SessionLocal", return_value=_ctx(mock_db)):
+        resp = client.post(f"/webhooks/railway/{_TOKEN}", content=payload)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ignored"


### PR DESCRIPTION
## 요약 (2026-06-29 Claude+Codex cross-vendor 감사 — 저위험 P2 묶음)

전체 감사에서 식별한 **저위험·명확** P2 3건 (운영 영향 0~저, 회귀 0). 사용자 결정 = "저위험 quick-win 묶음만".

| # | 항목 | 파일 | 효과 |
|---|------|------|------|
| 1 | disabled_tools 주석 `(Alembic 0035)` → `0036` | `config_manager/manager.py` · `api/repos.py` | ORM 정본(#927)은 0036 정정됐으나 파생 2계층 stale — 실제 disabled_tools=0036, 0035=issue_registrations. **주석만(런타임 0)** |
| 2 | `_sync_state_if_stale` 예외 확장 | `services/issue_registration_service.py` | `except httpx.HTTPError` → `(httpx.HTTPError, KeyError, ValueError)`: GitHub malformed 응답의 `resp.json()["state"]` KeyError/JSONDecodeError 가 `GET /api/issues/*` **500 으로 전파되던 것을 silent fallback 의도대로 흡수** |
| 3 | railway provider 비-dict 바디 가드 | `webhook/providers/railway.py` | `if not isinstance(body, dict): body = {}`: 유효 토큰 + 배열/스칼라 JSON 바디 시 parse AttributeError→**500 차단** (telegram provider 대칭) |

## 검증

- `pytest tests/unit` = **5111 passed + 4 skipped** (회귀 가드 +2: `test_sync_keeps_state_on_malformed_github_response`, `test_non_dict_json_body_returns_200_ignored`)
- `pylint src/` = **10.00/10**

## 자율 판단 보고 (정책 3) — 보류 backlog
감사에서 식별했으나 본 묶음에 미포함(사용자 미결정 / 설계·마이그레이션 영역): hook_token repo 평문 커밋(아키텍처) · RLS fallback listener · gate_decision upsert TOCTOU · n8n HMAC byte-pin · `_required_contexts_cache` 상한 · insight try/finally · analyses.created_at server_default · verifier inactive 가시성 · generic webhook ai_review_status · build_notification_tasks is_enabled 격리. (audit 메모리 보존)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

**완료 — OK (5/5).** Codex가 ① 0036 마이그레이션 실측 ② 예외 확장 정상경로 불변 ③ railway post-auth 가드 정상 ④ 신규 테스트 실효성 ⑤ 주석 변경 회귀 0 전항 OK.

## 🔍 사용자 검증 필요 (정책 2)

- [ ] 코드 동작 변화는 "실패 경로 방어"뿐 — 정상 흐름 불변. (운영 시각 확인 항목 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
