### PR TITLE
fix(metrics): Opus·Haiku 가격 정합성 완결 — constants.py + i18n (#1015 후속)

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -167,14 +167,16 @@ BREAKDOWN_KEY_TEST_COVERAGE = "test_coverage"
 
 # ── Claude AI 모델 목록 + 요금 (Anthropic 공식 기준, USD/1M 토큰) ─────────
 # ── Claude AI model catalog + pricing (Anthropic official, USD per 1M tokens) ─
-# 출처: https://www.anthropic.com/pricing (2025-05 기준 — 실제 청구와 다를 수 있음)
-# Source: https://www.anthropic.com/pricing (as of 2025-05 — actual billing may differ)
+# 출처: https://www.anthropic.com/pricing (2026-07 재확인 — 실제 청구와 다를 수 있음)
+# Source: https://www.anthropic.com/pricing (reconfirmed 2026-07 — actual billing may differ)
+# 2026-07 갱신: Opus $15/$75 → $5/$25 (3× 인하), Haiku $0.80/$4 → $1/$5 — claude_metrics.py 와 단일 기준 정합
+# 2026-07 update: Opus $15/$75 → $5/$25 (3× drop), Haiku $0.80/$4 → $1/$5 — unified with claude_metrics.py
 CLAUDE_MODELS: list[dict] = [
     {
         "id": "claude-haiku-4-5-20251001",
         "label": "Claude Haiku 4.5 (빠름/저렴 · Fast/Cheap)",
-        "input_price": 0.80,
-        "output_price": 4.00,
+        "input_price": 1.00,
+        "output_price": 5.00,
     },
     {
         "id": "claude-sonnet-4-6",
@@ -185,8 +187,8 @@ CLAUDE_MODELS: list[dict] = [
     {
         "id": "claude-opus-4-7",
         "label": "Claude Opus 4.7 (고품질 · High Quality)",
-        "input_price": 15.00,
-        "output_price": 75.00,
+        "input_price": 5.00,
+        "output_price": 25.00,
     },
 ]
 

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -453,7 +453,7 @@
     "show_value": "Show value",
     "save_toast_ok": "✅ Settings saved.",
     "save_toast_err": "❌ Save failed. The approve threshold is lower than the reject threshold.",
-    "model_hint": "Select an AI review model per repo. Haiku → fast & cheap ($0.80/1M) · Sonnet → balanced ($3/1M) · Opus → high quality ($15/1M). Leave empty to use the server global default (claude-sonnet-4-6). ※ Prices are based on Anthropic official rates (actual billing may differ)."
+    "model_hint": "Select an AI review model per repo. Haiku → fast & cheap ($1/1M) · Sonnet → balanced ($3/1M) · Opus → high quality ($5/1M). Leave empty to use the server global default (claude-sonnet-4-6). ※ Prices are based on Anthropic official rates (actual billing may differ)."
   },
   "settings_page": {
     "title_prefix": "Settings",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -453,7 +453,7 @@
     "show_value": "値を表示",
     "save_toast_ok": "✅ 設定が保存されました。",
     "save_toast_err": "❌ 保存に失敗しました。承認基準点が却下基準点より低いです。",
-    "model_hint": "リポジトリ別のAIレビューモデルを選択します。Haiku → 高速・低コスト ($0.80/1M) · Sonnet → バランス ($3/1M) · Opus → 高品質 ($15/1M)。空欄の場合はサーバー全体のデフォルト(claude-sonnet-4-6)を使用します。※ 価格はAnthropic公式基準です(実際の請求と異なる場合があります)。"
+    "model_hint": "リポジトリ別のAIレビューモデルを選択します。Haiku → 高速・低コスト ($1/1M) · Sonnet → バランス ($3/1M) · Opus → 高品質 ($5/1M)。空欄の場合はサーバー全体のデフォルト(claude-sonnet-4-6)を使用します。※ 価格はAnthropic公式基準です(実際の請求と異なる場合があります)。"
   },
   "settings_page": {
     "title_prefix": "設定",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -453,7 +453,7 @@
     "show_value": "값 보이기",
     "save_toast_ok": "✅ 설정이 저장되었습니다.",
     "save_toast_err": "❌ 저장에 실패했습니다. 승인 기준점이 반려 기준점보다 낮습니다.",
-    "model_hint": "리포별 AI 리뷰 모델을 선택합니다. Haiku → 빠름·저렴 ($0.80/1M) · Sonnet → 균형 ($3/1M) · Opus → 고품질 ($15/1M). 비어두면 서버 전역 기본값(claude-sonnet-4-6)을 따릅니다. ※ 가격은 Anthropic 공식 기준 (실제 청구와 다를 수 있습니다)."
+    "model_hint": "리포별 AI 리뷰 모델을 선택합니다. Haiku → 빠름·저렴 ($1/1M) · Sonnet → 균형 ($3/1M) · Opus → 고품질 ($5/1M). 비어두면 서버 전역 기본값(claude-sonnet-4-6)을 따릅니다. ※ 가격은 Anthropic 공식 기준 (실제 청구와 다를 수 있습니다)."
   },
   "settings_page": {
     "title_prefix": "설정",


### PR DESCRIPTION
## 요약 / Summary

#1015 (Opus 가격 $15/$75 → $5/$25, 머지 완료)가 `src/shared/claude_metrics.py` **만** 갱신하고 남긴 잔여 stale 가격을 완결합니다. 머지 직후 정합성 감사에서 두 번째 pricing source(`constants.py`)와 UI 힌트(i18n)가 여전히 구가격이었음을 발견했습니다.
Completes the pricing consistency that #1015 applied only to `claude_metrics.py`.

### 변경 (Opus + Haiku 전면 정합 — 사용자 결정)

| 파일 | 모델 | 변경 |
|------|------|------|
| `constants.py:190-191` | Opus 4.7 | $15/$75 → **$5/$25** |
| `constants.py:178-179` | Haiku 4.5 | $0.80/$4 → **$1/$5** |
| `i18n en/ko/ja:456` | Opus 힌트 | $15/1M → **$5/1M** |
| `i18n en/ko/ja:456` | Haiku 힌트 | $0.80/1M → **$1/1M** |

Sonnet($3/$15)는 정확하여 미변경. 이제 `constants.py` `CLAUDE_MODEL_PRICING` ↔ `claude_metrics.py` `_PRICING_USD_PER_MTOK` ↔ claude-api 공식 레퍼런스가 **단일 기준**으로 정합됩니다.

### 근거 / Basis

claude-api 공식 레퍼런스 (2026-07 기준): Opus 4.6/4.7/4.8 = **$5/$25**, Sonnet = $3/$15, Haiku 4.5 = **$1/$5**.

## ✅ 검증 / Verification

- JSON en/ko/ja 3종 유효 (파싱 성공)
- 관련 테스트 **95건 green**: `test_claude_metrics` · `test_admin_settings_i18n_render` · `test_operations_i18n_kpi` · `test_operations_service` · `test_i18n_smoke`
- 잔여 stale 가격 grep 0건 (src/ 전체 — `$15/1M` · `$0.80/1M` · Opus 15.00/75.00 · Haiku 0.80/4.00)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- **VERDICT: OK** — mutual 검증 완료 (Claude ✅ + Codex ✅, **push 전**)
- Codex 독립 검증: diff 4파일 정확 · `constants.py` ↔ `claude_metrics.py` parity 확인 · i18n 힌트 정확 · **stale/누락 pricing source 0건** (#1015가 놓친 4번째 소스 없음). 샌드박스가 pytest/json 실행을 차단하여 초기 NG → 실행 증거(JSON 유효 + 95 passed) 전달 후 최종 **OK**.

## 🔍 사용자 검증 필요 (정책 2)

- 운영 대시보드 **모델 선택 힌트**(admin settings)에서 Opus `$5/1M` · Haiku `$1/1M`로 표기되는지 (텍스트 변경이라 4-테마 시각 회귀 위험 낮음)
- **API 비용 KPI**(operations)의 Opus/Haiku 추정 비용이 신가격 기준으로 계산되는지 (운영 데이터 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
