### PR TITLE
docs(sync): C5 SSOT drift 정정 — STATE 날짜헤더·#1023 트레일·env-vars N2 (회고 2026-07-03)

### DIFF
--- a/docs/STATE.md
+++ b/docs/STATE.md
@@ -2,9 +2,9 @@
 
 > 이 파일이 단일 진실 소스(Single Source of Truth)다. Phase 완료·주요 변경 시 여기를 먼저 갱신한다.
 
-## 현재 수치 (2026-06-29 기준)
+## 현재 수치 (2026-07-03 기준)
 
-> 📌 **이전 세션·PR별 누적 작업 서사는 [`docs/cycle-history.md`](cycle-history.md) 단일 출처** (사이클 60~166, 최신순). 본 헤더는 **최신 1건 + 종합 수치만** 유지 — 32KB 단일 라인 SSOT 가독성 복원 (품질감사 docclr-1, 2026-06-17, cycle-history.md 에 서사 전량 보존[append-only] 확인 후 트리밍). 🔴 **다음 세션 갱신 규칙**: 신규 작업 완료 시 (1) 본 "최신" 블록을 새 작업으로 교체 + 종합 수치 갱신, (2) 직전 작업의 전체 서사는 `docs/cycle-history.md` 최신순 맨 앞에 본문 섹션으로 이관 (헤더에 "직전" 체인 누적 금지 — 본 정리의 회귀 방지).
+> 📌 **이전 세션·PR별 누적 작업 서사는 [`docs/cycle-history.md`](cycle-history.md) 단일 출처** (사이클 60~166, 최신순). 본 헤더는 **최신 1건 + 종합 수치만** 유지 — 32KB 단일 라인 SSOT 가독성 복원 (품질감사 docclr-1, 2026-06-17, cycle-history.md 에 서사 전량 보존[append-only] 확인 후 트리밍). 🔴 **다음 세션 갱신 규칙**: 신규 작업 완료 시 (0) **본 섹션 날짜 헤더(line 5 `## 현재 수치 (YYYY-MM-DD 기준)`)를 최신 세션 날짜로 갱신** (회고 2026-07-03 C5 #60 — 절차에서 상시 누락되던 필드), (1) 본 "최신" 블록을 새 작업으로 교체 + 종합 수치 갱신, (2) 직전 작업의 전체 서사는 `docs/cycle-history.md` 최신순 맨 앞에 본문 섹션으로 이관 (헤더에 "직전" 체인 누적 금지 — 본 정리의 회귀 방지).
 
 **최신 (PR 검토·머지 + 다중에이전트 심층 감사 + note 하드닝, 2026-07-03)** — 열린 3 PR(**#1015** Opus 가격 $15/$75→$5/$25·**#1018** actions/checkout v7·**#1016** trufflehog v3.95.7) 머지 + 발견 갭 후속 3 PR: **#1019** Opus+Haiku 가격 3-소스 정합 완결(#1015 가 `claude_metrics.py` 만 고쳐 `constants.py`+i18n stale → Opus $5/$25·Haiku $1/$5 단일화)·**#1020** trufflehog 버전주석 v3.95.5→v3.95.7·**#1021** 심층 감사 note 3건 하드닝. **심층 감사**(다중에이전트 wf `wf_df542848` 10차원 17에이전트 + 실테스트): 단위 5117 + 통합 150 = **5267 passed**·flake8/bandit med-high 0·**운영 P0/P1/P2=0**·**은닉/악성 코드 8벡터 전부 CLEAN**(백도어·exfil·난독화·타임밤·매직토큰·하드코딩시크릿·eval/exec·shell=True — Codex cross-vendor 2026-06-29 일치). Code Scanning #537(`py/ineffectual-statement` `await result`)=false-positive dismiss → open alert 0. **#1021 하드닝**(각 정책 18 Codex mutual): N1 operations `days` 상한(API+**HTML** 2 라우트 `Query(ge=1,le=365)` — 없으면 거대값→`timedelta` OverflowError→500)·N2 `config.py` default_locale·locale_fallback ∈ supported_locales `model_validator(after)` **startup fail-fast**·N3 `cli/git_diff.py` `--name-status` R### 리네임 탭2개 파싱(`split("\t")`+`parts[-1]`), 회귀 +13. 🔴 **교훈**: Codex mutual 이 N1 을 API 라우트만 고친 것 적발(동일 `operations_kpi` 호출 HTML 라우트 500 노출)=#1015 가격 3-소스 갭과 **동형**→공유 서비스 호출처 `grep -rn` 전수 의무. 단위 5121→**5134**(#1021 +13). [[project-pr-merge-session-2026-07-03]]
 

--- a/docs/cycle-history.md
+++ b/docs/cycle-history.md
@@ -145,7 +145,9 @@
 
 **#1021 하드닝** (각 정책 18 Claude+Codex mutual): N1 `/operations` `days` 상한 — API(`api/admin.py:94`) + **HTML**(`ui/routes/admin.py:107`) 2 라우트 `Annotated[int, Query(ge=1, le=365)]`(없으면 거대값→`operations_service` `timedelta(days=)` OverflowError→HTTP 500, repo_report.py 대칭) / N2 `config.py` `default_locale`·`locale_fallback` ∈ `supported_locales` `model_validator(mode=after)` **startup fail-fast**(api/repos.py 대칭·env-vars.md 동기화) / N3 `cli/git_diff.py:39` `--name-status` R### 리네임(탭 2개) 파싱 → 탭 전체 split + `parts[-1]` 대상 파일명. 회귀 +13, 단위 5121→5134.
 
-🔴 **교훈**: (1) Codex mutual 검증이 **Claude 가 놓친 실제 결함 적발** — N1 을 API 라우트만 고쳤는데 동일 `operations_kpi` 호출하는 HTML 라우트 미수정(동일 500 노출). #1015 가격 3-소스 갭과 **동형 패턴**(같은 로직 2+곳 → 한 곳만 수정). default = 공유 서비스 호출처 `grep -rn` 전 라우트 전수 확인. (2) 정적 감사 ≠ 운영 정상(정책 11/12/13 별도 트랙 — E2E·4-테마 시각·운영 데이터는 사용자 검증 영역). [[project-pr-merge-session-2026-07-03]]
+**#1023 self-inflicted CodeQL 봉인** (#1021 후속): #1021 N2 테스트가 `from src.config import Settings` 추가 → 기존 `import src.config as cfg` 와 공존 → CodeQL `py/import-and-import-from`(note) #538/#539 **자초**. `testing.md` "이중 import 회피" 규칙 위반 → fix = `import src.config as cfg`+`cfg.Settings` 통일. 선례 `#996`(env.py py/unused-import) 과 동형(자초 CodeQL → 파일 터치 재스캔 노출 → 봉인). main 재스캔 후 auto-close, open alert 0.
+
+🔴 **교훈**: (1) Codex mutual 검증이 **Claude 가 놓친 실제 결함 적발** — N1 을 API 라우트만 고쳤는데 동일 `operations_kpi` 호출하는 HTML 라우트 미수정(동일 500 노출). #1015 가격 3-소스 갭과 **동형 패턴**(같은 로직 2+곳 → 한 곳만 수정). default = 공유 서비스 호출처 `grep -rn` 전 라우트 전수 확인. (2) 정적 감사 ≠ 운영 정상(정책 11/12/13 별도 트랙 — E2E·4-테마 시각·운영 데이터는 사용자 검증 영역). (3) **신규 테스트에 `from src.x import` 추가 전 파일에 `import src.x as` 존재 여부 확인 의무** (#1023 self-inflicted CodeQL 재발 — testing.md 규칙 실전 미적용). [[project-pr-merge-session-2026-07-03]]
 
 ## cross-vendor 감사 및 구조검토 (2026-06-29)
 

--- a/docs/reference/env-vars.md
+++ b/docs/reference/env-vars.md
@@ -69,7 +69,7 @@ Sentry 외 자동 로깅은 별도 환경변수 없이 동작:
 
 > **🔴 운영 안전**: `I18N_DISABLED` 는 운영 사고 (번역 파일 손상 등) 시 즉각 비활성용 — Railway Variables 에 미리 배치 권장. 사이클 78 NEW-P0-2 패턴 (`is_disabled("I18N")` helper) 페어. 신규 환경변수 추가 시 `src/shared/feature_kill_switch.py::is_disabled(feature)` helper 사용 default.
 
-> **검증**: pydantic `field_validator` 4건 신설 (supported_locales / default_locale / locale_fallback) — 공백 제거 + 길이 2~10 + 영숫자/하이픈 제한. 단위 테스트 = `tests/unit/test_config.py` (Phase 1 PR-1a 회귀 가드 16건+).
+> **검증**: pydantic `field_validator` 3건 (supported_locales / default_locale / locale_fallback) — 공백 제거 + 길이 2~10 + 영숫자/하이픈 제한 — **+ `model_validator(mode=after)` 1건** (default_locale·locale_fallback ∈ supported_locales 멤버십 startup fail-fast, 2026-07-03 하드닝 N2). 단위 테스트 = `tests/unit/test_config.py` (Phase 1 PR-1a 회귀 가드 16건+).
 
 ## 알림 채널 (선택)
 


### PR DESCRIPTION
## 요약

회고 2026-07-03 **C5** — docs SSOT drift 4건 정정 (P1 #43 + P2 다수). 매 세션 재발하던 문서 정합 갭을 근본 절차와 함께 해소.

## 변경 (docs-only, 수치 무변경)

| # | 항목 | finding |
|---|------|---------|
| 1 | `STATE.md:5` 날짜 헤더 `(2026-06-29 기준)` → `(2026-07-03 기준)` | #11·#27·#38·#44·#59 |
| 2 | `STATE.md:7` 갱신 규칙에 **(0) 날짜 헤더 갱신** 절차 명문화 (근본 — 상시 누락 필드) | #60 |
| 3 | `cycle-history.md` 2026-07-03 섹션에 **#1023** self-inflicted CodeQL 봉인 엔트리 + 교훈 (3) | #12·#43 |
| 4 | `env-vars.md` 검증 요약 `field_validator 4건` → **3건 + `model_validator` 1건(N2)** 정정 | #29 |

- **#43 근본**: `#1023`(자초 CodeQL)이 SSOT 서사 트레일에 누락 — 선례 `#996`은 전용 엔트리 보유 = 비대칭. 6-step 문서 최신화가 후속 fix에 미적용.
- **#60 근본**: `STATE.md:7` 갱신 규칙이 날짜 헤더 필드를 절차에서 누락 → 매 세션 재발 보장. (0) 단계 추가로 봉인.

## 검증

- ✅ pre-commit 훅 전부 통과: **docs 수치 정합**·**cycle-history TOC 앵커**·**env-vars 싱크(config.py↔env-vars.md)**
- ✅ STATE 수치 무변경 (단위 5134·통합 154·전체 5288)
- ✅ env-vars 정정이 실제 `config.py` 부합 — field_validator 3(locale) + model_validator 1(locale 멤버십 `_validate_locale_membership`)

## 🔍 사용자 검증 필요

- docs-only — **코드/동작 변경 0**, 시각/운영 확인 항목 없음
- 근본 절차 개선((0) 날짜 헤더 갱신)으로 다음 세션부터 STATE 날짜 stale 재발 차단

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex mutual 검증 **OK (4/4 PASS)**: (1) STATE 날짜 헤더 ↔ 본문 일치 (2) env-vars 정정이 config.py 실측 부합(field_validator 3 + model_validator 1) (3) #1023 엔트리 사실 정합(git log/show 확인) (4) STATE 수치 무변경(git diff 확인). git show 기반 검증(브랜치 독립).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
