### PR TITLE
docs(rules): services.md path-scoped rule 신설 — 서비스 계층 커버리지 갭 (구조검토 ①)

### DIFF
--- a/.claude/rules/services.md
+++ b/.claude/rules/services.md
@@ -1,0 +1,38 @@
+---
+description: 서비스 계층 (집계·외부통합·tenant·2nd-LLM verifier·config·cli) 작업 시 적용되는 SCAManager 규칙 (path-scoped)
+paths:
+  - "src/services/**"
+  - "src/verifier/**"
+  - "src/config_manager/**"
+  - "src/railway_client/**"
+  - "src/mcp/**"
+  - "src/cli/**"
+---
+
+# 서비스 계층 규칙
+
+> 서비스 계층 = 라우트/파이프라인과 repository 사이의 비즈니스 로직 (집계 `dashboard_service`/`repo_insight_service`/`analytics_service`·외부 통합 `railway_client`·tenant `saas_service`·2nd-LLM `verifier`·config `config_manager`·cli). 아래는 **서비스 계층 고유 규칙** + cross-cutting 가드의 **타 rule 포인터**(중복 금지·정책 16 단일출처).
+
+## 세션 · 동시성
+- **서비스 함수 시그니처**: `fn(db: Session, *, arg1, ...)` keyword-only — 호출자가 연 `Session` 을 주입받는다 (서비스 내부에서 `SessionLocal()` 새로 열지 않음 — lazy-load 금지, 세션 종료 전 필요 값 추출).
+- 🔴 **`asyncio.gather()` 내 Session 공유 금지**: 동시 실행 코루틴은 각각 독립 `with SessionLocal() as db:` (identity map 오염·동시 commit 충돌 차단). cross-ref [`api.md`](api.md)·[`pipeline.md`](pipeline.md) §asyncio.gather.
+- 🔴 **시스템/background 서비스 세션 라우팅**: cron·merge_retry 등 세션 없는 컨텍스트는 `from src.database import WorkerSessionLocal as SessionLocal` alias (BYPASSRLS worker role). cross-ref [`db.md`](db.md) §WorkerSessionLocal.
+
+## RLS · tenant (cross-ref db.md)
+- 🔴 **RLS 1차 안전망 (app-layer)**: `dashboard_service._apply_*_user_filter` + `security_alert_log_repo._apply_owner_filter` — 신규 집계/조회 함수는 동일 owner 필터 적용 의무. legacy(`user_id IS NULL`) 노출 방향은 테이블별 의도적 비대칭(0026 노출 vs 0027 strict). cross-ref [`db.md`](db.md) §RLS legacy 비대칭.
+- 🔴 **`saas_service._RLS_MATRIX` bijection 동기화 의무**: alembic `ENABLE ROW LEVEL SECURITY` 테이블 집합 ↔ `_RLS_MATRIX` 양방향 일치 (`tests/unit/test_rls_matrix_completeness.py`). 신규 RLS 테이블 추가 시 매트릭스 동기화. `rls_coverage_summary(db)` = `pg_class.relforcerowsecurity` **실측**(정적 거짓안심 차단). cross-ref [`db.md`](db.md) §_RLS_MATRIX.
+
+## 외부 통합 (cross-ref api.md)
+- 🔴 **외부 SDK timeout/aclose**: GitHub/Railway/OpenAI-verifier 호출은 `timeout` 명시 + sync I/O(PyGithub 등)는 `asyncio.to_thread` wrap + try/finally `aclose`. 신뢰 API = `shared/http_client.py` 싱글톤 / untrusted(discord·slack·n8n·custom) = `notifier/_http.py::build_safe_client`. cross-ref [`api.md`](api.md) §외부 SDK timeout.
+- 🔴 **`merge_retry_service` SHA-bound 검증자 staleness 안전**: retry 경로는 `sha_drift` 검사(`head_sha != row.commit_sha → abandon`) + `merge_pr(expected_sha=row.commit_sha)` 로 검증자가 승인한 정확한 SHA 만 머지. `expected_sha` 바인딩 제거 금지(force-push 미검증 코드 머지 위험). cross-ref [`api.md`](api.md) §검증자 staleness.
+- 🔴 **`issue_registration_service`**: GitHub Issue 를 **먼저 생성**한 뒤 DB INSERT — `IntegrityError`(중복/TOCTOU)=`DUPLICATE:N` / **비-IntegrityError(`SQLAlchemyError`)=orphan ERROR 로깅(repo/number/url/key)+재전파**(services-001 #997). TTL 동기화 `_sync_state_if_stale` 예외는 `(httpx.HTTPError, KeyError, ValueError)` 흡수 — GitHub malformed 응답의 `resp.json()["state"]` 가 `GET /api/issues/*` 500 으로 전파되지 않도록(#1008).
+- **`railway_client`**: GitHub payload None-able 키는 `(data.get(k) or {})` 정규화 + 토큰 인증 통과 후 비-dict JSON 바디는 `if not isinstance(body, dict): body = {}` 가드(telegram provider 대칭, #1008).
+
+## verifier · config · 집계
+- 🔴 **2nd-LLM verifier (`src/verifier/`)**: **fail-closed** — `merge_verifier.verifier_blocks_merge` 가드(should_verify + verify_merge_safety + 차단 시 PR 코멘트)는 `gate/engine._run_auto_merge` **단일출처**(자동·반자동 공유). `OPENAI_API_KEY` 미설정=완전 비활성(순수 opt-in·비용 0). 활성화 절차: [`docs/runbooks/merge-verifier.md`](../../docs/runbooks/merge-verifier.md). cross-ref [`api.md`](api.md) §2nd-LLM 검증자 가드.
+- 🔴 **`config_manager` 5-way sync**: RepoConfig 신규 필드 = ORM(`models/repo_config.py`)↔`RepoConfigData`↔`RepoConfigUpdate`↔`settings.html` 폼↔PRESETS 동기화 의무 — 누락 시 REST 업데이트가 해당 필드를 NULL 로 덮어씀. pre-commit `check-config-5way-sync` 훅은 **3-layer(ORM↔Data↔Update) Python 자동 검증만**, 폼·PRESETS 2-layer 는 HTML/JS 파싱 fragile 로 수동 검토(범위 외). cross-ref [`api.md`](api.md) §알림 채널 추가 체크리스트(ORM↔Data↔Update↔폼 4곳) + [`pipeline.md`](pipeline.md) §5-way 동기화(PRESETS 5번째).
+- **N+1 배치**: 집계 함수 신규 추가 시 `dashboard_service._fetch_analyses_for_window`/`_group_analyses_by_repo` 배치 패턴 사용 — repo 별 개별 쿼리 루프 금지.
+- 🔴 **메모리 캐시 상한 의무**: 서비스/클라이언트 모듈 레벨 캐시(dict)는 **상한 + 만료 evict** 패턴(`webhook/_helpers._store_secret`·`add_repo._store_user_repos` 미러). pre-auth 도달 가능 캐시는 특히 필수(무한 증가 DoS). 신규 캐시 도입 시 `tests/conftest.py` autouse 클리어 fixture 동반.
+
+## 발신 메시지 i18n (cross-ref i18n.md)
+- 🔴 `cron_service`·`analytics_service` 등 서비스가 알림을 발신/조립할 때 사용자 노출 문자열은 i18n — `tests/unit/notifier/test_no_hardcoded_korean_in_send_modules.py` AST 가드가 `src/services/{merge_retry,cron}` 포함 스캔. logger 메시지는 운영자용(i18n 대상 아님). cross-ref [`i18n.md`](i18n.md) §발신 경로.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,7 +362,7 @@ GitHub Code Scanning 점검 detail 절차 + 운영 통합 = `docs/runbooks/opera
   | `docs/architecture.md` `services/` 한 줄 | 신규 service 함수 목록 갱신 |
   | `docs/architecture.md` 핵심 데이터 흐름 | 신규 경로가 흐름도에 포함되어야 하면 추가 |
   | `docs/reference/env-vars.md` | **신규 환경변수 (`*_DISABLED` kill-switch / `SAAS_*` / 모델 분기 / DB 등) 추가 시 적정 섹션 등재 의무** (사이클 82 5+1 cross-verify P0 학습 — 4건 누적 누락). **+ `config.py` `field_validator`/최솟값 제약 추가·변경 시에도** env-vars.md 해당 행 설명·예시 동기화 의무 (사이클 119 P0-C/P1-D 재발 방지 — SESSION_SECRET 32자 이상 예시 누락·MERGE_UNKNOWN_RETRY 미등재) |
-  | `.claude/rules/<area>.md` | **🔴 사이클 86 Q2 신설 (사용자 명시 결정)** — 영역별 path-scoped rules 본문 sync 의무. `tests/**` / `alembic/**` / `src/<area>/**` 등 path 매칭 영역 변경 시 해당 `.claude/rules/<area>.md` 본문 갱신 의무. 8 영역 매트릭스: testing.md (`tests/**`, `e2e/**`, `pytest.ini`) / db.md (`alembic/**`, `src/models/**`, `src/database.py`, `src/repositories/**`) / pipeline.md (`src/worker/pipeline.py`, `src/analyzer/**`, `src/scorer/**`, `src/webhook/**`, `src/gate/**`) / api.md (`src/api/**`, `src/notifier/**`, `src/webhook/**`, `src/gate/**`, `src/main.py`) / security.md (`src/auth/**`, `src/crypto.py`, `src/shared/log_safety.py`, `src/api/auth.py`, `src/webhook/validator.py`, `src/main.py`) / ui.md (`src/templates/**`, `src/static/**`, `src/ui/**`) / i18n.md (`src/i18n/**`, `src/middleware/locale.py`, `src/notifier/_language.py`, `src/analyzer/pure/review_guides/**`) / deploy.md (`railway.toml`, `nixpacks.toml`, `requirements.txt`, `sonar-project.properties` 등). path 매칭 시 자동 로드 (Anthropic 공식 패턴) — 본문 stale 시 Claude rule guidance drift 위험 |
+  | `.claude/rules/<area>.md` | **🔴 사이클 86 Q2 신설 (사용자 명시 결정)** — 영역별 path-scoped rules 본문 sync 의무. `tests/**` / `alembic/**` / `src/<area>/**` 등 path 매칭 영역 변경 시 해당 `.claude/rules/<area>.md` 본문 갱신 의무. 9 영역 매트릭스: testing.md (`tests/**`, `e2e/**`, `pytest.ini`) / db.md (`alembic/**`, `src/models/**`, `src/database.py`, `src/repositories/**`) / pipeline.md (`src/worker/pipeline.py`, `src/analyzer/**`, `src/scorer/**`, `src/webhook/**`, `src/gate/**`) / api.md (`src/api/**`, `src/notifier/**`, `src/webhook/**`, `src/gate/**`, `src/main.py`) / security.md (`src/auth/**`, `src/crypto.py`, `src/shared/log_safety.py`, `src/api/auth.py`, `src/webhook/validator.py`, `src/main.py`) / ui.md (`src/templates/**`, `src/static/**`, `src/ui/**`) / i18n.md (`src/i18n/**`, `src/middleware/locale.py`, `src/notifier/_language.py`, `src/analyzer/pure/review_guides/**`) / deploy.md (`railway.toml`, `nixpacks.toml`, `requirements.txt`, `sonar-project.properties` 등) / services.md (`src/services/**`, `src/verifier/**`, `src/config_manager/**`, `src/railway_client/**`, `src/mcp/**`, `src/cli/**`). path 매칭 시 자동 로드 (Anthropic 공식 패턴) — 본문 stale 시 Claude rule guidance drift 위험 |
 
 ### 모바일 환경 보호 — 수정 금지 파일
 
@@ -394,7 +394,7 @@ GitHub Code Scanning 점검 detail 절차 + 운영 통합 = `docs/runbooks/opera
 
 ## 주의사항 (카테고리별 — `.claude/rules/<area>.md` path-scoped)
 
-> **사이클 85 정리**: 8 카테고리 본문은 `.claude/rules/<area>.md` 로 분리 (Anthropic 공식 path-scoped rules 패턴). Claude Code 가 해당 영역 파일 작업 시 자동 로드. 매 세션 의무 read 부담 0.
+> **사이클 85 정리**: 9 카테고리 본문은 `.claude/rules/<area>.md` 로 분리 (Anthropic 공식 path-scoped rules 패턴). Claude Code 가 해당 영역 파일 작업 시 자동 로드. 매 세션 의무 read 부담 0.
 
 | 영역 | path-scoped 파일 | 매칭 경로 |
 |------|----------------|----------|
@@ -406,6 +406,7 @@ GitHub Code Scanning 점검 detail 절차 + 운영 통합 = `docs/runbooks/opera
 | UI / 템플릿 | [`.claude/rules/ui.md`](.claude/rules/ui.md) | `src/templates/**`, `src/static/**`, `src/ui/**` |
 | 다국어 / i18n | [`.claude/rules/i18n.md`](.claude/rules/i18n.md) | `src/i18n/**`, `src/middleware/locale.py`, `src/notifier/_language.py`, `src/analyzer/pure/review_guides/**` |
 | 배포 | [`.claude/rules/deploy.md`](.claude/rules/deploy.md) | `railway.toml`, `nixpacks.toml`, `requirements.txt`, `requirements-dev.txt`, `.env.example`, `.python-version`, `alembic.ini`, `sonar-project.properties` |
+| 서비스 계층 | [`.claude/rules/services.md`](.claude/rules/services.md) | `src/services/**`, `src/verifier/**`, `src/config_manager/**`, `src/railway_client/**`, `src/mcp/**`, `src/cli/**` |
 
 🔴 표시는 과거 사고로 검증된 고위험 규칙이다 (각 `.claude/rules/<area>.md` 파일 본문 참조).
 


### PR DESCRIPTION
## 요약

다중에이전트 구조 검토(2026-06-29)에서 승인된 propose-confirm **①**: `src/services/**`(9 서비스) + `verifier`/`config_manager`/`railway_client`/`mcp`/`cli` 6 디렉토리가 **어떤 `.claude/rules` frontmatter 에도 매칭되지 않아**, 해당 파일 편집 시 관련 🔴 가드(saas `_RLS_MATRIX`·dashboard RLS 필터·merge_retry SHA-bound·issue orphan·verifier fail-closed·config 5-way sync)가 **자동 로드 0**인 커버리지 갭을 해소한다.

## 변경

- **`.claude/rules/services.md` 신설** — `paths:` frontmatter(6 디렉토리) + 서비스 계층 **고유 규칙**(세션/`asyncio.gather`·N+1 배치·메모리 캐시 상한·발신 i18n) + cross-cutting 가드는 db.md/api.md/pipeline.md/i18n.md **포인터만**(정책 16 단일출처·중복 0).
- **CLAUDE.md 8→9 영역** — 동기화 체크리스트 매트릭스 + 주의사항 카테고리별 표 + "9 카테고리" 인트로 3곳 정합.

path 매칭 자동 로드(Anthropic 공식 path-scoped 패턴)로 서비스 파일 편집 시 가드가 surface 된다.

## ⚠️ stack 관계 (#1010 위)

이 PR 은 **#1010(구조검토 apply-now-safe 9건) 브랜치 위에 stack** 되어 있다 (CLAUDE.md 동기화 체크리스트 매트릭스가 #1010 의 pipeline 경로 정정과 같은 줄이라 충돌 회피 목적).
- **#1010 을 먼저 머지** 하면 이 PR 의 diff 가 자동으로 `services.md` + CLAUDE.md 9영역 변경만으로 정리됩니다.
- 현재 diff 에 #1010 변경이 함께 보이는 것은 정상(stack).

## 🔍 사용자 검증 필요

- [ ] `.claude/rules/services.md` 의 서비스 계층 규칙이 실제 운영 의도와 일치하는지 (특히 cross-ref 4건이 올바른 rule 을 가리키는지)
- [ ] #1010 머지 후 이 PR diff 가 services.md/CLAUDE.md 만으로 정리되는지

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- **1차 NG**: services.md `config_manager` 5-way cross-ref 가 `api.md §5-way`(존재하지 않는 섹션)를 가리킴 → 환각.
- **정정**: `api.md §알림 채널 추가 체크리스트`(ORM↔Data↔Update↔폼 4곳) + `pipeline.md §5-way 동기화`(PRESETS 5번째) 로 분리 + pre-commit `check-config-5way-sync` 훅은 3-layer(ORM↔Data↔Update) **자동 검증만**·폼/PRESETS 수동 명시.
- **재검증 OK** (실측): api.md:15 4곳 / pipeline.md:40 5-way / `scripts/check_config_5way_sync.py` 3-layer 확인 — 환각 해소.

## 테스트

코드 변경 0 (순수 docs/rule). 6 디렉토리 실재 확인 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
