### PR TITLE
docs(architecture): scripts/ 레지스트리에 check_dual_import.py 등재 (회고 C2 후속)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,6 +160,8 @@ scripts/
 │                                # config sync — 3-layer RepoConfig field parity via AST
 ├── check_bilingual_comments.py  # 이중언어 주석 점검 — staged 신규 주석 한글-only 탐지 (CLAUDE.md 한+영 규칙 보조, pre-commit only)
 │                                # bilingual-comment checker — flag Korean-only added comment lines
+├── check_dual_import.py         # 신규 이중 import PR 가드 — diff ADDED `from X import` + 기존 `import X` 공존 검출 (self-inflicted CodeQL py/import-and-import-from 봉인, 회고 C2, ci.yml lint-changed-tests)
+│                                # new dual-import guard — diff-scoped `from X import` + coexisting `import X` (retro C2, CI)
 ├── capture_design_screenshots.py # 디자인 스크린샷 자동 캡처 — 12페이지 × 4테마 (Claude Design 브리프 패키지용, 사이클 131)
 │                                # Auto-capture design screenshots — 12 pages × 4 themes (Claude Design brief)
 ├── extract_design_tokens.py     # 디자인 토큰 추출 — tokens.css/themes.css → Claude Design 입력 JSON


### PR DESCRIPTION
## 요약

회고 C2(#1027)가 추가한 `scripts/check_dual_import.py` 가 `docs/architecture.md` scripts/ 레지스트리에 미등재였음 → **6-step ⑥(신규 파일 architecture.md 동기화)** 준수 + 회고가 지적한 docs drift 재발 방지(정확히 C5/C8 유형).

## 변경 (docs-only, pure append)
- `docs/architecture.md` scripts/ 레지스트리에 `check_dual_import.py` 1항목 등재 (check_bilingual_comments.py 다음)

## 🔍 사용자 검증 필요
- docs 등재 — 코드/동작 변경 0

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)
- [x] Codex mutual **OK (4/4)**: 기능 부합(실제 스크립트+ci.yml 배선)·pure append(기존 항목 삭제 0)·이중언어 형식 일관·트리 마크업 정합. git show blob 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
