### PR TITLE
fix(metrics): Claude Opus 가격 2026-Q3 갱신 — $15/$75 → $5/$25 per MTok (3× 인하)

### DIFF
--- a/src/shared/claude_metrics.py
+++ b/src/shared/claude_metrics.py
@@ -2,8 +2,8 @@
 
 Phase E.2b — Claude API cost/latency/token 추적 기반.
 
-Anthropic API 가격 정책 (USD per 1M tokens, **2026-04 기준**):
-  - Opus : $15 input / $75 output
+Anthropic API 가격 정책 (USD per 1M tokens, **2026-07 기준**):
+  - Opus : $5 input / $25 output   (Opus 4.8/4.7/4.6 — 분기 재확인 2026-07, 이전 $15/$75 대비 3× 인하)
   - Sonnet: $3 input / $15 output  ← 기본값 (claude-sonnet-4-6 등)
   - Haiku : $1 input / $5 output
 
@@ -34,9 +34,11 @@ async def aclose_anthropic_client(client) -> None:
     if inspect.isawaitable(result):
         await result
 
-# 모델 패밀리별 가격 (USD per 1M tokens, input/output)
+# 모델 패밀리별 가격 (USD per 1M tokens, input/output) — 2026-07 기준
+# Model family pricing (USD per 1M tokens, input/output) — 2026-07 basis
 _PRICING_USD_PER_MTOK = {
-    "opus": (15.0, 75.0),
+    "opus": (5.0, 25.0),    # Opus 4.8/4.7/4.6 — 이전 (15.0, 75.0) 대비 3× 인하 (2026-07 확인)
+                             # Previously (15.0, 75.0) — 3× price drop confirmed 2026-07
     "sonnet": (3.0, 15.0),
     "haiku": (1.0, 5.0),
 }

--- a/tests/unit/shared/test_claude_metrics.py
+++ b/tests/unit/shared/test_claude_metrics.py
@@ -31,13 +31,14 @@ class TestEstimateCostUsd:
         assert cost == pytest.approx(15.0)
 
     def test_opus_rates(self):
-        # opus: $15/M input, $75/M output
+        # opus: $5/M input, $25/M output (2026-07 기준 — 이전 $15/$75 대비 3× 인하)
+        # opus: $5/M input, $25/M output (2026-07 basis — 3× drop from prior $15/$75)
         cost = claude_metrics.estimate_claude_cost_usd(
             model="claude-opus-4",
             input_tokens=1_000_000,
             output_tokens=1_000_000,
         )
-        assert cost == pytest.approx(15.0 + 75.0)
+        assert cost == pytest.approx(5.0 + 25.0)
 
     def test_haiku_rates(self):
         # haiku: $1/M input, $5/M output


### PR DESCRIPTION
## 개요 / Summary

분기 정기 확인 (2026-Q3): Anthropic Claude Opus 패밀리 가격이 **3× 인하**됨.
코드에 남아있던 2026-04 기준 `$15/$75` 값을 현행 `$5/$25` (USD per 1M tokens)로 갱신.

Quarterly recheck (Q3 2026): Claude Opus family price dropped 3×.
Updates stale 2026-04 values `$15/$75` → current `$5/$25` USD/MTok.

---

## 가격 변경 상세 / Pricing Change Detail

| 패밀리 | 코드 이전 값 (2026-04) | 현행 Anthropic 가격 (2026-07) | 변경 |
|--------|----------------------|-------------------------------|------|
| **opus** | $15.0 input / $75.0 output | **$5.00 input / $25.00 output** | ✅ 3× 인하 |
| sonnet | $3.0 / $15.0 | $3.00 / $15.00 | — 무변경 |
| haiku  | $1.0 / $5.0  | $1.00 / $5.00  | — 무변경 |
| cache_read_multiplier | 0.1 | 0.1 | — 무변경 |
| cache_creation_multiplier | 1.25 | 1.25 | — 무변경 |

**가격 근거**: Anthropic claude-api skill 캐시 (2026-06-24 기준) — Claude Opus 4.8/4.7/4.6 모두 `$5.00/$25.00`.

---

## 변경 파일 / Changed Files

- `src/shared/claude_metrics.py`: docstring 기준일 `2026-04` → `2026-07`, `_PRICING_USD_PER_MTOK["opus"]` `(15.0, 75.0)` → `(5.0, 25.0)`, 한국어+영어 bilingual 주석 갱신
- `tests/unit/shared/test_claude_metrics.py`: `test_opus_rates` 기대값 `90.0` → `30.0`, 주석 반영

---

## 테스트 / Tests

```
24 passed in 0.08s  (tests/unit/shared/test_claude_metrics.py — 전체 통과)
```

---

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

> **참고**: 본 저장소의 원격 실행 환경에서는 Codex CLI 를 직접 호출할 수 없습니다.
> 분기 정기 확인 루틴에서 단독으로 실행된 작업이므로, 아래 내용을 사용자 또는 Codex 가 검토해 주세요.

검증 요청 항목:
1. `_PRICING_USD_PER_MTOK["opus"] = (5.0, 25.0)` — Anthropic 공식 가격과 일치 여부
2. `estimate_claude_cost_usd` 로직에 opus 가격 적용이 올바른지 (substring match `"opus"`)
3. `test_opus_rates` 기대값 `30.0` (`5.0 + 25.0`) 정확성

---

## 🔍 사용자 검증 필요 (정책 2)

- [ ] **가격 직접 확인**: https://www.anthropic.com/pricing 에서 Claude Opus 4.8/4.7/4.6 현행 가격이 `$5.00 input / $25.00 output per 1M tokens` 임을 확인
- [ ] **cost_usd 로그 확인**: 운영 로그에서 `cost_usd` 필드가 Opus 호출 시 이전 대비 ~3× 감소했는지 확인 (실제 청구 대비 ±10% 오차 범위 내 추적)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCR2gqNMzKnZ8FtSqwpfxt)_