### PR TITLE
feat(cost): DOC_REVIEW_GATE_DISABLED kill-switch — 문서훅 로컬 Anthropic 비용 제어 (.claude+.codex 트윈)

### DIFF
--- a/.claude/hooks/doc_review_gate.py
+++ b/.claude/hooks/doc_review_gate.py
@@ -71,6 +71,12 @@ def classify_file_grade(file_path: str) -> str:
     return "skip"
 
 
+def gate_disabled() -> bool:
+    """DOC_REVIEW_GATE_DISABLED=1 시 True — 문서 리뷰 게이트 비용 kill-switch(로컬 Anthropic 호출 0).
+    Return True when DOC_REVIEW_GATE_DISABLED is truthy — cost kill-switch (zero local Anthropic calls)."""
+    return os.environ.get("DOC_REVIEW_GATE_DISABLED", "").strip().lower() in ("1", "true", "yes")
+
+
 # ─── 거부권 매트릭스 ──────────────────────────────────────────────────────────
 # Veto matrix
 
@@ -261,6 +267,11 @@ def _format_warn(file_path: str, results: list[dict], reasons: list[str]) -> str
 def main() -> None:
     """PreToolUse Hook 진입점 — stdin에서 payload 읽고 심의 결과 출력.
     PreToolUse hook entry point — reads payload from stdin and outputs review result."""
+    # 비용 제어 — kill-switch 시 리뷰 없이 즉시 허용(sys.exit(0)=편집 통과, API 호출 0).
+    # Cost control — when the kill-switch is on, allow the edit immediately with no review (no API call).
+    if gate_disabled():
+        sys.exit(0)
+
     try:
         data = json.load(sys.stdin)
     except Exception:  # pylint: disable=broad-exception-caught

--- a/.codex/hooks/doc_review_gate.py
+++ b/.codex/hooks/doc_review_gate.py
@@ -71,6 +71,12 @@ def classify_file_grade(file_path: str) -> str:
     return "skip"
 
 
+def gate_disabled() -> bool:
+    """DOC_REVIEW_GATE_DISABLED=1 시 True — 문서 리뷰 게이트 비용 kill-switch(로컬 Anthropic 호출 0).
+    Return True when DOC_REVIEW_GATE_DISABLED is truthy — cost kill-switch (zero local Anthropic calls)."""
+    return os.environ.get("DOC_REVIEW_GATE_DISABLED", "").strip().lower() in ("1", "true", "yes")
+
+
 # ─── 거부권 매트릭스 ──────────────────────────────────────────────────────────
 # Veto matrix
 
@@ -261,6 +267,11 @@ def _format_warn(file_path: str, results: list[dict], reasons: list[str]) -> str
 def main() -> None:
     """PreToolUse Hook 진입점 — stdin에서 payload 읽고 심의 결과 출력.
     PreToolUse hook entry point — reads payload from stdin and outputs review result."""
+    # 비용 제어 — kill-switch 시 리뷰 없이 즉시 허용(sys.exit(0)=편집 통과, API 호출 0).
+    # Cost control — when the kill-switch is on, allow the edit immediately with no review (no API call).
+    if gate_disabled():
+        sys.exit(0)
+
     try:
         data = json.load(sys.stdin)
     except Exception:  # pylint: disable=broad-exception-caught

--- a/docs/runbooks/cost-controls.md
+++ b/docs/runbooks/cost-controls.md
@@ -41,7 +41,7 @@ AI 리뷰가 꺼진 리포(전역 또는 리포별)는 `_default_result("disable
 | 경로 | 위치 | 모델 | 차단 방법 |
 |------|------|------|-----------|
 | ④ pre-push 훅 | `src/github_client/repos.py` `_INSTALL_HOOK_SH` | Haiku | 로컬 `ANTHROPIC_API_KEY` 미설정 또는 `.git/hooks/pre-push` 제거 |
-| ⑤ Claude Code 문서훅 | `.claude/hooks/doc_review_gate.py` | Haiku (문서 편집마다 최대 3회) | 로컬 `ANTHROPIC_API_KEY` 미설정 또는 훅 비활성화 |
+| ⑤ Claude Code 문서훅 | `.claude/hooks/doc_review_gate.py` (+`.codex` 트윈) | Haiku (문서 편집마다 최대 3회) | 로컬 `ANTHROPIC_API_KEY` 미설정 또는 `DOC_REVIEW_GATE_DISABLED=1` 환경변수 설정(훅 제거 없이 on/off, Haiku 호출 skip) |
 
 ## 6. 살아있는 문서 유지 규칙
 

--- a/tests/unit/hooks/test_doc_review_gate.py
+++ b/tests/unit/hooks/test_doc_review_gate.py
@@ -302,3 +302,20 @@ class TestHookMain:
         assert "[문서 심의]" in output
         assert "quality" in output
         mock_exit.assert_called_with(0)
+
+
+class TestGateKillSwitch:
+    """DOC_REVIEW_GATE_DISABLED env kill-switch (로컬 Anthropic 비용 제어)."""
+
+    def test_disabled_when_env_truthy(self, monkeypatch):
+        from doc_review_gate import gate_disabled
+        for v in ("1", "true", "TRUE", "yes"):
+            monkeypatch.setenv("DOC_REVIEW_GATE_DISABLED", v)
+            assert gate_disabled() is True
+
+    def test_enabled_when_env_unset_or_falsy(self, monkeypatch):
+        from doc_review_gate import gate_disabled
+        monkeypatch.delenv("DOC_REVIEW_GATE_DISABLED", raising=False)
+        assert gate_disabled() is False
+        monkeypatch.setenv("DOC_REVIEW_GATE_DISABLED", "0")
+        assert gate_disabled() is False


### PR DESCRIPTION
## 개요
비용 조사에서 식별한 **로컬 키 Anthropic 비용 경로 ⑤**(Claude Code 문서훅 — 문서 편집마다 3× Haiku)에 kill-switch 신설. 서버 env로 제어 불가한 로컬 경로를 훅 제거 없이 on/off 가능하게 함(비용 제어 3종의 로컬 보완).

## 변경
- **`.claude/hooks/doc_review_gate.py` + `.codex/hooks/doc_review_gate.py`**(트윈 byte-identical): `gate_disabled()` 헬퍼 + `main()` 첫 문장 가드 — `DOC_REVIEW_GATE_DISABLED=1` 시 리뷰 없이 즉시 통과(로컬 Anthropic 호출 0). default-on(env 미설정 시 기존 동작 불변).
- **docs/runbooks/cost-controls.md** §5(로컬 키 경로): kill-switch 사용법 문서화.
- 테스트: `TestGateKillSwitch` 2 케이스(truthy/falsy) — `tests/unit/hooks/test_doc_review_gate.py` 35 passed.

## 사용법
```bash
export DOC_REVIEW_GATE_DISABLED=1   # 문서 편집 시 Haiku 호출 skip (로컬 비용 0)
```

## 🔴 PARITY
`.claude`/`.codex` 트윈 동일 변경(`diff` byte-identical 검증). 향후 한쪽 수정 시 양쪽 동시.

## 🔍 Codex 검증 (정책 18)
⚠️ Codex CLI 미설치(환경 불변) → 사용자 waiver(정책 18 예외1) 계속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
