### PR TITLE
chore: codex-pytest-*/ · review-tmp-*/ gitignore — 세션 임시 디렉토리 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,11 @@ db_probe.py
 #   The `.codex_*` pattern does NOT match the tracked `.codex/` config dir.
 .codex_*
 
+# codex-rescue / 리뷰 도구가 repo 루트에서 pytest 실행 시 생성하는 임시 디렉토리 (절대 커밋 금지)
+# Temp dirs created when codex-rescue / review tooling runs pytest with cwd = repo root (NEVER commit).
+codex-pytest-*/
+review-tmp-*/
+
 # IDE
 .vscode/
 .idea/


### PR DESCRIPTION
## 요약

세션 정리작업 — codex-rescue / 리뷰 도구가 repo 루트를 cwd 로 pytest 실행할 때 생성하는 임시 디렉토리(`codex-pytest-<uuid>/`·`review-tmp-e2e/`)를 `.gitignore` 에 등재. 이번 세션에서 `git status` 경고로 노출됨(권한 잠금으로 물리 삭제 불가).

## 변경

`.gitignore` 에 2 패턴 추가 (기존 `.codex_*` 바로 아래):
```
codex-pytest-*/
review-tmp-*/
```

## 근거

- git 이 해당 디렉토리를 읽지 못해(권한 거부) **현재 우발 커밋 위험은 0** 이나, 읽기 가능한 미래 세션의 우발 커밋 방지 + codex-rescue 실행마다 재생성되는 점 대비 **durable 가드**.
- 패턴 접두(`codex-pytest-`·`review-tmp-`)가 특정적이라 정상 소스/문서 over-match 위험 없음.

## 🔍 사용자 검증 필요

- [ ] 로컬에 잔존하는 `codex-pytest-*`/`review-tmp-e2e` 디렉토리는 권한 잠금으로 이 세션에서 삭제 불가 — 필요 시 재부팅 후 수동 삭제 가능 (gitignore 로 git 추적에서는 제외됨)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- **OK** (Claude 직접 실측 + Codex fallback 교차):
  - `git check-ignore` → 두 디렉토리 모두 매칭 ✅
  - `git ls-files | grep -E "^codex-pytest-|^review-tmp-"` → 빈 출력 (tracked 파일 over-match 0) ✅
  - Codex: 두 패턴 추가 + `!!`(ignored) 확인 + tracked over-match 0 확인 (정책 차단으로 `git status --ignored` fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
