### PR TITLE
chore(workflow): integrity-audit C10 회복력 + 동시성 교훈 문서화 (구조검토 ②③)

### DIFF
--- a/.claude/workflows/integrity-audit.mjs
+++ b/.claude/workflows/integrity-audit.mjs
@@ -299,19 +299,29 @@ while (dry < DRY_THRESHOLD && round < MAX_ROUNDS && (!budget.total || budget.rem
 }
 
 // ── completeness critic + 표적 gap 라운드 (Task 5) ──
+// completeness/gap 라운드는 best-effort — API 오류(예: 일시 500)가 이미 confirmed 결함과
+// Report 단계를 무효화하지 않도록 try/catch 로 격리 (C10 — retrospective.mjs 동일 패턴 계승).
+// Completeness/gap is best-effort — isolate API errors (e.g. a transient 500) via try/catch so they
+// can't void the already-confirmed findings or the Report phase (C10 — same pattern as retrospective.mjs).
 phase('Completeness')
-const gaps = await agent(completenessPrompt(domains, confirmed, scope), { label: 'completeness', phase: 'Completeness', schema: GAPS_SCHEMA })
-if (gaps?.items?.length) {
-  log(`completeness: gap ${gaps.items.length}건 → 표적 라운드`)
-  const gapFound = (await parallel(gaps.items.map((g) => () =>
-    agent(gapAuditPrompt(g), { label: `gap:${g.domain}`, phase: 'Discover', schema: FINDINGS_SCHEMA })
-  ))).filter(Boolean).flatMap((r) => r.findings ?? []).filter((f) => !seen.has(key(f)))
-  gapFound.forEach((f) => seen.add(key(f)))
-  if (gapFound.length) {
-    const gapJudged = await verifyFresh(gapFound)
-    confirmed.push(...gapJudged.filter((j) => j.real))
-    unverifiedAll.push(...gapJudged.filter((j) => j.unverified))
+try {
+  const gaps = await agent(completenessPrompt(domains, confirmed, scope), { label: 'completeness', phase: 'Completeness', schema: GAPS_SCHEMA })
+  if (gaps?.items?.length) {
+    log(`completeness: gap ${gaps.items.length}건 → 표적 라운드`)
+    const gapFound = (await parallel(gaps.items.map((g) => () =>
+      agent(gapAuditPrompt(g), { label: `gap:${g.domain}`, phase: 'Discover', schema: FINDINGS_SCHEMA })
+    ))).filter(Boolean).flatMap((r) => r.findings ?? []).filter((f) => !seen.has(key(f)))
+    gapFound.forEach((f) => seen.add(key(f)))
+    if (gapFound.length) {
+      const gapJudged = await verifyFresh(gapFound)
+      confirmed.push(...gapJudged.filter((j) => j.real))
+      unverifiedAll.push(...gapJudged.filter((j) => j.unverified))
+    }
   }
+} catch (e) {
+  // confirmed[] 는 그대로 Report 로 진행 — 부분 결과 보존 (조용한 전체 실패 방지).
+  // Proceed to Report with confirmed[] intact — preserve partial results (avoid silent total failure).
+  log(`completeness 라운드 실패 — best-effort 건너뜀 (confirmed ${confirmed.length}건 보존): ${e?.message ?? e}`)
 }
 
 // ── Report (구조화 데이터 반환 — 리포트 파일 작성은 호출자 책임) ──

--- a/docs/runbooks/integrity-audit.md
+++ b/docs/runbooks/integrity-audit.md
@@ -66,3 +66,12 @@
 
 scope 인식 팬아웃(C)으로 감싼 loop-until-dry 도메인 탐색(B) + 다관점 adversarial verify(B) + completeness critic(C)
 + `MAX_ROUNDS`·`budget` 비용 상한(C). 설계 상세: [docs/design/2026-06-05-integrity-audit-workflow-design.md](../design/2026-06-05-integrity-audit-workflow-design.md).
+
+## 🔴 워크플로우 작성·운영 교훈 (동시성·회복력)
+
+다중 에이전트 워크플로우(integrity-audit·retrospective·구조검토 등) 작성/실행 시 검증된 운영 제약:
+
+- **무거운 Opus 에이전트 동시 실행 ≤ 3 (웨이브 분할 의무)** — 무거운 리뷰/감사 에이전트 15개 동시 실행 시 서버 버스트 rate-limit("not your usage limit")로 전멸한 사고(2026-06-25). `chunk(items, 3)` + 웨이브별 `await parallel` 로 분할. verify 등 경량 단계는 무관.
+- **StructuredOutput placeholder 소실 위험** — 장시간(수 분)·고 tool-호출 에이전트가 schema 강제 최종 출력에서 placeholder(예: `"test summary"`)로 결과를 소실하는 사례(2026-06-29 구조검토 차원 5). 핵심 차원 결과가 placeholder 면 단일 Agent 재감사로 보완. finder/verify 는 `try { ... } catch { 재시도 }` 로 StructuredOutput flake 1회 재시도.
+- **completeness/gap 라운드 try/catch 격리 (C10)** — 마지막 best-effort 라운드의 일시 API 오류가 이미 confirmed 결함·Report 를 무효화하지 않도록 try/catch 로 격리. integrity-audit.mjs + retrospective.mjs 동일 패턴. 회귀 가드: `tests/unit/scripts/test_retrospective_resilience.py`.
+- **cross-vendor 필수 (정책 18)** — 단일 LLM 다중에이전트 sweep 도 P1 누락 가능. Codex(또는 타 vendor) 독립 감사로 교차 검증 — 2026-06-29 감사서 Codex 가 Claude 8-에이전트가 놓친 P1 2건(crypto invalid-key·migration fail-open) 발견.

--- a/tests/unit/scripts/test_retrospective_resilience.py
+++ b/tests/unit/scripts/test_retrospective_resilience.py
@@ -12,6 +12,7 @@ from pathlib import Path
 # 리포 루트 / repo root
 _ROOT = Path(__file__).resolve().parents[3]
 _RETRO = _ROOT / ".claude" / "workflows" / "retrospective.mjs"
+_INTEGRITY = _ROOT / ".claude" / "workflows" / "integrity-audit.mjs"
 
 
 def _strip_comments(text: str) -> str:
@@ -55,6 +56,14 @@ def test_confirmed_output_surfaces_evidence_and_citation():
 def test_completeness_round_is_resilient():
     assert _completeness_is_resilient(_code()), \
         "Completeness 라운드가 try/catch 로 보호되지 않음 (C10 회귀 — 2026-06-23 500 사고)"
+
+
+def test_integrity_audit_completeness_round_is_resilient():
+    """integrity-audit.mjs 도 Completeness 라운드를 try/catch 로 격리 (C10 패턴 계승, 2026-06-29 구조검토).
+    integrity-audit.mjs's Completeness round is also try/catch-isolated (C10 pattern inherited)."""
+    code = _strip_comments(_INTEGRITY.read_text(encoding="utf-8"))
+    assert _completeness_is_resilient(code), \
+        "integrity-audit.mjs Completeness 라운드가 try/catch 로 보호되지 않음 (C10 회귀)"
 
 
 # --- 합성 위반 적발 (주석 false-pass 봉인) / synthetic violation caught ---


### PR DESCRIPTION
## 요약

다중에이전트 구조 검토(2026-06-29)에서 승인된 propose-confirm **②③** — 워크플로우 회복력 + 동시성 교훈 codify. 코드(src/) 변경 0.

## 변경

### ② integrity-audit.mjs C10 회복력 계승
`.claude/workflows/integrity-audit.mjs` 의 **Completeness 라운드를 `try/catch` 로 격리** — retrospective.mjs 의 C10 패턴(2026-06-23 회고가 completeness API 500 으로 gap 라운드를 통째로 소실한 사고 방지)을 계승. 일시 API 오류(500 등)가 이미 `confirmed[]` 결함 + Report 단계를 무효화하지 않도록 best-effort 격리.

- 회귀 가드: `tests/unit/scripts/test_retrospective_resilience.py` 에 `test_integrity_audit_completeness_round_is_resilient` +1 (generic `_completeness_is_resilient` 헬퍼 재사용 + 주석 strip false-pass 방지).

### ③ 워크플로우 동시성·회복력 교훈 문서화
`docs/runbooks/integrity-audit.md` §"🔴 워크플로우 작성·운영 교훈" 신설 — 이번 세션 검증 학습 4건:
- 무거운 Opus 에이전트 동시 ≤3 (웨이브 분할 의무) — 2026-06-25 15개 동시 rate-limit 전멸
- StructuredOutput placeholder 소실 위험 → 핵심 차원 단일 Agent 재감사
- completeness/gap try/catch 격리 (C10)
- cross-vendor 필수 (정책 18) — 2026-06-29 Codex 가 Claude 8-에이전트 미발견 P1 2건 적발

## 🔍 사용자 검증 필요

- [ ] `/integrity-audit` 실행 시 completeness 라운드 API 오류가 발생해도 confirmed 결과가 보존되는지 (다음 실 운영 시 확인)
- [ ] 런북 §워크플로우 교훈의 동시성 가이드(≤3)가 향후 워크플로우 작성에 실제 도움이 되는지

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- **OK** (5/5): JS 문법(node --check 의 `Illegal return` 은 런타임 함수 래핑 설계로 인한 false-positive — 원본 main 동일, ReferenceError 0) / 격리 정확(confirmed·unverifiedAll try 진입 전 선언·catch 미변경) / 가드 유효(7 pass·주석 strip) / 회귀 0(`tests/unit/scripts/` 79 pass) / 교훈 사실 정합(과장 0).

## 테스트

`python -m pytest tests/unit/scripts/ -q` → 79 passed. integrity-audit C10 가드 +1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
