### PR TITLE
chore: .gitignore Codex 무시 패턴 제거 — 잠긴 잔여 디렉토리 실제 삭제 완료

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,16 +31,6 @@ db_probe.py
 # Temp dirs created when review tooling runs pytest with cwd = repo root (NEVER commit).
 review-tmp-*/
 
-# ⛔ 폐기된 Codex 도구(2026-07-10 구독 해지·제거)가 남긴 임시 디렉토리.
-#    Windows 권한 잠금으로 삭제 불가(takeown/icacls/rd 전부 거부) → git 이 스캔 시
-#    "Permission denied" warning 을 뿜으므로 무시 패턴만 유지한다. 정책이 아닌 기능적 가드.
-# Leftover temp dirs from the removed Codex tooling; permission-locked and undeletable on Windows,
-# so we keep the ignore patterns to suppress git's "Permission denied" scan warnings.
-.codex_tmp/
-.codex_*
-codex-pytest-*/
-codex-write-test-*/
-
 # IDE
 .vscode/
 .idea/


### PR DESCRIPTION
## 요약

`#1051` 에서 **삭제하지 못했던** Codex 잔여 임시 디렉토리를 사용자 승인 하에 **UAC 상승(takeown/icacls/rd)** 으로 실제 제거했습니다. 이제 git `Permission denied` 스캔 warning 이 사라져, 당시 넣었던 **무해화용 무시 패턴이 불필요**해졌으므로 되돌립니다.

## 변경

`.gitignore` — 제거: `.codex_tmp/` · `.codex_*` · `codex-pytest-*/` · `codex-write-test-*/` (+ 사유 주석)
존치: 제네릭 `review-tmp-*/`

## 배경 — 왜 삭제할 수 있게 됐나

- 잠금 원인: 해당 디렉토리 소유자가 Codex 샌드박스가 만든 로컬 계정(`XZAWED-DEV\CodexSandbox*`)이라 `dirtc` 에게 권한이 없었음(`icacls` 읽기조차 거부).
- `dirtc` 는 로컬 **Administrators 멤버**였고, 현재 셸이 **UAC 필터링 토큰**이라 실패했던 것 → 사용자 승인 후 상승 실행으로 `takeown` 성공.

## 함께 수행한 정리 (저장소 밖)

- **`C:\Users\dirtc\.codex` (2,662 MB · 29,200 항목) 완전 제거** — VS Code 확장이 띄운 `codex.exe` 2개가 `logs_2.sqlite` 등을 점유하고 있어(권한 아님, **파일 잠금**) 프로세스 정지 후 삭제.
- `codex-write-test-*` (빈 디렉토리) 제거.

## 검증

- 프로젝트 내 codex 디렉토리 **0** · `git status` warning **0**.
- 코드/테스트 무변경(.gitignore only) — 단위 테스트 영향 없음.

## 🔍 사용자 검증 필요

- **VS Code 확장 `openai.chatgpt-26.707.31428` (877 MB) 이 아직 설치돼 있습니다.** 이 확장의 `codex.exe` 가 `~/.codex` 를 **재생성**할 수 있습니다(현재는 재생성 안 됨). 제거 여부는 별도 확인 예정.
- 로컬 계정 `CodexSandboxOffline` / `CodexSandboxOnline` 이 남아 있습니다(관리자 권한 필요, 시스템 변경).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
