### PR TITLE
chore(ci): 신규 이중 import PR 가드 — self-inflicted CodeQL 봉인 (회고 C2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,13 @@ jobs:
           echo "검사 대상 / checking:"; echo "$changed"
           python -m flake8 --isolated --select=F401,F841 $changed
 
+      - name: Block new dual-import in PR-changed tests (py/import-and-import-from — C2)
+        # 🔴 신규 diff 한정 — PR 에서 ADDED 된 `from X import` 가 기존 `import X` 와 공존하는 경우만 차단.
+        # #1023 형(test_config.py 이중 import → self-inflicted CodeQL)의 pre-merge 봉인(회고 2026-07-03 C2).
+        # flake8 F401/F841 는 양쪽 import 모두 used 라 미검출 — 별도 stdlib 가드 필요. 기존 legacy idiom 무관.
+        # Diff-scoped: only NEW `from X import` coexisting with an `import X` is blocked (retro C2, #1023 pattern).
+        run: python scripts/check_dual_import.py "${{ github.event.pull_request.base.sha }}" HEAD
+
   test-and-analyze:
     name: pytest + Codecov + SonarCloud
     runs-on: ubuntu-latest

--- a/scripts/check_dual_import.py
+++ b/scripts/check_dual_import.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""PR-diff 한정 신규 이중 import 가드 — CodeQL py/import-and-import-from self-inflict 차단.
+PR-diff-scoped new dual-import guard — blocks self-inflicted CodeQL py/import-and-import-from.
+
+회고 2026-07-03 C2: #1021 N2 테스트가 `from src.config import Settings` 를 추가해 기존
+`import src.config as cfg` 와 공존 → CodeQL `py/import-and-import-from`(#538/#539) 자초 → #1023 봉인.
+flake8 F401/F841(#979)·noqa 는 이 패턴을 원리상 미검출(양쪽 import 모두 used).
+Retro 2026-07-03 C2: a test added `from src.config import Settings` alongside an existing
+`import src.config as cfg`, self-inflicting CodeQL py/import-and-import-from → sealed by #1023.
+flake8 F401/F841 cannot detect it (both imports are used).
+
+🔴 신규 diff 한정 (정책 17 안정성 우선): PR diff 에서 **ADDED 된** `from X import` 만 검사한다.
+기존 28 legacy idiom(`import X as mock` + `from X import fn`)은 무관 — 2026-06-23 회고가 전면
+pre-commit 훅(WF-1)을 idiom churn 사유로 DROP 한 결정을 존중 (신규 도입만 차단, 기존 미churn).
+Only NEW `from X import` lines added in the diff are checked; legacy idioms are left untouched
+(respects the 2026-06-23 decision to DROP a blanket pre-commit hook to avoid idiom churn).
+
+사용법 / Usage: python scripts/check_dual_import.py <base_sha> [head_sha]
+  base 미지정 시 origin/main, head 미지정 시 HEAD. tests/ 하위 .py 만 대상(#979 lint-changed-tests 페어).
+"""
+import re
+import subprocess
+import sys
+
+# diff -U0 의 ADDED 라인(`+from x import ...`) 에서 모듈명 추출 (`+++` 헤더는 제외).
+# Extract module from an added `+from x import ...` line in `git diff -U0` (excludes `+++` header).
+_ADDED_FROM_IMPORT = re.compile(r"^\+\s*from\s+([\w.]+)\s+import\b")
+
+
+def parse_added_from_modules(diff_text: str) -> set[str]:
+    """diff -U0 텍스트에서 ADDED 된 `from <mod> import` 의 <mod> 집합 반환 (순수 함수).
+    Return the set of <mod> for `from <mod> import` lines added in a `git diff -U0` text."""
+    mods: set[str] = set()
+    for line in diff_text.splitlines():
+        if line.startswith("+++"):  # diff 파일 헤더 — 스킵 / diff file header — skip
+            continue
+        match = _ADDED_FROM_IMPORT.match(line)
+        if match:
+            mods.add(match.group(1))
+    return mods
+
+
+def content_has_plain_import(content: str, module: str) -> bool:
+    """파일 내용에 `import <module>` (plain 또는 `as alias`) 존재 여부 (순수 함수).
+    Whether the content has an `import <module>` (plain or `as alias`) statement."""
+    pattern = re.compile(
+        rf"^\s*import\s+{re.escape(module)}(\s+as\s+\w+)?\s*(#.*)?$", re.MULTILINE
+    )
+    return bool(pattern.search(content))
+
+
+def find_violations_for_file(diff_text: str, head_content: str) -> list[str]:
+    """한 파일의 diff + 최종 내용에서 신규 이중 import 를 유발하는 모듈 목록 (순수 함수).
+    Modules that introduce a new dual-import for one file (added `from`, coexisting plain `import`)."""
+    return sorted(
+        mod
+        for mod in parse_added_from_modules(diff_text)
+        if content_has_plain_import(head_content, mod)
+    )
+
+
+def _git(*args: str) -> str:
+    """git 명령 실행 → stdout (실패 시 빈 문자열). / Run git, return stdout ('' on failure)."""
+    result = subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=False, encoding="utf-8"
+    )
+    return result.stdout or ""
+
+
+def find_violations(base: str, head: str) -> list[tuple[str, str]]:
+    """PR-changed tests/ .py 전체에서 (파일, 모듈) 위반 목록 (git I/O).
+    All (file, module) violations across PR-changed tests/ .py files."""
+    names = _git("diff", "--name-only", "--diff-filter=ACMR", base, head, "--", "tests/")
+    violations: list[tuple[str, str]] = []
+    for path in (p for p in names.splitlines() if p.endswith(".py")):
+        diff_text = _git("diff", "-U0", base, head, "--", path)
+        head_content = _git("show", f"{head}:{path}")
+        for mod in find_violations_for_file(diff_text, head_content):
+            violations.append((path, mod))
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    """CLI 진입점 — 위반 시 사유 출력 후 exit 1, 없으면 exit 0 (CI 게이트).
+    CLI entry point — print violations and exit 1, else exit 0 (CI gate)."""
+    base = argv[1] if len(argv) > 1 else "origin/main"
+    head = argv[2] if len(argv) > 2 else "HEAD"
+    violations = find_violations(base, head)
+    if violations:
+        print("🔴 신규 이중 import 감지 (CodeQL py/import-and-import-from 자초 위험):")
+        print("🔴 New dual-import detected (self-inflicted CodeQL py/import-and-import-from risk):")
+        for path, mod in violations:
+            print(
+                f"  {path}: 신규 `from {mod} import ...` 가 기존 `import {mod}` 와 공존 "
+                f"→ 하나로 통일 (testing.md '모듈 패치 시 이중 import 회피 — string-path 우선')"
+            )
+        return 1
+    print("신규 이중 import 없음 — OK / no new dual-import — OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/unit/scripts/test_dual_import_guard.py
+++ b/tests/unit/scripts/test_dual_import_guard.py
@@ -1,0 +1,132 @@
+"""신규 이중 import 가드 정합 (회고 2026-07-03 C2 — self-inflicted CodeQL py/import-and-import-from 봉인).
+New dual-import guard integrity (retro 2026-07-03 C2 — seals self-inflicted CodeQL py/import-and-import-from).
+
+#1023(test_config.py 이중 import → CodeQL #538/#539) 같은 신규 도입만 pre-merge 차단하고,
+기존 28 legacy idiom(`import X as mock` + `from X import fn`)은 무관함을 봉인한다(정책 17 안정성 우선).
+Blocks only NEW dual-imports like #1023 pre-merge, leaving the 28 legacy idioms untouched.
+
+🔴 메타테스트 3중 봉인 (test_ci_dead_symbol_guard.py 선례):
+  (R1) lint-changed-tests job 영역 한정 — 다른 job 토큰 false-pass 차단.
+  (R2) 스크립트 실행이 PR base SHA 를 diff base 로 전달 — 신규 diff 한정 긍정 단언.
+  (R3) run: 셸 주석 제거 후 매칭 — 주석 decoy false-pass 봉인 (#936 학습).
+"""
+import re
+from pathlib import Path
+
+import yaml
+
+from scripts.check_dual_import import (
+    content_has_plain_import,
+    find_violations_for_file,
+    parse_added_from_modules,
+)
+
+_ROOT = Path(__file__).resolve().parents[3]
+_CI = _ROOT / ".github" / "workflows" / "ci.yml"
+
+
+# ── 순수 함수: parse_added_from_modules ──────────────────────────────────
+# Pure function: parse_added_from_modules
+
+
+def test_parse_added_from_modules_extracts_added_only():
+    """diff -U0 의 `+from X import` 만 추출 — 문맥/삭제 라인·`+++` 헤더 제외."""
+    diff = (
+        "+++ b/tests/unit/test_x.py\n"
+        "@@ -1,0 +2 @@\n"
+        "+from src.config import Settings\n"
+        " from src.other import kept\n"       # 문맥(공백) — 미추출 / context line
+        "-from src.removed import gone\n"      # 삭제 — 미추출 / removed line
+    )
+    assert parse_added_from_modules(diff) == {"src.config"}
+
+
+def test_parse_added_from_modules_ignores_plusplus_header():
+    """`+++ b/...` diff 헤더는 from-import 로 오인하지 않는다."""
+    diff = "+++ b/tests/from_import_named.py\n+from a.b import c\n"
+    assert parse_added_from_modules(diff) == {"a.b"}
+
+
+def test_parse_added_from_modules_empty_when_no_from():
+    """ADDED from-import 없으면 빈 집합 (plain import 추가·문서 변경 등)."""
+    assert parse_added_from_modules("+import src.config as cfg\n+# comment\n") == set()
+
+
+# ── 순수 함수: content_has_plain_import ──────────────────────────────────
+# Pure function: content_has_plain_import
+
+
+def test_content_has_plain_import_matches_alias_and_plain():
+    """`import X` 와 `import X as alias` 둘 다 매칭."""
+    assert content_has_plain_import("import src.config as cfg\n", "src.config")
+    assert content_has_plain_import("import src.config\n", "src.config")
+
+
+def test_content_has_plain_import_no_false_match_on_from():
+    """`from X import ...` 는 plain import 로 오인하지 않는다 (이중 import 성립 안 함)."""
+    assert not content_has_plain_import("from src.config import Settings\n", "src.config")
+
+
+def test_content_has_plain_import_no_prefix_false_match():
+    """`import src.config_manager` 는 module `src.config` 로 오매칭하지 않는다 (경계)."""
+    assert not content_has_plain_import("import src.config_manager as cm\n", "src.config")
+
+
+# ── 순수 함수: find_violations_for_file (통합) ───────────────────────────
+# Pure function: find_violations_for_file (combined)
+
+
+def test_find_violations_flags_1023_pattern():
+    """#1023 재현: 기존 `import src.config as cfg` + 신규 `from src.config import Settings` → 위반."""
+    diff = "+++ b/tests/unit/test_config.py\n+from src.config import Settings\n"
+    head = "import src.config as cfg\nfrom src.config import Settings\n\n\ndef test_x():\n    pass\n"
+    assert find_violations_for_file(diff, head) == ["src.config"]
+
+
+def test_find_violations_ignores_legacy_untouched():
+    """기존 이중 import 파일이지만 이번 diff 에서 from-import 추가 안 하면 미검출 (legacy 무churn)."""
+    diff = "+++ b/tests/unit/test_legacy.py\n+    result = do_something()\n"  # from-import 추가 없음
+    head = "import src.x as mod\nfrom src.x import fn\n"  # 기존 legacy idiom
+    assert find_violations_for_file(diff, head) == []
+
+
+def test_find_violations_ignores_added_from_without_coexisting_import():
+    """신규 from-import 만 있고 plain import 공존 안 하면 이중 import 아님 → 미검출."""
+    diff = "+++ b/tests/unit/test_x.py\n+from src.config import Settings\n"
+    head = "from src.config import Settings\n"
+    assert find_violations_for_file(diff, head) == []
+
+
+# ── CI 배선 메타테스트 (self-inflicted CodeQL 재발 방지 실효) ─────────────
+# CI wiring meta-test (ensures the guard actually runs in CI)
+
+
+def _lint_job() -> dict:
+    """ci.yml 에서 lint-changed-tests job 만 추출 (R1 — 다른 job 토큰 false-pass 차단)."""
+    data = yaml.safe_load(_CI.read_text(encoding="utf-8"))
+    job = data["jobs"].get("lint-changed-tests")
+    assert job is not None, "lint-changed-tests job 부재"
+    return job
+
+
+def _lint_run_code() -> str:
+    """lint job 의 run: 스크립트만 합치고 셸 주석 제거 (R3/#936 — 주석 decoy false-pass 봉인)."""
+    job = _lint_job()
+    runs = "\n".join(
+        s["run"] for s in job.get("steps", []) if isinstance(s, dict) and "run" in s
+    )
+    return re.sub(r"(?m)(?:^|\s)#.*$", "", runs)
+
+
+def test_ci_wires_dual_import_guard():
+    """lint-changed-tests job 이 check_dual_import.py 를 실제 실행한다 (주석 제외)."""
+    code = _lint_run_code()
+    assert "scripts/check_dual_import.py" in code, "check_dual_import.py 가 CI 에서 미실행 (가드 무력)"
+
+
+def test_ci_dual_import_guard_is_pr_diff_scoped():
+    """가드가 PR base SHA 를 diff base 로 전달 — 신규 diff 한정(R2), 전체 스캔 아님."""
+    code = _lint_run_code()
+    assert re.search(
+        r"check_dual_import\.py[^\n]*pull_request\.base\.sha", code
+    ), "dual-import 가드가 PR base SHA(신규 diff 한정) 미전달 — legacy churn 위험"


### PR DESCRIPTION
## 요약

회고 2026-07-03 **C2** — self-inflicted CodeQL `py/import-and-import-from` 신규 PR 가드 (사용자 결정: "경량 dual-import 가드, 신규 diff 한정").

`#1023`(test_config.py 가 `import src.config as cfg` 에 `from src.config import Settings` 를 추가 → CodeQL `py/import-and-import-from` #538/#539 자초)의 **pre-merge 봉인**. `flake8 F401/F841`(#979)·`noqa` 는 양쪽 import 모두 used 라 이 패턴을 원리상 미검출 → 별도 stdlib 가드 필요.

## 설계 (정책 17 안정성 우선)

🔴 **신규 diff 한정** — PR diff 에서 **ADDED 된** `from X import` 가 기존 `import X` 와 공존하는 경우만 차단. 기존 28 legacy idiom(`import X as mock` + `from X import fn`)은 **무관** — 2026-06-23 회고가 전면 pre-commit 훅(WF-1)을 idiom churn 사유로 DROP 한 결정을 존중.

## 변경

- **신규** `scripts/check_dual_import.py` — 순수 함수 3종(`parse_added_from_modules` / `content_has_plain_import` / `find_violations_for_file`) + git I/O 래퍼. pylint 10.00.
- `.github/workflows/ci.yml` `lint-changed-tests` job 에 step 추가 — PR base SHA diff 한정(#979 F401/F841 페어), `tests/` .py.
- **신규** `tests/unit/scripts/test_dual_import_guard.py` (+11) — 순수 함수 9(#1023 재현·legacy 무churn·prefix 오매칭 방지·`+++` 헤더 스킵) + CI 배선 메타 2(R1 job 한정·R2 신규 diff 한정·R3 주석 decoy 봉인).

## 검증

- ✅ 11 테스트 PASS · **end-to-end**: #1023형 감지(`['src.config']`)·legacy 무churn(`[]`)·현재 브랜치 clean(exit 0)
- ✅ pylint 10.00 · flake8 0

## 🔍 사용자 검증 필요

- CI 검사 추가 — **프로덕션 런타임 동작 변경 0** (import 정적 검사만)
- 다음 PR 부터 신규 이중 import 도입 시 CI 에서 즉시 차단 → self-inflicted CodeQL 사후 seal PR 루프 종결

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

- [x] Codex mutual **OK (6/6 PASS)**: (1) 신규 diff 한정 정확 — legacy 무churn (2) #1023 재현 감지 (3) prefix 오매칭 방지(`src.config_manager`≠`src.config`) (4) `+++` 헤더 스킵 (5) CI 배선 실효(PR-only) (6) 메타테스트 실 단언(빈 loop 없음). git show blob 정적 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
