### PR TITLE
fix(cost): resolve_ai_summary — disabled 전용 알림 메시지 (설정 비활성 vs 불가) (#1033 후속)

### DIFF
--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -866,7 +866,8 @@
     },
     "common": {
       "commit_ref": "Commit {sha}",
-      "ai_unavailable": "AI review unavailable (defaults applied)"
+      "ai_unavailable": "AI review unavailable (defaults applied)",
+      "ai_disabled": "AI code review is disabled by configuration; only static-analysis scores apply."
     },
     "railway": {
       "build_failed": "Railway Build Failed",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -866,7 +866,8 @@
     },
     "common": {
       "commit_ref": "コミット {sha}",
-      "ai_unavailable": "AIレビュー不可 (デフォルト適用)"
+      "ai_unavailable": "AIレビュー不可 (デフォルト適用)",
+      "ai_disabled": "AIコードレビューは設定で無効化されており、静的解析スコアのみ反映されています。"
     },
     "railway": {
       "build_failed": "Railwayビルド失敗",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -866,7 +866,8 @@
     },
     "common": {
       "commit_ref": "커밋 {sha}",
-      "ai_unavailable": "AI 리뷰 불가 (기본값 적용)"
+      "ai_unavailable": "AI 리뷰 불가 (기본값 적용)",
+      "ai_disabled": "AI 코드리뷰가 설정으로 비활성화되어 정적 분석 점수만 반영되었습니다."
     },
     "railway": {
       "build_failed": "Railway 빌드 실패",

--- a/src/notifier/_common.py
+++ b/src/notifier/_common.py
@@ -36,9 +36,13 @@ def resolve_ai_summary(ai_review, language: str = "ko") -> "str | None":
         return None
     # 실패 fallback (no_api_key/api_error/empty_diff/parse_error) → 수신자 언어로 현지화
     # Failure fallback → localize in the recipient's language
-    if getattr(ai_review, "status", "success") != "success":
+    status = getattr(ai_review, "status", "success")
+    if status != "success":
         from src.i18n.loader import get_text  # noqa: WPS433  # pylint: disable=import-outside-toplevel
-        return get_text("notifier.common.ai_unavailable", language)
+        # 의도적 비활성(disabled)은 "실패/불가"가 아니라 "설정으로 끔"으로 안내 — 그 외 실패는 generic.
+        # disabled (intentional off) → "turned off by config"; other non-success → generic unavailable.
+        key = "notifier.common.ai_disabled" if status == "disabled" else "notifier.common.ai_unavailable"
+        return get_text(key, language)
     return ai_review.summary or None
 
 

--- a/tests/unit/notifier/test_resolve_ai_summary_disabled.py
+++ b/tests/unit/notifier/test_resolve_ai_summary_disabled.py
@@ -1,0 +1,28 @@
+"""resolve_ai_summary: disabled 상태는 'AI 불가'가 아니라 '설정으로 비활성' 메시지.
+
+disabled → a distinct 'turned off by config' message, not the generic 'unavailable'.
+"""
+from types import SimpleNamespace
+
+from src.i18n.loader import get_text
+from src.notifier._common import resolve_ai_summary
+
+
+def test_disabled_returns_distinct_message():
+    ai = SimpleNamespace(status="disabled", summary="ignored")
+    msg = resolve_ai_summary(ai, "ko")
+    assert msg  # 비어있지 않음
+    # ai_unavailable 과 다른 메시지여야 함 (disabled 전용 키)
+    assert msg == get_text("notifier.common.ai_disabled", "ko")
+    assert msg != get_text("notifier.common.ai_unavailable", "ko")
+
+
+def test_api_error_still_unavailable():
+    # 회귀 가드 — 실패 status 는 여전히 generic ai_unavailable
+    ai = SimpleNamespace(status="api_error", summary="ignored")
+    assert resolve_ai_summary(ai, "ko") == get_text("notifier.common.ai_unavailable", "ko")
+
+
+def test_success_returns_summary():
+    ai = SimpleNamespace(status="success", summary="좋은 코드")
+    assert resolve_ai_summary(ai, "ko") == "좋은 코드"


### PR DESCRIPTION
## 개요
#1033(비용 제어) whole-branch 리뷰의 Minor #3 해소 — `resolve_ai_summary`가 신규 `disabled`(의도적 off) 상태를 generic "AI 리뷰 불가"로 오표기하던 것을 "설정으로 비활성" 전용 메시지로 정정.

## 변경
- **src/notifier/_common.py** `resolve_ai_summary`: `status == "disabled"` → `notifier.common.ai_disabled`("설정으로 비활성, 정적 점수만 반영"), 그 외 non-success → 기존 generic `ai_unavailable`(회귀 없음).
- **src/i18n/translations/{ko,en,ja}.json**: `notifier.common.ai_disabled` 키 신설(3 로케일).

## 왜
리포 소유자가 비용 절감을 위해 AI 리뷰를 **의도적으로 끈** 경우, PR 댓글/알림에 "AI 리뷰 불가"(실패 뉘앙스)가 아니라 "설정으로 비활성"이 정확. `disabled`=의도적-skip 버킷 의미론과 정합.

## 검증
- TDD: disabled→전용 메시지 / api_error→여전히 generic(회귀 가드) / success→summary 반환.
- `tests/unit/notifier/` 289 passed · fast suite 5161 passed · pre-commit 훅 통과.

## 🔍 Codex 검증 (정책 18)
⚠️ Codex CLI 미설치(환경 불변) → 사용자 waiver(정책 18 예외1) 계속 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
