### PR TITLE
fix(hardening): 감사 note급 견고성 3건 — operations days 상한·config locale 멤버십·git rename 파싱

### DIFF
--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -61,9 +61,9 @@ Sentry 외 자동 로깅은 별도 환경변수 없이 동작:
 
 | 변수 | 설명 | 기본값 | 예시 |
 |------|------|-------|------|
-| `DEFAULT_LOCALE` | 신규 사용자 기본 언어 (User.preferred_language 초기값 — alembic 0030 페어, Phase 1 PR-1c 영역) | `en` | `en` / `ko` / `ja` |
+| `DEFAULT_LOCALE` | 신규 사용자 기본 언어 (User.preferred_language 초기값 — alembic 0030 페어, Phase 1 PR-1c 영역). 🔴 **`SUPPORTED_LOCALES` 에 포함된 값이어야 함** — 미포함 시 startup ValidationError (config.py `_validate_locale_membership`, 2026-07-03 하드닝 N2) | `en` | `en` / `ko` / `ja` |
 | `SUPPORTED_LOCALES` | 지원 언어 목록 (쉼표 구분, 공백 제거 의무 — pydantic field_validator 검증) | `en,ko,ja` | `en,ko,ja` / `en,ko` |
-| `LOCALE_FALLBACK` | 극한 fallback 언어 (모든 감지 실패 시 / 번역 파일 미존재 등) | `en` | `en` |
+| `LOCALE_FALLBACK` | 극한 fallback 언어 (모든 감지 실패 시 / 번역 파일 미존재 등). 🔴 **`SUPPORTED_LOCALES` 에 포함된 값이어야 함** — 미포함 시 startup ValidationError (config.py `_validate_locale_membership`, 2026-07-03 하드닝 N2) | `en` | `en` |
 | `I18N_TRANSLATIONS_DIR` | JSON dict 번역 파일 위치 (en.json/ko.json/ja.json — 상대 또는 절대 경로) | `src/i18n/translations` | 개발: `src/i18n/translations` / 운영: `/app/src/i18n/translations` |
 | `I18N_DISABLED` | i18n 기능 kill-switch (1=비활성, 운영 사고 시 응급 차단용) | `0` | `0` (활성) / `1` (긴급 차단) |
 

--- a/src/api/admin.py
+++ b/src/api/admin.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from src.auth.session import CurrentUser, require_admin
@@ -91,9 +91,14 @@ def get_rls_audit(
 def get_operations(
     _admin: Annotated[CurrentUser, Depends(require_admin)],
     db: Annotated[Session, Depends(_get_worker_db)],
-    days: int = 7,
+    days: Annotated[int, Query(ge=1, le=365)] = 7,
 ) -> dict[str, Any]:
     """admin 운영 모니터링 KPI 5 카드 (Cycle 80 PR 2 — 영역 🅔).
+
+    days 는 1~365 범위 강제 (repo_report.py 와 대칭) — 상한 없으면 거대값이
+    operations_service 의 timedelta(days=...) 에서 OverflowError → HTTP 500.
+    days is clamped to 1~365 (mirrors repo_report.py); without an upper bound a
+    huge value overflows timedelta(days=...) in operations_service → HTTP 500.
 
     Admin operations dashboard KPI 5 cards (Cycle 80 PR 2).
     """

--- a/src/cli/git_diff.py
+++ b/src/cli/git_diff.py
@@ -36,10 +36,15 @@ def _collect_file(
     line: str, base: str, staged: bool
 ) -> ChangedFile | None:
     """`--name-status` 한 줄을 ChangedFile 로 변환. 바이너리·스킵 케이스는 None."""
-    parts = line.split("\t", 1)
+    parts = line.split("\t")
     if len(parts) < 2:
         return None
-    status, filename = parts[0], parts[1]
+    status = parts[0]
+    # 리네임(R###)·복사(C###) 라인은 `status\told\tnew` (탭 2개) → 대상(new) 파일명 사용.
+    # 일반 라인은 `status\tfile` → parts[-1] 이 곧 파일명 (양쪽 모두 정확).
+    # Rename(R###)/copy(C###) lines are `status<TAB>old<TAB>new`; use the destination (new)
+    # filename. Normal lines are `status<TAB>file`, so parts[-1] is correct in both cases.
+    filename = parts[-1]
 
     patch_args = ("diff", "--cached", "--", filename) if staged else ("diff", base, "--", filename)
     patch = _git(*patch_args, check=False).stdout

--- a/src/config.py
+++ b/src/config.py
@@ -368,5 +368,33 @@ class Settings(BaseSettings):
             )
         return v
 
