### PR TITLE
fix(test): test_config.py 이중 import 제거 — CodeQL py/import-and-import-from 봉인 (#1021 self-inflicted)

### DIFF
--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -508,25 +508,25 @@ def test_active_env_assignments_normalizes_value(tmp_path, line, expected):
 
 def test_default_locale_must_be_in_supported_locales():
     """DEFAULT_LOCALE 가 SUPPORTED_LOCALES 밖 → ValidationError (startup fail-fast)."""
+    import src.config as cfg
     from pydantic import ValidationError
-    from src.config import Settings
     with pytest.raises(ValidationError) as exc:
-        Settings(default_locale="fr", supported_locales="en,ko,ja", locale_fallback="en")
+        cfg.Settings(default_locale="fr", supported_locales="en,ko,ja", locale_fallback="en")
     assert "SUPPORTED_LOCALES" in str(exc.value)
 
 
 def test_locale_fallback_must_be_in_supported_locales():
     """LOCALE_FALLBACK 가 SUPPORTED_LOCALES 밖 → ValidationError."""
+    import src.config as cfg
     from pydantic import ValidationError
-    from src.config import Settings
     with pytest.raises(ValidationError) as exc:
-        Settings(default_locale="en", supported_locales="en,ko,ja", locale_fallback="de")
+        cfg.Settings(default_locale="en", supported_locales="en,ko,ja", locale_fallback="de")
     assert "SUPPORTED_LOCALES" in str(exc.value)
 
 
 def test_locale_membership_valid_config_constructs():
     """세 locale 모두 supported 안이면 정상 생성 (기본값 회귀 가드)."""
-    from src.config import Settings
-    s = Settings(default_locale="ko", supported_locales="en,ko,ja", locale_fallback="en")
+    import src.config as cfg
+    s = cfg.Settings(default_locale="ko", supported_locales="en,ko,ja", locale_fallback="en")
     assert s.default_locale == "ko"
     assert s.locale_fallback == "en"


### PR DESCRIPTION
## 요약 / Summary

#1021 의 N2 테스트가 추가한 `from src.config import Settings` 가 기존 `import src.config as cfg` 와 공존 → CodeQL `py/import-and-import-from` (note) 경고 **#538/#539** 자초. `.claude/rules/testing.md` "이중 import 회피" 규칙에 따라 정리.
Removes the from-import that #1021 introduced, restoring the file's single `import src.config as cfg` idiom.

- 3 N2 테스트: `from src.config import Settings` → `import src.config as cfg` + `cfg.Settings(...)`
- 파일 내 `from src.config import` **0건** → import 형식 통일 (기존 파일 idiom 일치)

## ✅ 검증 / Verification

- `tests/unit/test_config.py` **61 passed** · `from src.config import` grep 0건
- 머지 후 CodeQL main 재스캔 시 #538/#539 자동 close 예상 (코드가 더 이상 룰 미발동)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- **VERDICT: OK** — mutual (Claude ✅ + Codex ✅, push 전). from-import 0건·3 테스트 `cfg.Settings` 기능 동등·assertion(ValidationError + "SUPPORTED_LOCALES") 불변·단일 파일 diff 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
