### PR TITLE
chore(ci): trufflehog SHA 핀 버전 주석 정정 v3.95.5 → v3.95.7 (#1016 후속)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         # PR diff 범위만 스캔 — 2026-05-03 사고 유형 방어
         # Scans PR diff range only — guards against 2026-05-03 incident type
         if: github.event_name == 'pull_request'
-        uses: trufflesecurity/trufflehog@f446421baf832d6356c42c1743d99abff52ff334  # v3.95.5 (SHA 핀 — 공급망 무결성, @main 가변 태그 위험 차단)
+        uses: trufflesecurity/trufflehog@f446421baf832d6356c42c1743d99abff52ff334  # v3.95.7 (SHA 핀 — 공급망 무결성, @main 가변 태그 위험 차단)
         with:
           path: ./
           base: ${{ github.event.pull_request.base.sha }}
@@ -42,7 +42,7 @@ jobs:
         # before == zeros(첫 push / force-push) 시 invalid SHA 오류 방지를 위해 건너뜀
         # Skip when before is zeros (first push / force-push) to avoid invalid SHA error
         if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
-        uses: trufflesecurity/trufflehog@f446421baf832d6356c42c1743d99abff52ff334  # v3.95.5 (SHA 핀 — 공급망 무결성, @main 가변 태그 위험 차단)
+        uses: trufflesecurity/trufflehog@f446421baf832d6356c42c1743d99abff52ff334  # v3.95.7 (SHA 핀 — 공급망 무결성, @main 가변 태그 위험 차단)
         with:
           path: ./
           base: ${{ github.event.before }}


### PR DESCRIPTION
## 요약 / Summary

#1016 (dependabot, 머지 완료)이 trufflehog SHA 핀을 v3.95.7로 bump 했으나 인라인 버전 주석은 미갱신하여 `.github/workflows/ci.yml` 에 `# v3.95.5` stale 주석이 남았습니다. SHA(공급망 무결성 핀)는 정확했고 **주석만** 정정합니다.
dependabot bumped the pinned SHA in #1016 but left the stale version comment; this fixes the comment only.

- `ci.yml:34, 45` (2 trufflehog 스텝): `# v3.95.5` → `# v3.95.7`
- 핀 SHA `f446421baf832d6356c42c1743d99abff52ff334` 는 **byte-identical 유지** (기능 영향 0)
- `f446421…` = trufflehog **v3.95.7** (GitHub git-refs API 실측 검증)

## ✅ 검증 / Verification

- diff = comment-only (SHA 불변, 2 lines)
- pre-commit `check yaml` 통과

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- **VERDICT: OK** — mutual 검증 완료 (Claude ✅ + Codex ✅, **push 전**)
- Codex 독립 확인: `ci.yml` 단일 파일 · 핀 SHA byte-identical · 주석만 v3.95.5→v3.95.7 · YAML 구조 불변

## 🔍 사용자 검증 필요 (정책 2)

- CI **TruffleHog** 스텝이 기존과 동일하게 통과하는지 (SHA 불변 → 동작 변화 없음, 주석 정합만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
