### PR TITLE
test(pricing): Claude 가격 3-소스 parity 회귀 가드 — 회고 C3 (정책 4)

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -171,6 +171,10 @@ BREAKDOWN_KEY_TEST_COVERAGE = "test_coverage"
 # Source: https://www.anthropic.com/pricing (reconfirmed 2026-07 — actual billing may differ)
 # 2026-07 갱신: Opus $15/$75 → $5/$25 (3× 인하), Haiku $0.80/$4 → $1/$5 — claude_metrics.py 와 단일 기준 정합
 # 2026-07 update: Opus $15/$75 → $5/$25 (3× drop), Haiku $0.80/$4 → $1/$5 — unified with claude_metrics.py
+# 🔴 PARITY GUARD: 가격 SSOT = claude_metrics._PRICING_USD_PER_MTOK. 여기 input/output_price 변경 시
+#   SSOT + i18n model_hint(en/ko/ja) 3곳 동시 수정 의무 (test_pricing_parity.py 가 CI 차단 — 정책 4).
+# 🔴 PARITY GUARD: pricing SSOT = claude_metrics._PRICING_USD_PER_MTOK. Changing input/output_price here
+#   requires updating the SSOT + i18n model_hint (en/ko/ja) too; test_pricing_parity.py blocks drift (policy 4).
 CLAUDE_MODELS: list[dict] = [
     {
         "id": "claude-haiku-4-5-20251001",

--- a/src/shared/claude_metrics.py
+++ b/src/shared/claude_metrics.py
@@ -36,6 +36,10 @@ async def aclose_anthropic_client(client) -> None:
 
 # 모델 패밀리별 가격 (USD per 1M tokens, input/output) — 2026-07 기준
 # Model family pricing (USD per 1M tokens, input/output) — 2026-07 basis
+# 🔴 PARITY GUARD: 본 dict 가 가격 SSOT. 변경 시 constants.CLAUDE_MODELS + i18n model_hint(en/ko/ja)
+#   3곳 동시 수정 의무 (tests/unit/shared/test_pricing_parity.py 가 drift 를 CI 에서 차단 — 정책 4).
+# 🔴 PARITY GUARD: this dict is the pricing SSOT. On change, also update constants.CLAUDE_MODELS and
+#   the i18n model_hint (en/ko/ja); test_pricing_parity.py blocks any drift in CI (policy 4).
 _PRICING_USD_PER_MTOK = {
     "opus": (5.0, 25.0),    # Opus 4.8/4.7/4.6 — 이전 (15.0, 75.0) 대비 3× 인하 (2026-07 확인)
                              # Previously (15.0, 75.0) — 3× price drop confirmed 2026-07

--- a/tests/unit/shared/test_pricing_parity.py
+++ b/tests/unit/shared/test_pricing_parity.py
@@ -1,0 +1,91 @@
+"""Claude 모델 가격 3-소스 정합성 회귀 가드 (정책 4 — 회고 2026-07-03 C3).
+Claude model pricing 3-source parity regression guard (policy 4 — retro 2026-07-03 C3).
+
+🔴 **PARITY GUARD**: Claude 가격이 3곳에 중복 존재 — 하나만 수정하면 이 테스트가 즉시 fail.
+🔴 **PARITY GUARD**: Claude pricing lives in 3 places — editing only one makes this test fail.
+
+  1. `src/shared/claude_metrics.py::_PRICING_USD_PER_MTOK` — SSOT (실제 비용 계산, family별 튜플)
+     SSOT — actual cost calculation, per-family (input, output) tuple.
+  2. `src/constants.py::CLAUDE_MODELS` — 모델 셀렉터 카탈로그 (model-id별 input/output_price)
+     model selector catalog, per model-id input/output_price.
+  3. `src/i18n/translations/{en,ko,ja}.json` `settings.model_hint` — UI 힌트 "$N/1M" (input만 노출)
+     UI hint text "$N/1M" (input rate only).
+
+배경: #1015 가 (1)만 갱신하고 (2)(3) 을 stale 로 남겨 #1019 split-fix 를 유발 (한 곳만 수정 안티패턴).
+가격 변경 시 3곳 전수 수정 의무 — 본 가드가 turn-0/CI 에서 drift 를 즉시 차단.
+Context: #1015 updated only (1), leaving (2)(3) stale → #1019 split-fix. This guard blocks that drift.
+"""
+import re
+
+import pytest
+
+from src.constants import CLAUDE_MODELS
+from src.i18n.loader import load_translations
+from src.shared.claude_metrics import _PRICING_USD_PER_MTOK
+
+
+def setup_function():
+    """각 테스트 전 i18n LRU 캐시 초기화 (테스트 격리).
+    Clear i18n LRU cache before each test (test isolation)."""
+    load_translations.cache_clear()
+
+
+def _family_of(model_id: str) -> str:
+    """모델 id → pricing family 키 (haiku/sonnet/opus) 추출 — SSOT 매칭 로직과 동일.
+    Map a model id to its pricing family key, mirroring the SSOT lookup logic."""
+    model_lower = model_id.lower()
+    for family in _PRICING_USD_PER_MTOK:
+        if family in model_lower:
+            return family
+    raise AssertionError(
+        f"모델 id {model_id!r} 가 어떤 pricing family({list(_PRICING_USD_PER_MTOK)}) 에도 매칭 안 됨"
+    )
+
+
+def test_constants_catalog_matches_metrics_ssot():
+    """constants.CLAUDE_MODELS 각 모델의 (input, output) 가 claude_metrics SSOT 와 일치.
+    Every CLAUDE_MODELS entry's (input, output) must equal the claude_metrics SSOT rate."""
+    for model in CLAUDE_MODELS:
+        family = _family_of(model["id"])
+        in_rate, out_rate = _PRICING_USD_PER_MTOK[family]
+        assert model["input_price"] == in_rate, (
+            f"{model['id']} input_price={model['input_price']} 가 "
+            f"claude_metrics {family} input={in_rate} 와 불일치 (3-소스 drift)"
+        )
+        assert model["output_price"] == out_rate, (
+            f"{model['id']} output_price={model['output_price']} 가 "
+            f"claude_metrics {family} output={out_rate} 와 불일치 (3-소스 drift)"
+        )
+
+
+def test_every_family_has_a_catalog_model():
+    """모든 pricing family 가 CLAUDE_MODELS 에 최소 1개 대표 모델 보유 (셀렉터 커버리지).
+    Every pricing family must have at least one representative model in the catalog."""
+    families_in_catalog = {_family_of(m["id"]) for m in CLAUDE_MODELS}
+    assert families_in_catalog == set(_PRICING_USD_PER_MTOK), (
+        f"카탈로그 family {sorted(families_in_catalog)} 가 "
+        f"SSOT family {sorted(_PRICING_USD_PER_MTOK)} 와 불일치"
+    )
+
+
+@pytest.mark.parametrize("locale", ["en", "ko", "ja"])
+def test_i18n_model_hint_input_price_matches_ssot(locale):
+    """각 언어 model_hint 의 'Haiku/Sonnet/Opus $N/1M' input 단가가 SSOT input rate 와 일치.
+    Each locale's model_hint '$N/1M' per family must equal the SSOT input rate."""
+    trans = load_translations(locale)
+    hint = trans.get("settings", {}).get("model_hint", "")
+    assert hint, f"{locale}.json 에 settings.model_hint 부재 — i18n 키 회귀"
+
+    for family, (in_rate, _out_rate) in _PRICING_USD_PER_MTOK.items():
+        # 힌트 텍스트에서 'Haiku ... ($N/1M)' 패턴의 N 추출 (family 명은 3 언어 공통 영문).
+        # Extract N from 'Haiku ... ($N/1M)' (family names are English across all 3 locales).
+        match = re.search(rf"{family.capitalize()}[^$]*\$(\d+(?:\.\d+)?)\s*/\s*1M", hint)
+        assert match, (
+            f"{locale} model_hint 에서 {family.capitalize()} '$N/1M' 패턴 미발견 "
+            f"(힌트 구조 변경 시 본 가드·정책 4 재검토): {hint[:80]}"
+        )
+        hint_rate = float(match.group(1))
+        assert hint_rate == in_rate, (
+            f"{locale} model_hint {family} 표기 ${hint_rate}/1M 가 "
+            f"SSOT input=${in_rate} 와 불일치 (3-소스 drift — 가격 변경 시 i18n 3언어 동시 갱신 의무)"
+        )


### PR DESCRIPTION
## 요약

회고 2026-07-03 **C3** — Claude 모델 가격 3-소스 정합성 회귀 가드 신설 (정책 4 위반 해소).

Claude 가격이 3곳에 중복 존재하는데 정합성 회귀 가드가 없어 `#1015`→`#1019` split-fix("한 곳만 수정" 안티패턴)를 유발했습니다. 정책 4(단언과 회귀 가드를 같은 PR에)를 위반한 상태였습니다.

| 소스 | 역할 |
|------|------|
| `src/shared/claude_metrics.py::_PRICING_USD_PER_MTOK` | 가격 SSOT (실제 비용 계산, family별) |
| `src/constants.py::CLAUDE_MODELS` | 모델 셀렉터 카탈로그 (model-id별) |
| `src/i18n/translations/{en,ko,ja}.json` `settings.model_hint` | UI 힌트 "$N/1M" (input만) |

## 변경

- **신규** `tests/unit/shared/test_pricing_parity.py` (+5):
  - `constants.CLAUDE_MODELS` (input,output) == `claude_metrics` SSOT family rate
  - 모든 family 가 카탈로그에 대표 모델 보유 (셀렉터 커버리지)
  - i18n `model_hint`(en/ko/ja) `$N/1M` input 단가 == SSOT input rate (3언어 parametrize)
- `src/shared/claude_metrics.py`·`src/constants.py`: 🔴 **PARITY GUARD** 마커 주석 (로직 무변경) — `testing.md` "의도적 중복 코드 PARITY GUARD 패턴" 규약

## 검증

- ✅ 5 테스트 PASS (현재 3소스 정합: opus 5/25·sonnet 3/15·haiku 1/5)
- ✅ **mutation 검증**: constants Opus input 5→4 drift·i18n hint $5→$9 drift 둘 다 가드가 fail 유발 확인
- ✅ pylint **10.00/10** 유지 · 기존 claude_metrics 테스트 24건 회귀 0
- ⚠️ flake8 E131 1건은 **pre-existing**(HEAD line 41 opus 주석 정렬, 본 PR 무관·CI `|| true` soft-pass)
- 선례 `check_config_5way_sync.py` 재사용, 신규 추상화 0 (정책 16)

## 🔍 사용자 검증 필요

- 이 PR은 회귀 가드(테스트 + 주석)로 **프로덕션 동작 변경 0** — 시각/운영 확인 항목 없음
- 향후 Claude 가격 변경 시 이 가드가 CI에서 3소스 drift를 즉시 차단 (turn-0 피드백)

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex 검증 의뢰 완료 — **Codex mutual OK (5/5 항목 PASS)**: family 매핑 정확·regex 대소문자 안전(소문자 `claude-sonnet-4-6` 오매칭 없음)·정적 정합 확인·실 assert(빈 loop/조기 return 없음)·PARITY 마커 상호참조 정확
- push 전 로컬 커밋 → Codex 검증 → OK 수신 후 push (정책 18 §1·§2 준수)

## 메모

- 단위 테스트 +5 (STATE.md 수치 갱신은 전체 회고 fix PR 머지 후 sync PR에서 일괄 반영)
- 회고 클러스터 C3 (P1×3: #6·#33·#56). 상세: `docs/_archive/reports/2026-07-03-retrospective.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