+    @model_validator(mode="after")
+    def _validate_locale_membership(self) -> "Settings":
+        """default_locale·locale_fallback 가 supported_locales 에 포함되는지 교차검증.
+
+        Cross-check that default_locale and locale_fallback are members of supported_locales.
+
+        field_validator 는 형식만 검사 → 오타 시 조용히 영어 fallback(또는 loader
+        fallback 오타 시 raw 키 노출)으로 열화한다. startup 에서 fail-fast 하여 운영자
+        설정 오류를 즉시 드러낸다 (api/repos.py per-repo 검증과 대칭).
+        The field_validators check format only, so a typo silently degrades to English
+        fallback (or raw i18n keys if LOCALE_FALLBACK itself is mistyped). Fail fast at
+        startup instead, surfacing the operator config error (mirrors api/repos.py).
+        """
+        supported = {
+            loc.strip() for loc in self.supported_locales.split(",") if loc.strip()
+        }
+        if self.default_locale not in supported:
+            raise ValueError(
+                f"DEFAULT_LOCALE '{self.default_locale}' must be one of "
+                f"SUPPORTED_LOCALES {sorted(supported)}"
+            )
+        if self.locale_fallback not in supported:
+            raise ValueError(
+                f"LOCALE_FALLBACK '{self.locale_fallback}' must be one of "
+                f"SUPPORTED_LOCALES {sorted(supported)}"
+            )
+        return self
+
 
 settings = Settings()

--- a/src/ui/routes/admin.py
+++ b/src/ui/routes/admin.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse
 from sqlalchemy.orm import Session
 
@@ -104,9 +104,14 @@ def admin_operations(
     request: Request,
     admin: Annotated[CurrentUser, Depends(require_admin)],
     db: Annotated[Session, Depends(_get_worker_db)],
-    days: int = 7,
+    days: Annotated[int, Query(ge=1, le=365)] = 7,
 ) -> HTMLResponse:
     """운영 모니터링 KPI 5 카드 admin dashboard (Cycle 80 PR 2 — 영역 🅔).
+
+    days 는 1~365 범위 강제 (API /api/admin/operations 대칭) — 상한 없으면 거대값이
+    operations_service timedelta(days=...) 에서 OverflowError → HTTP 500.
+    days is clamped to 1~365 (mirrors the API route); an unbounded huge value overflows
+    timedelta(days=...) in operations_service → HTTP 500.
 
     Operations dashboard admin (Cycle 80 PR 2 — area 🅔).
     """

--- a/tests/unit/api/test_admin_endpoints.py
+++ b/tests/unit/api/test_admin_endpoints.py
@@ -348,3 +348,29 @@ def test_admin_operations_active_returns_200(client):
     ):
         response = client.get("/admin/operations")
     assert response.status_code == 200
+
+
+# ── operations days 범위 검증 (감사 하드닝 N1) ────────────────────
+# operations days-parameter range validation (audit hardening N1)
+
+@pytest.mark.parametrize("bad_days", [0, -1, 366, 1000000000])
+def test_operations_rejects_out_of_range_days(client, bad_days):
+    """days 가 1~365 밖이면 endpoint body 진입 전 422 로 차단.
+
+    상한 없으면 거대 days 가 operations_service 의 timedelta(days=...) 에서
+    OverflowError → HTTP 500 (repo_report.py 와 동일한 Query(ge=1, le=365) 대칭).
+    """
+    response = client.get(f"/api/admin/operations?days={bad_days}")
+    assert response.status_code == 422
+
+
+def test_operations_accepts_valid_days(client):
+    """1~365 범위 내 days 는 정상 처리."""
+    from unittest.mock import patch
+    with patch(
+        "src.api.admin.operations_service.operations_kpi",
+        return_value={"ok": True},
+    ):
+        response = client.get("/api/admin/operations?days=7")
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}

