### PR TITLE
test: CodeQL py/unused-import 봉인 — side-effect ORM import 명시 참조 (#540~543)

### DIFF
--- a/tests/unit/migrations/test_orm_alembic_parity.py
+++ b/tests/unit/migrations/test_orm_alembic_parity.py
@@ -47,6 +47,26 @@ import src.models.repository  # noqa: F401  pylint: disable=unused-import
 import src.models.security_alert_log  # noqa: F401  pylint: disable=unused-import
 import src.models.user  # noqa: F401  pylint: disable=unused-import
 
+# 🔴 CodeQL py/unused-import(#542/#543) 봉인 — 위 side-effect 모듈 import 를 실참조로 'used' 처리.
+# 각 `# noqa: F401` 은 flake8 만 억제하고 CodeQL py/unused-import(별도 룰)는 명시 참조로만 해소된다
+# (alembic/env.py `_REGISTERED_MODELS` 동일 패턴). 아래 검증이 튜플을 읽어 py/unused-global 도 회피하며,
+# import 부작용(Base.metadata 테이블 등록) 소실 시 loud-fail 로 잡아 autogenerate drop_table 함정을 잠근다.
+# 🔴 Seal CodeQL py/unused-import (#542/#543): reference every side-effect module import so CodeQL
+# treats them as used (`# noqa: F401` silences flake8 only). Same pattern as alembic/env.py's
+# _REGISTERED_MODELS; the check below reads the tuple (avoids an unused-global alert) and loud-fails
+# if the import side-effect (table registration into Base.metadata) ever breaks.
+_REGISTERED_MODEL_MODULES = (
+    src.models.analysis, src.models.analysis_feedback, src.models.claude_api_call,
+    src.models.gate_decision, src.models.insight_narrative_cache, src.models.issue_registration,
+    src.models.merge_attempt, src.models.merge_retry, src.models.repo_config,
+    src.models.repository, src.models.security_alert_log, src.models.user,
+)
+if len(_REGISTERED_MODEL_MODULES) != 12 or not Base.metadata.tables:
+    raise RuntimeError(
+        "ORM 모델 side-effect import 소실 — Base.metadata 미완성 (autogenerate drop 위험) / "
+        "ORM model side-effect imports lost — Base.metadata incomplete"
+    )
+
 
 # 방언 정규화 차이로 FP 인 attribute-level diff op (type/default 은 opts 로 이미 미생성).
 # Attribute-level diff ops that are dialect-normalization FPs (type/default already disabled via opts).

--- a/tests/unit/services/test_dashboard_service.py
+++ b/tests/unit/services/test_dashboard_service.py
@@ -25,6 +25,16 @@ from src.models.repository import Repository
 from src.models.user import User
 from src.repositories import claude_api_cost_repo
 
+# 🔴 CodeQL py/unused-import(#540) 봉인 — side-effect import(claude_api_calls 테이블 등록) 실참조.
+# `# noqa: F401` 은 flake8 전용이라 CodeQL py/unused-import(별도 룰)는 명시 참조로만 'used' 처리된다
+# (alembic/env.py `_REGISTERED_MODELS` 동일 패턴). 아래 검증이 튜플을 읽어 py/unused-global 도 회피하고,
+# import 부작용(테이블 등록) 소실 시 loud-fail 한다.
+# 🔴 Seal CodeQL py/unused-import (#540): reference the side-effect ORM import (registers the
+# claude_api_calls table). `# noqa: F401` silences flake8 only; CodeQL needs an explicit reference.
+_SIDE_EFFECT_MODELS = (ClaudeApiCall,)
+if any(m.__tablename__ not in Base.metadata.tables for m in _SIDE_EFFECT_MODELS):
+    raise RuntimeError("side-effect ORM import 소실 — 테이블 미등록 / side-effect ORM import lost")
+
 
 # ─── Fixtures ──────────────────────────────────────────────────────────────
 

--- a/tests/unit/services/test_dashboard_service_user_id_filter.py
+++ b/tests/unit/services/test_dashboard_service_user_id_filter.py
@@ -62,6 +62,15 @@ from src.models.merge_attempt import MergeAttempt
 from src.models.repository import Repository
 from src.models.user import User
 
+# 🔴 CodeQL py/unused-import(#541) 봉인 — side-effect import 실참조 (alembic/env.py `_REGISTERED_MODELS` 패턴).
+# `# noqa: F401` 은 flake8 전용이라 CodeQL py/unused-import(별도 룰)는 명시 참조로만 'used' 처리된다.
+# InsightNarrativeCache 도 동일 side-effect 라 선제 포함(향후 재-flag 방지). 튜플 read → py/unused-global 회피.
+# 🔴 Seal CodeQL py/unused-import (#541): reference the side-effect ORM imports (register their tables).
+# `# noqa: F401` silences flake8 only; CodeQL needs an explicit reference.
+_SIDE_EFFECT_MODELS = (ClaudeApiCall, InsightNarrativeCache)
+if any(m.__tablename__ not in Base.metadata.tables for m in _SIDE_EFFECT_MODELS):
+    raise RuntimeError("side-effect ORM import 소실 — 테이블 미등록 / side-effect ORM import lost")
+
 
 # ─── Fixtures ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## 개요

정리(cleanup) 요청 후속 — main 전체 CodeQL 스캔의 **`py/unused-import` [note] 4건(#540~543)** 봉인. 직전 #1037(Anthropic 비용 메트릭)이 추가한 **테스트 side-effect ORM import**(`Base.metadata` 테이블 등록용 — testing.md "empty `__init__` + explicit ORM import 의무")가 원인. 기능 무해하나 정책 14(open alert 0 유지) 대상.

## 근본 + 수정

`# noqa: F401` 은 **flake8 전용** — CodeQL `py/unused-import` 는 별도 룰이라 **명시 참조로만 'used' 처리**된다(메모리 #989/#996 학습). 검증된 선례 `alembic/env.py::_REGISTERED_MODELS` 패턴 그대로:

| 파일 | side-effect import | seal |
|------|--------------------|------|
| `test_orm_alembic_parity.py` | 12 모듈(`import src.models.*`) | `_REGISTERED_MODEL_MODULES` 튜플 실참조 + `Base.metadata` 완성 loud-fail |
| `test_dashboard_service.py` | `ClaudeApiCall` | `_SIDE_EFFECT_MODELS` 튜플 + `__tablename__` 등록 검증 |
| `test_dashboard_service_user_id_filter.py` | `ClaudeApiCall` + `InsightNarrativeCache`(선제 포함) | 동일 |

튜플을 읽는 검증이 **py/unused-import + py/unused-global 동시 봉인**하며, import 부작용(테이블 등록) 소실 시 loud-fail 로 autogenerate drop 함정도 잠근다.

## 검증

- 3 파일 26 passed / 1 skipped · migrations+services 디렉토리 363 passed 무회귀
- flake8 `--isolated --select=F401` clean(noqa 유효) · **테스트 수 불변(5208)** = 모듈 seal(테스트 함수 아님)
- 🔴 CodeQL 봉인은 **main 전체 스캔에서만 검증 가능**(self-inflicted alert 특성·정책 14) → 머지 후 main 재스캔에서 open 0 확인 예정.

## 🔍 Codex 검증 의뢰 (push 전, 정책 18)

⚠️ Codex CLI 미설치 → 사용자 waiver(정책 18 예외 1) 계속. 검증된 #989/#996 선례 동형 + 로컬 테스트/flake8 green.

## 🔍 사용자 검증 필요 (정책 2/14)

- **머지 후 main CodeQL 재스캔**: `gh api .../code-scanning/alerts --jq '[.[]|select(.state=="open")]|length'` → 0 확인(현재 4 → 0 기대). PR diff 스캔은 self-inflicted alert 를 노출 안 할 수 있어 **main 스캔이 최종**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