--- a/tests/unit/api/test_admin_endpoints.py
+++ b/tests/unit/api/test_admin_endpoints.py
@@ -353,14 +353,16 @@ def test_admin_operations_active_returns_200(client):
 # ── operations days 범위 검증 (감사 하드닝 N1) ────────────────────
 # operations days-parameter range validation (audit hardening N1)
 
+@pytest.mark.parametrize("path", ["/api/admin/operations", "/admin/operations"])
 @pytest.mark.parametrize("bad_days", [0, -1, 366, 1000000000])
-def test_operations_rejects_out_of_range_days(client, bad_days):
-    """days 가 1~365 밖이면 endpoint body 진입 전 422 로 차단.
+def test_operations_rejects_out_of_range_days(client, path, bad_days):
+    """API·HTML 두 라우트 모두 days 1~365 밖 → endpoint body 진입 전 422 차단.
 
     상한 없으면 거대 days 가 operations_service 의 timedelta(days=...) 에서
     OverflowError → HTTP 500 (repo_report.py 와 동일한 Query(ge=1, le=365) 대칭).
+    두 경로(API admin.py + HTML ui/routes/admin.py)가 동일 operations_kpi 를 호출하므로 둘 다 가드.
     """
-    response = client.get(f"/api/admin/operations?days={bad_days}")
+    response = client.get(f"{path}?days={bad_days}")
     assert response.status_code == 422
 
 

--- a/tests/unit/cli/test_git_diff.py
+++ b/tests/unit/cli/test_git_diff.py
@@ -162,3 +162,26 @@ def test_get_repo_name_no_remote(mock_run):
     """Falls back to empty string when no remote."""
     mock_run.side_effect = subprocess.CalledProcessError(128, "git")
     assert get_repo_name() == ""
+
+
+# ── --name-status 리네임 라인 파싱 (감사 하드닝 N3) ──────────────
+# --name-status rename-line parsing (audit hardening N3)
+
+@patch("subprocess.run")
+def test_get_diff_files_rename_uses_destination_filename(mock_run):
+    """R### 리네임 라인(status<TAB>old<TAB>new)은 대상(new) 파일명으로 파싱 — 탭 혼입 금지.
+
+    이전 split('\\t', 1) 은 filename='old.py\\tnew.py' 로 오염 → patch/content 조회 실패.
+    """
+    mock_run.side_effect = [
+        # 1) git diff --name-status : 리네임 라인 (탭 2개)
+        _run_result(stdout="R100\told_name.py\tnew_name.py\n"),
+        # 2) patch for new_name.py
+        _run_result(stdout="--- a/new_name.py\n+++ b/new_name.py\n@@ -1 +1 @@\n-x\n+y"),
+        # 3) content (git show HEAD:new_name.py)
+        _run_result(stdout="renamed content"),
+    ]
+    files = get_diff_files(base="HEAD~1")
+    assert len(files) == 1
+    assert files[0].filename == "new_name.py"
+    assert "\t" not in files[0].filename

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -501,3 +501,32 @@ def test_active_env_assignments_normalizes_value(tmp_path, line, expected):
     env_file = tmp_path / "env.under_test"
     env_file.write_text(line + "\n", encoding="utf-8")
     assert _active_env_assignments(env_file).get("API_AUTH_DISABLED") == expected
+
+
+# ── locale membership 교차검증 (감사 하드닝 N2) ──────────────────
+# locale membership cross-validation (audit hardening N2)
+
+def test_default_locale_must_be_in_supported_locales():
+    """DEFAULT_LOCALE 가 SUPPORTED_LOCALES 밖 → ValidationError (startup fail-fast)."""
+    from pydantic import ValidationError
+    from src.config import Settings
+    with pytest.raises(ValidationError) as exc:
+        Settings(default_locale="fr", supported_locales="en,ko,ja", locale_fallback="en")
+    assert "SUPPORTED_LOCALES" in str(exc.value)
+
+
+def test_locale_fallback_must_be_in_supported_locales():
+    """LOCALE_FALLBACK 가 SUPPORTED_LOCALES 밖 → ValidationError."""
+    from pydantic import ValidationError
+    from src.config import Settings
+    with pytest.raises(ValidationError) as exc:
+        Settings(default_locale="en", supported_locales="en,ko,ja", locale_fallback="de")
+    assert "SUPPORTED_LOCALES" in str(exc.value)
+
+
+def test_locale_membership_valid_config_constructs():
+    """세 locale 모두 supported 안이면 정상 생성 (기본값 회귀 가드)."""
+    from src.config import Settings
+    s = Settings(default_locale="ko", supported_locales="en,ko,ja", locale_fallback="en")
+    assert s.default_locale == "ko"
+    assert s.locale_fallback == "en"


### PR DESCRIPTION
## 요약 / Summary

2026-07-03 심층 감사(다중 에이전트 10차원 + adversarial verify)에서 확정된 **note급 견고성 3건**을 수정 + 회귀 가드 13건. 감사 종합 판정은 **P0/P1/P2=0 · 은닉/악성코드 CLEAN**이었고, 본 PR은 그 note급 하드닝만 다룹니다.
Fixes the 3 confirmed note-level robustness gaps from the 2026-07-03 deep audit (+13 regression guards). The audit verdict was clean (no P0/P1/P2, no hidden/malicious code); this PR only addresses the note-level items.

### 수정 (감사 N1/N2/N3)

| # | 위치 | 문제 | 수정 |
|---|------|------|------|
| N1 | `api/admin.py:94` + `ui/routes/admin.py:107` | `/operations` (API+HTML **2 라우트**) `days` 상한 미검증 → 거대값 `timedelta` OverflowError → HTTP 500 | `Annotated[int, Query(ge=1, le=365)]` (repo_report.py 대칭) |
| N2 | `config.py` | `default_locale`·`locale_fallback` 이 `supported_locales` 멤버십 미검증 (api/repos.py 와 비대칭) | `model_validator(mode=after)` 교차검증 → **startup fail-fast** |
| N3 | `cli/git_diff.py:39` | `--name-status` 리네임(R###) 라인 탭2개 파싱 시 filename 탭 혼입 → 로컬 CLI 리뷰 no-op | `line.split("\t")` + `parts[-1]` (대상 파일명) |

+ `docs/reference/env-vars.md`: DEFAULT_LOCALE/LOCALE_FALLBACK 멤버십 제약 명시 (config.py validator 변경 체크리스트).

## ✅ 검증 / Verification

- 단위 **5130 passed** (+13 회귀 가드: N1 두 라우트 × bad값 4 + valid, N2 3, N3 1), 4 skipped
- flake8 clean (변경 파일 전체)
- 각 회귀 가드는 수정 없으면 fail (Red→Green 성립 확인)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- **VERDICT: OK** — mutual 검증 완료 (Claude ✅ + Codex ✅, **push 전**)
- 🔴 **1차 NG → 반영 (cross-vendor 가치)**: Codex 가 N1 을 **API 라우트만 고치고 HTML 라우트(`ui/routes/admin.py`)가 동일 OverflowError 노출**임을 적발 → 즉시 동일 패턴 보강(`559672a`) + 테스트를 두 라우트 parametrize → 재검증 OK. Codex sibling 스캔: 다른 `operations_kpi`/`timedelta(days=...)` 호출처(dashboard·repo_insights·repo_report)는 **이미 bound** 확인.

## 🔍 사용자 검증 필요 (정책 2)

- 🔴 **N2 는 startup 동작 변경**: 운영 배포의 `DEFAULT_LOCALE`·`LOCALE_FALLBACK` 이 `SUPPORTED_LOCALES` 밖 값이면 이제 **부팅 시 ValidationError**(의도된 fail-fast — 조용한 영어 열화/raw 키 노출 방지). **Railway/운영 env 의 locale 3종 정합 여부 배포 전 확인 권장** (기본값 `en` / `en,ko,ja` / `en` 은 안전).
- admin `/operations` 에 극단 `days` 입력 시 500 대신 422 반환 확인 (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
